### PR TITLE
feat: add bilingual restaurant sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Restofront turns an existing restaurant website—or just a restaurant name—in
 2. Import public website content with SSRF-safe fetching and bounded HTML reads.
 3. Recover the menu, contact details, imagery, and external integrations.
 4. Derive the colour palette from the source branding and select a cuisine-aware layout.
-5. Generate a structured website draft with AI Gateway when configured, or a deterministic demo draft locally.
+5. Detect the source language, preserve it as canonical, and generate a complete English translation during the same structured AI pass.
 6. Reuse source photography as visual direction and generate up to three missing dish images as one consistent restaurant campaign.
 7. Save a private preview through a durable Vercel Workflow.
 8. Claim the restaurant through Stripe Checkout; the completed checkout creates the prefilled owner account.
@@ -30,6 +30,22 @@ cuisine-aware layout:
 
 Each template changes the hero structure, menu layout, weight, spacing, image
 treatment, and copy—not only the colours.
+
+## Internationalization
+
+Restaurant data uses one canonical source locale plus structured translation
+overlays. Prices, currencies, images, addresses, provider names, and external
+booking or ordering URLs remain shared, so translating a site cannot fork its
+operational data. Menu sections, menu items, descriptions, dietary labels, and
+link labels keep the same order and count in every locale.
+If an existing provider URL already exposes a `lang` parameter, the rendered
+link updates only that preference while preserving the same provider and flow.
+
+Imports read the document language when available. Non-English sources receive
+an English translation in the same schema-validated OpenRouter generation.
+Restaurant templates and interface copy use small server-side dictionaries.
+The canonical site is available at `/preview/[slug]`; translations use
+`/preview/[slug]/[locale]` and expose language alternates in metadata.
 
 ## Stack
 
@@ -160,3 +176,4 @@ The application first attaches the hostname to the project. It then shows Vercel
 - `/dashboard` — authenticated restaurant management
 - `/dashboard?demo=1` — local demo dashboard
 - `/preview/[slug]` — private full-screen restaurant preview
+- `/preview/[slug]/[locale]` — translated restaurant preview

