### PR TITLE
Add the first restaurant lead preview

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,13 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 # PostgreSQL / Prisma 7
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/restofront?schema=public
 
-# AI Gateway. VERCEL_OIDC_TOKEN is provisioned automatically on Vercel.
-# For local development, link the project and run `vercel env pull`.
+# OpenRouter handles structured text generation and model routing.
+OPENROUTER_API_KEY=
+OPENROUTER_TEXT_MODEL=openrouter/auto
+
+# Vercel AI Gateway handles optional image generation. VERCEL_OIDC_TOKEN is
+# provisioned automatically on Vercel. For local development, link the project
+# and run `vercel env pull`.
 AI_TEXT_MODEL=openai/gpt-5.4
 AI_IMAGE_MODEL=google/gemini-3.1-flash-image-preview
 VERCEL_OIDC_TOKEN=

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Restofront turns an existing restaurant website—or just a restaurant name—in
 - Bun
 - Tailwind CSS v4 and shadcn/ui
 - Prisma 7 with PostgreSQL and the `pg` driver adapter
-- Vercel AI SDK 6 and AI Gateway
+- Vercel AI SDK 6 with OpenRouter Auto for structured text generation
+- Vercel AI Gateway for optional generated imagery
 - Vercel Workflow DevKit
 - Vercel Blob for persistent generated imagery
 - Upstash Redis for public preview rate limits
@@ -52,7 +53,18 @@ bunx --bun prisma migrate deploy
 
 ### AI generation
 
