### PR TITLE
ci: deploy production when a release is published

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches:
       - main
+  release:
+    types:
+      - published
 
 jobs:
   verify:
@@ -29,7 +32,10 @@ jobs:
       - run: bun run build
 
   deploy:
-    if: github.event_name == 'workflow_dispatch'
+    # Ships on a manual dispatch or when a GitHub release is published. Release
+    # events check out the release tag, so cutting a release deploys that exact
+    # commit. The verify gate and the Production environment protection still apply.
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'release'
     needs: verify
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,11 @@ jobs:
       - run: bun run build
 
   deploy:
-    # Ships on a manual dispatch or when a GitHub release is published. Release
-    # events check out the release tag, so cutting a release deploys that exact
-    # commit. The verify gate and the Production environment protection still apply.
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'release'
+    # Ships on a manual dispatch or when a stable GitHub release is published.
+    # Release events check out the release tag, so cutting a release deploys that
+    # exact commit. Prereleases (RC/beta) are excluded so only stable releases reach
+    # production. The verify gate and the Production environment protection still apply.
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && github.event.release.prerelease == false)
     needs: verify
     permissions:
       contents: read


### PR DESCRIPTION
## Why

Cutting a GitHub release did nothing — `deploy-production.yml` only triggers on `workflow_call` / `workflow_dispatch`, and the `deploy` job in `ci.yml` was gated `if: github.event_name == 'workflow_dispatch'`. So `v0.1.0` published but never shipped.

## What

- Add `release: types: [published]` to `ci.yml`.
- Allow the existing `deploy` job to run on `release` events as well as manual dispatch.

Release events check out the release tag, so publishing a release now builds and deploys that exact commit. The `verify` gate (`needs: verify`) and the `Production` GitHub Environment protection both remain in force — this wires the trigger, it does not remove the human/CI gates.

## After merge

Future releases auto-deploy on publish. `v0.1.0` predates this trigger, so it still needs a one-time manual dispatch:

```
gh workflow run deploy-production.yml --ref v0.1.0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic deployment when a GitHub release is published.
  * Release deployments use the release tag’s commit and retain verification and production safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->