### PR TITLE
feat(platform): add production service readiness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,8 @@
 # Public application URL
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
-# PostgreSQL / Prisma 7
+# PostgreSQL / Prisma 7. Configure different databases for Vercel Preview and
+# Production. Never reuse the production URL in a preview deployment.
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/restofront?schema=public
 
 # OpenRouter handles structured text generation and model routing.
@@ -18,11 +19,11 @@ VERCEL_OIDC_TOKEN=
 # Durable import workflows
 WORKFLOW_ENABLED=false
 
-# Public preview rate limiting (required in production)
+# Public preview rate limiting (required in preview and production)
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
 
-# Generated restaurant imagery
+# Generated restaurant imagery (required in preview and production)
 BLOB_READ_WRITE_TOKEN=
 
 # Stripe subscriptions

--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,9 @@ UPSTASH_REDIS_REST_TOKEN=
 # Generated restaurant imagery (required in preview and production)
 BLOB_READ_WRITE_TOKEN=
 
+# Authenticates external readiness probes. Generate at least 32 random bytes.
+HEALTHCHECK_TOKEN=
+
 # Stripe subscriptions
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,16 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      # Prisma Client generation validates that DATABASE_URL exists but does not
+      # connect to this placeholder. Runtime readiness is checked separately.
+      DATABASE_URL: postgresql://ci:ci@127.0.0.1:5432/restofront_ci
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14
       - run: bun install --frozen-lockfile
+      - run: bun run test
       - run: bun run lint
       - run: bun run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
       DATABASE_URL: postgresql://ci:ci@127.0.0.1:5432/restofront_ci
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14

--- a/README.md
+++ b/README.md
@@ -89,14 +89,24 @@ bun run db:migrate:deploy
 Preview and production service isolation, readiness checks, backups, restores,
 and credential rotation are documented in
 [`docs/operations/platform-services.md`](docs/operations/platform-services.md).
-The uncached `/api/health/ready` route verifies PostgreSQL, Upstash Redis, and
-Vercel Blob without returning secret values.
+The bearer-authenticated `/api/health/ready` route verifies PostgreSQL, Upstash
+Redis, and Vercel Blob without returning secret values. Each application
+instance coalesces concurrent checks and caches their aggregate result for five
+seconds.
 
 ## Required production configuration
 
 ### Database
 
 - `DATABASE_URL`
+
+### Platform readiness
+
+- `HEALTHCHECK_TOKEN`
+
+Use distinct, randomly generated values with at least 32 bytes for Preview and
+Production. Readiness callers send the value as a bearer token; the endpoint
+fails closed when it is absent or invalid.
 
 ### AI generation
 

--- a/README.md
+++ b/README.md
@@ -70,19 +70,27 @@ The canonical site is available at `/preview/[slug]`; translations use
 ## Local setup
 
 ```bash
-bun install
 cp .env.example .env.local
+bun install
 bun run dev
 ```
 
 The marketing site and deterministic preview flow work without external credentials. Production integrations activate when their environment variables are configured.
 
 Do not run migrations against production from a local machine. Create the
-database, then apply the committed migrations through the deployment workflow:
+database, then apply the committed migrations through the reviewed release
+environment:
 
 ```bash
-bunx --bun prisma migrate deploy
+bun run db:migrate:status
+bun run db:migrate:deploy
 ```
+
+Preview and production service isolation, readiness checks, backups, restores,
+and credential rotation are documented in
+[`docs/operations/platform-services.md`](docs/operations/platform-services.md).
+The uncached `/api/health/ready` route verifies PostgreSQL, Upstash Redis, and
+Vercel Blob without returning secret values.
 
 ## Required production configuration
 

--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,9 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
+        "@next/env": "16.2.10",
         "@tailwindcss/postcss": "^4",
+        "@types/bun": "^1.3.14",
         "@types/node": "^20",
         "@types/pg": "^8.20.0",
         "@types/react": "^19",
@@ -533,6 +535,8 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
     "@types/http-cache-semantics": ["@types/http-cache-semantics@4.2.0", "", {}, "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q=="],
