### PR TITLE
feat(nav): smooth scroll to landing sections

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -129,6 +129,16 @@
   }
   html {
     @apply font-sans;
+    scroll-behavior: smooth;
+  }
+  /* Keep anchored sections clear of the sticky 64px header on jump. */
+  section[id] {
+    scroll-margin-top: 5rem;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    html {
+      scroll-behavior: auto;
+    }
   }
 }
 

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -4,6 +4,7 @@ import { Brand } from "@/components/brand";
 import { Button } from "@/components/ui/button";
 import {
   Sheet,
+  SheetClose,
   SheetContent,
   SheetHeader,
   SheetTitle,
@@ -65,11 +66,16 @@ export function SiteHeader() {
             </SheetHeader>
             <nav className="mt-10 flex flex-col gap-5 text-lg">
               {links.map((link) => (
-                <Link key={link.href} href={link.href}>
+                <SheetClose
+                  key={link.href}
+                  render={<Link href={link.href} />}
+                >
                   {link.label}
-                </Link>
+                </SheetClose>
               ))}
-              <Link href="/dashboard">Sign in</Link>
+              <SheetClose render={<Link href="/dashboard" />}>
+                Sign in
+              </SheetClose>
               <Button
                 render={<Link href="/create" />}
                 nativeButton={false}


### PR DESCRIPTION
## What

Enables smooth scroll-to-section for the landing page header nav. The nav links (\`#how-it-works\`, \`#features\`, \`#pricing\`) previously jumped instantly and landed under the sticky header.

## Changes

- **\`globals.css\`**
  - \`scroll-behavior: smooth\` on \`html\`, with a \`prefers-reduced-motion\` guard that reverts to instant scrolling.
  - \`scroll-margin-top: 5rem\` on \`section[id]\` so anchor targets clear the 64px sticky header instead of hiding beneath it.
- **\`site-header.tsx\`**
  - Mobile Sheet nav links now wrap in \`SheetClose\`, so tapping a section link closes the sheet and the smooth scroll is visible rather than hidden behind the overlay.

## Verification

- ESLint clean on changed files.
- Desktop and mobile both smooth-scroll to the target section, landing just below the header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)