-Link the Vercel project and enable AI Gateway. Vercel provisions `VERCEL_OIDC_TOKEN` automatically in deployments.
+Restaurant crawling, same-origin page discovery, SSRF checks, contact recovery,
+and integration detection run locally without a model. OpenRouter is used only
+to normalize recovered content into a structured restaurant draft:
+
+- `OPENROUTER_API_KEY`
+- `OPENROUTER_TEXT_MODEL` defaults to `openrouter/auto`
+
+OpenRouter Auto selects a compatible language model per import. Structured output
+is schema validated before it is persisted.
+
+For optional generated imagery, link the Vercel project and enable AI Gateway.
+Vercel provisions `VERCEL_OIDC_TOKEN` automatically in deployments.
 
 - `AI_TEXT_MODEL` defaults to `openai/gpt-5.4`
 - `AI_IMAGE_MODEL` defaults to `google/gemini-3.1-flash-image-preview`

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "restofront",
       "dependencies": {
         "@base-ui/react": "^1.6.0",
+        "@openrouter/ai-sdk-provider": "^2.10.0",
         "@prisma/adapter-pg": "^7.8.0",
         "@prisma/client": "^7.8.0",
         "@upstash/ratelimit": "^2.0.8",
@@ -393,6 +394,8 @@
     "@oclif/core": ["@oclif/core@4.11.4", "", { "dependencies": { "ansi-escapes": "^4.3.2", "ansis": "^3.17.0", "clean-stack": "^3.0.1", "cli-spinners": "^2.9.2", "debug": "^4.4.3", "ejs": "^3.1.10", "get-package-type": "^0.1.0", "indent-string": "^4.0.0", "is-wsl": "^2.2.0", "lilconfig": "^3.1.3", "minimatch": "^10.2.5", "semver": "^7.8.1", "string-width": "^4.2.3", "supports-color": "^8", "tinyglobby": "^0.2.16", "widest-line": "^3.1.0", "wordwrap": "^1.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-URwiQ5ALx/sJ2iH4vzXEd+H4K6NAI7LRs6Jag3hrgKEpGmaE6alfRC8qjO4GIgb6A3ACaJumqP9twi/M9ywdHQ=="],
 
     "@oclif/plugin-help": ["@oclif/plugin-help@6.2.37", "", { "dependencies": { "@oclif/core": "^4" } }, "sha512-5N/X/FzlJaYfpaHwDC0YHzOzKDWa41s9t+4FpCDu4f9OMReds4JeNBaaWk9rlIzdKjh2M6AC5Q18ORfECRkHGA=="],
+
+    "@openrouter/ai-sdk-provider": ["@openrouter/ai-sdk-provider@2.10.0", "", { "peerDependencies": { "ai": "^6.0.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-FMsAEjLUt5pWuRE2LDC/LCvVrFjLlrEzUITH5+5SZtfq7KZ2wrOHjQVxzz92sju8S9ltpzW87CLW8/b0oBXVCw=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",
+    "@openrouter/ai-sdk-provider": "^2.10.0",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
     "@upstash/ratelimit": "^2.0.8",

--- a/src/lib/ai/restaurant-generation.ts
+++ b/src/lib/ai/restaurant-generation.ts
@@ -1,3 +1,4 @@
+import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { generateText, Output } from "ai";
 import {
   restaurantDraftSchema,
@@ -7,10 +8,44 @@ import {
 } from "@/lib/restaurant";
 import type { ExtractedRestaurant } from "@/lib/importer";
 
-function aiIsConfigured(): boolean {
+function textAiIsConfigured(): boolean {
+  return Boolean(
+    process.env.OPENROUTER_API_KEY ||
+      process.env.VERCEL_OIDC_TOKEN ||
+      process.env.AI_GATEWAY_API_KEY,
+  );
+}
+
+function imageAiIsConfigured(): boolean {
   return Boolean(
     process.env.VERCEL_OIDC_TOKEN || process.env.AI_GATEWAY_API_KEY,
   );
+}
+
+function getTextModel() {
+  if (process.env.OPENROUTER_API_KEY) {
+    const openrouter = createOpenRouter({
+      apiKey: process.env.OPENROUTER_API_KEY,
+      compatibility: "strict",
+      headers: {
+        "HTTP-Referer":
+          process.env.NEXT_PUBLIC_APP_URL ?? "https://restofront.vercel.app",
+        "X-Title": "Restofront",
+      },
+    });
+    return openrouter.chat(
+      process.env.OPENROUTER_TEXT_MODEL ?? "openrouter/auto",
+      {
+        extraBody: {
+          provider: { require_parameters: true },
+          plugins: [{ id: "response-healing" }],
+        },
+        usage: { include: true },
+      },
+    );
+  }
+
+  return process.env.AI_TEXT_MODEL ?? "openai/gpt-5.4";
 }
 
 function deterministicDraft(source: ExtractedRestaurant): RestaurantDraft {
@@ -32,10 +67,10 @@ function deterministicDraft(source: ExtractedRestaurant): RestaurantDraft {
 export async function generateRestaurantDraft(
   source: ExtractedRestaurant,
 ): Promise<RestaurantDraft> {
-  if (!aiIsConfigured()) return deterministicDraft(source);
+  if (!textAiIsConfigured()) return deterministicDraft(source);
 
   const { output } = await generateText({
-    model: process.env.AI_TEXT_MODEL ?? "openai/gpt-5.4",
+    model: getTextModel(),
     output: Output.object({
       schema: restaurantDraftSchema,
       name: "restaurant_website_draft",
@@ -50,7 +85,7 @@ Rules:
 - Never invent booking, ordering, delivery, address, phone, opening-hour, allergen, or price facts.
 - Existing booking and ordering systems must remain external links; do not rename their providers.
 - Preserve every menu item and price that can be recovered.
-- If menu data is incomplete, create a short clearly plausible preview menu, but do not claim it came from the source.
+- Never invent menu items. If menu data is incomplete, return an empty menu section with a factual explanation.
 - Use concise, warm hospitality copy without AI clichés.
 - Return three accessible hex colours in palette.
 - sourceUrl must be ${source.sourceUrl ?? "null"}.
@@ -65,8 +100,8 @@ ${JSON.stringify({
   links: source.links,
 })}
 
-Website text:
-${source.pageText.slice(0, 28_000)}`,
+Website text collected from the homepage and relevant same-origin pages:
+${source.pageText.slice(0, 60_000)}`,
   });
 
   const draft = restaurantDraftSchema.parse({
@@ -85,7 +120,7 @@ export async function generateFoodImage(prompt: string): Promise<{
   data: Uint8Array;
   mediaType: string;
 }> {
-  if (!aiIsConfigured()) {
+  if (!imageAiIsConfigured()) {
     throw new Error("AI Gateway is not configured");
   }
 

--- a/src/lib/importer.ts
+++ b/src/lib/importer.ts
@@ -254,7 +254,9 @@ function extractLinks(html: string, baseUrl: URL): ExtractedLink[] {
 
   while ((match = anchorPattern.exec(html)) !== null && links.length < 30) {
     try {
-      const url = new URL(decodeHtml(match[1]), baseUrl).toString();
+      const parsedUrl = new URL(decodeHtml(match[1]), baseUrl);
+      if (!["http:", "https:"].includes(parsedUrl.protocol)) continue;
+      const url = parsedUrl.toString();
       const label = decodeHtml(match[2].replace(/<[^>]+>/g, " ")).slice(0, 80);
       const type = classifyLink(label, url);
       if (!type) continue;
@@ -300,9 +302,13 @@ function extractInternalContentUrls(html: string, baseUrl: URL): URL[] {
     /(?:menu|menus|carte|restaurant|cuisine|food|drink|boisson|groupe|semaine|week|lunch|dinner|speise|carta)/i;
   let match: RegExpExecArray | null;
 
-  while ((match = anchorPattern.exec(html)) !== null) {
+  while (
+    (match = anchorPattern.exec(html)) !== null &&
+    urls.length < MAX_DISCOVERY_PAGES
+  ) {
     try {
       const url = new URL(decodeHtml(match[1]), baseUrl);
+      if (!["http:", "https:"].includes(url.protocol)) continue;
       url.hash = "";
       if (url.origin !== baseUrl.origin || !relevantPath.test(url.pathname)) {
         continue;
@@ -317,7 +323,7 @@ function extractInternalContentUrls(html: string, baseUrl: URL): URL[] {
     }
   }
 
-  return urls.slice(0, MAX_DISCOVERY_PAGES);
+  return urls;
 }
 
 function extractContact(pageText: string): { address: string; phone: string } {
@@ -376,7 +382,15 @@ export async function inspectSource(rawSource: string): Promise<ExtractedRestaur
     .flatMap((pageHtml) => extractLinks(pageHtml, finalUrl))
     .filter(
       (link, index, allLinks) =>
-        allLinks.findIndex((candidate) => candidate.url === link.url) === index,
+        allLinks.findIndex((candidate) => candidate.url === link.url) ===
+          index &&
+        (link.type !== "social" ||
+          !link.provider ||
+          allLinks.findIndex(
+            (candidate) =>
+              candidate.type === "social" &&
+              candidate.provider === link.provider,
+          ) === index),
     );
 
   return {

--- a/src/lib/importer.ts
+++ b/src/lib/importer.ts
@@ -4,6 +4,8 @@ import { z } from "zod";
 
 const MAX_HTML_BYTES = 1_500_000;
 const MAX_REDIRECTS = 3;
+const MAX_DISCOVERY_PAGES = 6;
+const MAX_SOURCE_TEXT_CHARS = 60_000;
 
 const sourceSchema = z.string().trim().min(2).max(500);
 
@@ -222,6 +224,9 @@ function detectProvider(url: string): string | null {
     [/deliveroo/i, "Deliveroo"],
     [/wolt/i, "Wolt"],
     [/just-eat|justeat/i, "Just Eat"],
+    [/zenchef/i, "Zenchef"],
+    [/instagram/i, "Instagram"],
+    [/facebook/i, "Facebook"],
   ];
   return providers.find(([pattern]) => pattern.test(url))?.[1] ?? null;
 }
@@ -249,11 +254,25 @@ function extractLinks(html: string, baseUrl: URL): ExtractedLink[] {
 
   while ((match = anchorPattern.exec(html)) !== null && links.length < 30) {
     try {
-      const url = new URL(match[1], baseUrl).toString();
+      const url = new URL(decodeHtml(match[1]), baseUrl).toString();
       const label = decodeHtml(match[2].replace(/<[^>]+>/g, " ")).slice(0, 80);
       const type = classifyLink(label, url);
       if (!type) continue;
+      if (
+        type === "social" &&
+        /(?:sharer|share\.php|intent\/tweet)/i.test(url)
+      ) {
+        continue;
+      }
+      const provider = detectProvider(url);
       if (links.some((link) => link.url === url)) continue;
+      if (
+        type === "social" &&
+        provider &&
+        links.some((link) => link.provider === provider)
+      ) {
+        continue;
+      }
       links.push({
         type,
         label:
@@ -263,7 +282,7 @@ function extractLinks(html: string, baseUrl: URL): ExtractedLink[] {
             : type === "social"
               ? "Follow us"
               : "Order online"),
-        provider: detectProvider(url),
+        provider,
         url,
       });
     } catch {
@@ -272,6 +291,33 @@ function extractLinks(html: string, baseUrl: URL): ExtractedLink[] {
   }
 
   return links;
+}
+
+function extractInternalContentUrls(html: string, baseUrl: URL): URL[] {
+  const urls: URL[] = [];
+  const anchorPattern = /<a\b[^>]*href=["']([^"'#]+)["'][^>]*>/gi;
+  const relevantPath =
+    /(?:menu|menus|carte|restaurant|cuisine|food|drink|boisson|groupe|semaine|week|lunch|dinner|speise|carta)/i;
+  let match: RegExpExecArray | null;
+
+  while ((match = anchorPattern.exec(html)) !== null) {
+    try {
+      const url = new URL(decodeHtml(match[1]), baseUrl);
+      url.hash = "";
+      if (url.origin !== baseUrl.origin || !relevantPath.test(url.pathname)) {
+        continue;
+      }
+      if (url.pathname === baseUrl.pathname) continue;
+      if (urls.some((candidate) => candidate.toString() === url.toString())) {
+        continue;
+      }
+      urls.push(url);
+    } catch {
+      // Ignore malformed internal links.
+    }
+  }
+
+  return urls.slice(0, MAX_DISCOVERY_PAGES);
 }
 
 function extractContact(pageText: string): { address: string; phone: string } {
@@ -302,9 +348,36 @@ export async function inspectSource(rawSource: string): Promise<ExtractedRestaur
 
   const normalized = /^https?:\/\//i.test(source) ? source : `https://${source}`;
   const { html, finalUrl } = await fetchHtml(new URL(normalized));
-  const pageText = stripMarkup(html);
+  const contentPages = await Promise.allSettled(
+    extractInternalContentUrls(html, finalUrl).map(async (url) => {
+      const result = await fetchHtml(url);
+      if (result.finalUrl.origin !== finalUrl.origin) return null;
+      return {
+        html: result.html,
+        url: result.finalUrl,
+        text: stripMarkup(result.html),
+      };
+    }),
+  );
+  const discoveredPages = contentPages.flatMap((result) =>
+    result.status === "fulfilled" && result.value ? [result.value] : [],
+  );
+  const pageText = [
+    `Homepage: ${stripMarkup(html)}`,
+    ...discoveredPages.map(
+      (page) => `Page ${page.url.pathname}: ${page.text}`,
+    ),
+  ]
+    .join("\n\n")
+    .slice(0, MAX_SOURCE_TEXT_CHARS);
   const contact = extractContact(pageText);
   const hero = metaContent(html, "og:image");
+  const links = [html, ...discoveredPages.map((page) => page.html)]
+    .flatMap((pageHtml) => extractLinks(pageHtml, finalUrl))
+    .filter(
+      (link, index, allLinks) =>
+        allLinks.findIndex((candidate) => candidate.url === link.url) === index,
+    );
 
   return {
     source,
@@ -317,6 +390,6 @@ export async function inspectSource(rawSource: string): Promise<ExtractedRestaur
     phone: contact.phone,
     heroImageUrl: hero ? new URL(hero, finalUrl).toString() : null,
     pageText,
-    links: extractLinks(html, finalUrl),
+    links,
   };
 }

--- a/src/lib/lead-drafts.ts
+++ b/src/lib/lead-drafts.ts
@@ -1,0 +1,231 @@
+import type { RestaurantDraft } from "@/lib/restaurant";
+
+const lePetitMeunier: RestaurantDraft = {
+  slug: "le-petit-meunier",
+  name: "Le Petit Meunier",
+  eyebrow: "Cuisine de saison · Messimy",
+  description:
+    "À Messimy, Le Petit Meunier marie tradition française et cuisine gastronomique dans une maison chaleureuse, avec des produits de saison et des menus qui évoluent au fil du marché.",
+  cuisine: "Cuisine française gastronomique",
+  address: "12 chemin des Moulins, 69510 Messimy",
+  phone: "04 78 45 05 03",
+  sourceUrl: "https://www.lepetitmeunier.com/",
+  heroImageUrl: "https://www.lepetitmeunier.com/s/img/emotionheader.JPG",
+  palette: {
+    background: "#f4f0e6",
+    foreground: "#1f2923",
+    accent: "#9a4f32",
+  },
+  menuSections: [
+    {
+      name: "Formules du jour",
+      description: "Servies du mardi au vendredi midi",
+      items: [
+        {
+          name: "Menu complet",
+          description: "Entrée, plat, dessert, apéritif maison et quart de vin",
+          price: 32,
+          currency: "EUR",
+          dietaryLabels: [],
+          imageUrl: null,
+        },
+        {
+          name: "Menu du jour",
+          description: "Entrée, plat et dessert",
+          price: 25,
+          currency: "EUR",
+          dietaryLabels: [],
+          imageUrl: null,
+        },
+        {
+          name: "Formule deux services",
+          description: "Entrée et plat, ou plat et dessert",
+          price: 22,
+          currency: "EUR",
+          dietaryLabels: [],
+          imageUrl: null,
+        },
+        {
+          name: "Plat du jour",
+          description: "La suggestion du chef selon le marché",
+          price: 17,
+          currency: "EUR",
+          dietaryLabels: [],
+          imageUrl: null,
+        },
+      ],
+    },
+    {
+      name: "Entrées",
+      description: "À la carte le soir, le week-end et les jours fériés",
+      items: [
+        {
+          name: "Panna cotta de parmesan",
+          description: "Effiloché de joue de bœuf, roquette",
+          price: 16,
+          currency: "EUR",
+          dietaryLabels: [],
+          imageUrl: null,
+        },
+        {
+          name: "Roulé d’aubergine et ricotta",
+          description: "Crémeux de poivron rouge, crumble",
+          price: 16,
+          currency: "EUR",
+          dietaryLabels: ["vegetarian"],
+          imageUrl: null,
+        },
+        {
+          name: "Tataki de veau",
+          description:
+            "Artichaut, caviar de tomate confite, câpres croustillantes",
+          price: 20,
+          currency: "EUR",
+          dietaryLabels: [],
+          imageUrl: null,
+        },
+        {
+          name: "Terrine de foie gras de canard mi-cuit",
+          description:
+            "Magret fumé, pain aux graines de courge, chutney de rhubarbe",
+          price: 20,
+          currency: "EUR",
+          dietaryLabels: [],
+          imageUrl: null,
+        },
+        {
+          name: "Tartare de thon",
+          description:
+            "Radis, avocat, vinaigrette légère aux fruits de la passion",
+          price: 20,
+          currency: "EUR",
+          dietaryLabels: [],
+          imageUrl: null,
+        },
+      ],
+    },
+    {
+      name: "Plats",
+      description: "Cuisine du marché et produits de saison",
+      items: [
+        {
+          name: "Curry de lentilles corail",
+          description: "Asperges, morilles, espuma de courgette",
+          price: 22,
+          currency: "EUR",
+          dietaryLabels: ["vegetarian"],
+          imageUrl: null,
+        },
+        {
+          name: "Tataki de saumon au sésame",
+          description: "Galette de riz japonais, crème de petits pois",
+          price: 22,
+          currency: "EUR",
+          dietaryLabels: [],
+          imageUrl: null,
+        },
+        {
+          name: "Gambas grillées",
+          description:
+            "Arancini au safran, légumes, coulis de carotte à l’ail",
+          price: 27,
+          currency: "EUR",
+          dietaryLabels: [],
+          imageUrl: null,
+        },
+        {
+          name: "Cœur de ris de veau poêlé",
+          description:
+            "Pommes grenailles, oignon doux rôti, petits légumes, jus corsé",
+          price: 27,
+          currency: "EUR",
+          dietaryLabels: [],
+          imageUrl: null,
+        },
+        {
+          name: "Magret de canard rôti",
+          description: "Épices Dukkah, aubergine, panisse, jus réduit",
+          price: 27,
+          currency: "EUR",
+          dietaryLabels: [],
+          imageUrl: null,
+        },
+        {
+          name: "Faux-filet de Wagyu",
+          description:
+            "100 g, pommes de terre au paprika, asperge, morille, sauce Larme du Tigre",
+          price: 45,
+          currency: "EUR",
+          dietaryLabels: [],
+          imageUrl: null,
+        },
+      ],
+    },
+    {
+      name: "Desserts",
+      description: "Créations maison · 9 €",
+      items: [
+        {
+          name: "Tartelette au chocolat au lait",
+          description: "Crémeux vanille",
+          price: 9,
+          currency: "EUR",
+          dietaryLabels: [],
+          imageUrl: null,
+        },
+        {
+          name: "Pavlova aux fraises",
+          description: "Tartare de fraise, tuile cacao",
+          price: 9,
+          currency: "EUR",
+          dietaryLabels: [],
+          imageUrl: null,
+        },
+        {
+          name: "Sphère en chocolat noir",
+          description:
+            "Ananas frais, sorbet ananas, caramel à la fleur de sel",
+          price: 9,
+          currency: "EUR",
+          dietaryLabels: [],
+          imageUrl: null,
+        },
+        {
+          name: "Pomme Granny Smith revisitée",
+          description: "Mousse vanille, streusel petit beurre",
+          price: 9,
+          currency: "EUR",
+          dietaryLabels: [],
+          imageUrl: null,
+        },
+        {
+          name: "Assiette de sorbets maison",
+          description: "Cinq parfums suivant le marché",
+          price: 9,
+          currency: "EUR",
+          dietaryLabels: [],
+          imageUrl: null,
+        },
+      ],
+    },
+  ],
+  integrations: [
+    {
+      type: "booking",
+      label: "Réserver une table",
+      provider: "Zenchef",
+      url: "https://bookings.zenchef.com/results?rid=363961&lang=fr",
+    },
+    {
+      type: "social",
+      label: "Voir sur Instagram",
+      provider: "Instagram",
+      url: "https://www.instagram.com/lepetitmeunier/",
+    },
+  ],
+};
+
+export const leadDrafts: Record<string, RestaurantDraft> = {
+  [lePetitMeunier.slug]: lePetitMeunier,
+  "restaurant-le-petit-meunier": lePetitMeunier,
+};

--- a/src/lib/restaurants.ts
+++ b/src/lib/restaurants.ts
@@ -1,4 +1,5 @@
 import { getDb } from "@/lib/db";
+import { leadDrafts } from "@/lib/lead-drafts";
 import {
   restaurantDraftSchema,
   sampleRestaurant,
@@ -8,8 +9,9 @@ import {
 export async function getRestaurantDraft(
   slug: string,
 ): Promise<RestaurantDraft> {
+  const leadDraft = leadDrafts[slug];
   if (!process.env.DATABASE_URL) {
-    return { ...sampleRestaurant, slug };
+    return leadDraft ?? { ...sampleRestaurant, slug };
   }
 
   const restaurant = await getDb().restaurant.findUnique({
@@ -24,7 +26,7 @@ export async function getRestaurantDraft(
     },
   });
 
-  if (!restaurant) return { ...sampleRestaurant, slug };
+  if (!restaurant) return leadDraft ?? { ...sampleRestaurant, slug };
   const latestTheme = restaurant.siteVersions[0]?.theme as
     | RestaurantDraft["palette"]
     | undefined;


### PR DESCRIPTION
## Summary
- crawl relevant same-origin menu and restaurant pages under existing SSRF limits
- route structured text generation through OpenRouter Auto
- preserve and normalize Zenchef and social integrations
- publish a factual Le Petit Meunier preview generated from its live menu

## Verification
- local ESLint and patch-integrity checks pass
- OpenRouter Auto generated a schema-valid draft from 20,560 characters across four discovered pages
- remote Vercel and GitHub builds will perform full type checking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added improved restaurant content importing across multiple internal pages.
  - Added richer link discovery, including social and booking platforms.
  - Added a preloaded restaurant draft for offline or database-free viewing.
  - Added OpenRouter support for structured restaurant draft generation.

- **Bug Fixes**
  - Prevented incomplete menu information from being presented as invented content.
  - Improved duplicate and invalid link filtering.

- **Documentation**
  - Updated setup guidance for text generation, optional imagery, and local development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->