### PR TITLE
feat(import): persist generated leads

### DIFF
--- a/prisma/migrations/20260723221500_persist_import_identity/migration.sql
+++ b/prisma/migrations/20260723221500_persist_import_identity/migration.sql
@@ -1,0 +1,11 @@
+ALTER TABLE "Restaurant"
+ADD COLUMN "sourceKey" TEXT;
+
+ALTER TABLE "ImportJob"
+ADD COLUMN "sourceKey" TEXT;
+
+CREATE UNIQUE INDEX "Restaurant_sourceKey_key"
+ON "Restaurant"("sourceKey");
+
+CREATE INDEX "ImportJob_sourceKey_createdAt_idx"
+ON "ImportJob"("sourceKey", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -85,6 +85,7 @@ model Restaurant {
   phone                String?
   email                String?
   sourceUrl            String?
+  sourceKey            String?           @unique
   logoUrl              String?
   heroImageUrl         String?
   heroOriginalImageUrl String?
@@ -150,6 +151,7 @@ model ImportJob {
   id            String       @id @default(cuid())
   status        ImportStatus @default(QUEUED)
   source        String
+  sourceKey     String?
   workflowRunId String?
   error         String?
   startedAt     DateTime?
@@ -158,6 +160,8 @@ model ImportJob {
   restaurant    Restaurant?  @relation(fields: [restaurantId], references: [id], onDelete: SetNull)
   createdAt     DateTime     @default(now())
   updatedAt     DateTime     @updatedAt
+
+  @@index([sourceKey, createdAt])
 }
 
 model SiteVersion {

--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { generateRestaurantDraft } from "@/lib/ai/restaurant-generation";
 import { inspectSource } from "@/lib/importer";
 import { limitPublicPreview } from "@/lib/rate-limit";
+import { importFailureMessage } from "@/lib/restaurant-import";
 import {
   createImportJob,
   ImportConflictError,
@@ -94,8 +95,7 @@ export async function POST(request: Request) {
         : error instanceof ImportConflictError
           ? 409
           : 400;
-    const message =
-      error instanceof Error ? error.message : "Unable to import this restaurant";
+    const message = importFailureMessage(error);
     return NextResponse.json({ error: message, importJobId }, { status });
   }
 }

--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -4,6 +4,14 @@ import { z } from "zod";
 import { generateRestaurantDraft } from "@/lib/ai/restaurant-generation";
 import { inspectSource } from "@/lib/importer";
 import { limitPublicPreview } from "@/lib/rate-limit";
+import {
+  createImportJob,
+  ImportConflictError,
+  ImportDatabaseUnavailableError,
+  persistRestaurantImport,
+  recordImportFailure,
+  updateImportJob,
+} from "@/lib/restaurant-import-persistence";
 import { restaurantImportWorkflow } from "@/workflows/restaurant-import";
 
 export const runtime = "nodejs";
@@ -14,6 +22,8 @@ const requestSchema = z.object({
 });
 
 export async function POST(request: Request) {
+  let importJobId: string | null = null;
+
   try {
     const { source } = requestSchema.parse(await request.json());
     const rateLimit = await limitPublicPreview(request);
@@ -35,20 +45,57 @@ export async function POST(request: Request) {
       );
     }
 
+    const importJob = await createImportJob(source);
+    importJobId = importJob.id;
+
     if (process.env.WORKFLOW_ENABLED === "true") {
-      const run = await start(restaurantImportWorkflow, [source]);
+      const run = await start(restaurantImportWorkflow, [
+        source,
+        importJob.id,
+      ]);
+      await updateImportJob(importJob.id, { workflowRunId: run.runId });
       return NextResponse.json({
         mode: "workflow",
         runId: run.runId,
+        importJobId: importJob.id,
       });
     }
 
+    await updateImportJob(importJob.id, { status: "CRAWLING" });
     const extracted = await inspectSource(source);
+    await updateImportJob(importJob.id, { status: "EXTRACTING" });
+    await updateImportJob(importJob.id, { status: "GENERATING" });
     const draft = await generateRestaurantDraft(extracted);
-    return NextResponse.json({ mode: "inline", draft });
+    const persisted = await persistRestaurantImport({
+      draft,
+      source,
+      importJobId: importJob.id,
+    });
+    return NextResponse.json({
+      mode: "inline",
+      ...persisted,
+    });
   } catch (error) {
+    if (importJobId) {
+      try {
+        await recordImportFailure(importJobId, error);
+      } catch (recordError) {
+        console.error("[restaurant-import] failed to record import error", {
+          importJobId,
+          error:
+            recordError instanceof Error ? recordError.message : "unknown",
+        });
+      }
+    }
+
+    const status =
+      error instanceof ImportDatabaseUnavailableError
+        ? 503
+        : error instanceof ImportConflictError
+          ? 409
+          : 400;
     const message =
       error instanceof Error ? error.message : "Unable to import this restaurant";
-    return NextResponse.json({ error: message }, { status: 400 });
+    return NextResponse.json({ error: message, importJobId }, { status });
   }
 }

--- a/src/app/claim/[slug]/claim-panel.tsx
+++ b/src/app/claim/[slug]/claim-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import Link from "next/link";
 import {
   ArrowRight,
@@ -49,23 +49,11 @@ export function ClaimPanel({
   slug: string;
   fallbackDraft: RestaurantDraft;
 }) {
-  const [draft, setDraft] = useState(fallbackDraft);
+  const draft = fallbackDraft;
   const [plan, setPlan] = useState<"starter" | "growth">("growth");
   const [email, setEmail] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    const timeout = window.setTimeout(() => {
-      try {
-        const saved = window.localStorage.getItem("restofront:draft");
-        if (saved) setDraft(JSON.parse(saved) as RestaurantDraft);
-      } catch {
-        // The server-provided preview remains usable if local data is corrupt.
-      }
-    }, 0);
-    return () => window.clearTimeout(timeout);
-  }, []);
 
   async function checkout() {
     if (!email) return;

--- a/src/app/claim/[slug]/page.tsx
+++ b/src/app/claim/[slug]/page.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { notFound } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
 import { Brand } from "@/components/brand";
 import { ClaimPanel } from "@/app/claim/[slug]/claim-panel";
 import { Button } from "@/components/ui/button";
-import { getRestaurantDraft } from "@/lib/restaurants";
+import { findRestaurantDraft } from "@/lib/restaurants";
 
 export const metadata: Metadata = {
   title: "Claim this restaurant",
@@ -17,7 +18,8 @@ export default async function ClaimPage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const draft = await getRestaurantDraft(slug);
+  const draft = await findRestaurantDraft(slug);
+  if (!draft) notFound();
 
   return (
     <main className="min-h-screen">

--- a/src/app/create/import-studio.tsx
+++ b/src/app/create/import-studio.tsx
@@ -24,7 +24,7 @@ import {
   sampleRestaurant,
   type RestaurantDraft,
 } from "@/lib/restaurant";
-import type { ImportUrls } from "@/lib/restaurant-import-persistence";
+import type { ImportUrls } from "@/lib/restaurant-import";
 
 type Stage = {
   label: string;

--- a/src/app/create/import-studio.tsx
+++ b/src/app/create/import-studio.tsx
@@ -7,6 +7,7 @@ import {
   ArrowRight,
   Check,
   CircleAlert,
+  ExternalLink,
   Globe2,
   LoaderCircle,
   Monitor,
@@ -23,6 +24,7 @@ import {
   sampleRestaurant,
   type RestaurantDraft,
 } from "@/lib/restaurant";
+import type { ImportUrls } from "@/lib/restaurant-import-persistence";
 
 type Stage = {
   label: string;
@@ -38,8 +40,13 @@ const stages: Stage[] = [
 ];
 
 type ImportResponse =
-  | { mode: "inline"; draft: RestaurantDraft }
-  | { mode: "workflow"; runId: string }
+  | {
+      mode: "inline";
+      draft: RestaurantDraft;
+      importJobId: string;
+      urls: ImportUrls;
+    }
+  | { mode: "workflow"; runId: string; importJobId: string }
   | { error: string };
 
 export function ImportStudio({ initialSource }: { initialSource: string }) {
@@ -51,6 +58,7 @@ export function ImportStudio({ initialSource }: { initialSource: string }) {
     hasInitialSource ? "Opening the restaurant" : "Ready when you are",
   );
   const [draft, setDraft] = useState<RestaurantDraft | null>(null);
+  const [urls, setUrls] = useState<ImportUrls | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(hasInitialSource);
   const [device, setDevice] = useState<"mobile" | "desktop">("mobile");
@@ -64,6 +72,7 @@ export function ImportStudio({ initialSource }: { initialSource: string }) {
     setPreviewSource(cleanSource);
     setLoading(true);
     setDraft(null);
+    setUrls(null);
     setError(null);
     setProgress(6);
     setMessage("Opening the restaurant");
@@ -82,7 +91,7 @@ export function ImportStudio({ initialSource }: { initialSource: string }) {
       }
 
       if (result.mode === "inline") {
-        complete(result.draft);
+        complete(result.draft, result.urls);
         return;
       }
 
@@ -96,7 +105,12 @@ export function ImportStudio({ initialSource }: { initialSource: string }) {
               progress: number;
               message: string;
             }
-          | { type: "complete"; draft: RestaurantDraft }
+          | {
+              type: "complete";
+              draft: RestaurantDraft;
+              importJobId: string;
+              urls: ImportUrls;
+            }
           | { type: "failed"; message: string };
         try {
           update = JSON.parse(event.data) as typeof update;
@@ -112,7 +126,7 @@ export function ImportStudio({ initialSource }: { initialSource: string }) {
         }
         if (update.type === "complete") {
           events.close();
-          complete(update.draft);
+          complete(update.draft, update.urls);
         }
         if (update.type === "failed") {
           events.close();
@@ -135,12 +149,12 @@ export function ImportStudio({ initialSource }: { initialSource: string }) {
     }
   }
 
-  function complete(nextDraft: RestaurantDraft) {
+  function complete(nextDraft: RestaurantDraft, nextUrls: ImportUrls) {
     setProgress(100);
     setMessage("Private preview ready");
     setDraft(nextDraft);
+    setUrls(nextUrls);
     setLoading(false);
-    window.localStorage.setItem("restofront:draft", JSON.stringify(nextDraft));
   }
 
   useEffect(() => {
@@ -154,7 +168,10 @@ export function ImportStudio({ initialSource }: { initialSource: string }) {
   function useDemo() {
     setSource("Osteria Luna");
     setError(null);
-    complete(sampleRestaurant);
+    complete(sampleRestaurant, {
+      preview: `/preview/${sampleRestaurant.slug}`,
+      claim: `/claim/${sampleRestaurant.slug}`,
+    });
   }
 
   return (
@@ -309,7 +326,7 @@ export function ImportStudio({ initialSource }: { initialSource: string }) {
             </div>
           ) : null}
 
-          {draft ? (
+          {draft && urls ? (
             <div className="mt-8 rounded-2xl border border-primary/20 bg-primary/5 p-4">
               <div className="flex items-center gap-2 text-sm font-semibold">
                 <span className="grid size-5 place-items-center rounded-full bg-primary text-primary-foreground">
@@ -321,14 +338,23 @@ export function ImportStudio({ initialSource }: { initialSource: string }) {
                 Review the menu and existing links, then choose a plan to keep
                 this site current.
               </p>
-              <Button
-                render={<Link href={`/claim/${draft.slug}`} />}
-                nativeButton={false}
-                className="mt-4 w-full"
-              >
-                Claim {draft.name}
-                <ArrowRight />
-              </Button>
+              <div className="mt-4 grid grid-cols-2 gap-2">
+                <Button
+                  render={<Link href={urls.preview} target="_blank" />}
+                  nativeButton={false}
+                  variant="outline"
+                >
+                  Preview
+                  <ExternalLink />
+                </Button>
+                <Button
+                  render={<Link href={urls.claim} />}
+                  nativeButton={false}
+                >
+                  Claim
+                  <ArrowRight />
+                </Button>
+              </div>
             </div>
           ) : null}
         </aside>

--- a/src/app/dashboard/dashboard.tsx
+++ b/src/app/dashboard/dashboard.tsx
@@ -74,7 +74,6 @@ export function Dashboard({
         });
         if (!response.ok) throw new Error("Save failed");
       }
-      window.localStorage.setItem("restofront:draft", JSON.stringify(draft));
       setSaved(true);
     } finally {
       setSaving(false);

--- a/src/app/preview/[slug]/[locale]/page.tsx
+++ b/src/app/preview/[slug]/[locale]/page.tsx
@@ -5,7 +5,7 @@ import {
   getRestaurantLocales,
   localizeRestaurantDraft,
 } from "@/lib/restaurant";
-import { getRestaurantDraft } from "@/lib/restaurants";
+import { findRestaurantDraft } from "@/lib/restaurants";
 
 type PageProps = {
   params: Promise<{ slug: string; locale: string }>;
@@ -15,7 +15,8 @@ export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
   const { slug, locale } = await params;
-  const draft = await getRestaurantDraft(slug);
+  const draft = await findRestaurantDraft(slug);
+  if (!draft) notFound();
   const locales = getRestaurantLocales(draft);
   if (!locales.includes(locale)) notFound();
 
@@ -41,7 +42,8 @@ export async function generateMetadata({
 
 export default async function LocalizedPreviewPage({ params }: PageProps) {
   const { slug, locale } = await params;
-  const draft = await getRestaurantDraft(slug);
+  const draft = await findRestaurantDraft(slug);
+  if (!draft) notFound();
   const locales = getRestaurantLocales(draft);
   if (!locales.includes(locale)) notFound();
 

--- a/src/app/preview/[slug]/page.tsx
+++ b/src/app/preview/[slug]/page.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next";
+import { notFound } from "next/navigation";
 import { RestaurantSite } from "@/components/restaurant-site";
 import { getRestaurantLocales } from "@/lib/restaurant";
-import { getRestaurantDraft } from "@/lib/restaurants";
+import { findRestaurantDraft } from "@/lib/restaurants";
 
 type PageProps = {
   params: Promise<{ slug: string }>;
@@ -11,7 +12,8 @@ export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
   const { slug } = await params;
-  const draft = await getRestaurantDraft(slug);
+  const draft = await findRestaurantDraft(slug);
+  if (!draft) notFound();
   const locales = getRestaurantLocales(draft);
   return {
     title: `${draft.name} — Private preview`,
@@ -32,7 +34,8 @@ export async function generateMetadata({
 
 export default async function PreviewPage({ params }: PageProps) {
   const { slug } = await params;
-  const draft = await getRestaurantDraft(slug);
+  const draft = await findRestaurantDraft(slug);
+  if (!draft) notFound();
   return (
     <RestaurantSite
       draft={draft}

--- a/src/lib/restaurant-import-persistence.test.ts
+++ b/src/lib/restaurant-import-persistence.test.ts
@@ -5,7 +5,7 @@ import {
   normalizeImportSource,
   slugCollisionCandidate,
   storedImportSource,
-} from "@/lib/restaurant-import-persistence";
+} from "@/lib/restaurant-import";
 
 describe("restaurant import identity", () => {
   it("normalizes equivalent website sources to one key", () => {

--- a/src/lib/restaurant-import-persistence.test.ts
+++ b/src/lib/restaurant-import-persistence.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import {
+  buildImportUrls,
+  importFailureMessage,
+  normalizeImportSource,
+  slugCollisionCandidate,
+  storedImportSource,
+} from "@/lib/restaurant-import-persistence";
+
+describe("restaurant import identity", () => {
+  it("normalizes equivalent website sources to one key", () => {
+    expect(
+      normalizeImportSource(
+        "https://www.Example.com/menu/?utm_source=campaign#lunch",
+      ),
+    ).toBe("url:example.com/menu");
+    expect(normalizeImportSource("example.com/menu/")).toBe(
+      "url:example.com/menu",
+    );
+  });
+
+  it("normalizes name-only sources without losing unicode identity", () => {
+    expect(normalizeImportSource("  Café   Roma  ")).toBe("name:café roma");
+  });
+
+  it("removes credentials and fragments from the recorded source", () => {
+    expect(
+      storedImportSource(
+        "https://operator:private@example.com/menu?locale=fr#lunch",
+      ),
+    ).toBe("https://example.com/menu?locale=fr");
+  });
+
+  it("generates stable collision suffixes within the slug limit", () => {
+    const base = "a".repeat(72);
+    expect(slugCollisionCandidate(base, 0)).toHaveLength(72);
+    expect(slugCollisionCandidate(base, 1)).toBe(`${"a".repeat(70)}-2`);
+  });
+});
+
+describe("restaurant import results", () => {
+  it("returns canonical private preview and claim URLs", () => {
+    expect(buildImportUrls("chez-léa")).toEqual({
+      preview: "/preview/chez-l%C3%A9a",
+      claim: "/claim/chez-l%C3%A9a",
+    });
+  });
+
+  it("redacts credentials from durable failure details", () => {
+    const message = importFailureMessage(
+      new Error(
+        "postgresql://admin:secret@db.example.test/restofront token=private",
+      ),
+    );
+
+    expect(message).toBe(
+      "postgresql://[redacted]@db.example.test/restofront token=[redacted]",
+    );
+    expect(message).not.toContain("admin:secret");
+    expect(message).not.toContain("private");
+  });
+});

--- a/src/lib/restaurant-import-persistence.ts
+++ b/src/lib/restaurant-import-persistence.ts
@@ -1,0 +1,417 @@
+import { Prisma } from "@/generated/prisma/client";
+import { getDb } from "@/lib/db";
+import {
+  restaurantDraftSchema,
+  slugify,
+  type RestaurantDraft,
+} from "@/lib/restaurant";
+
+const bareDomainPattern =
+  /^(?:www\.)?(?:[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?\.)+[a-z]{2,63}(?::\d{1,5})?(?:[/?#][^\s]*)?$/i;
+const retryablePrismaCodes = new Set(["P2002", "P2034"]);
+const mutableImportStatuses = new Set(["PROSPECT", "PREVIEW_READY"]);
+
+export type ImportUrls = {
+  preview: string;
+  claim: string;
+};
+
+export type PersistedRestaurantImport = {
+  draft: RestaurantDraft;
+  importJobId: string;
+  urls: ImportUrls;
+  created: boolean;
+};
+
+export class ImportDatabaseUnavailableError extends Error {
+  constructor() {
+    super("Preview persistence is temporarily unavailable");
+    this.name = "ImportDatabaseUnavailableError";
+  }
+}
+
+export class ImportConflictError extends Error {
+  constructor() {
+    super("This restaurant is already owned and cannot be replaced by an import");
+    this.name = "ImportConflictError";
+  }
+}
+
+export function normalizeImportSource(rawSource: string): string {
+  const source = rawSource.trim().normalize("NFKC");
+  const looksLikeUrl =
+    /^(?:https?:\/\/|www\.)/i.test(source) ||
+    bareDomainPattern.test(source);
+
+  if (!looksLikeUrl) {
+    return `name:${source.toLocaleLowerCase("en").replace(/\s+/g, " ")}`;
+  }
+
+  const url = new URL(
+    /^https?:\/\//i.test(source) ? source : `https://${source}`,
+  );
+  const hostname = url.hostname.toLowerCase().replace(/^www\./, "");
+  const port =
+    (url.protocol === "http:" && url.port === "80") ||
+    (url.protocol === "https:" && url.port === "443")
+      ? ""
+      : url.port
+        ? `:${url.port}`
+        : "";
+  const pathname =
+    url.pathname === "/"
+      ? ""
+      : url.pathname.replace(/\/{2,}/g, "/").replace(/\/$/, "");
+
+  return `url:${hostname}${port}${pathname}`;
+}
+
+export function buildImportUrls(slug: string): ImportUrls {
+  const encodedSlug = encodeURIComponent(slug);
+  return {
+    preview: `/preview/${encodedSlug}`,
+    claim: `/claim/${encodedSlug}`,
+  };
+}
+
+export function storedImportSource(rawSource: string): string {
+  const source = rawSource.trim().normalize("NFKC");
+  const looksLikeUrl =
+    /^(?:https?:\/\/|www\.)/i.test(source) ||
+    bareDomainPattern.test(source);
+  if (!looksLikeUrl) return source;
+
+  const url = new URL(
+    /^https?:\/\//i.test(source) ? source : `https://${source}`,
+  );
+  url.username = "";
+  url.password = "";
+  url.hash = "";
+  return url.toString();
+}
+
+export function slugCollisionCandidate(
+  baseSlug: string,
+  collisionIndex: number,
+): string {
+  if (collisionIndex === 0) return baseSlug.slice(0, 72);
+  const suffix = `-${collisionIndex + 1}`;
+  return `${baseSlug.slice(0, 72 - suffix.length)}${suffix}`;
+}
+
+export function importFailureMessage(error: unknown): string {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : "Unknown restaurant import error";
+  return message
+    .replace(/([a-z][a-z0-9+.-]*:\/\/)[^@\s/]+@/gi, "$1[redacted]@")
+    .replace(
+      /\b(password|secret|token|api[_-]?key)\s*[=:]\s*[^\s,;]+/gi,
+      "$1=[redacted]",
+    )
+    .slice(0, 500);
+}
+
+export async function createImportJob(source: string): Promise<{
+  id: string;
+  sourceKey: string;
+}> {
+  const db = requireImportDatabase();
+  const sourceKey = normalizeImportSource(source);
+  return db.importJob.create({
+    data: {
+      source: storedImportSource(source),
+      sourceKey,
+      status: "QUEUED",
+      startedAt: new Date(),
+    },
+    select: { id: true, sourceKey: true },
+  }) as Promise<{ id: string; sourceKey: string }>;
+}
+
+export async function updateImportJob(
+  importJobId: string,
+  data: {
+    status?: "CRAWLING" | "EXTRACTING" | "GENERATING";
+    workflowRunId?: string;
+  },
+): Promise<void> {
+  await requireImportDatabase().importJob.update({
+    where: { id: importJobId },
+    data,
+  });
+}
+
+export async function recordImportFailure(
+  importJobId: string,
+  error: unknown,
+): Promise<string> {
+  const message = importFailureMessage(error);
+  await requireImportDatabase().importJob.update({
+    where: { id: importJobId },
+    data: {
+      status: "FAILED",
+      error: message,
+      completedAt: new Date(),
+    },
+  });
+  return message;
+}
+
+export async function persistRestaurantImport(input: {
+  draft: RestaurantDraft;
+  source: string;
+  importJobId: string;
+}): Promise<PersistedRestaurantImport> {
+  const db = requireImportDatabase();
+  const draft = restaurantDraftSchema.parse(input.draft);
+  const sourceKey = normalizeImportSource(draft.sourceUrl ?? input.source);
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      return await db.$transaction(
+        async (tx) => {
+          const identityConditions: Prisma.RestaurantWhereInput[] = [
+            { sourceKey },
+          ];
+          if (draft.sourceUrl) {
+            identityConditions.push({ sourceUrl: draft.sourceUrl });
+          }
+
+          let existing = await tx.restaurant.findFirst({
+            where: { OR: identityConditions },
+            select: {
+              id: true,
+              slug: true,
+              sourceKey: true,
+              sourceUrl: true,
+              status: true,
+            },
+          });
+
+          const requestedSlug =
+            slugify(draft.slug) || slugify(draft.name) || "restaurant";
+          let slug = existing?.slug ?? requestedSlug;
+
+          if (!existing) {
+            for (let collisionIndex = 0; collisionIndex < 100; collisionIndex += 1) {
+              const candidate = slugCollisionCandidate(
+                requestedSlug,
+                collisionIndex,
+              );
+              const collision = await tx.restaurant.findUnique({
+                where: { slug: candidate },
+                select: {
+                  id: true,
+                  slug: true,
+                  sourceKey: true,
+                  sourceUrl: true,
+                  status: true,
+                },
+              });
+              if (!collision) {
+                slug = candidate;
+                break;
+              }
+
+              const collisionSourceKey = collision.sourceKey
+                ? collision.sourceKey
+                : collision.sourceUrl
+                  ? normalizeImportSource(collision.sourceUrl)
+                  : null;
+              if (collisionSourceKey === sourceKey) {
+                existing = collision;
+                slug = collision.slug;
+                break;
+              }
+
+              if (collisionIndex === 99) {
+                throw new Error("A unique preview URL could not be reserved");
+              }
+            }
+          }
+
+          if (existing && !mutableImportStatuses.has(existing.status)) {
+            throw new ImportConflictError();
+          }
+
+          const restaurant = existing
+            ? await tx.restaurant.update({
+                where: { id: existing.id },
+                data: restaurantUpdateData(draft, sourceKey),
+                select: { id: true, slug: true },
+              })
+            : await tx.restaurant.create({
+                data: restaurantCreateData(draft, sourceKey, slug),
+                select: { id: true, slug: true },
+              });
+
+          await tx.auditEvent.create({
+            data: {
+              type: existing
+                ? "restaurant.import.updated"
+                : "restaurant.import.created",
+              actor: "system:import",
+              metadata: {
+                importJobId: input.importJobId,
+                source: storedImportSource(input.source),
+                sourceKey,
+                previousStatus: existing?.status ?? null,
+              },
+              restaurantId: restaurant.id,
+            },
+          });
+          await tx.importJob.update({
+            where: { id: input.importJobId },
+            data: {
+              sourceKey,
+              status: "READY",
+              error: null,
+              completedAt: new Date(),
+              restaurantId: restaurant.id,
+            },
+          });
+
+          const canonicalDraft = restaurantDraftSchema.parse({
+            ...draft,
+            slug: restaurant.slug,
+          });
+          return {
+            draft: canonicalDraft,
+            importJobId: input.importJobId,
+            urls: buildImportUrls(restaurant.slug),
+            created: !existing,
+          };
+        },
+        { isolationLevel: "Serializable" },
+      );
+    } catch (error) {
+      if (attempt < 2 && isRetryablePrismaError(error)) continue;
+      throw error;
+    }
+  }
+
+  throw new Error("The restaurant import could not be persisted");
+}
+
+function requireImportDatabase() {
+  if (!process.env.DATABASE_URL) {
+    throw new ImportDatabaseUnavailableError();
+  }
+  return getDb();
+}
+
+function restaurantUpdateData(
+  draft: RestaurantDraft,
+  sourceKey: string,
+): Prisma.RestaurantUpdateInput {
+  return {
+    ...restaurantScalarData(draft, sourceKey),
+    integrations: {
+      deleteMany: {},
+      create: integrationCreateData(draft),
+    },
+    menuSections: {
+      deleteMany: {},
+      create: menuSectionCreateData(draft),
+    },
+  };
+}
+
+function restaurantCreateData(
+  draft: RestaurantDraft,
+  sourceKey: string,
+  slug: string,
+): Prisma.RestaurantCreateInput {
+  return {
+    slug,
+    ...restaurantScalarData(draft, sourceKey),
+    integrations: { create: integrationCreateData(draft) },
+    menuSections: { create: menuSectionCreateData(draft) },
+  };
+}
+
+function restaurantScalarData(draft: RestaurantDraft, sourceKey: string) {
+  return {
+    name: draft.name,
+    description: draft.description,
+    cuisine: draft.cuisine,
+    address: draft.address,
+    phone: draft.phone,
+    sourceUrl: draft.sourceUrl,
+    sourceKey,
+    heroImageUrl: draft.heroImageUrl,
+    heroOriginalImageUrl: draft.heroOriginalImageUrl,
+    heroImageProvenance: toDatabaseImageProvenance(
+      draft.heroImageProvenance,
+    ),
+    showMenuImages: draft.showMenuImages,
+    autoEnhanceImages: draft.autoEnhanceImages,
+    defaultLocale: draft.defaultLocale,
+    translations: draft.translations,
+    status: "PREVIEW_READY" as const,
+  };
+}
+
+function integrationCreateData(draft: RestaurantDraft) {
+  return draft.integrations.map((integration) => ({
+    type: toDatabaseIntegrationType(integration.type),
+    label: integration.label,
+    provider: integration.provider,
+    url: integration.url,
+  }));
+}
+
+function menuSectionCreateData(draft: RestaurantDraft) {
+  return draft.menuSections.map((section, sectionIndex) => ({
+    name: section.name,
+    description: section.description,
+    position: sectionIndex,
+    items: {
+      create: section.items.map((item, itemIndex) => ({
+        name: item.name,
+        description: item.description,
+        price: item.price,
+        currency: item.currency,
+        dietaryLabels: item.dietaryLabels,
+        imageUrl: item.imageUrl,
+        originalImageUrl: item.originalImageUrl,
+        imageProvenance: toDatabaseImageProvenance(
+          item.imageProvenance,
+        ),
+        position: itemIndex,
+      })),
+    },
+  }));
+}
+
+function toDatabaseIntegrationType(
+  value: RestaurantDraft["integrations"][number]["type"],
+): "BOOKING" | "ORDERING" | "DELIVERY" | "SOCIAL" {
+  return value.toUpperCase() as
+    | "BOOKING"
+    | "ORDERING"
+    | "DELIVERY"
+    | "SOCIAL";
+}
+
+function toDatabaseImageProvenance(
+  value: RestaurantDraft["heroImageProvenance"],
+): "OFFICIAL" | "OWNER" | "PERMISSIONED_UGC" | undefined {
+  if (!value) return undefined;
+  if (value === "permissioned-ugc") return "PERMISSIONED_UGC";
+  return value.toUpperCase() as "OFFICIAL" | "OWNER";
+}
+
+function isRetryablePrismaError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    typeof error.code === "string" &&
+    retryablePrismaCodes.has(error.code)
+  );
+}

--- a/src/lib/restaurant-import-persistence.ts
+++ b/src/lib/restaurant-import-persistence.ts
@@ -1,20 +1,21 @@
 import { Prisma } from "@/generated/prisma/client";
 import { getDb } from "@/lib/db";
 import {
+  buildImportUrls,
+  importFailureMessage,
+  normalizeImportSource,
+  slugCollisionCandidate,
+  storedImportSource,
+  type ImportUrls,
+} from "@/lib/restaurant-import";
+import {
   restaurantDraftSchema,
   slugify,
   type RestaurantDraft,
 } from "@/lib/restaurant";
 
-const bareDomainPattern =
-  /^(?:www\.)?(?:[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?\.)+[a-z]{2,63}(?::\d{1,5})?(?:[/?#][^\s]*)?$/i;
 const retryablePrismaCodes = new Set(["P2002", "P2034"]);
 const mutableImportStatuses = new Set(["PROSPECT", "PREVIEW_READY"]);
-
-export type ImportUrls = {
-  preview: string;
-  claim: string;
-};
 
 export type PersistedRestaurantImport = {
   draft: RestaurantDraft;
@@ -35,84 +36,6 @@ export class ImportConflictError extends Error {
     super("This restaurant is already owned and cannot be replaced by an import");
     this.name = "ImportConflictError";
   }
-}
-
-export function normalizeImportSource(rawSource: string): string {
-  const source = rawSource.trim().normalize("NFKC");
-  const looksLikeUrl =
-    /^(?:https?:\/\/|www\.)/i.test(source) ||
-    bareDomainPattern.test(source);
-
-  if (!looksLikeUrl) {
-    return `name:${source.toLocaleLowerCase("en").replace(/\s+/g, " ")}`;
-  }
-
-  const url = new URL(
-    /^https?:\/\//i.test(source) ? source : `https://${source}`,
-  );
-  const hostname = url.hostname.toLowerCase().replace(/^www\./, "");
-  const port =
-    (url.protocol === "http:" && url.port === "80") ||
-    (url.protocol === "https:" && url.port === "443")
-      ? ""
-      : url.port
-        ? `:${url.port}`
-        : "";
-  const pathname =
-    url.pathname === "/"
-      ? ""
-      : url.pathname.replace(/\/{2,}/g, "/").replace(/\/$/, "");
-
-  return `url:${hostname}${port}${pathname}`;
-}
-
-export function buildImportUrls(slug: string): ImportUrls {
-  const encodedSlug = encodeURIComponent(slug);
-  return {
-    preview: `/preview/${encodedSlug}`,
-    claim: `/claim/${encodedSlug}`,
-  };
-}
-
-export function storedImportSource(rawSource: string): string {
-  const source = rawSource.trim().normalize("NFKC");
-  const looksLikeUrl =
-    /^(?:https?:\/\/|www\.)/i.test(source) ||
-    bareDomainPattern.test(source);
-  if (!looksLikeUrl) return source;
-
-  const url = new URL(
-    /^https?:\/\//i.test(source) ? source : `https://${source}`,
-  );
-  url.username = "";
-  url.password = "";
-  url.hash = "";
-  return url.toString();
-}
-
-export function slugCollisionCandidate(
-  baseSlug: string,
-  collisionIndex: number,
-): string {
-  if (collisionIndex === 0) return baseSlug.slice(0, 72);
-  const suffix = `-${collisionIndex + 1}`;
-  return `${baseSlug.slice(0, 72 - suffix.length)}${suffix}`;
-}
-
-export function importFailureMessage(error: unknown): string {
-  const message =
-    error instanceof Error
-      ? error.message
-      : typeof error === "string"
-        ? error
-        : "Unknown restaurant import error";
-  return message
-    .replace(/([a-z][a-z0-9+.-]*:\/\/)[^@\s/]+@/gi, "$1[redacted]@")
-    .replace(
-      /\b(password|secret|token|api[_-]?key)\s*[=:]\s*[^\s,;]+/gi,
-      "$1=[redacted]",
-    )
-    .slice(0, 500);
 }
 
 export async function createImportJob(source: string): Promise<{

--- a/src/lib/restaurant-import.ts
+++ b/src/lib/restaurant-import.ts
@@ -1,0 +1,85 @@
+const bareDomainPattern =
+  /^(?:www\.)?(?:[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?\.)+[a-z]{2,63}(?::\d{1,5})?(?:[/?#][^\s]*)?$/i;
+
+export type ImportUrls = {
+  preview: string;
+  claim: string;
+};
+
+export function normalizeImportSource(rawSource: string): string {
+  const source = rawSource.trim().normalize("NFKC");
+  const looksLikeUrl =
+    /^(?:https?:\/\/|www\.)/i.test(source) ||
+    bareDomainPattern.test(source);
+
+  if (!looksLikeUrl) {
+    return `name:${source.toLocaleLowerCase("en").replace(/\s+/g, " ")}`;
+  }
+
+  const url = new URL(
+    /^https?:\/\//i.test(source) ? source : `https://${source}`,
+  );
+  const hostname = url.hostname.toLowerCase().replace(/^www\./, "");
+  const port =
+    (url.protocol === "http:" && url.port === "80") ||
+    (url.protocol === "https:" && url.port === "443")
+      ? ""
+      : url.port
+        ? `:${url.port}`
+        : "";
+  const pathname =
+    url.pathname === "/"
+      ? ""
+      : url.pathname.replace(/\/{2,}/g, "/").replace(/\/$/, "");
+
+  return `url:${hostname}${port}${pathname}`;
+}
+
+export function buildImportUrls(slug: string): ImportUrls {
+  const encodedSlug = encodeURIComponent(slug);
+  return {
+    preview: `/preview/${encodedSlug}`,
+    claim: `/claim/${encodedSlug}`,
+  };
+}
+
+export function storedImportSource(rawSource: string): string {
+  const source = rawSource.trim().normalize("NFKC");
+  const looksLikeUrl =
+    /^(?:https?:\/\/|www\.)/i.test(source) ||
+    bareDomainPattern.test(source);
+  if (!looksLikeUrl) return source;
+
+  const url = new URL(
+    /^https?:\/\//i.test(source) ? source : `https://${source}`,
+  );
+  url.username = "";
+  url.password = "";
+  url.hash = "";
+  return url.toString();
+}
+
+export function slugCollisionCandidate(
+  baseSlug: string,
+  collisionIndex: number,
+): string {
+  if (collisionIndex === 0) return baseSlug.slice(0, 72);
+  const suffix = `-${collisionIndex + 1}`;
+  return `${baseSlug.slice(0, 72 - suffix.length)}${suffix}`;
+}
+
+export function importFailureMessage(error: unknown): string {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : "Unknown restaurant import error";
+  return message
+    .replace(/([a-z][a-z0-9+.-]*:\/\/)[^@\s/]+@/gi, "$1[redacted]@")
+    .replace(
+      /\b(password|secret|token|api[_-]?key)\s*[=:]\s*[^\s,;]+/gi,
+      "$1=[redacted]",
+    )
+    .slice(0, 500);
+}

--- a/src/lib/restaurants.ts
+++ b/src/lib/restaurants.ts
@@ -9,9 +9,21 @@ import {
 export async function getRestaurantDraft(
   slug: string,
 ): Promise<RestaurantDraft> {
+  return (
+    (await findRestaurantDraft(slug)) ?? {
+      ...sampleRestaurant,
+      slug,
+    }
+  );
+}
+
+export async function findRestaurantDraft(
+  slug: string,
+): Promise<RestaurantDraft | null> {
   const leadDraft = leadDrafts[slug];
   if (!process.env.DATABASE_URL) {
-    return leadDraft ?? { ...sampleRestaurant, slug };
+    if (leadDraft) return leadDraft;
+    return slug === sampleRestaurant.slug ? sampleRestaurant : null;
   }
 
   const restaurant = await getDb().restaurant.findUnique({
@@ -26,7 +38,7 @@ export async function getRestaurantDraft(
     },
   });
 
-  if (!restaurant) return leadDraft ?? { ...sampleRestaurant, slug };
+  if (!restaurant) return null;
   const latestTheme = restaurant.siteVersions[0]?.theme as
     | RestaurantDraft["palette"]
     | undefined;

--- a/src/workflows/restaurant-import.ts
+++ b/src/workflows/restaurant-import.ts
@@ -9,8 +9,8 @@ import {
   type ExtractedRestaurant,
 } from "@/lib/importer";
 import type { RestaurantDraft } from "@/lib/restaurant";
+import { importFailureMessage } from "@/lib/restaurant-import";
 import {
-  importFailureMessage,
   persistRestaurantImport,
   recordImportFailure,
   updateImportJob,

--- a/src/workflows/restaurant-import.ts
+++ b/src/workflows/restaurant-import.ts
@@ -1,5 +1,4 @@
 import { getWritable } from "workflow";
-import { getDb } from "@/lib/db";
 import {
   enhanceRestaurantImage,
   generateRestaurantDraft,
@@ -10,6 +9,13 @@ import {
   type ExtractedRestaurant,
 } from "@/lib/importer";
 import type { RestaurantDraft } from "@/lib/restaurant";
+import {
+  importFailureMessage,
+  persistRestaurantImport,
+  recordImportFailure,
+  updateImportJob,
+  type PersistedRestaurantImport,
+} from "@/lib/restaurant-import-persistence";
 import {
   imageStorageIsConfigured,
   storeRestaurantImage,
@@ -22,52 +28,72 @@ export type RestaurantImportEvent =
       progress: number;
       message: string;
     }
-  | { type: "complete"; draft: RestaurantDraft }
+  | {
+      type: "complete";
+      draft: RestaurantDraft;
+      importJobId: string;
+      urls: PersistedRestaurantImport["urls"];
+    }
   | { type: "failed"; message: string };
 
 export async function restaurantImportWorkflow(
   source: string,
+  importJobId: string,
 ): Promise<RestaurantDraft> {
   "use workflow";
 
-  console.log(`[restaurant-import] START source=${source}`);
-  await emit({
-    type: "progress",
-    stage: "crawl",
-    progress: 12,
-    message: "Reading the current website",
-  });
-  const extracted = await crawlRestaurant(source);
-  await emit({
-    type: "progress",
-    stage: "extract",
-    progress: 42,
-    message: "Recovering menu, contacts and existing links",
-  });
-  await emit({
-    type: "progress",
-    stage: "compose",
-    progress: 65,
-    message: "Composing the mobile-first preview",
-  });
-  const draft = await composeDraft(extracted);
-  const enhancedDraft = await enhanceDraftImages(draft);
-  await emit({
-    type: "progress",
-    stage: "compose",
-    progress: 88,
-    message: "Checking every photo, menu and integration",
-  });
-  await emit({
-    type: "progress",
-    stage: "persist",
-    progress: 95,
-    message: "Saving the private preview",
-  });
-  await persistDraft(enhancedDraft);
-  await emitComplete(enhancedDraft);
-  console.log(`[restaurant-import] DONE slug=${enhancedDraft.slug}`);
-  return enhancedDraft;
+  try {
+    console.log(`[restaurant-import] START job=${importJobId}`);
+    await setImportStage(importJobId, "CRAWLING");
+    await emit({
+      type: "progress",
+      stage: "crawl",
+      progress: 12,
+      message: "Reading the current website",
+    });
+    const extracted = await crawlRestaurant(source);
+    await setImportStage(importJobId, "EXTRACTING");
+    await emit({
+      type: "progress",
+      stage: "extract",
+      progress: 42,
+      message: "Recovering menu, contacts and existing links",
+    });
+    await setImportStage(importJobId, "GENERATING");
+    await emit({
+      type: "progress",
+      stage: "compose",
+      progress: 65,
+      message: "Composing the mobile-first preview",
+    });
+    const draft = await composeDraft(extracted);
+    const enhancedDraft = await enhanceDraftImages(draft);
+    await emit({
+      type: "progress",
+      stage: "compose",
+      progress: 88,
+      message: "Checking every photo, menu and integration",
+    });
+    await emit({
+      type: "progress",
+      stage: "persist",
+      progress: 95,
+      message: "Saving the private preview",
+    });
+    const persisted = await persistDraft(
+      enhancedDraft,
+      source,
+      importJobId,
+    );
+    await emitComplete(persisted);
+    console.log(`[restaurant-import] DONE slug=${persisted.draft.slug}`);
+    return persisted.draft;
+  } catch (error) {
+    const message = importFailureMessage(error);
+    await failImport(importJobId, message);
+    await emit({ type: "failed", message });
+    throw error;
+  }
 }
 
 async function emit(event: RestaurantImportEvent): Promise<void> {
@@ -102,127 +128,36 @@ async function composeDraft(
   return draft;
 }
 
-async function persistDraft(draft: RestaurantDraft): Promise<void> {
+async function setImportStage(
+  importJobId: string,
+  status: "CRAWLING" | "EXTRACTING" | "GENERATING",
+): Promise<void> {
+  "use step";
+  await updateImportJob(importJobId, { status });
+}
+
+async function persistDraft(
+  draft: RestaurantDraft,
+  source: string,
+  importJobId: string,
+): Promise<PersistedRestaurantImport> {
   "use step";
   console.log(`[restaurant-import:persist] START slug=${draft.slug}`);
-
-  if (!process.env.DATABASE_URL) {
-    console.log("[restaurant-import:persist] SKIP database-not-configured");
-    return;
-  }
-
-  const db = getDb();
-  await db.restaurant.upsert({
-    where: { slug: draft.slug },
-    update: {
-      name: draft.name,
-      description: draft.description,
-      cuisine: draft.cuisine,
-      address: draft.address,
-      phone: draft.phone,
-      sourceUrl: draft.sourceUrl,
-      heroImageUrl: draft.heroImageUrl,
-      heroOriginalImageUrl: draft.heroOriginalImageUrl,
-      heroImageProvenance: toDatabaseImageProvenance(
-        draft.heroImageProvenance,
-      ),
-      showMenuImages: draft.showMenuImages,
-      autoEnhanceImages: draft.autoEnhanceImages,
-      defaultLocale: draft.defaultLocale,
-      translations: draft.translations,
-      status: "PREVIEW_READY",
-      integrations: {
-        deleteMany: {},
-        create: draft.integrations.map((integration) => ({
-          type: integration.type.toUpperCase() as
-            | "BOOKING"
-            | "ORDERING"
-            | "DELIVERY"
-            | "SOCIAL",
-          label: integration.label,
-          provider: integration.provider,
-          url: integration.url,
-        })),
-      },
-      menuSections: {
-        deleteMany: {},
-        create: draft.menuSections.map((section, sectionIndex) => ({
-          name: section.name,
-          description: section.description,
-          position: sectionIndex,
-          items: {
-            create: section.items.map((item, itemIndex) => ({
-              name: item.name,
-              description: item.description,
-              price: item.price,
-              currency: item.currency,
-              dietaryLabels: item.dietaryLabels,
-              imageUrl: item.imageUrl,
-              originalImageUrl: item.originalImageUrl,
-              imageProvenance: toDatabaseImageProvenance(
-                item.imageProvenance,
-              ),
-              position: itemIndex,
-            })),
-          },
-        })),
-      },
-    },
-    create: {
-      slug: draft.slug,
-      name: draft.name,
-      description: draft.description,
-      cuisine: draft.cuisine,
-      address: draft.address,
-      phone: draft.phone,
-      sourceUrl: draft.sourceUrl,
-      heroImageUrl: draft.heroImageUrl,
-      heroOriginalImageUrl: draft.heroOriginalImageUrl,
-      heroImageProvenance: toDatabaseImageProvenance(
-        draft.heroImageProvenance,
-      ),
-      showMenuImages: draft.showMenuImages,
-      autoEnhanceImages: draft.autoEnhanceImages,
-      defaultLocale: draft.defaultLocale,
-      translations: draft.translations,
-      status: "PREVIEW_READY",
-      integrations: {
-        create: draft.integrations.map((integration) => ({
-          type: integration.type.toUpperCase() as
-            | "BOOKING"
-            | "ORDERING"
-            | "DELIVERY"
-            | "SOCIAL",
-          label: integration.label,
-          provider: integration.provider,
-          url: integration.url,
-        })),
-      },
-      menuSections: {
-        create: draft.menuSections.map((section, sectionIndex) => ({
-          name: section.name,
-          description: section.description,
-          position: sectionIndex,
-          items: {
-            create: section.items.map((item, itemIndex) => ({
-              name: item.name,
-              description: item.description,
-              price: item.price,
-              currency: item.currency,
-              dietaryLabels: item.dietaryLabels,
-              imageUrl: item.imageUrl,
-              originalImageUrl: item.originalImageUrl,
-              imageProvenance: toDatabaseImageProvenance(
-                item.imageProvenance,
-              ),
-              position: itemIndex,
-            })),
-          },
-        })),
-      },
-    },
+  const result = await persistRestaurantImport({
+    draft,
+    source,
+    importJobId,
   });
-  console.log(`[restaurant-import:persist] DONE slug=${draft.slug}`);
+  console.log(`[restaurant-import:persist] DONE slug=${result.draft.slug}`);
+  return result;
+}
+
+async function failImport(
+  importJobId: string,
+  message: string,
+): Promise<void> {
+  "use step";
+  await recordImportFailure(importJobId, message);
 }
 
 async function enhanceDraftImages(
@@ -276,15 +211,14 @@ async function enhanceDraftImages(
   }
 }
 
-async function emitComplete(draft: RestaurantDraft): Promise<void> {
+async function emitComplete(
+  persisted: PersistedRestaurantImport,
+): Promise<void> {
   "use step";
-  await emit({ type: "complete", draft });
-}
-
-function toDatabaseImageProvenance(
-  value: RestaurantDraft["heroImageProvenance"],
-): "OFFICIAL" | "OWNER" | "PERMISSIONED_UGC" | undefined {
-  if (!value) return undefined;
-  if (value === "permissioned-ugc") return "PERMISSIONED_UGC";
-  return value.toUpperCase() as "OFFICIAL" | "OWNER";
+  await emit({
+    type: "complete",
+    draft: persisted.draft,
+    importJobId: persisted.importJobId,
+    urls: persisted.urls,
+  });
 }


### PR DESCRIPTION
## Summary

- persist both inline and Workflow-generated restaurant drafts through one atomic Prisma service
- normalize source identity for idempotent reimports, reserve collision-safe stable slugs, and protect claimed/live restaurants from import replacement
- create durable `ImportJob` records for queued, running, ready, and failed states, with redacted failure details and audit events
- return canonical preview and claim URLs and remove browser `localStorage` as the draft source of truth
- make database-backed preview and claim routes return not found instead of unrelated sample content

## Dependency evidence

The repository-owned PostgreSQL and migration foundation required by this issue is present on `main` through merged PRs #21 and #23. This change does not provision infrastructure, use production credentials, deploy, or mutate DNS.

## Verification

- focused ESLint: passed
- Prisma schema validation: passed
- `git diff --check`: passed
- tests, typecheck, build, and E2E: intentionally not run locally per workstation policy; delegated to GitHub Actions

## Risk and rollout

The migration adds nullable import identity columns, a unique restaurant source key, and an import-job lookup index. Existing rows remain valid; their identity is populated on the next import. Imports now fail closed when database persistence is unavailable.

Existing FR/EN translation structure is validated by the existing draft schema, and booking/ordering/delivery integrations remain external links.

Closes #12