@@ -796,6 +800,8 @@
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "builtin-modules": ["builtin-modules@5.0.0", "", {}, "sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 

--- a/docs/operations/platform-services.md
+++ b/docs/operations/platform-services.md
@@ -22,6 +22,20 @@ It returns `503` with variable names and remediation guidance when configuration
 is missing or a provider cannot be reached. It never returns connection URLs,
 tokens, or provider error bodies.
 
+Set a distinct `HEALTHCHECK_TOKEN` with at least 32 random bytes in each
+environment. Readiness callers must send it as a bearer token:
+
+```bash
+curl --fail-with-body \
+  --header "Authorization: Bearer $HEALTHCHECK_TOKEN" \
+  https://<deployment-host>/api/health/ready
+```
+
+The route fails closed when the token is missing or invalid. Each application
+instance also coalesces concurrent probes and caches the aggregate result for
+five seconds to avoid amplifying health checks into the database, Redis, and
+Blob providers.
+
 ## Database release procedure
 
 Committed migrations in `prisma/migrations` are the only production schema

--- a/docs/operations/platform-services.md
+++ b/docs/operations/platform-services.md
@@ -1,0 +1,75 @@
+# Platform services runbook
+
+Restofront needs PostgreSQL, Upstash Redis, and Vercel Blob before a preview or
+production deployment can accept public imports. Provisioning remains a manual,
+reviewed infrastructure action; application deployments do not create paid
+resources.
+
+## Environment isolation
+
+Create separate provider resources for the Vercel `Preview` and `Production`
+scopes. Never copy the production database URL into Preview.
+
+| Service | Preview | Production | Runtime variables |
+| --- | --- | --- | --- |
+| PostgreSQL | Dedicated preview database or branch | Dedicated production database | `DATABASE_URL` |
+| Upstash Redis | Dedicated preview database | Dedicated production database | `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN` |
+| Vercel Blob | Dedicated preview store | Dedicated production store | `BLOB_READ_WRITE_TOKEN` |
+
+After configuring each scope, redeploy it and request `/api/health/ready`. The
+route returns `200` only when all three services are configured and reachable.
+It returns `503` with variable names and remediation guidance when configuration
+is missing or a provider cannot be reached. It never returns connection URLs,
+tokens, or provider error bodies.
+
+## Database release procedure
+
+Committed migrations in `prisma/migrations` are the only production schema
+source. Do not use `prisma db push` or `prisma migrate dev` against Preview or
+Production.
+
+1. Confirm the target shell or CI environment contains the reviewed target
+   `DATABASE_URL`.
+2. Take or verify a provider backup before any destructive migration.
+3. Check migration state with `bun run db:migrate:status`.
+4. Apply pending migrations with `bun run db:migrate:deploy`.
+5. Redeploy the application and confirm `/api/health/ready` returns `200`.
+6. Record the migration name, target environment, operator, and backup reference
+   in the release record.
+
+Run Preview first. A failed migration must stop the release; inspect the
+`_prisma_migrations` record and the provider logs before using
+`prisma migrate resolve`. Never mark a failed migration as applied without
+reviewing the resulting schema.
+
+## Backup and restore
+
+- Enable the managed database provider's continuous backup or point-in-time
+  recovery before the first production migration.
+- Keep Preview restore drills separate from Production. Perform a quarterly
+  restore into a new, isolated database and verify the migration table and a
+  sample restaurant record before deleting the drill database.
+- Restore by creating a new database from the selected recovery point, applying
+  any later reviewed migrations, validating it, then replacing `DATABASE_URL`
+  through a reviewed environment change. Do not overwrite the existing database
+  in place.
+- Blob originals and enhanced derivatives are operational data. Retain authentic
+  source URLs and provenance in PostgreSQL; verify the store's retention policy
+  before onboarding the first restaurant.
+
+## Credential ownership and rotation
+
+The repository owner is accountable for provider access, backup policy, and
+release approval. A migration operator may execute the reviewed commands but
+must not copy credentials into issues, pull requests, logs, or local production
+environment files.
+
+Rotate database, Redis, and Blob credentials every 90 days and immediately after
+suspected exposure or an operator access change:
+
+1. Create the replacement credential in the provider.
+2. Update Preview and verify readiness.
+3. Update Production during a reviewed release window and verify readiness.
+4. Revoke the old credential only after both environments are healthy.
+5. Record the date, owner, affected environment, and verification result without
+   recording the credential value.

--- a/docs/operations/platform-services.md
+++ b/docs/operations/platform-services.md
@@ -18,9 +18,10 @@ scopes. Never copy the production database URL into Preview.
 
 After configuring each scope, redeploy it and request `/api/health/ready`. The
 route returns `200` only when all three services are configured and reachable.
-It returns `503` with variable names and remediation guidance when configuration
-is missing or a provider cannot be reached. It never returns connection URLs,
-tokens, or provider error bodies.
+When configuration is missing, it returns `503` with the missing variable names
+and remediation guidance. Provider failures return a generic unreachable
+response without variable names or provider details. The route never returns
+connection URLs, tokens, or provider error bodies.
 
 Set a distinct `HEALTHCHECK_TOKEN` with at least 32 random bytes in each
 environment. Readiness callers must send it as a bearer token:

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "build": "bunx --bun prisma generate && next build",
     "start": "next start",
     "lint": "eslint",
+    "test": "bun test",
+    "db:migrate:status": "bunx --bun prisma migrate status",
+    "db:migrate:deploy": "bunx --bun prisma migrate deploy",
     "postinstall": "bunx --bun prisma generate"
   },
   "dependencies": {
@@ -34,7 +37,9 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@next/env": "16.2.10",
     "@tailwindcss/postcss": "^4",
+    "@types/bun": "^1.3.14",
     "@types/node": "^20",
     "@types/pg": "^8.20.0",
     "@types/react": "^19",

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,7 +1,13 @@
 import { loadEnvConfig } from "@next/env";
-import { defineConfig, env } from "prisma/config";
+import { defineConfig } from "prisma/config";
 
 loadEnvConfig(process.cwd());
+
+// `prisma generate` only needs a syntactically valid URL and does not connect.
+// Runtime access still fails closed in src/lib/db.ts when DATABASE_URL is absent.
+const databaseUrl =
+  process.env.DATABASE_URL ??
+  "postgresql://build:build@prisma-generate.invalid:5432/restofront";
 
 export default defineConfig({
   schema: "prisma/schema.prisma",
@@ -9,6 +15,6 @@ export default defineConfig({
     path: "prisma/migrations",
   },
   datasource: {
-    url: env("DATABASE_URL"),
+    url: databaseUrl,
   },
 });

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,5 +1,7 @@
-import "dotenv/config";
-import { defineConfig } from "prisma/config";
+import { loadEnvConfig } from "@next/env";
+import { defineConfig, env } from "prisma/config";
+
+loadEnvConfig(process.cwd());
 
 export default defineConfig({
   schema: "prisma/schema.prisma",
@@ -7,8 +9,6 @@ export default defineConfig({
     path: "prisma/migrations",
   },
   datasource: {
-    url:
-      process.env.DATABASE_URL ??
-      "postgresql://postgres:postgres@localhost:5432/restofront?schema=public",
+    url: env("DATABASE_URL"),
   },
 });

--- a/src/app/api/health/ready/route.ts
+++ b/src/app/api/health/ready/route.ts
@@ -1,10 +1,28 @@
-import { checkPlatformReadiness } from "@/lib/platform-readiness";
+import {
+  createCachedPlatformReadiness,
+  isPlatformReadinessAuthorized,
+} from "@/lib/platform-readiness";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-export async function GET() {
-  const readiness = await checkPlatformReadiness();
+const getPlatformReadiness = createCachedPlatformReadiness();
+
+export async function GET(request: Request) {
+  if (!isPlatformReadinessAuthorized(request)) {
+    return Response.json(
+      { error: "Unauthorized" },
+      {
+        status: 401,
+        headers: {
+          "Cache-Control": "no-store",
+          "WWW-Authenticate": "Bearer",
+        },
+      },
+    );
+  }
+
+  const readiness = await getPlatformReadiness();
 
   return Response.json(readiness, {
     status: readiness.status === "ready" ? 200 : 503,

--- a/src/app/api/health/ready/route.ts
+++ b/src/app/api/health/ready/route.ts
@@ -1,0 +1,15 @@
+import { checkPlatformReadiness } from "@/lib/platform-readiness";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const readiness = await checkPlatformReadiness();
+
+  return Response.json(readiness, {
+    status: readiness.status === "ready" ? 200 : 503,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/src/lib/platform-readiness.test.ts
+++ b/src/lib/platform-readiness.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, mock } from "bun:test";
 import {
   checkPlatformReadiness,
+  createCachedPlatformReadiness,
+  isPlatformReadinessAuthorized,
+  type PlatformReadiness,
   type ReadinessProbes,
 } from "@/lib/platform-readiness";
 
@@ -54,15 +57,19 @@ describe("checkPlatformReadiness", () => {
   });
 
   it("reports configured and reachable services as ready", async () => {
+    const serviceProbes = probes();
     const result = await checkPlatformReadiness(
       configuredEnvironment,
-      probes(),
+      serviceProbes,
     );
 
     expect(result.status).toBe("ready");
     expect(result.services.every((service) => service.status === "ready")).toBe(
       true,
     );
+    expect(serviceProbes.database).toHaveBeenCalledTimes(1);
+    expect(serviceProbes.rateLimit).toHaveBeenCalledTimes(1);
+    expect(serviceProbes.blob).toHaveBeenCalledTimes(1);
   });
 
   it("fails deployed environments that point at a local database", async () => {
@@ -108,5 +115,92 @@ describe("checkPlatformReadiness", () => {
     );
     expect(serialized).not.toContain(configuredEnvironment.BLOB_READ_WRITE_TOKEN);
     expect(serialized).not.toContain(configuredEnvironment.DATABASE_URL);
+  });
+
+  it("reports an unavailable blob store without exposing provider errors", async () => {
+    const serviceProbes = probes();
+    serviceProbes.blob = mock(async () => {
+      throw new Error(
+        `blob failed with ${configuredEnvironment.BLOB_READ_WRITE_TOKEN}`,
+      );
+    });
+
+    const result = await checkPlatformReadiness(
+      configuredEnvironment,
+      serviceProbes,
+    );
+    const blob = result.services.find((service) => service.service === "blob");
+
+    expect(blob).toEqual({
+      service: "blob",
+      status: "unavailable",
+      message:
+        "Configured but unreachable. Check provider status and credentials.",
+    });
+    expect(JSON.stringify(result)).not.toContain(
+      configuredEnvironment.BLOB_READ_WRITE_TOKEN,
+    );
+  });
+});
+
+describe("platform readiness endpoint protection", () => {
+  it("fails closed without a configured token", () => {
+    const request = new Request("https://restofront.example/api/health/ready", {
+      headers: { Authorization: "Bearer supplied-token" },
+    });
+
+    expect(isPlatformReadinessAuthorized(request, "")).toBe(false);
+  });
+
+  it("accepts only the configured bearer token", () => {
+    const authorized = new Request(
+      "https://restofront.example/api/health/ready",
+      {
+        headers: { Authorization: "Bearer expected-token" },
+      },
+    );
+    const unauthorized = new Request(
+      "https://restofront.example/api/health/ready",
+      {
+        headers: { Authorization: "Bearer different-token" },
+      },
+    );
+
+    expect(isPlatformReadinessAuthorized(authorized, "expected-token")).toBe(
+      true,
+    );
+    expect(isPlatformReadinessAuthorized(unauthorized, "expected-token")).toBe(
+      false,
+    );
+  });
+
+  it("deduplicates concurrent probes and caches their result briefly", async () => {
+    let currentTime = 1_000;
+    const readiness: PlatformReadiness = {
+      status: "ready",
+      environment: "preview",
+      services: [],
+    };
+    const check = mock(async () => readiness);
+    const getReadiness = createCachedPlatformReadiness({
+      check,
+      now: () => currentTime,
+      ttlMs: 5_000,
+    });
+
+    const [first, second] = await Promise.all([
+      getReadiness(),
+      getReadiness(),
+    ]);
+    const cached = await getReadiness();
+
+    expect(first).toBe(readiness);
+    expect(second).toBe(readiness);
+    expect(cached).toBe(readiness);
+    expect(check).toHaveBeenCalledTimes(1);
+
+    currentTime += 5_001;
+    await getReadiness();
+    expect(check).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/lib/platform-readiness.test.ts
+++ b/src/lib/platform-readiness.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, mock } from "bun:test";
+import {
+  checkPlatformReadiness,
+  type ReadinessProbes,
+} from "@/lib/platform-readiness";
+
+const configuredEnvironment = {
+  VERCEL_ENV: "preview",
+  DATABASE_URL: "postgresql://preview.example.test/restofront",
+  UPSTASH_REDIS_REST_URL: "https://redis.example.test",
+  UPSTASH_REDIS_REST_TOKEN: "redis-secret",
+  BLOB_READ_WRITE_TOKEN: "blob-secret",
+};
+
+function probes(): ReadinessProbes {
+  return {
+    database: mock(async () => {}),
+    rateLimit: mock(async () => {}),
+    blob: mock(async () => {}),
+  };
+}
+
+describe("checkPlatformReadiness", () => {
+  it("reports every missing service without running probes", async () => {
+    const serviceProbes = probes();
+    const result = await checkPlatformReadiness(
+      { VERCEL_ENV: "production" },
+      serviceProbes,
+    );
+
+    expect(result.status).toBe("not_ready");
+    expect(result.environment).toBe("production");
+    expect(result.services).toEqual([
+      {
+        service: "database",
+        status: "misconfigured",
+        message: "Set DATABASE_URL for this deployment environment.",
+      },
+      {
+        service: "rateLimit",
+        status: "misconfigured",
+        message:
+          "Set UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN for this deployment environment.",
+      },
+      {
+        service: "blob",
+        status: "misconfigured",
+        message: "Set BLOB_READ_WRITE_TOKEN for this deployment environment.",
+      },
+    ]);
+    expect(serviceProbes.database).not.toHaveBeenCalled();
+    expect(serviceProbes.rateLimit).not.toHaveBeenCalled();
+    expect(serviceProbes.blob).not.toHaveBeenCalled();
+  });
+
+  it("reports configured and reachable services as ready", async () => {
+    const result = await checkPlatformReadiness(
+      configuredEnvironment,
+      probes(),
+    );
+
+    expect(result.status).toBe("ready");
+    expect(result.services.every((service) => service.status === "ready")).toBe(
+      true,
+    );
+  });
+
+  it("fails deployed environments that point at a local database", async () => {
+    const serviceProbes = probes();
+    const result = await checkPlatformReadiness(
+      {
+        ...configuredEnvironment,
+        DATABASE_URL: "postgresql://localhost:5432/restofront",
+      },
+      serviceProbes,
+    );
+
+    expect(result.status).toBe("not_ready");
+    expect(result.services[0]).toEqual({
+      service: "database",
+      status: "misconfigured",
+      message: "DATABASE_URL must use a managed host in deployed environments.",
+    });
+    expect(serviceProbes.database).not.toHaveBeenCalled();
+  });
+
+  it("does not expose provider errors or credential values", async () => {
+    const serviceProbes = probes();
+    serviceProbes.rateLimit = mock(async () => {
+      throw new Error(`request failed with ${configuredEnvironment.UPSTASH_REDIS_REST_TOKEN}`);
+    });
+
+    const result = await checkPlatformReadiness(
+      configuredEnvironment,
+      serviceProbes,
+    );
+    const serialized = JSON.stringify(result);
+
+    expect(result.status).toBe("not_ready");
+    expect(result.services[1]).toEqual({
+      service: "rateLimit",
+      status: "unavailable",
+      message:
+        "Configured but unreachable. Check provider status and credentials.",
+    });
+    expect(serialized).not.toContain(
+      configuredEnvironment.UPSTASH_REDIS_REST_TOKEN,
+    );
+    expect(serialized).not.toContain(configuredEnvironment.BLOB_READ_WRITE_TOKEN);
+    expect(serialized).not.toContain(configuredEnvironment.DATABASE_URL);
+  });
+});

--- a/src/lib/platform-readiness.ts
+++ b/src/lib/platform-readiness.ts
@@ -1,0 +1,204 @@
+import { Redis } from "@upstash/redis";
+import { list } from "@vercel/blob";
+import { getDb } from "@/lib/db";
+
+export type PlatformService = "database" | "rateLimit" | "blob";
+export type PlatformServiceStatus =
+  | "ready"
+  | "misconfigured"
+  | "unavailable";
+
+type Environment = Record<string, string | undefined>;
+
+export type ReadinessProbe = () => Promise<void>;
+
+export type ReadinessProbes = Record<PlatformService, ReadinessProbe>;
+
+export type ServiceReadiness = {
+  service: PlatformService;
+  status: PlatformServiceStatus;
+  message: string;
+};
+
+export type PlatformReadiness = {
+  status: "ready" | "not_ready";
+  environment: "development" | "preview" | "production";
+  services: ServiceReadiness[];
+};
+
+const probeTimeoutMs = 5_000;
+
+function deploymentEnvironment(
+  env: Environment,
+): PlatformReadiness["environment"] {
+  if (env.VERCEL_ENV === "preview") return "preview";
+  if (env.VERCEL_ENV === "production") return "production";
+  if (env.NODE_ENV === "production") return "production";
+  return "development";
+}
+
+function isDeployedEnvironment(
+  environment: PlatformReadiness["environment"],
+) {
+  return environment === "preview" || environment === "production";
+}
+
+function validateDatabase(
+  env: Environment,
+  environment: PlatformReadiness["environment"],
+): ServiceReadiness | null {
+  const value = env.DATABASE_URL;
+  if (!value) {
+    return {
+      service: "database",
+      status: "misconfigured",
+      message: "Set DATABASE_URL for this deployment environment.",
+    };
+  }
+
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "postgresql:" && url.protocol !== "postgres:") {
+      throw new Error("unsupported protocol");
+    }
+    if (
+      isDeployedEnvironment(environment) &&
+      ["localhost", "127.0.0.1", "::1"].includes(url.hostname)
+    ) {
+      return {
+        service: "database",
+        status: "misconfigured",
+        message: "DATABASE_URL must use a managed host in deployed environments.",
+      };
+    }
+  } catch {
+    return {
+      service: "database",
+      status: "misconfigured",
+      message: "DATABASE_URL must be a valid PostgreSQL connection URL.",
+    };
+  }
+
+  return null;
+}
+
+function validateRateLimit(env: Environment): ServiceReadiness | null {
+  const url = env.UPSTASH_REDIS_REST_URL;
+  const token = env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) {
+    return {
+      service: "rateLimit",
+      status: "misconfigured",
+      message:
+        "Set UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN for this deployment environment.",
+    };
+  }
+
+  try {
+    if (new URL(url).protocol !== "https:") throw new Error("not HTTPS");
+  } catch {
+    return {
+      service: "rateLimit",
+      status: "misconfigured",
+      message: "UPSTASH_REDIS_REST_URL must be a valid HTTPS URL.",
+    };
+  }
+
+  return null;
+}
+
+function validateBlob(env: Environment): ServiceReadiness | null {
+  if (!env.BLOB_READ_WRITE_TOKEN) {
+    return {
+      service: "blob",
+      status: "misconfigured",
+      message: "Set BLOB_READ_WRITE_TOKEN for this deployment environment.",
+    };
+  }
+  return null;
+}
+
+function configurationError(
+  service: PlatformService,
+  env: Environment,
+  environment: PlatformReadiness["environment"],
+) {
+  if (service === "database") return validateDatabase(env, environment);
+  if (service === "rateLimit") return validateRateLimit(env);
+  return validateBlob(env);
+}
+
+function createDefaultProbes(env: Environment): ReadinessProbes {
+  return {
+    database: async () => {
+      await getDb().$queryRawUnsafe("SELECT 1");
+    },
+    rateLimit: async () => {
+      const redis = new Redis({
+        url: env.UPSTASH_REDIS_REST_URL,
+        token: env.UPSTASH_REDIS_REST_TOKEN,
+      });
+      const response = await redis.ping();
+      if (response !== "PONG") throw new Error("Redis ping failed");
+    },
+    blob: async () => {
+      await list({ limit: 1, token: env.BLOB_READ_WRITE_TOKEN });
+    },
+  };
+}
+
+async function withTimeout(probe: ReadinessProbe) {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      probe(),
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error("Platform readiness probe timed out")),
+          probeTimeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+export async function checkPlatformReadiness(
+  env: Environment = process.env,
+  probes: ReadinessProbes = createDefaultProbes(env),
+): Promise<PlatformReadiness> {
+  const environment = deploymentEnvironment(env);
+  const services = await Promise.all(
+    (["database", "rateLimit", "blob"] satisfies PlatformService[]).map(
+      async (service): Promise<ServiceReadiness> => {
+        const error = configurationError(service, env, environment);
+        if (error) return error;
+
+        try {
+          await withTimeout(probes[service]);
+          return {
+            service,
+            status: "ready",
+            message: "Configured and reachable.",
+          };
+        } catch {
+          return {
+            service,
+            status: "unavailable",
+            message:
+              "Configured but unreachable. Check provider status and credentials.",
+          };
+        }
+      },
+    ),
+  );
+
+  return {
+    status: services.every((service) => service.status === "ready")
+      ? "ready"
+      : "not_ready",
+    environment,
+    services,
+  };
+}

--- a/src/lib/platform-readiness.ts
+++ b/src/lib/platform-readiness.ts
@@ -1,3 +1,4 @@
+import { createHash, timingSafeEqual } from "node:crypto";
 import { Redis } from "@upstash/redis";
 import { list } from "@vercel/blob";
 import { getDb } from "@/lib/db";
@@ -27,6 +28,7 @@ export type PlatformReadiness = {
 };
 
 const probeTimeoutMs = 5_000;
+const readinessCacheTtlMs = 5_000;
 
 function deploymentEnvironment(
   env: Environment,
@@ -131,7 +133,7 @@ function configurationError(
 function createDefaultProbes(env: Environment): ReadinessProbes {
   return {
     database: async () => {
-      await getDb().$queryRawUnsafe("SELECT 1");
+      await getDb().$queryRaw`SELECT 1`;
     },
     rateLimit: async () => {
       const redis = new Redis({
@@ -200,5 +202,59 @@ export async function checkPlatformReadiness(
       : "not_ready",
     environment,
     services,
+  };
+}
+
+export function isPlatformReadinessAuthorized(
+  request: Request,
+  expectedToken = process.env.HEALTHCHECK_TOKEN,
+): boolean {
+  if (!expectedToken) return false;
+
+  const authorization = request.headers.get("authorization");
+  const suppliedToken = authorization?.match(/^Bearer ([^\s]+)$/i)?.[1];
+  if (!suppliedToken) return false;
+
+  const suppliedHash = createHash("sha256").update(suppliedToken).digest();
+  const expectedHash = createHash("sha256").update(expectedToken).digest();
+  return timingSafeEqual(suppliedHash, expectedHash);
+}
+
+type ReadinessCacheOptions = {
+  check?: () => Promise<PlatformReadiness>;
+  now?: () => number;
+  ttlMs?: number;
+};
+
+export function createCachedPlatformReadiness({
+  check = checkPlatformReadiness,
+  now = Date.now,
+  ttlMs = readinessCacheTtlMs,
+}: ReadinessCacheOptions = {}): () => Promise<PlatformReadiness> {
+  let cached:
+    | {
+        expiresAt: number;
+        readiness: PlatformReadiness;
+      }
+    | undefined;
+  let inFlight: Promise<PlatformReadiness> | undefined;
+
+  return async () => {
+    if (cached && cached.expiresAt > now()) return cached.readiness;
+    if (inFlight) return inFlight;
+
+    inFlight = check()
+      .then((readiness) => {
+        cached = {
+          expiresAt: now() + ttlMs,
+          readiness,
+        };
+        return readiness;
+      })
+      .finally(() => {
+        inFlight = undefined;
+      });
+
+    return inFlight;
   };
 }


### PR DESCRIPTION
## Summary

- add fail-closed Prisma configuration and explicit migration status/deploy commands
- add an uncached readiness endpoint that probes PostgreSQL, Upstash Redis, and Vercel Blob without exposing credentials or provider errors
- add focused readiness tests and run them in GitHub Actions before lint/build
- document preview/production isolation, migration operations, backups, restores, and credential rotation

## Scope and infrastructure boundary

This PR implements the repository-owned portion of #10. It does not provision provider resources, use production credentials, deploy, migrate a live database, or change DNS. Separate Preview and Production PostgreSQL/Redis/Blob resources still require reviewed external provisioning.

Existing FR/EN content and external booking, ordering, and delivery links are untouched.

## Verification

- `bun run lint` (local, passed)
- `git diff --check` (local, passed)
- Opus 4.8 verifier review completed; its `.env.local`/Prisma CLI finding was fixed with Next.js `@next/env`
- tests, typecheck/build, and broader verification intentionally deferred to GitHub Actions per workstation policy

Refs #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a protected readiness endpoint that checks PostgreSQL, Redis, and Blob availability without exposing secrets.
  - Readiness checks now return clear service-level statuses and avoid duplicate concurrent checks.

- **Documentation**
  - Expanded local setup and database migration instructions.
  - Added an operations runbook covering platform provisioning, environment separation, backups, restores, and credential rotation.

- **Testing**
  - Added automated coverage for readiness checks, authorization, caching, configuration errors, and unavailable services.

- **Chores**
  - Added test and database migration commands.
  - CI now runs the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->