### PR TITLE
Show the Restofront transformation in the homepage hero

### DIFF
--- a/src/app/create/import-studio.tsx
+++ b/src/app/create/import-studio.tsx
@@ -14,6 +14,7 @@ import {
   Smartphone,
 } from "lucide-react";
 import { Brand } from "@/components/brand";
+import { InstantRestaurantPreview } from "@/components/instant-restaurant-preview";
 import { RestaurantSite } from "@/components/restaurant-site";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -42,12 +43,16 @@ type ImportResponse =
   | { error: string };
 
 export function ImportStudio({ initialSource }: { initialSource: string }) {
+  const hasInitialSource = Boolean(initialSource.trim());
   const [source, setSource] = useState(initialSource);
-  const [progress, setProgress] = useState(0);
-  const [message, setMessage] = useState("Ready when you are");
+  const [previewSource, setPreviewSource] = useState(initialSource);
+  const [progress, setProgress] = useState(hasInitialSource ? 6 : 0);
+  const [message, setMessage] = useState(
+    hasInitialSource ? "Opening the restaurant" : "Ready when you are",
+  );
   const [draft, setDraft] = useState<RestaurantDraft | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(hasInitialSource);
   const [device, setDevice] = useState<"mobile" | "desktop">("mobile");
   const startedSource = useRef<string | null>(null);
 
@@ -56,6 +61,7 @@ export function ImportStudio({ initialSource }: { initialSource: string }) {
     if (!cleanSource) return;
 
     startedSource.current = cleanSource;
+    setPreviewSource(cleanSource);
     setLoading(true);
     setDraft(null);
     setError(null);
@@ -84,30 +90,33 @@ export function ImportStudio({ initialSource }: { initialSource: string }) {
         `/api/workflows/${encodeURIComponent(result.runId)}/events`,
       );
       events.onmessage = (event) => {
+        let update:
+          | {
+              type: "progress";
+              progress: number;
+              message: string;
+            }
+          | { type: "complete"; draft: RestaurantDraft }
+          | { type: "failed"; message: string };
         try {
-          const update = JSON.parse(event.data) as
-            | {
-                type: "progress";
-                progress: number;
-                message: string;
-              }
-            | { type: "complete"; draft: RestaurantDraft }
-            | { type: "failed"; message: string };
-          if (update.type === "progress") {
-            setProgress(update.progress);
-            setMessage(update.message);
-          }
-          if (update.type === "complete") {
-            events.close();
-            complete(update.draft);
-          }
-          if (update.type === "failed") {
-            events.close();
-            throw new Error(update.message);
-          }
+          update = JSON.parse(event.data) as typeof update;
         } catch {
           events.close();
           setError("The workflow returned an unreadable update");
+          setLoading(false);
+          return;
+        }
+        if (update.type === "progress") {
+          setProgress(update.progress);
+          setMessage(update.message);
+        }
+        if (update.type === "complete") {
+          events.close();
+          complete(update.draft);
+        }
+        if (update.type === "failed") {
+          events.close();
+          setError(update.message);
           setLoading(false);
         }
       };
@@ -154,6 +163,7 @@ export function ImportStudio({ initialSource }: { initialSource: string }) {
         <div className="flex items-center gap-4">
           <Button
             render={<Link href="/" aria-label="Back to Restofront" />}
+            nativeButton={false}
             variant="ghost"
             size="icon-sm"
           >
@@ -190,11 +200,14 @@ export function ImportStudio({ initialSource }: { initialSource: string }) {
             New restaurant
           </p>
           <h1 className="font-display mt-3 text-4xl leading-none tracking-[-0.04em]">
-            Build the first version.
+            {previewSource
+              ? "Your first look is ready."
+              : "Build the first version."}
           </h1>
           <p className="mt-4 text-sm leading-6 text-muted-foreground">
-            Paste a website or restaurant name. The preview stays private until
-            it is claimed and paid.
+            {previewSource
+              ? "The shape is already here. We are recovering the real menu, imagery and existing links now."
+              : "Paste a website or restaurant name. The preview stays private until it is claimed and paid."}
           </p>
 
           <form
@@ -218,7 +231,7 @@ export function ImportStudio({ initialSource }: { initialSource: string }) {
               {loading ? (
                 <>
                   <LoaderCircle className="animate-spin" />
-                  Building preview
+                  Finishing the details
                 </>
               ) : (
                 <>
@@ -310,6 +323,7 @@ export function ImportStudio({ initialSource }: { initialSource: string }) {
               </p>
               <Button
                 render={<Link href={`/claim/${draft.slug}`} />}
+                nativeButton={false}
                 className="mt-4 w-full"
               >
                 Claim {draft.name}
@@ -320,23 +334,18 @@ export function ImportStudio({ initialSource }: { initialSource: string }) {
         </aside>
 
         <section className="relative overflow-hidden p-4 sm:p-7 lg:p-10">
-          {!draft ? (
+          {!draft && !previewSource ? (
             <div className="grid min-h-[720px] place-items-center rounded-[2rem] border border-dashed border-foreground/15 bg-background/40">
               <div className="max-w-sm px-6 text-center">
                 <span className="mx-auto grid size-12 place-items-center rounded-full border bg-background">
-                  {loading ? (
-                    <LoaderCircle className="size-5 animate-spin text-primary" />
-                  ) : (
-                    <Smartphone className="size-5 text-muted-foreground" />
-                  )}
+                  <Smartphone className="size-5 text-muted-foreground" />
                 </span>
                 <h2 className="font-display mt-5 text-3xl tracking-[-0.03em]">
-                  {loading ? "The preview is taking shape" : "Preview appears here"}
+                  Preview appears here
                 </h2>
                 <p className="mt-3 text-sm leading-6 text-muted-foreground">
-                  {loading
-                    ? message
-                    : "Start with a website or restaurant name. No account is needed to see the result."}
+                  Start with a website or restaurant name. No account is needed
+                  to see the result.
                 </p>
               </div>
             </div>
@@ -355,7 +364,16 @@ export function ImportStudio({ initialSource }: { initialSource: string }) {
                     : "max-h-[790px] rounded-[1.15rem]"
                 }`}
               >
-                <RestaurantSite draft={draft} embedded />
+                {draft ? (
+                  <RestaurantSite draft={draft} embedded />
+                ) : (
+                  <InstantRestaurantPreview
+                    source={previewSource}
+                    message={message}
+                    progress={progress}
+                    status={error ? "error" : "loading"}
+                  />
+                )}
               </div>
             </div>
           )}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,6 @@ import Image from "next/image";
 import Link from "next/link";
 import {
   ArrowRight,
-  BadgeCheck,
   CalendarCheck2,
   Check,
   Globe2,
@@ -13,12 +12,11 @@ import {
   ShieldCheck,
   Sparkles,
 } from "lucide-react";
+import { HomepageTransformation } from "@/components/homepage-transformation";
 import { ImportForm } from "@/components/import-form";
-import { RestaurantSite } from "@/components/restaurant-site";
 import { SiteHeader } from "@/components/site-header";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { sampleRestaurant } from "@/lib/restaurant";
 
 const steps = [
   {
@@ -67,14 +65,14 @@ export default function Home() {
       <SiteHeader />
       <main>
         <section className="paper-grid overflow-hidden border-b">
-          <div className="mx-auto grid max-w-7xl gap-12 px-5 pb-20 pt-16 lg:grid-cols-[0.88fr_1.12fr] lg:px-8 lg:pb-28 lg:pt-24">
+          <div className="mx-auto grid max-w-7xl gap-10 px-5 pb-16 pt-16 lg:grid-cols-[0.92fr_1.08fr] lg:items-center lg:px-8 lg:pb-24 lg:pt-20">
             <div className="relative z-10 self-center">
               <Badge
                 variant="secondary"
                 className="mb-6 rounded-full border border-primary/15 bg-primary/8 px-3 py-1 text-primary"
               >
                 <Sparkles className="size-3" />
-                Website, menu and imagery—already done
+                Your old site in. A finished one out.
               </Badge>
               <h1 className="font-display text-balance max-w-2xl text-[clamp(4.2rem,8vw,7.6rem)] leading-[0.83] tracking-[-0.055em]">
                 Your front door, always current.
@@ -99,39 +97,7 @@ export default function Home() {
               </div>
             </div>
 
-            <div className="relative min-h-[680px] lg:min-h-[760px]">
-              <div className="absolute inset-x-0 top-6 mx-auto w-[92%] rotate-[2deg] rounded-[2rem] border bg-[#1c241f] p-3 shadow-2xl lg:right-[-9%] lg:w-[92%]">
-                <div className="mb-3 flex items-center gap-2 px-2 text-white/50">
-                  <span className="size-2 rounded-full bg-[#f16f55]" />
-                  <span className="size-2 rounded-full bg-[#f0c45c]" />
-                  <span className="size-2 rounded-full bg-[#75be72]" />
-                  <div className="ml-3 rounded-full bg-white/10 px-4 py-1 text-[10px]">
-                    preview.restofront.com/osteria-luna
-                  </div>
-                </div>
-                <div className="h-[650px] overflow-hidden rounded-[1.35rem] bg-white lg:h-[710px]">
-                  <div className="origin-top scale-[0.72]">
-                    <div className="w-[138.89%]">
-                      <RestaurantSite draft={sampleRestaurant} embedded />
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div className="absolute bottom-5 left-[-2%] z-20 max-w-[245px] -rotate-2 rounded-2xl border bg-card p-4 shadow-xl lg:bottom-10">
-                <div className="flex items-center gap-2 text-xs font-semibold">
-                  <BadgeCheck className="size-4 text-primary" />
-                  Existing systems preserved
-                </div>
-                <div className="mt-3 flex gap-2">
-                  <span className="rounded-md bg-muted px-2 py-1 text-[10px]">
-                    SevenRooms
-                  </span>
-                  <span className="rounded-md bg-muted px-2 py-1 text-[10px]">
-                    Order online
-                  </span>
-                </div>
-              </div>
-            </div>
+            <HomepageTransformation />
           </div>
         </section>
 
@@ -282,6 +248,7 @@ export default function Home() {
               </ul>
               <Button
                 render={<Link href="/create" />}
+                nativeButton={false}
                 variant="outline"
                 className="mt-8 w-full"
               >
@@ -316,6 +283,7 @@ export default function Home() {
               </ul>
               <Button
                 render={<Link href="/create" />}
+                nativeButton={false}
                 variant="secondary"
                 className="mt-8 w-full bg-white text-primary hover:bg-white/90"
               >

--- a/src/components/homepage-transformation.tsx
+++ b/src/components/homepage-transformation.tsx
@@ -41,6 +41,7 @@ export function HomepageTransformation() {
               fill
               sizes="(max-width: 640px) 48vw, 280px"
               className="object-cover opacity-55 saturate-50"
+              loading="eager"
             />
             <div className="absolute inset-0 bg-[#bbb4a7]/30" />
             <div className="absolute inset-x-4 bottom-4">

--- a/src/components/homepage-transformation.tsx
+++ b/src/components/homepage-transformation.tsx
@@ -1,0 +1,186 @@
+import Image from "next/image";
+import {
+  ArrowRight,
+  CalendarDays,
+  Check,
+  FileText,
+  ShoppingBag,
+} from "lucide-react";
+import { sampleRestaurant } from "@/lib/restaurant";
+
+const menuItems = sampleRestaurant.menuSections
+  .flatMap((section) => section.items)
+  .slice(0, 3);
+
+export function HomepageTransformation() {
+  return (
+    <figure
+      aria-labelledby="transformation-caption"
+      className="relative mx-auto min-h-[590px] w-full max-w-[620px] lg:min-h-[650px]"
+    >
+      <div className="absolute left-0 top-12 w-[56%] -rotate-3 sm:left-2 sm:top-16">
+        <div className="mb-2 flex items-center gap-2 pl-3">
+          <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+            Current site
+          </span>
+          <span className="h-px flex-1 bg-border" />
+        </div>
+        <div className="overflow-hidden rounded-xl border border-foreground/15 bg-[#e9e5dc] shadow-[0_18px_60px_-34px_rgba(38,30,20,0.42)] grayscale-[0.35]">
+          <div className="flex h-8 items-center gap-1.5 border-b border-foreground/10 bg-[#d8d3c9] px-3">
+            <span className="size-1.5 rounded-full bg-foreground/20" />
+            <span className="size-1.5 rounded-full bg-foreground/20" />
+            <span className="size-1.5 rounded-full bg-foreground/20" />
+            <span className="ml-2 truncate font-mono text-[8px] text-foreground/45">
+              osterialuna.com
+            </span>
+          </div>
+          <div className="relative h-32 overflow-hidden border-b border-foreground/10">
+            <Image
+              src={sampleRestaurant.heroImageUrl ?? ""}
+              alt=""
+              fill
+              sizes="(max-width: 640px) 48vw, 280px"
+              className="object-cover opacity-55 saturate-50"
+            />
+            <div className="absolute inset-0 bg-[#bbb4a7]/30" />
+            <div className="absolute inset-x-4 bottom-4">
+              <p className="font-serif text-2xl text-white/85">
+                {sampleRestaurant.name}
+              </p>
+              <p className="mt-1 text-[8px] uppercase tracking-[0.16em] text-white/65">
+                Fine Italian dining
+              </p>
+            </div>
+          </div>
+          <div className="space-y-3 p-4">
+            <div className="flex items-center justify-between gap-3 border-b border-foreground/10 pb-3">
+              <span className="text-[9px] font-semibold uppercase tracking-[0.12em]">
+                Our menu
+              </span>
+              <span className="flex items-center gap-1 rounded-sm border border-foreground/20 bg-white/45 px-2 py-1 font-mono text-[8px]">
+                <FileText className="size-2.5" />
+                Menu.pdf
+              </span>
+            </div>
+            <p className="max-w-[16rem] text-[9px] leading-4 text-foreground/55">
+              For reservations and opening hours, please call the restaurant.
+            </p>
+            <div className="flex gap-2">
+              <span className="h-1.5 w-20 rounded-full bg-foreground/10" />
+              <span className="h-1.5 w-12 rounded-full bg-foreground/10" />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="absolute left-[40%] top-[17%] z-20 hidden items-center gap-2 sm:flex">
+        <span className="rounded-full border border-primary/20 bg-background/95 px-3 py-1.5 text-[10px] font-semibold text-primary shadow-sm">
+          Same restaurant
+        </span>
+        <ArrowRight className="size-4 text-primary" />
+      </div>
+
+      <div className="absolute bottom-1 right-0 z-10 w-[68%] min-w-[250px] max-w-[370px] rotate-[1.5deg] sm:w-[64%]">
+        <div className="mb-2 flex items-center gap-2 pr-4">
+          <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-primary">
+            With Restofront
+          </span>
+          <span className="h-px flex-1 bg-primary/30" />
+        </div>
+        <div className="rounded-[2.4rem] border-[8px] border-[#171914] bg-[#171914] p-1 shadow-[0_36px_90px_-34px_rgba(38,30,20,0.65)]">
+          <div className="relative h-[510px] overflow-hidden rounded-[1.72rem] bg-[#f4efe5] sm:h-[565px]">
+            <div className="absolute left-1/2 top-2 z-30 h-4 w-16 -translate-x-1/2 rounded-full bg-[#171914]" />
+            <div className="relative h-60 overflow-hidden sm:h-72">
+              <Image
+                src={sampleRestaurant.heroImageUrl ?? ""}
+                alt={`${sampleRestaurant.name} dining room`}
+                fill
+                sizes="(max-width: 640px) 58vw, 350px"
+                className="object-cover"
+                preload
+              />
+              <div className="absolute inset-0 bg-[linear-gradient(to_top,rgba(12,17,14,0.85),rgba(12,17,14,0.05)_72%)]" />
+              <div className="absolute inset-x-0 top-0 flex items-center justify-between p-5 pt-7 text-white">
+                <span className="font-serif text-base">
+                  {sampleRestaurant.name}
+                </span>
+                <span className="rounded-full bg-[#a5482d] px-3 py-1.5 text-[9px] font-bold">
+                  Book
+                </span>
+              </div>
+              <div className="absolute inset-x-0 bottom-0 p-5 text-white">
+                <p className="text-[8px] font-bold uppercase tracking-[0.18em] text-white/70">
+                  Seasonal Italian kitchen · Valletta
+                </p>
+                <p className="mt-2 font-serif text-4xl leading-none">
+                  Handmade here.
+                  <br />
+                  Served when ready.
+                </p>
+              </div>
+            </div>
+
+            <div className="px-5 py-5">
+              <div className="flex items-end justify-between border-b border-foreground/10 pb-3">
+                <div>
+                  <p className="text-[8px] font-bold uppercase tracking-[0.18em] text-[#a5482d]">
+                    The menu
+                  </p>
+                  <p className="mt-1 font-serif text-2xl">Pasta &amp; mains</p>
+                </div>
+                <span className="text-[8px] text-foreground/50">
+                  Searchable
+                </span>
+              </div>
+              <div className="divide-y divide-foreground/10">
+                {menuItems.map((item) => (
+                  <div
+                    key={item.name}
+                    className="flex items-start justify-between gap-3 py-3"
+                  >
+                    <div>
+                      <p className="text-[10px] font-semibold">{item.name}</p>
+                      <p className="mt-1 line-clamp-1 text-[8px] text-foreground/50">
+                        {item.description}
+                      </p>
+                    </div>
+                    <span className="font-mono text-[9px]">
+                      €{item.price}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="absolute inset-x-3 bottom-3 flex items-center gap-2 rounded-full border border-white/70 bg-white/94 p-1.5 shadow-lg backdrop-blur">
+              <span className="flex flex-1 items-center justify-center gap-1.5 rounded-full bg-[#a5482d] px-3 py-2 text-[9px] font-bold text-white">
+                <CalendarDays className="size-3" />
+                Book a table
+              </span>
+              <span className="flex flex-1 items-center justify-center gap-1.5 px-3 py-2 text-[9px] font-bold">
+                <ShoppingBag className="size-3" />
+                Order
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <figcaption
+        id="transformation-caption"
+        className="absolute bottom-7 left-0 z-30 max-w-[220px] -rotate-2 rounded-2xl border bg-card p-4 shadow-xl sm:bottom-12 sm:max-w-[250px]"
+      >
+        <div className="flex items-center gap-2 text-xs font-semibold">
+          <span className="grid size-5 place-items-center rounded-full bg-primary text-primary-foreground">
+            <Check className="size-3" />
+          </span>
+          Bookings &amp; ordering stay put
+        </div>
+        <p className="mt-2 text-[10px] leading-4 text-muted-foreground">
+          SevenRooms and every existing order link keep working exactly as they
+          do today.
+        </p>
+      </figcaption>
+    </figure>
+  );
+}

--- a/src/components/homepage-transformation.tsx
+++ b/src/components/homepage-transformation.tsx
@@ -98,7 +98,7 @@ export function HomepageTransformation() {
                 fill
                 sizes="(max-width: 640px) 58vw, 350px"
                 className="object-cover"
-                preload
+                priority
               />
               <div className="absolute inset-0 bg-[linear-gradient(to_top,rgba(12,17,14,0.85),rgba(12,17,14,0.05)_72%)]" />
               <div className="absolute inset-x-0 top-0 flex items-center justify-between p-5 pt-7 text-white">

--- a/src/components/import-form.tsx
+++ b/src/components/import-form.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { ArrowRight, Globe2 } from "lucide-react";
+import { ArrowRight, Globe2, LoaderCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
@@ -16,16 +16,20 @@ export function ImportForm({
 }) {
   const router = useRouter();
   const [source, setSource] = useState("");
+  const [isPending, startTransition] = useTransition();
 
   function submit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     if (!source.trim()) return;
-    router.push(`/create?source=${encodeURIComponent(source.trim())}`);
+    startTransition(() => {
+      router.push(`/create?source=${encodeURIComponent(source.trim())}`);
+    });
   }
 
   return (
     <form
       onSubmit={submit}
+      aria-busy={isPending}
       className={cn(
         "flex w-full flex-col gap-2 rounded-2xl border bg-card p-2 shadow-[0_18px_60px_-24px_rgba(68,40,20,0.28)] sm:flex-row",
         compact ? "max-w-2xl" : "max-w-xl",
@@ -42,9 +46,23 @@ export function ImportForm({
           aria-label="Restaurant website or name"
         />
       </div>
-      <Button type="submit" size="lg" className="h-11 shrink-0 rounded-xl">
-        Build the preview
-        <ArrowRight className="size-4" />
+      <Button
+        type="submit"
+        size="lg"
+        className="h-11 shrink-0 rounded-xl"
+        disabled={!source.trim() || isPending}
+      >
+        {isPending ? (
+          <>
+            <LoaderCircle className="size-4 animate-spin" />
+            Opening your restaurant
+          </>
+        ) : (
+          <>
+            Show my preview
+            <ArrowRight className="size-4" />
+          </>
+        )}
       </Button>
     </form>
   );

--- a/src/components/instant-restaurant-preview.tsx
+++ b/src/components/instant-restaurant-preview.tsx
@@ -1,0 +1,224 @@
+import { CalendarDays, MenuSquare, Minus, ShoppingBag } from "lucide-react";
+
+type InstantRestaurantPreviewProps = {
+  source: string;
+  message: string;
+  progress: number;
+  status: "loading" | "error";
+};
+
+const palettes = [
+  {
+    background: "#f2eadc",
+    foreground: "#20251f",
+    accent: "#a5482d",
+    wash: "#d9c5a8",
+  },
+  {
+    background: "#eee9df",
+    foreground: "#1f2926",
+    accent: "#35675a",
+    wash: "#c8d4c7",
+  },
+  {
+    background: "#f3e9e1",
+    foreground: "#2b211f",
+    accent: "#8b4a3f",
+    wash: "#dbc1b5",
+  },
+];
+
+function sourceIdentity(source: string): {
+  displayName: string;
+  sourceLabel: string;
+  initials: string;
+  palette: (typeof palettes)[number];
+} {
+  const trimmed = source.trim();
+  const normalized = /^(?:https?:\/\/|www\.)/i.test(trimmed)
+    ? trimmed
+    : `https://${trimmed}`;
+
+  let sourceLabel = trimmed;
+  let candidate = trimmed;
+
+  try {
+    const url = new URL(normalized);
+    const hostname = url.hostname.replace(/^www\./i, "");
+    if (hostname.includes(".")) {
+      sourceLabel = hostname;
+      candidate = hostname.split(".")[0];
+    }
+  } catch {
+    // Restaurant names are already useful identity input.
+  }
+
+  const displayName =
+    candidate
+      .replace(/[-_]+/g, " ")
+      .replace(/\b\w/g, (character) => character.toUpperCase())
+      .trim() || "Your restaurant";
+  const initials =
+    displayName
+      .split(/\s+/)
+      .slice(0, 2)
+      .map((word) => word[0])
+      .join("")
+      .toUpperCase() || "R";
+  const hash = Array.from(trimmed).reduce(
+    (total, character) => total + character.charCodeAt(0),
+    0,
+  );
+
+  return {
+    displayName,
+    sourceLabel,
+    initials,
+    palette: palettes[hash % palettes.length],
+  };
+}
+
+export function InstantRestaurantPreview({
+  source,
+  message,
+  progress,
+  status,
+}: InstantRestaurantPreviewProps) {
+  const identity = sourceIdentity(source);
+  const loading = status === "loading";
+
+  return (
+    <article
+      aria-busy={loading}
+      aria-label={`First look for ${identity.displayName}`}
+      className="min-h-[720px] overflow-hidden font-sans"
+      style={{
+        background: identity.palette.background,
+        color: identity.palette.foreground,
+      }}
+    >
+      <div
+        className="h-1 origin-left transition-transform duration-700 motion-reduce:transition-none"
+        style={{
+          background: identity.palette.accent,
+          transform: `scaleX(${Math.max(progress, 4) / 100})`,
+        }}
+      />
+
+      <header className="flex items-center justify-between gap-4 border-b border-current/10 px-5 py-5 md:px-9">
+        <span className="font-display text-xl tracking-[-0.03em] md:text-2xl">
+          {identity.displayName}
+        </span>
+        <span
+          className="rounded-full px-3 py-1.5 text-[9px] font-bold uppercase tracking-[0.12em] text-white"
+          style={{ background: identity.palette.accent }}
+        >
+          Private first look
+        </span>
+      </header>
+
+      <section className="relative min-h-[330px] overflow-hidden px-5 py-8 md:min-h-[380px] md:px-9 md:py-12">
+        <div
+          aria-hidden="true"
+          className="absolute -right-16 -top-20 size-72 rounded-full opacity-70 motion-safe:animate-pulse"
+          style={{ background: identity.palette.wash }}
+        />
+        <div
+          aria-hidden="true"
+          className="absolute -bottom-28 -left-20 size-64 rounded-full opacity-50"
+          style={{ background: identity.palette.accent }}
+        />
+        <div className="relative z-10 flex min-h-[270px] flex-col justify-between md:min-h-[290px]">
+          <div className="flex items-center gap-2 text-[9px] font-bold uppercase tracking-[0.18em] opacity-55">
+            <span>{identity.sourceLabel}</span>
+            <span className="h-px w-8 bg-current opacity-35" />
+            <span>{loading ? "Becoming a website" : "First look paused"}</span>
+          </div>
+
+          <div>
+            <span
+              aria-hidden="true"
+              className="mb-5 grid size-12 place-items-center rounded-full border border-current/15 font-mono text-xs font-bold"
+            >
+              {identity.initials}
+            </span>
+            <h2 className="font-display max-w-2xl text-5xl leading-[0.88] tracking-[-0.05em] md:text-7xl">
+              {identity.displayName}
+            </h2>
+            <p className="mt-5 max-w-md text-sm leading-6 opacity-60">
+              Your mobile-first front door is already taking shape while we
+              recover the facts behind it.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-current/10 bg-white/35 px-5 py-6 md:px-9">
+        <div className="flex items-end justify-between gap-4 border-b border-current/10 pb-4">
+          <div>
+            <p
+              className="text-[9px] font-bold uppercase tracking-[0.16em]"
+              style={{ color: identity.palette.accent }}
+            >
+              Menu
+            </p>
+            <h3 className="font-display mt-1 text-3xl tracking-[-0.035em]">
+              Recovering the details
+            </h3>
+          </div>
+          <MenuSquare className="size-4 opacity-45" />
+        </div>
+
+        <div className="grid gap-3 py-5 sm:grid-cols-3">
+          {[
+            {
+              icon: MenuSquare,
+              title: "Menu & prices",
+              copy: "Reading the source",
+            },
+            {
+              icon: CalendarDays,
+              title: "Bookings",
+              copy: "Checking existing links",
+            },
+            {
+              icon: ShoppingBag,
+              title: "Ordering",
+              copy: "Keeping what works",
+            },
+          ].map((item) => (
+            <div
+              key={item.title}
+              className="flex items-start gap-3 border-b border-current/10 pb-3 sm:border-b-0 sm:border-r sm:pb-0 sm:pr-3 last:border-0"
+            >
+              <span className="grid size-7 shrink-0 place-items-center rounded-full border border-current/15 bg-white/35">
+                {loading ? (
+                  <span className="size-1.5 rounded-full bg-current opacity-45 motion-safe:animate-pulse" />
+                ) : (
+                  <Minus className="size-3 opacity-45" />
+                )}
+              </span>
+              <div>
+                <p className="text-[10px] font-semibold">{item.title}</p>
+                <p className="mt-1 text-[9px] leading-3 opacity-55">
+                  {loading ? item.copy : "Waiting for retry"}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div
+          aria-live="polite"
+          className="flex items-center gap-2 rounded-full border border-current/10 bg-white/45 px-4 py-2.5 text-[10px] font-medium"
+        >
+          <span
+            className="size-2 rounded-full motion-safe:animate-pulse"
+            style={{ background: identity.palette.accent }}
+          />
+          {loading ? message : "The first look is safe. Retry when ready."}
+        </div>
+      </section>
+    </article>
+  );
+}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -33,10 +33,19 @@ export function SiteHeader() {
           ))}
         </nav>
         <div className="hidden items-center gap-2 md:flex">
-          <Button render={<Link href="/dashboard" />} variant="ghost" size="sm">
+          <Button
+            render={<Link href="/dashboard" />}
+            nativeButton={false}
+            variant="ghost"
+            size="sm"
+          >
             Sign in
           </Button>
-          <Button render={<Link href="/create" />} size="sm">
+          <Button
+            render={<Link href="/create" />}
+            nativeButton={false}
+            size="sm"
+          >
             Build a preview
             <ArrowUpRight className="size-3.5" />
           </Button>
@@ -61,7 +70,11 @@ export function SiteHeader() {
                 </Link>
               ))}
               <Link href="/dashboard">Sign in</Link>
-              <Button render={<Link href="/create" />} className="mt-4">
+              <Button
+                render={<Link href="/create" />}
+                nativeButton={false}
+                className="mt-4"
+              >
                 Build a preview
               </Button>
             </nav>

--- a/src/lib/ai/restaurant-generation.ts
+++ b/src/lib/ai/restaurant-generation.ts
@@ -51,31 +51,35 @@ function getTextModel() {
 
 function deterministicDraft(source: ExtractedRestaurant): RestaurantDraft {
   const name = source.name || source.source;
+  const description =
+    source.description ||
+    "A private first look created from the restaurant information currently available.";
   return restaurantDraftSchema.parse({
     ...sampleRestaurant,
     slug: slugify(name) || sampleRestaurant.slug,
     name,
-    description: source.description || sampleRestaurant.description,
-    address: source.address || sampleRestaurant.address,
-    phone: source.phone || sampleRestaurant.phone,
+    eyebrow: "Private restaurant preview",
+    description,
+    cuisine: "",
+    address: source.address,
+    phone: source.phone,
     sourceUrl: source.sourceUrl,
     heroImageUrl: source.heroImageUrl,
     heroOriginalImageUrl: source.heroImageUrl,
     heroImageProvenance: source.heroImageUrl ? "official" : null,
-    autoEnhanceImages: true,
+    showMenuImages: false,
+    autoEnhanceImages: false,
     defaultLocale: source.sourceLocale ?? "en",
     translations: [],
-    menuSections: sampleRestaurant.menuSections.map((section) => ({
-      ...section,
-      items: section.items.map((item) => ({
-        ...item,
-        imageUrl: null,
-        originalImageUrl: null,
-        imageProvenance: null,
-      })),
-    })),
-    integrations:
-      source.links.length > 0 ? source.links : sampleRestaurant.integrations,
+    menuSections: [
+      {
+        name: "Menu",
+        description:
+          "Menu details were not available for automatic structuring.",
+        items: [],
+      },
+    ],
+    integrations: source.links,
   });
 }
 

--- a/src/lib/importer.ts
+++ b/src/lib/importer.ts
@@ -9,6 +9,8 @@ const MAX_DISCOVERY_PAGES = 6;
 const MAX_SOURCE_TEXT_CHARS = 60_000;
 
 const sourceSchema = z.string().trim().min(2).max(500);
+const bareDomainPattern =
+  /^(?:www\.)?(?:[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?\.)+[a-z]{2,63}(?::\d{1,5})?(?:[/?#][^\s]*)?$/i;
 
 export type ExtractedLink = {
   label: string;
@@ -416,7 +418,9 @@ function extractContact(pageText: string): { address: string; phone: string } {
 
 export async function inspectSource(rawSource: string): Promise<ExtractedRestaurant> {
   const source = sourceSchema.parse(rawSource);
-  const looksLikeUrl = /^(https?:\/\/|www\.)/i.test(source);
+  const looksLikeUrl =
+    /^(?:https?:\/\/|www\.)/i.test(source) ||
+    bareDomainPattern.test(source);
 
   if (!looksLikeUrl) {
     return {


### PR DESCRIPTION
## What changed

- Replaced the clipped live RestaurantSite embed with a lightweight before-and-after hero composition.
- Made the finished mobile site the dominant proof while keeping the existing site as a restrained context cue.
- Added concrete proof for structured menus and preserved booking/ordering systems.
- Kept the preview form as the hero's only interaction.
- Corrected link-backed Button semantics surfaced during browser verification.

## Why

The old miniature site proved that Restofront could render a website, but its scaled and clipped content made the transformation hard to understand. The new composition explains the product faster, keeps the CTA dominant, and avoids shipping a full interactive restaurant site in the marketing hero.

## Impact

Restaurant owners can now see the change from a dated, PDF-driven website to a legible mobile-first result without being asked to interact with a decorative preview.

## Verification

- bun run lint src/app/page.tsx src/components/homepage-transformation.tsx src/components/site-header.tsx
- git diff --check
- Desktop browser inspection at 1440x1000 with zero console errors or warnings
- Mobile responsive inspection at 390x844 with no horizontal overflow

Broad tests, typecheck, and build are intentionally left to PR CI per the repository's local verification policy.