--- a/prisma/migrations/20260719153000_add_restaurant_locales/migration.sql
+++ b/prisma/migrations/20260719153000_add_restaurant_locales/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "Restaurant"
+ADD COLUMN "defaultLocale" TEXT NOT NULL DEFAULT 'en',
+ADD COLUMN "translations" JSONB NOT NULL DEFAULT '[]';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -81,6 +81,8 @@ model Restaurant {
   sourceUrl        String?
   logoUrl          String?
   heroImageUrl     String?
+  defaultLocale    String            @default("en")
+  translations     Json              @default("[]")
   status           RestaurantStatus  @default(PROSPECT)
   organizationId   String?
   organization     Organization?     @relation(fields: [organizationId], references: [id], onDelete: SetNull)

--- a/src/app/api/restaurants/[slug]/route.ts
+++ b/src/app/api/restaurants/[slug]/route.ts
@@ -26,6 +26,8 @@ export async function PUT(request: Request, { params }: RouteContext) {
         address: draft.address,
         phone: draft.phone,
         heroImageUrl: draft.heroImageUrl,
+        defaultLocale: draft.defaultLocale,
+        translations: draft.translations,
         menuSections: {
           deleteMany: {},
           create: draft.menuSections.map((section, sectionIndex) => ({

--- a/src/app/preview/[slug]/[locale]/page.tsx
+++ b/src/app/preview/[slug]/[locale]/page.tsx
@@ -1,0 +1,56 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { RestaurantSite } from "@/components/restaurant-site";
+import {
+  getRestaurantLocales,
+  localizeRestaurantDraft,
+} from "@/lib/restaurant";
+import { getRestaurantDraft } from "@/lib/restaurants";
+
+type PageProps = {
+  params: Promise<{ slug: string; locale: string }>;
+};
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { slug, locale } = await params;
+  const draft = await getRestaurantDraft(slug);
+  const locales = getRestaurantLocales(draft);
+  if (!locales.includes(locale)) notFound();
+
+  return {
+    title: `${draft.name} — Private preview`,
+    robots: { index: false, follow: false },
+    alternates: {
+      canonical:
+        locale === draft.defaultLocale
+          ? `/preview/${slug}`
+          : `/preview/${slug}/${locale}`,
+      languages: Object.fromEntries(
+        locales.map((availableLocale) => [
+          availableLocale,
+          availableLocale === draft.defaultLocale
+            ? `/preview/${slug}`
+            : `/preview/${slug}/${availableLocale}`,
+        ]),
+      ),
+    },
+  };
+}
+
+export default async function LocalizedPreviewPage({ params }: PageProps) {
+  const { slug, locale } = await params;
+  const draft = await getRestaurantDraft(slug);
+  const locales = getRestaurantLocales(draft);
+  if (!locales.includes(locale)) notFound();
+
+  return (
+    <RestaurantSite
+      draft={localizeRestaurantDraft(draft, locale)}
+      locale={locale}
+      localeBasePath={`/preview/${slug}`}
+      availableLocales={locales}
+    />
+  );
+}

--- a/src/app/preview/[slug]/page.tsx
+++ b/src/app/preview/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { RestaurantSite } from "@/components/restaurant-site";
+import { getRestaurantLocales } from "@/lib/restaurant";
 import { getRestaurantDraft } from "@/lib/restaurants";
 
 type PageProps = {
@@ -11,15 +12,33 @@ export async function generateMetadata({
 }: PageProps): Promise<Metadata> {
   const { slug } = await params;
   const draft = await getRestaurantDraft(slug);
+  const locales = getRestaurantLocales(draft);
   return {
     title: `${draft.name} — Private preview`,
     robots: { index: false, follow: false },
-    alternates: { canonical: `/preview/${slug}` },
+    alternates: {
+      canonical: `/preview/${slug}`,
+      languages: Object.fromEntries(
+        locales.map((locale) => [
+          locale,
+          locale === draft.defaultLocale
+            ? `/preview/${slug}`
+            : `/preview/${slug}/${locale}`,
+        ]),
+      ),
+    },
   };
 }
 
 export default async function PreviewPage({ params }: PageProps) {
   const { slug } = await params;
   const draft = await getRestaurantDraft(slug);
-  return <RestaurantSite draft={draft} />;
+  return (
+    <RestaurantSite
+      draft={draft}
+      locale={draft.defaultLocale}
+      localeBasePath={`/preview/${slug}`}
+      availableLocales={getRestaurantLocales(draft)}
+    />
+  );
 }

--- a/src/components/restaurant-site.tsx
+++ b/src/components/restaurant-site.tsx
@@ -5,6 +5,12 @@ import {
   ShoppingBag,
 } from "lucide-react";
 import Image from "next/image";
+import Link from "next/link";
+import {
+  getRestaurantDictionary,
+  getRestaurantTemplateCopy,
+  localizeIntegrationUrl,
+} from "@/lib/restaurant-i18n";
 import { formatPrice, type RestaurantDraft } from "@/lib/restaurant";
 import { resolveRestaurantTemplate } from "@/lib/restaurant-templates";
 import { cn } from "@/lib/utils";
@@ -12,11 +18,17 @@ import { cn } from "@/lib/utils";
 type RestaurantSiteProps = {
   draft: RestaurantDraft;
   embedded?: boolean;
+  locale?: string;
+  localeBasePath?: string;
+  availableLocales?: string[];
 };
 
 export function RestaurantSite({
   draft,
   embedded = false,
+  locale = draft.defaultLocale,
+  localeBasePath,
+  availableLocales = [draft.defaultLocale],
 }: RestaurantSiteProps) {
   const booking = draft.integrations.find(
     (integration) => integration.type === "booking",
@@ -25,6 +37,8 @@ export function RestaurantSite({
     ["ordering", "delivery"].includes(integration.type),
   );
   const template = resolveRestaurantTemplate(draft.cuisine);
+  const copy = getRestaurantTemplateCopy(template, locale);
+  const dictionary = getRestaurantDictionary(locale);
   const picturedItems = draft.menuSections
     .flatMap((section) => section.items)
     .filter(
@@ -36,6 +50,7 @@ export function RestaurantSite({
 
   return (
     <article
+      lang={locale}
       data-restaurant-template={template.id}
       className={cn(
         "overflow-hidden font-sans",
@@ -63,9 +78,45 @@ export function RestaurantSite({
           {draft.name}
         </span>
         <div className="flex items-center gap-2">
+          {localeBasePath && availableLocales.length > 1 ? (
+            <nav
+              aria-label={dictionary.language}
+              className={cn(
+                "flex items-center rounded-full border p-1 text-[10px] font-bold uppercase tracking-[0.08em] backdrop-blur",
+                immersiveHero
+                  ? "border-white/35 bg-black/10"
+                  : "border-current/20",
+              )}
+            >
+              {availableLocales.map((availableLocale) => (
+                <Link
+                  key={availableLocale}
+                  href={
+                    availableLocale === draft.defaultLocale
+                      ? localeBasePath
+                      : `${localeBasePath}/${availableLocale}`
+                  }
+                  hrefLang={availableLocale}
+                  aria-current={
+                    availableLocale === locale ? "page" : undefined
+                  }
+                  className={cn(
+                    "rounded-full px-2 py-1 transition-colors",
+                    availableLocale === locale
+                      ? immersiveHero
+                        ? "bg-white text-black"
+                        : "bg-[var(--restaurant-fg)] text-[var(--restaurant-bg)]"
+                      : "opacity-65 hover:opacity-100",
+                  )}
+                >
+                  {availableLocale.split("-")[0]}
+                </Link>
+              ))}
+            </nav>
+          ) : null}
           {ordering ? (
             <a
-              href={ordering.url}
+              href={localizeIntegrationUrl(ordering.url, locale)}
               target="_blank"
               rel="noreferrer"
               className={cn(
@@ -81,7 +132,7 @@ export function RestaurantSite({
           ) : null}
           {booking ? (
             <a
-              href={booking.url}
+              href={localizeIntegrationUrl(booking.url, locale)}
               target="_blank"
               rel="noreferrer"
               className={cn(
@@ -126,7 +177,11 @@ export function RestaurantSite({
               </p>
             </div>
           </div>
-          <HeroImage draft={draft} className="min-h-[420px] lg:min-h-full" />
+          <HeroImage
+            draft={draft}
+            locale={locale}
+            className="min-h-[420px] lg:min-h-full"
+          />
         </section>
       ) : template.heroLayout === "card" ? (
         <section className="p-4 pt-1 md:p-8 md:pt-2">
@@ -136,7 +191,11 @@ export function RestaurantSite({
               embedded ? "min-h-[500px]" : "min-h-[76svh]",
             )}
           >
-            <HeroImage draft={draft} className="absolute inset-0" />
+            <HeroImage
+              draft={draft}
+              locale={locale}
+              className="absolute inset-0"
+            />
             <div className="absolute inset-0 bg-[linear-gradient(to_top,rgba(10,18,15,0.86),rgba(10,18,15,0.02)_70%)]" />
             <HeroCopy draft={draft} embedded={embedded} template={template} />
           </div>
@@ -148,7 +207,11 @@ export function RestaurantSite({
             embedded ? "min-h-[520px]" : "min-h-[82svh]",
           )}
         >
-          <HeroImage draft={draft} className="absolute inset-0" />
+          <HeroImage
+            draft={draft}
+            locale={locale}
+            className="absolute inset-0"
+          />
           <div className="absolute inset-0 bg-[linear-gradient(to_top,rgba(10,12,11,0.88),rgba(10,12,11,0.04)_68%)]" />
           <HeroCopy draft={draft} embedded={embedded} template={template} />
         </section>
@@ -162,10 +225,10 @@ export function RestaurantSite({
                 className="text-xs font-bold uppercase tracking-[0.18em]"
                 style={{ color: "var(--restaurant-accent)" }}
               >
-                {template.featuredHeading}
+                {copy.featuredHeading}
               </p>
               <h2 className="mt-3 text-3xl font-bold tracking-[-0.04em] md:text-5xl">
-                {template.featuredSubheading}
+                {copy.featuredSubheading}
               </h2>
             </div>
           </div>
@@ -202,7 +265,7 @@ export function RestaurantSite({
                   <div className="flex items-start justify-between gap-4">
                     <h3 className="font-semibold leading-tight">{item.name}</h3>
                     <span className="font-mono text-xs">
-                      {formatPrice(item.price, item.currency)}
+                      {formatPrice(item.price, item.currency, locale)}
                     </span>
                   </div>
                   <p className="mt-2 text-sm leading-5 opacity-60">
@@ -218,10 +281,10 @@ export function RestaurantSite({
       <section className="mx-auto grid max-w-7xl gap-12 px-6 py-16 md:px-10 md:py-24 lg:grid-cols-[0.68fr_1.32fr]">
         <div>
           <p className="text-xs font-bold uppercase tracking-[0.18em] opacity-55">
-            {template.menuEyebrow}
+            {copy.menuEyebrow}
           </p>
           <h2 className="mt-3 max-w-md text-4xl font-bold leading-[0.96] tracking-[-0.045em] md:text-6xl">
-            {template.menuHeading}
+            {copy.menuHeading}
           </h2>
           <div className="mt-8 flex flex-col gap-3 text-sm opacity-75">
             <span className="flex items-start gap-2">
@@ -230,19 +293,20 @@ export function RestaurantSite({
             </span>
             {booking ? (
               <a
-                href={booking.url}
+                href={localizeIntegrationUrl(booking.url, locale)}
                 target="_blank"
                 rel="noreferrer"
                 className="flex items-center gap-2 font-semibold opacity-100"
               >
                 <CalendarDays className="size-4" />
-                Reservations via {booking.provider ?? "our booking partner"}
+                {dictionary.reservationsVia}{" "}
+                {booking.provider ?? dictionary.bookingPartner}
                 <ArrowUpRight className="size-3.5" />
               </a>
             ) : null}
             {ordering ? (
               <a
-                href={ordering.url}
+                href={localizeIntegrationUrl(ordering.url, locale)}
                 target="_blank"
                 rel="noreferrer"
                 className="flex items-center gap-2 font-semibold opacity-100"
@@ -302,7 +366,7 @@ export function RestaurantSite({
                       </p>
                     </div>
                     <span className="font-mono text-sm">
-                      {formatPrice(item.price, item.currency)}
+                      {formatPrice(item.price, item.currency, locale)}
                     </span>
                   </div>
                 ))}
@@ -316,7 +380,7 @@ export function RestaurantSite({
         <span>
           {draft.name} · {draft.address}
         </span>
-        <span>Menu and availability may change with the season.</span>
+        <span>{dictionary.seasonalNotice}</span>
       </footer>
     </article>
   );
@@ -325,13 +389,19 @@ export function RestaurantSite({
 type HeroImageProps = {
   draft: RestaurantDraft;
   className?: string;
+  locale?: string;
 };
 
-function HeroImage({ draft, className }: HeroImageProps) {
+function HeroImage({
+  draft,
+  className,
+  locale = draft.defaultLocale,
+}: HeroImageProps) {
+  const dictionary = getRestaurantDictionary(locale);
   return draft.heroImageUrl ? (
     <div
       role="img"
-      aria-label={`Dining room at ${draft.name}`}
+      aria-label={`${dictionary.diningRoomAlt} ${draft.name}`}
       className={cn("bg-cover bg-center", className)}
       style={{ backgroundImage: `url("${draft.heroImageUrl}")` }}
     />

--- a/src/lib/ai/restaurant-generation.ts
+++ b/src/lib/ai/restaurant-generation.ts
@@ -119,6 +119,16 @@ ${source.pageText.slice(0, 60_000)}`,
     heroImageUrl: source.heroImageUrl || output.heroImageUrl,
     integrations:
       source.links.length > 0 ? source.links : output.integrations,
+    translations: output.translations.map((translation) => ({
+      ...translation,
+      integrationLabels:
+        source.links.length > 0
+          ? source.links.map(
+              (link, index) =>
+                translation.integrationLabels[index] ?? link.label,
+            )
+          : translation.integrationLabels,
+    })),
   });
 
   return draft;

--- a/src/lib/ai/restaurant-generation.ts
+++ b/src/lib/ai/restaurant-generation.ts
@@ -59,6 +59,8 @@ function deterministicDraft(source: ExtractedRestaurant): RestaurantDraft {
     phone: source.phone || sampleRestaurant.phone,
     sourceUrl: source.sourceUrl,
     heroImageUrl: source.heroImageUrl || sampleRestaurant.heroImageUrl,
+    defaultLocale: source.sourceLocale ?? "en",
+    translations: [],
     integrations:
       source.links.length > 0 ? source.links : sampleRestaurant.integrations,
   });
@@ -85,6 +87,11 @@ Rules:
 - Never invent booking, ordering, delivery, address, phone, opening-hour, allergen, or price facts.
 - Existing booking and ordering systems must remain external links; do not rename their providers.
 - Preserve every menu item and price that can be recovered.
+- Treat ${source.sourceLocale ?? "the detected source language"} as the canonical locale and put the source wording in the main fields.
+- Set defaultLocale to the canonical source locale using a two-letter language code.
+- When the canonical locale is not English, include one complete "en" translation. When it is English, do not duplicate it in translations.
+- A translation is a linguistic overlay only: its menu sections, items and integrationLabels must have exactly the same order and counts as the canonical data.
+- Translate customer-facing cuisine, eyebrow, description, menu names, menu descriptions, dietary labels and link labels. Never translate restaurant names, provider names, URLs, prices, currencies or image references.
 - Never invent menu items. If menu data is incomplete, return an empty menu section with a factual explanation.
 - Use concise, warm hospitality copy without AI clichés.
 - Return three accessible hex colours in palette, derived from the source website's visible branding and photography rather than a generic restaurant palette.
@@ -97,6 +104,7 @@ ${JSON.stringify({
   description: source.description,
   address: source.address,
   phone: source.phone,
+  sourceLocale: source.sourceLocale,
   links: source.links,
 })}
 

--- a/src/lib/importer.ts
+++ b/src/lib/importer.ts
@@ -19,6 +19,7 @@ export type ExtractedLink = {
 export type ExtractedRestaurant = {
   source: string;
   sourceUrl: string | null;
+  sourceLocale: string | null;
   name: string;
   description: string;
   address: string;
@@ -200,6 +201,16 @@ function extractTitle(html: string): string {
   );
 }
 
+function extractDocumentLocale(html: string): string | null {
+  const locale =
+    html.match(/<html[^>]+lang=["']([^"']+)["']/i)?.[1] ??
+    metaContent(html, "content-language");
+  const normalized = locale?.trim().replace("_", "-");
+  return normalized && /^[a-z]{2}(?:-[A-Z]{2})?$/i.test(normalized)
+    ? normalized.split("-")[0].toLowerCase()
+    : null;
+}
+
 function stripMarkup(html: string): string {
   return decodeHtml(
     html
@@ -342,6 +353,7 @@ export async function inspectSource(rawSource: string): Promise<ExtractedRestaur
     return {
       source,
       sourceUrl: null,
+      sourceLocale: null,
       name: source,
       description: "",
       address: "",
@@ -396,6 +408,7 @@ export async function inspectSource(rawSource: string): Promise<ExtractedRestaur
   return {
     source,
     sourceUrl: finalUrl.toString(),
+    sourceLocale: extractDocumentLocale(html),
     name: extractTitle(html) || finalUrl.hostname.replace(/^www\./, ""),
     description:
       metaContent(html, "og:description") ||

--- a/src/lib/lead-drafts.ts
+++ b/src/lib/lead-drafts.ts
@@ -16,6 +16,154 @@ const lePetitMeunier: RestaurantDraft = {
     foreground: "#1f2923",
     accent: "#9a4f32",
   },
+  defaultLocale: "fr",
+  translations: [
+    {
+      locale: "en",
+      cuisine: "French fine dining",
+      eyebrow: "Seasonal cuisine · Messimy",
+      description:
+        "In Messimy, Le Petit Meunier brings French tradition and fine dining together in a warm setting, with seasonal produce and menus shaped by the market.",
+      menuSections: [
+        {
+          name: "Daily set menus",
+          description: "Served Tuesday to Friday at lunchtime",
+          items: [
+            {
+              name: "Complete set menu",
+              description:
+                "Starter, main course, dessert, house aperitif and a quarter-bottle of wine",
+              dietaryLabels: [],
+            },
+            {
+              name: "Menu of the day",
+              description: "Starter, main course and dessert",
+              dietaryLabels: [],
+            },
+            {
+              name: "Two-course set menu",
+              description:
+                "Starter and main course, or main course and dessert",
+              dietaryLabels: [],
+            },
+            {
+              name: "Dish of the day",
+              description: "The chef’s market-led suggestion",
+              dietaryLabels: [],
+            },
+          ],
+        },
+        {
+          name: "Starters",
+          description:
+            "À la carte in the evening, at weekends and on public holidays",
+          items: [
+            {
+              name: "Parmesan panna cotta",
+              description: "Pulled beef cheek and rocket",
+              dietaryLabels: [],
+            },
+            {
+              name: "Aubergine and ricotta roll",
+              description: "Red pepper cream and crumble",
+              dietaryLabels: ["vegetarian"],
+            },
+            {
+              name: "Veal tataki",
+              description:
+                "Artichoke, confit tomato caviar and crispy capers",
+              dietaryLabels: [],
+            },
+            {
+              name: "Semi-cooked duck foie gras terrine",
+              description:
+                "Smoked duck breast, pumpkin seed bread and rhubarb chutney",
+              dietaryLabels: [],
+            },
+            {
+              name: "Tuna tartare",
+              description:
+                "Radish, avocado and a light passion fruit vinaigrette",
+              dietaryLabels: [],
+            },
+          ],
+        },
+        {
+          name: "Main courses",
+          description: "Market cooking and seasonal produce",
+          items: [
+            {
+              name: "Red lentil curry",
+              description: "Asparagus, morels and courgette espuma",
+              dietaryLabels: ["vegetarian"],
+            },
+            {
+              name: "Sesame salmon tataki",
+              description: "Japanese rice cake and pea cream",
+              dietaryLabels: [],
+            },
+            {
+              name: "Grilled king prawns",
+              description:
+                "Saffron arancini, vegetables and garlic carrot coulis",
+              dietaryLabels: [],
+            },
+            {
+              name: "Pan-seared veal sweetbread",
+              description:
+                "Baby potatoes, roasted sweet onion, young vegetables and rich jus",
+              dietaryLabels: [],
+            },
+            {
+              name: "Roast duck breast",
+              description:
+                "Dukkah spices, aubergine, panisse and reduced jus",
+              dietaryLabels: [],
+            },
+            {
+              name: "Wagyu sirloin",
+              description:
+                "100 g, paprika potatoes, asparagus, morel and Tiger Tear sauce",
+              dietaryLabels: [],
+            },
+          ],
+        },
+        {
+          name: "Desserts",
+          description: "House creations · €9",
+          items: [
+            {
+              name: "Milk chocolate tartlet",
+              description: "Vanilla cream",
+              dietaryLabels: [],
+            },
+            {
+              name: "Strawberry pavlova",
+              description: "Strawberry tartare and cocoa tuile",
+              dietaryLabels: [],
+            },
+            {
+              name: "Dark chocolate sphere",
+              description:
+                "Fresh pineapple, pineapple sorbet and salted caramel",
+              dietaryLabels: [],
+            },
+            {
+              name: "Reimagined Granny Smith apple",
+              description: "Vanilla mousse and butter biscuit streusel",
+              dietaryLabels: [],
+            },
+            {
+              name: "Selection of house sorbets",
+              description: "Five flavours selected according to the market",
+              dietaryLabels: [],
+            },
+          ],
+        },
+      ],
+      integrationLabels: ["Book a table", "View on Instagram"],
+    },
+  ],
   menuSections: [
     {
       name: "Formules du jour",

--- a/src/lib/restaurant-i18n.ts
+++ b/src/lib/restaurant-i18n.ts
@@ -1,0 +1,43 @@
+import type { RestaurantTemplate } from "@/lib/restaurant-templates";
+
+export type SupportedUiLocale = "en" | "fr";
+
+const dictionaries = {
+  en: {
+    language: "Language",
+    reservationsVia: "Reservations via",
+    bookingPartner: "our booking partner",
+    seasonalNotice: "Menu and availability may change with the season.",
+    diningRoomAlt: "Dining room at",
+  },
+  fr: {
+    language: "Langue",
+    reservationsVia: "Réservations via",
+    bookingPartner: "notre partenaire de réservation",
+    seasonalNotice:
+      "Le menu et les disponibilités peuvent évoluer au fil des saisons.",
+    diningRoomAlt: "Salle du restaurant",
+  },
+} satisfies Record<string, Record<string, string>>;
+
+export function getRestaurantDictionary(locale: string) {
+  return dictionaries[toUiLocale(locale)];
+}
+
+export function getRestaurantTemplateCopy(
+  template: RestaurantTemplate,
+  locale: string,
+) {
+  return template.copy[toUiLocale(locale)];
+}
+
+export function localizeIntegrationUrl(url: string, locale: string): string {
+  const localizedUrl = new URL(url);
+  if (!localizedUrl.searchParams.has("lang")) return url;
+  localizedUrl.searchParams.set("lang", locale.split("-")[0].toLowerCase());
+  return localizedUrl.toString();
+}
+
+function toUiLocale(locale: string): SupportedUiLocale {
+  return locale.toLowerCase().startsWith("fr") ? "fr" : "en";
+}

--- a/src/lib/restaurant-i18n.ts
+++ b/src/lib/restaurant-i18n.ts
@@ -32,10 +32,14 @@ export function getRestaurantTemplateCopy(
 }
 
 export function localizeIntegrationUrl(url: string, locale: string): string {
-  const localizedUrl = new URL(url);
-  if (!localizedUrl.searchParams.has("lang")) return url;
-  localizedUrl.searchParams.set("lang", locale.split("-")[0].toLowerCase());
-  return localizedUrl.toString();
+  try {
+    const localizedUrl = new URL(url);
+    if (!localizedUrl.searchParams.has("lang")) return url;
+    localizedUrl.searchParams.set("lang", locale.split("-")[0].toLowerCase());
+    return localizedUrl.toString();
+  } catch {
+    return url;
+  }
 }
 
 function toUiLocale(locale: string): SupportedUiLocale {

--- a/src/lib/restaurant-templates.ts
+++ b/src/lib/restaurant-templates.ts
@@ -15,10 +15,15 @@ export type RestaurantTemplate = {
   brandClassName: string;
   titleClassName: string;
   sectionClassName: string;
-  menuEyebrow: string;
-  menuHeading: string;
-  featuredHeading: string;
-  featuredSubheading: string;
+  copy: Record<
+    "en" | "fr",
+    {
+      menuEyebrow: string;
+      menuHeading: string;
+      featuredHeading: string;
+      featuredSubheading: string;
+    }
+  >;
   photographyDirection: string;
 };
 
@@ -31,10 +36,20 @@ const templates: Record<RestaurantTemplateId, RestaurantTemplate> = {
     titleClassName:
       "font-extrabold leading-[0.9] tracking-[-0.055em] text-balance",
     sectionClassName: "border-t-2 border-current/15 pt-6",
-    menuEyebrow: "La carte",
-    menuHeading: "Une cuisine guidée par la saison.",
-    featuredHeading: "Quelques assiettes",
-    featuredSubheading: "Des plats fidèles à la saison.",
+    copy: {
+      en: {
+        menuEyebrow: "The menu",
+        menuHeading: "Cooking guided by the season.",
+        featuredHeading: "A few dishes",
+        featuredSubheading: "Plates faithful to the season.",
+      },
+      fr: {
+        menuEyebrow: "La carte",
+        menuHeading: "Une cuisine guidée par la saison.",
+        featuredHeading: "Quelques assiettes",
+        featuredSubheading: "Des plats fidèles à la saison.",
+      },
+    },
     photographyDirection:
       "Warm independent French restaurant photography, dark matte stoneware, rustic stone and wood, close three-quarter camera angle, directional amber side light, shallow depth of field and honest appetizing texture.",
   },
@@ -47,10 +62,20 @@ const templates: Record<RestaurantTemplateId, RestaurantTemplate> = {
       "font-semibold leading-[0.96] tracking-[-0.045em] text-balance",
     sectionClassName:
       "rounded-[1.5rem] border border-current/10 bg-white/45 p-6",
-    menuEyebrow: "Fresh today",
-    menuHeading: "Bright food, clearly served.",
-    featuredHeading: "What we are serving",
-    featuredSubheading: "Fresh food, shown honestly.",
+    copy: {
+      en: {
+        menuEyebrow: "Fresh today",
+        menuHeading: "Bright food, clearly served.",
+        featuredHeading: "What we are serving",
+        featuredSubheading: "Fresh food, shown honestly.",
+      },
+      fr: {
+        menuEyebrow: "Frais aujourd’hui",
+        menuHeading: "Une cuisine fraîche, servie simplement.",
+        featuredHeading: "À table aujourd’hui",
+        featuredSubheading: "Des produits frais, sans artifice.",
+      },
+    },
     photographyDirection:
       "Bright natural restaurant photography, pale stoneware, fresh produce colours, clean daylight, airy framing, soft shadows and realistic portions.",
   },
@@ -63,10 +88,20 @@ const templates: Record<RestaurantTemplateId, RestaurantTemplate> = {
       "font-black uppercase leading-[0.82] tracking-[-0.065em] text-balance",
     sectionClassName:
       "border-2 border-current bg-[var(--restaurant-accent)]/5 p-6 shadow-[6px_6px_0_currentColor]",
-    menuEyebrow: "The lineup",
-    menuHeading: "Big flavour. No detours.",
-    featuredHeading: "See what is cooking",
-    featuredSubheading: "The food does the talking.",
+    copy: {
+      en: {
+        menuEyebrow: "The lineup",
+        menuHeading: "Big flavour. No detours.",
+        featuredHeading: "See what is cooking",
+        featuredSubheading: "The food does the talking.",
+      },
+      fr: {
+        menuEyebrow: "La sélection",
+        menuHeading: "Du goût. Sans détour.",
+        featuredHeading: "En cuisine",
+        featuredSubheading: "Les plats parlent d’eux-mêmes.",
+      },
+    },
     photographyDirection:
       "Bold American restaurant photography, generous but realistic portions, direct flash balanced with warm kitchen light, saturated food colour, strong contrast and casual energy.",
   },
@@ -78,10 +113,20 @@ const templates: Record<RestaurantTemplateId, RestaurantTemplate> = {
     titleClassName:
       "font-medium leading-[0.92] tracking-[-0.055em] text-balance",
     sectionClassName: "border-t border-current/20 pt-6",
-    menuEyebrow: "Menu",
-    menuHeading: "Precision, texture and balance.",
-    featuredHeading: "From the kitchen",
-    featuredSubheading: "One visual language, plate by plate.",
+    copy: {
+      en: {
+        menuEyebrow: "Menu",
+        menuHeading: "Precision, texture and balance.",
+        featuredHeading: "From the kitchen",
+        featuredSubheading: "One visual language, plate by plate.",
+      },
+      fr: {
+        menuEyebrow: "Menu",
+        menuHeading: "Précision, texture et équilibre.",
+        featuredHeading: "Depuis la cuisine",
+        featuredSubheading: "Un même langage, assiette après assiette.",
+      },
+    },
     photographyDirection:
       "Low-key Japanese restaurant photography, precise plating, black ceramic, controlled pools of warm light, deep neutral shadows, restrained colour and meticulous texture.",
   },
@@ -93,10 +138,20 @@ const templates: Record<RestaurantTemplateId, RestaurantTemplate> = {
     titleClassName:
       "font-semibold leading-[0.94] tracking-[-0.05em] text-balance",
     sectionClassName: "border-t border-current/15 pt-6",
-    menuEyebrow: "From the coast",
-    menuHeading: "The catch, simply handled.",
-    featuredHeading: "From sea to table",
-    featuredSubheading: "Clean flavours in clear view.",
+    copy: {
+      en: {
+        menuEyebrow: "From the coast",
+        menuHeading: "The catch, simply handled.",
+        featuredHeading: "From sea to table",
+        featuredSubheading: "Clean flavours in clear view.",
+      },
+      fr: {
+        menuEyebrow: "Depuis la côte",
+        menuHeading: "La pêche, cuisinée simplement.",
+        featuredHeading: "De la mer à la table",
+        featuredSubheading: "Des saveurs nettes et franches.",
+      },
+    },
     photographyDirection:
       "Fresh coastal restaurant photography, cool daylight with warm highlights, pale textured ceramics, clean seafood colour, relaxed framing and natural table textures.",
   },
@@ -108,10 +163,20 @@ const templates: Record<RestaurantTemplateId, RestaurantTemplate> = {
     titleClassName:
       "font-bold leading-[0.9] tracking-[-0.055em] text-balance",
     sectionClassName: "border-t border-current/15 pt-6",
-    menuEyebrow: "The menu",
-    menuHeading: "Made here. Served when ready.",
-    featuredHeading: "A look at the table",
-    featuredSubheading: "The dishes, as they arrive.",
+    copy: {
+      en: {
+        menuEyebrow: "The menu",
+        menuHeading: "Made here. Served when ready.",
+        featuredHeading: "A look at the table",
+        featuredSubheading: "The dishes, as they arrive.",
+      },
+      fr: {
+        menuEyebrow: "La carte",
+        menuHeading: "Fait maison. Servi au bon moment.",
+        featuredHeading: "À table",
+        featuredSubheading: "Les plats, tels qu’ils arrivent.",
+      },
+    },
     photographyDirection:
       "Warm neighbourhood restaurant photography, natural table texture, handmade food, late-afternoon window light, gentle contrast and relaxed generous composition.",
   },

--- a/src/lib/restaurant.ts
+++ b/src/lib/restaurant.ts
@@ -71,7 +71,7 @@ export const restaurantDraftSchema = z.object({
   integrations: z.array(integrationSchema).max(12),
 }).superRefine((draft, context) => {
   const translatedLocales = new Set<string>();
-  for (const translation of draft.translations) {
+  draft.translations.forEach((translation, translationIndex) => {
     if (translation.locale === draft.defaultLocale) {
       context.addIssue({
         code: "custom",
@@ -90,10 +90,10 @@ export const restaurantDraftSchema = z.object({
     if (translation.menuSections.length !== draft.menuSections.length) {
       context.addIssue({
         code: "custom",
-        path: ["translations", translation.locale, "menuSections"],
+        path: ["translations", translationIndex, "menuSections"],
         message: "Translated menu sections must match the canonical menu",
       });
-      continue;
+      return;
     }
     translation.menuSections.forEach((section, sectionIndex) => {
       if (section.items.length !== draft.menuSections[sectionIndex].items.length) {
@@ -101,7 +101,7 @@ export const restaurantDraftSchema = z.object({
           code: "custom",
           path: [
             "translations",
-            translation.locale,
+            translationIndex,
             "menuSections",
             sectionIndex,
             "items",
@@ -113,11 +113,11 @@ export const restaurantDraftSchema = z.object({
     if (translation.integrationLabels.length !== draft.integrations.length) {
       context.addIssue({
         code: "custom",
-        path: ["translations", translation.locale, "integrationLabels"],
+        path: ["translations", translationIndex, "integrationLabels"],
         message: "Translated integration labels must match the canonical links",
       });
     }
-  }
+  });
 });
 
 export type RestaurantDraft = z.infer<typeof restaurantDraftSchema>;

--- a/src/lib/restaurant.ts
+++ b/src/lib/restaurant.ts
@@ -25,6 +25,31 @@ export const integrationSchema = z.object({
   url: z.url(),
 });
 
+export const localeSchema = z
+  .string()
+  .regex(/^[a-z]{2}(?:-[A-Z]{2})?$/, "Use a BCP 47 language code");
+
+export const restaurantTranslationSchema = z.object({
+  locale: localeSchema,
+  cuisine: z.string().max(80),
+  eyebrow: z.string().max(100),
+  description: z.string().min(20).max(500),
+  menuSections: z.array(
+    z.object({
+      name: z.string().min(1).max(80),
+      description: z.string().max(240).default(""),
+      items: z.array(
+        z.object({
+          name: z.string().min(1).max(120),
+          description: z.string().max(320).default(""),
+          dietaryLabels: z.array(z.string().max(30)).max(6).default([]),
+        }),
+      ),
+    }),
+  ),
+  integrationLabels: z.array(z.string().min(1).max(60)).max(12),
+});
+
 export const restaurantDraftSchema = z.object({
   slug: z.string().min(2).max(80),
   name: z.string().min(2).max(120),
@@ -40,11 +65,63 @@ export const restaurantDraftSchema = z.object({
     foreground: z.string(),
     accent: z.string(),
   }),
+  defaultLocale: localeSchema.default("en"),
+  translations: z.array(restaurantTranslationSchema).max(8).default([]),
   menuSections: z.array(menuSectionSchema).min(1).max(12),
   integrations: z.array(integrationSchema).max(12),
+}).superRefine((draft, context) => {
+  const translatedLocales = new Set<string>();
+  for (const translation of draft.translations) {
+    if (translation.locale === draft.defaultLocale) {
+      context.addIssue({
+        code: "custom",
+        path: ["translations"],
+        message: "Translations must not repeat the canonical locale",
+      });
+    }
+    if (translatedLocales.has(translation.locale)) {
+      context.addIssue({
+        code: "custom",
+        path: ["translations"],
+        message: `Duplicate translation locale: ${translation.locale}`,
+      });
+    }
+    translatedLocales.add(translation.locale);
+    if (translation.menuSections.length !== draft.menuSections.length) {
+      context.addIssue({
+        code: "custom",
+        path: ["translations", translation.locale, "menuSections"],
+        message: "Translated menu sections must match the canonical menu",
+      });
+      continue;
+    }
+    translation.menuSections.forEach((section, sectionIndex) => {
+      if (section.items.length !== draft.menuSections[sectionIndex].items.length) {
+        context.addIssue({
+          code: "custom",
+          path: [
+            "translations",
+            translation.locale,
+            "menuSections",
+            sectionIndex,
+            "items",
+          ],
+          message: "Translated menu items must match the canonical menu",
+        });
+      }
+    });
+    if (translation.integrationLabels.length !== draft.integrations.length) {
+      context.addIssue({
+        code: "custom",
+        path: ["translations", translation.locale, "integrationLabels"],
+        message: "Translated integration labels must match the canonical links",
+      });
+    }
+  }
 });
 
 export type RestaurantDraft = z.infer<typeof restaurantDraftSchema>;
+export type RestaurantLocale = z.infer<typeof localeSchema>;
 
 export const sampleRestaurant: RestaurantDraft = {
   slug: "osteria-luna",
@@ -63,6 +140,8 @@ export const sampleRestaurant: RestaurantDraft = {
     foreground: "#1d241f",
     accent: "#a5482d",
   },
+  defaultLocale: "en",
+  translations: [],
   menuSections: [
     {
       name: "To begin",
@@ -149,11 +228,54 @@ export function slugify(value: string): string {
 export function formatPrice(
   price: number | null,
   currency = "EUR",
+  locale = "en",
 ): string {
   if (price === null) return "";
-  return new Intl.NumberFormat("en", {
+  return new Intl.NumberFormat(locale, {
     style: "currency",
     currency,
     minimumFractionDigits: price % 1 === 0 ? 0 : 2,
   }).format(price);
+}
+
+export function getRestaurantLocales(draft: RestaurantDraft): string[] {
+  return [
+    draft.defaultLocale,
+    ...draft.translations.map((translation) => translation.locale),
+  ];
+}
+
+export function localizeRestaurantDraft(
+  draft: RestaurantDraft,
+  locale: string,
+): RestaurantDraft {
+  if (locale === draft.defaultLocale) return draft;
+  const translation = draft.translations.find(
+    (candidate) => candidate.locale === locale,
+  );
+  if (!translation) return draft;
+
+  return {
+    ...draft,
+    cuisine: translation.cuisine,
+    eyebrow: translation.eyebrow,
+    description: translation.description,
+    menuSections: draft.menuSections.map((section, sectionIndex) => ({
+      ...section,
+      name: translation.menuSections[sectionIndex].name,
+      description: translation.menuSections[sectionIndex].description,
+      items: section.items.map((item, itemIndex) => ({
+        ...item,
+        name: translation.menuSections[sectionIndex].items[itemIndex].name,
+        description:
+          translation.menuSections[sectionIndex].items[itemIndex].description,
+        dietaryLabels:
+          translation.menuSections[sectionIndex].items[itemIndex].dietaryLabels,
+      })),
+    })),
+    integrations: draft.integrations.map((integration, integrationIndex) => ({
+      ...integration,
+      label: translation.integrationLabels[integrationIndex],
+    })),
+  };
 }

--- a/src/lib/restaurants.ts
+++ b/src/lib/restaurants.ts
@@ -44,6 +44,8 @@ export async function getRestaurantDraft(
     sourceUrl: restaurant.sourceUrl,
     heroImageUrl: restaurant.heroImageUrl,
     palette: latestTheme ?? sampleRestaurant.palette,
+    defaultLocale: restaurant.defaultLocale,
+    translations: restaurant.translations,
     menuSections: restaurant.menuSections.map((section) => ({
       name: section.name,
       description: section.description ?? "",

--- a/src/workflows/restaurant-import.ts
+++ b/src/workflows/restaurant-import.ts
@@ -119,6 +119,8 @@ async function persistDraft(draft: RestaurantDraft): Promise<void> {
       phone: draft.phone,
       sourceUrl: draft.sourceUrl,
       heroImageUrl: draft.heroImageUrl,
+      defaultLocale: draft.defaultLocale,
+      translations: draft.translations,
       status: "PREVIEW_READY",
       integrations: {
         deleteMany: {},
@@ -162,6 +164,8 @@ async function persistDraft(draft: RestaurantDraft): Promise<void> {
       phone: draft.phone,
       sourceUrl: draft.sourceUrl,
       heroImageUrl: draft.heroImageUrl,
+      defaultLocale: draft.defaultLocale,
+      translations: draft.translations,
       status: "PREVIEW_READY",
       integrations: {
         create: draft.integrations.map((integration) => ({


### PR DESCRIPTION
## Summary
- preserve the imported source locale and generate a complete English overlay in the structured OpenRouter pass
- add locale-aware restaurant routes, language switcher, translated template copy, localized pricing, and hreflang metadata
- ship a full English Le Petit Meunier preview while keeping menu prices, imagery, and integrations shared
- persist locale data through Prisma, imports, and dashboard saves

## Verification
- `bunx --bun prisma format --check`
- `bun run lint`
- `git diff --check`
- build delegated to GitHub CI per workstation policy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added internationalized restaurant previews with English and French localization.
  * Added language switching and localized menu, featured content, labels, prices, and booking links.
  * Added locale-aware preview URLs and language metadata.
  * Source language is detected and preserved during restaurant imports, with English translations generated when needed.

* **Documentation**
  * Updated product flow, internationalization guidance, and available preview routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->