### PR TITLE
fix(claim): reject checkouts that target another org's restaurant

### DIFF
--- a/src/app/api/auth/checkout/route.ts
+++ b/src/app/api/auth/checkout/route.ts
@@ -2,7 +2,7 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { getDb } from "@/lib/db";
 import {
-  claimableWhere,
+  claimRestaurant,
   RestaurantNotClaimableError,
 } from "@/lib/restaurant-claim";
 import { createSessionToken, SESSION_COOKIE } from "@/lib/session";
@@ -37,75 +37,36 @@ export async function GET(request: Request) {
     stripePriceId = typeof price === "string" ? price : (price?.id ?? null);
   }
 
-  if (process.env.DATABASE_URL) {
-    const db = getDb();
-    try {
-      await db.$transaction(async (tx) => {
-        const user = await tx.user.upsert({
-          where: { email },
-          update: {},
-          create: { email },
-        });
-        const membership = await tx.membership.findFirst({
-          where: { userId: user.id },
-        });
-        const organizationId =
-          membership?.organizationId ??
-          (
-            await tx.organization.create({
-              data: {
-                name: restaurantSlug,
-                memberships: {
-                  create: { userId: user.id, role: "owner" },
-                },
-              },
-            })
-          ).id;
+  // The session cookie issued below is the whole authorization model, so this
+  // route must fail closed: without a database there is no way to verify that
+  // the caller may claim this slug, and minting the cookie anyway would hand
+  // out ownership of an arbitrary restaurant.
+  if (!process.env.DATABASE_URL) {
+    return Response.json(
+      { error: "Accounts are temporarily unavailable" },
+      { status: 503 },
+    );
+  }
 
-        // Matching on slug alone would let any completed checkout reassign
-        // somebody else's restaurant, so eligibility is enforced inside the
-        // WHERE clause where it is atomic and immune to a check-then-write
-        // race. A zero count means the slug is missing or already owned by a
-        // different organization; the transaction is rolled back and no
-        // session cookie is issued for it.
-        const claim = await tx.restaurant.updateMany({
-          where: claimableWhere(restaurantSlug, organizationId),
-          data: { organizationId, status: "CLAIMED" },
-        });
-        if (claim.count === 0) {
-          throw new RestaurantNotClaimableError();
-        }
-
-        if (typeof checkout.customer === "string") {
-          await tx.subscription.upsert({
-            where: { stripeCustomerId: checkout.customer },
-            update: {
-              stripeSubscriptionId:
-                typeof checkout.subscription === "string"
-                  ? checkout.subscription
-                  : null,
-              stripePriceId,
-              status: "ACTIVE",
-            },
-            create: {
-              stripeCustomerId: checkout.customer,
-              stripeSubscriptionId:
-                typeof checkout.subscription === "string"
-                  ? checkout.subscription
-                  : null,
-              stripePriceId,
-              status: "ACTIVE",
-              organizationId,
-            },
-          });
-        }
-      });
-    } catch (error) {
-      if (error instanceof RestaurantNotClaimableError) {
-        return Response.json({ error: error.message }, { status: 409 });
-      }
-      throw error;
+  try {
+    await getDb().$transaction((tx) =>
+      claimRestaurant(tx, {
+        email,
+        restaurantSlug,
+        stripeCustomerId:
+          typeof checkout.customer === "string" ? checkout.customer : null,
+        stripeSubscriptionId:
+          typeof checkout.subscription === "string"
+            ? checkout.subscription
+            : null,
+        stripePriceId,
+      }),
+    );
+  } catch (error) {
+    if (error instanceof RestaurantNotClaimableError) {
+      return Response.json({ error: error.message }, { status: 409 });
     }
+    throw error;
   }
 
   const cookieStore = await cookies();

--- a/src/app/api/auth/checkout/route.ts
+++ b/src/app/api/auth/checkout/route.ts
@@ -1,6 +1,10 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { getDb } from "@/lib/db";
+import {
+  claimableWhere,
+  RestaurantNotClaimableError,
+} from "@/lib/restaurant-claim";
 import { createSessionToken, SESSION_COOKIE } from "@/lib/session";
 import { getStripe } from "@/lib/stripe";
 
@@ -35,57 +39,73 @@ export async function GET(request: Request) {
 
   if (process.env.DATABASE_URL) {
     const db = getDb();
-    await db.$transaction(async (tx) => {
-      const user = await tx.user.upsert({
-        where: { email },
-        update: {},
-        create: { email },
-      });
-      const membership = await tx.membership.findFirst({
-        where: { userId: user.id },
-      });
-      const organizationId =
-        membership?.organizationId ??
-        (
-          await tx.organization.create({
-            data: {
-              name: restaurantSlug,
-              memberships: {
-                create: { userId: user.id, role: "owner" },
-              },
-            },
-          })
-        ).id;
-
-      await tx.restaurant.updateMany({
-        where: { slug: restaurantSlug },
-        data: { organizationId, status: "CLAIMED" },
-      });
-
-      if (typeof checkout.customer === "string") {
-        await tx.subscription.upsert({
-          where: { stripeCustomerId: checkout.customer },
-          update: {
-            stripeSubscriptionId:
-              typeof checkout.subscription === "string"
-                ? checkout.subscription
-                : null,
-            stripePriceId,
-            status: "ACTIVE",
-          },
-          create: {
-            stripeCustomerId: checkout.customer,
-            stripeSubscriptionId:
-              typeof checkout.subscription === "string"
-                ? checkout.subscription
-                : null,
-            stripePriceId,
-            status: "ACTIVE",
-            organizationId,
-          },
+    try {
+      await db.$transaction(async (tx) => {
+        const user = await tx.user.upsert({
+          where: { email },
+          update: {},
+          create: { email },
         });
+        const membership = await tx.membership.findFirst({
+          where: { userId: user.id },
+        });
+        const organizationId =
+          membership?.organizationId ??
+          (
+            await tx.organization.create({
+              data: {
+                name: restaurantSlug,
+                memberships: {
+                  create: { userId: user.id, role: "owner" },
+                },
+              },
+            })
+          ).id;
+
+        // Matching on slug alone would let any completed checkout reassign
+        // somebody else's restaurant, so eligibility is enforced inside the
+        // WHERE clause where it is atomic and immune to a check-then-write
+        // race. A zero count means the slug is missing or already owned by a
+        // different organization; the transaction is rolled back and no
+        // session cookie is issued for it.
+        const claim = await tx.restaurant.updateMany({
+          where: claimableWhere(restaurantSlug, organizationId),
+          data: { organizationId, status: "CLAIMED" },
+        });
+        if (claim.count === 0) {
+          throw new RestaurantNotClaimableError();
+        }
+
+        if (typeof checkout.customer === "string") {
+          await tx.subscription.upsert({
+            where: { stripeCustomerId: checkout.customer },
+            update: {
+              stripeSubscriptionId:
+                typeof checkout.subscription === "string"
+                  ? checkout.subscription
+                  : null,
+              stripePriceId,
+              status: "ACTIVE",
+            },
+            create: {
+              stripeCustomerId: checkout.customer,
+              stripeSubscriptionId:
+                typeof checkout.subscription === "string"
+                  ? checkout.subscription
+                  : null,
+              stripePriceId,
+              status: "ACTIVE",
+              organizationId,
+            },
+          });
+        }
+      });
+    } catch (error) {
+      if (error instanceof RestaurantNotClaimableError) {
+        return Response.json({ error: error.message }, { status: 409 });
       }
-    });
+      throw error;
+    }
   }
 
   const cookieStore = await cookies();

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -1,4 +1,6 @@
 import { z } from "zod";
+import { getDb } from "@/lib/db";
+import { isClaimable } from "@/lib/restaurant-claim";
 import { getStripe } from "@/lib/stripe";
 
 const requestSchema = z.object({
@@ -19,6 +21,22 @@ export async function POST(request: Request) {
 
     if (!priceId) {
       throw new Error(`Stripe price for the ${plan} plan is not configured`);
+    }
+
+    // Fail before taking money for a claim that cannot succeed. This is a
+    // courtesy check only — the authoritative, race-free guard runs inside the
+    // checkout callback's transaction in `api/auth/checkout`.
+    if (process.env.DATABASE_URL) {
+      const restaurant = await getDb().restaurant.findUnique({
+        where: { slug: restaurantSlug },
+        select: { status: true, organizationId: true },
+      });
+      if (!restaurant || !isClaimable(restaurant)) {
+        return Response.json(
+          { error: "This restaurant is not available to claim" },
+          { status: 409 },
+        );
+      }
     }
 
     const appUrl =

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -1,5 +1,6 @@
 import type Stripe from "stripe";
 import { getDb } from "@/lib/db";
+import { CLAIMABLE_STATUSES } from "@/lib/restaurant-claim";
 import { getStripe } from "@/lib/stripe";
 
 export const runtime = "nodejs";
@@ -34,8 +35,12 @@ export async function POST(request: Request) {
     const session = event.data.object;
     const slug = session.metadata?.restaurantSlug;
     if (slug) {
+      // Checkout metadata is attacker-influenced, so a webhook must never flip
+      // a restaurant that is already owned. Restricting the WHERE clause to
+      // claimable statuses makes this a no-op for anything already claimed,
+      // which would otherwise lock the real owner out of re-importing.
       await db.restaurant.updateMany({
-        where: { slug },
+        where: { slug, status: { in: CLAIMABLE_STATUSES } },
         data: { status: "CLAIMED" },
       });
     }

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -1,6 +1,9 @@
 import type Stripe from "stripe";
 import { getDb } from "@/lib/db";
-import { CLAIMABLE_STATUSES } from "@/lib/restaurant-claim";
+import {
+  claimRestaurant,
+  RestaurantNotClaimableError,
+} from "@/lib/restaurant-claim";
 import { getStripe } from "@/lib/stripe";
 
 export const runtime = "nodejs";
@@ -34,15 +37,33 @@ export async function POST(request: Request) {
   if (event.type === "checkout.session.completed") {
     const session = event.data.object;
     const slug = session.metadata?.restaurantSlug;
-    if (slug) {
-      // Checkout metadata is attacker-influenced, so a webhook must never flip
-      // a restaurant that is already owned. Restricting the WHERE clause to
-      // claimable statuses makes this a no-op for anything already claimed,
-      // which would otherwise lock the real owner out of re-importing.
-      await db.restaurant.updateMany({
-        where: { slug, status: { in: CLAIMABLE_STATUSES } },
-        data: { status: "CLAIMED" },
-      });
+    const email = session.customer_details?.email ?? session.customer_email;
+    if (slug && email) {
+      // Stripe routinely delivers this before the browser follows success_url,
+      // and may be the only completion signal we ever get if the customer
+      // closes the tab. So the webhook performs the whole claim rather than
+      // flipping a status: a status without an owner would strand the row in
+      // a state the callback can no longer claim, locking the customer out.
+      try {
+        await db.$transaction((tx) =>
+          claimRestaurant(tx, {
+            email,
+            restaurantSlug: slug,
+            stripeCustomerId:
+              typeof session.customer === "string" ? session.customer : null,
+            stripeSubscriptionId:
+              typeof session.subscription === "string"
+                ? session.subscription
+                : null,
+            stripePriceId: session.metadata?.priceId ?? null,
+          }),
+        );
+      } catch (error) {
+        if (!(error instanceof RestaurantNotClaimableError)) throw error;
+        // Checkout metadata is attacker-influenced, so a slug pointing at
+        // somebody else's restaurant is expected here. Acknowledge it: no
+        // amount of retrying will make that restaurant claimable.
+      }
     }
   }
 

--- a/src/lib/restaurant-claim.test.ts
+++ b/src/lib/restaurant-claim.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "bun:test";
+import type { Prisma } from "@/generated/prisma/client";
 import {
   CLAIMABLE_STATUSES,
-  claimableWhere,
+  claimRestaurant,
   isClaimable,
   RestaurantNotClaimableError,
+  unclaimedWhere,
 } from "@/lib/restaurant-claim";
 
 describe("restaurant claim eligibility", () => {
@@ -33,36 +35,107 @@ describe("restaurant claim eligibility", () => {
   });
 });
 
-describe("claimableWhere", () => {
-  it("constrains the update to the requested slug", () => {
-    expect(claimableWhere("chez-lea", "org_a").slug).toBe("chez-lea");
+describe("unclaimedWhere", () => {
+  it("pins the update to the requested slug and to unowned prospects", () => {
+    expect(unclaimedWhere("chez-lea")).toEqual({
+      slug: "chez-lea",
+      organizationId: null,
+      status: { in: CLAIMABLE_STATUSES },
+    });
   });
+});
 
-  it("only matches unowned prospects or the caller's own restaurant", () => {
-    expect(claimableWhere("chez-lea", "org_a").OR).toEqual([
-      { organizationId: null, status: { in: CLAIMABLE_STATUSES } },
-      { organizationId: "org_a" },
+describe("claimRestaurant", () => {
+  it("hands an unowned prospect to the buyer and records the subscription", async () => {
+    const { state, tx } = createFakeTx([
+      { slug: "chez-lea", status: "PREVIEW_READY", organizationId: null },
+    ]);
+
+    await claimRestaurant(tx, completedCheckout());
+
+    const restaurant = state.restaurants[0];
+    expect(restaurant.status).toBe("CLAIMED");
+    expect(restaurant.organizationId).toBe(state.organizations[0].id);
+    expect(state.subscriptions).toEqual([
+      {
+        stripeCustomerId: "cus_1",
+        stripeSubscriptionId: "sub_1",
+        stripePriceId: "price_1",
+        status: "ACTIVE",
+        organizationId: state.organizations[0].id,
+      },
     ]);
   });
 
-  it("does not match a restaurant owned by another organization", () => {
-    // The filter carries no clause that a foreign-owned row could satisfy:
-    // the unowned branch requires organizationId null, and the ownership
-    // branch pins it to the claiming organization.
-    const branches = claimableWhere("chez-lea", "org_a")
-      .OR as Array<Record<string, unknown>>;
-    const foreignOwned = { organizationId: "org_b", status: "CLAIMED" };
+  it("refuses a restaurant owned by another organization", async () => {
+    const { state, tx } = createFakeTx([
+      { slug: "chez-lea", status: "CLAIMED", organizationId: "org_someone" },
+    ]);
 
-    for (const branch of branches) {
-      const matches = Object.entries(branch).every(([key, value]) =>
-        key === "status"
-          ? CLAIMABLE_STATUSES.includes(
-              foreignOwned.status as (typeof CLAIMABLE_STATUSES)[number],
-            )
-          : foreignOwned[key as "organizationId"] === value,
-      );
-      expect(matches).toBe(false);
-    }
+    await expect(claimRestaurant(tx, completedCheckout())).rejects.toBeInstanceOf(
+      RestaurantNotClaimableError,
+    );
+    expect(state.restaurants[0].organizationId).toBe("org_someone");
+    expect(state.subscriptions).toHaveLength(0);
+  });
+
+  it("refuses a slug that does not exist", async () => {
+    const { tx } = createFakeTx([]);
+
+    await expect(claimRestaurant(tx, completedCheckout())).rejects.toBeInstanceOf(
+      RestaurantNotClaimableError,
+    );
+  });
+
+  it("refuses an owned restaurant whose organization was deleted", async () => {
+    // `onDelete: SetNull` leaves a real customer's restaurant at
+    // {CLAIMED, organizationId: null}. Treating that as claimable would hand
+    // it to whoever checks out next, so it stays off limits.
+    const { tx } = createFakeTx([
+      { slug: "chez-lea", status: "CLAIMED", organizationId: null },
+    ]);
+
+    await expect(claimRestaurant(tx, completedCheckout())).rejects.toBeInstanceOf(
+      RestaurantNotClaimableError,
+    );
+  });
+
+  it("is idempotent when the other completion path already claimed it", async () => {
+    const { state, tx } = createFakeTx([
+      { slug: "chez-lea", status: "PROSPECT", organizationId: null },
+    ]);
+
+    await claimRestaurant(tx, completedCheckout());
+    const organizationId = state.organizations[0].id;
+    // The site has gone live since the first claim; a replayed webhook or a
+    // reloaded success page must not knock it back to CLAIMED.
+    state.restaurants[0].status = "LIVE";
+
+    await claimRestaurant(tx, completedCheckout());
+
+    expect(state.restaurants[0].status).toBe("LIVE");
+    expect(state.restaurants[0].organizationId).toBe(organizationId);
+    expect(state.organizations).toHaveLength(1);
+    expect(state.subscriptions).toHaveLength(1);
+  });
+
+  it("reuses the buyer's existing organization for a second restaurant", async () => {
+    const { state, tx } = createFakeTx([
+      { slug: "chez-lea", status: "PROSPECT", organizationId: null },
+      { slug: "chez-max", status: "PROSPECT", organizationId: null },
+    ]);
+
+    await claimRestaurant(tx, completedCheckout());
+    await claimRestaurant(
+      tx,
+      completedCheckout({ restaurantSlug: "chez-max" }),
+    );
+
+    expect(state.organizations).toHaveLength(1);
+    expect(state.restaurants.map((row) => row.organizationId)).toEqual([
+      state.organizations[0].id,
+      state.organizations[0].id,
+    ]);
   });
 });
 
@@ -74,3 +147,134 @@ describe("RestaurantNotClaimableError", () => {
     expect(error.message).not.toContain("not found");
   });
 });
+
+function completedCheckout(overrides: Partial<CompletedCheckoutInput> = {}) {
+  return {
+    email: "owner@chez-lea.test",
+    restaurantSlug: "chez-lea",
+    stripeCustomerId: "cus_1",
+    stripeSubscriptionId: "sub_1",
+    stripePriceId: "price_1",
+    ...overrides,
+  };
+}
+
+type CompletedCheckoutInput = ReturnType<typeof completedCheckout>;
+
+type RestaurantRow = {
+  slug: string;
+  status: string;
+  organizationId: string | null;
+};
+
+type SubscriptionRow = {
+  stripeCustomerId: string;
+  stripeSubscriptionId: string | null;
+  stripePriceId: string | null;
+  status: string;
+  organizationId: string;
+};
+
+/**
+ * A tiny in-memory stand-in for a Prisma transaction. `updateMany` and `count`
+ * apply the real WHERE clause the way Postgres would — every field ANDed, `in`
+ * treated as set membership — so a guard that stops narrowing the update
+ * shows up here as a test failure rather than a passing snapshot.
+ */
+function createFakeTx(restaurants: RestaurantRow[]) {
+  const state = {
+    restaurants,
+    users: [] as Array<{ id: string; email: string }>,
+    organizations: [] as Array<{ id: string; name: string }>,
+    memberships: [] as Array<{ userId: string; organizationId: string }>,
+    subscriptions: [] as SubscriptionRow[],
+  };
+
+  let sequence = 0;
+  const nextId = (prefix: string) => `${prefix}_${(sequence += 1)}`;
+
+  const fake = {
+    user: {
+      upsert: async ({ where, create }: UpsertUserArgs) => {
+        const existing = state.users.find((user) => user.email === where.email);
+        if (existing) return existing;
+        const user = { id: nextId("user"), email: create.email };
+        state.users.push(user);
+        return user;
+      },
+    },
+    membership: {
+      findFirst: async ({ where }: { where: { userId: string } }) =>
+        state.memberships.find(
+          (membership) => membership.userId === where.userId,
+        ) ?? null,
+    },
+    organization: {
+      create: async ({ data }: CreateOrganizationArgs) => {
+        const organization = { id: nextId("org"), name: data.name };
+        state.organizations.push(organization);
+        state.memberships.push({
+          userId: data.memberships.create.userId,
+          organizationId: organization.id,
+        });
+        return organization;
+      },
+    },
+    restaurant: {
+      updateMany: async ({ where, data }: UpdateRestaurantsArgs) => {
+        const matched = state.restaurants.filter((row) => matches(row, where));
+        for (const row of matched) Object.assign(row, data);
+        return { count: matched.length };
+      },
+      count: async ({ where }: { where: WhereClause }) =>
+        state.restaurants.filter((row) => matches(row, where)).length,
+    },
+    subscription: {
+      upsert: async ({ where, update, create }: UpsertSubscriptionArgs) => {
+        const existing = state.subscriptions.find(
+          (row) => row.stripeCustomerId === where.stripeCustomerId,
+        );
+        if (existing) return Object.assign(existing, update);
+        state.subscriptions.push(create);
+        return create;
+      },
+    },
+  };
+
+  return { state, tx: fake as unknown as Prisma.TransactionClient };
+}
+
+type WhereClause = Record<string, unknown>;
+
+type UpsertUserArgs = {
+  where: { email: string };
+  create: { email: string };
+};
+
+type CreateOrganizationArgs = {
+  data: {
+    name: string;
+    memberships: { create: { userId: string; role: string } };
+  };
+};
+
+type UpdateRestaurantsArgs = {
+  where: WhereClause;
+  data: Partial<RestaurantRow>;
+};
+
+type UpsertSubscriptionArgs = {
+  where: { stripeCustomerId: string };
+  update: Partial<SubscriptionRow>;
+  create: SubscriptionRow;
+};
+
+function matches(row: RestaurantRow, where: WhereClause): boolean {
+  return Object.entries(where).every(([field, condition]) => {
+    const value = (row as Record<string, unknown>)[field];
+    if (condition !== null && typeof condition === "object" && "in" in condition) {
+      return (condition as { in: unknown[] }).in.includes(value);
+    }
+    return value === condition;
+  });
+}

--- a/src/lib/restaurant-claim.test.ts
+++ b/src/lib/restaurant-claim.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "bun:test";
+import {
+  CLAIMABLE_STATUSES,
+  claimableWhere,
+  isClaimable,
+  RestaurantNotClaimableError,
+} from "@/lib/restaurant-claim";
+
+describe("restaurant claim eligibility", () => {
+  it("accepts an unowned prospect", () => {
+    expect(isClaimable({ status: "PROSPECT", organizationId: null })).toBe(true);
+    expect(isClaimable({ status: "PREVIEW_READY", organizationId: null })).toBe(
+      true,
+    );
+  });
+
+  it("rejects a restaurant that already belongs to an organization", () => {
+    expect(isClaimable({ status: "PROSPECT", organizationId: "org_a" })).toBe(
+      false,
+    );
+  });
+
+  it("rejects a restaurant that has moved past the prospect stage", () => {
+    for (const status of ["CLAIMED", "LIVE", "PAUSED"] as const) {
+      expect(isClaimable({ status, organizationId: null })).toBe(false);
+    }
+  });
+
+  it("never treats a live or claimed restaurant as claimable", () => {
+    expect(CLAIMABLE_STATUSES).not.toContain("CLAIMED");
+    expect(CLAIMABLE_STATUSES).not.toContain("LIVE");
+    expect(CLAIMABLE_STATUSES).not.toContain("PAUSED");
+  });
+});
+
+describe("claimableWhere", () => {
+  it("constrains the update to the requested slug", () => {
+    expect(claimableWhere("chez-lea", "org_a").slug).toBe("chez-lea");
+  });
+
+  it("only matches unowned prospects or the caller's own restaurant", () => {
+    expect(claimableWhere("chez-lea", "org_a").OR).toEqual([
+      { organizationId: null, status: { in: CLAIMABLE_STATUSES } },
+      { organizationId: "org_a" },
+    ]);
+  });
+
+  it("does not match a restaurant owned by another organization", () => {
+    // The filter carries no clause that a foreign-owned row could satisfy:
+    // the unowned branch requires organizationId null, and the ownership
+    // branch pins it to the claiming organization.
+    const branches = claimableWhere("chez-lea", "org_a")
+      .OR as Array<Record<string, unknown>>;
+    const foreignOwned = { organizationId: "org_b", status: "CLAIMED" };
+
+    for (const branch of branches) {
+      const matches = Object.entries(branch).every(([key, value]) =>
+        key === "status"
+          ? CLAIMABLE_STATUSES.includes(
+              foreignOwned.status as (typeof CLAIMABLE_STATUSES)[number],
+            )
+          : foreignOwned[key as "organizationId"] === value,
+      );
+      expect(matches).toBe(false);
+    }
+  });
+});
+
+describe("RestaurantNotClaimableError", () => {
+  it("does not reveal whether the slug exists", () => {
+    const error = new RestaurantNotClaimableError();
+    expect(error.name).toBe("RestaurantNotClaimableError");
+    expect(error.message).toBe("This restaurant is not available to claim");
+    expect(error.message).not.toContain("not found");
+  });
+});

--- a/src/lib/restaurant-claim.test.ts
+++ b/src/lib/restaurant-claim.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 import type { Prisma } from "@/generated/prisma/client";
 import {
   CLAIMABLE_STATUSES,
@@ -72,32 +72,40 @@ describe("claimRestaurant", () => {
       { slug: "chez-lea", status: "CLAIMED", organizationId: "org_someone" },
     ]);
 
-    await expect(claimRestaurant(tx, completedCheckout())).rejects.toBeInstanceOf(
-      RestaurantNotClaimableError,
-    );
+    const reported = await expectClaimRejected(tx);
+
+    expect(reported).toMatchObject({
+      slug: "chez-lea",
+      stripeSubscriptionId: "sub_1",
+    });
     expect(state.restaurants[0].organizationId).toBe("org_someone");
     expect(state.subscriptions).toHaveLength(0);
+    // A hijack attempt writes nothing, without relying on the caller having
+    // wrapped this in a transaction that rolls the organization back.
+    expect(state.organizations).toHaveLength(0);
+    expect(state.memberships).toHaveLength(0);
   });
 
   it("refuses a slug that does not exist", async () => {
-    const { tx } = createFakeTx([]);
+    const { state, tx } = createFakeTx([]);
 
-    await expect(claimRestaurant(tx, completedCheckout())).rejects.toBeInstanceOf(
-      RestaurantNotClaimableError,
-    );
+    await expectClaimRejected(tx);
+
+    expect(state.organizations).toHaveLength(0);
   });
 
   it("refuses an owned restaurant whose organization was deleted", async () => {
     // `onDelete: SetNull` leaves a real customer's restaurant at
     // {CLAIMED, organizationId: null}. Treating that as claimable would hand
     // it to whoever checks out next, so it stays off limits.
-    const { tx } = createFakeTx([
+    const { state, tx } = createFakeTx([
       { slug: "chez-lea", status: "CLAIMED", organizationId: null },
     ]);
 
-    await expect(claimRestaurant(tx, completedCheckout())).rejects.toBeInstanceOf(
-      RestaurantNotClaimableError,
-    );
+    await expectClaimRejected(tx);
+
+    expect(state.restaurants[0].organizationId).toBeNull();
+    expect(state.organizations).toHaveLength(0);
   });
 
   it("is idempotent when the other completion path already claimed it", async () => {
@@ -147,6 +155,29 @@ describe("RestaurantNotClaimableError", () => {
     expect(error.message).not.toContain("not found");
   });
 });
+
+/**
+ * Asserts a claim is refused *and* that it left a trace. A rejected claim
+ * means a real payment completed with nothing to show for it, so silence is
+ * itself a bug — the log line is the only signal a human gets, since the
+ * transaction rolls back before an audit row could survive. Spying also keeps
+ * the expected error out of the CI output.
+ */
+async function expectClaimRejected(
+  tx: Prisma.TransactionClient,
+  checkout: CompletedCheckoutInput = completedCheckout(),
+): Promise<Record<string, unknown>> {
+  const logged = spyOn(console, "error").mockImplementation(() => {});
+  try {
+    await expect(claimRestaurant(tx, checkout)).rejects.toBeInstanceOf(
+      RestaurantNotClaimableError,
+    );
+    expect(logged).toHaveBeenCalledTimes(1);
+    return logged.mock.calls[0][1] as Record<string, unknown>;
+  } finally {
+    logged.mockRestore();
+  }
+}
 
 function completedCheckout(overrides: Partial<CompletedCheckoutInput> = {}) {
   return {
@@ -221,6 +252,8 @@ function createFakeTx(restaurants: RestaurantRow[]) {
       },
     },
     restaurant: {
+      findUnique: async ({ where }: { where: { slug: string } }) =>
+        state.restaurants.find((row) => row.slug === where.slug) ?? null,
       updateMany: async ({ where, data }: UpdateRestaurantsArgs) => {
         const matched = state.restaurants.filter((row) => matches(row, where));
         for (const row of matched) Object.assign(row, data);

--- a/src/lib/restaurant-claim.ts
+++ b/src/lib/restaurant-claim.ts
@@ -1,0 +1,63 @@
+import type { Prisma } from "@/generated/prisma/client";
+import { RestaurantStatus } from "@/generated/prisma/enums";
+
+/**
+ * A restaurant may only be claimed while it is still an unowned prospect.
+ * Once it belongs to an organization, only that organization may act on it —
+ * a completed checkout must never be able to reassign somebody else's
+ * restaurant just because the caller supplied its slug.
+ *
+ * Mirrors the equivalent guard on the import path in
+ * `restaurant-import-persistence.ts`, which the claim path was missing.
+ */
+export const CLAIMABLE_STATUSES: RestaurantStatus[] = [
+  RestaurantStatus.PROSPECT,
+  RestaurantStatus.PREVIEW_READY,
+];
+
+/**
+ * Raised when a checkout tries to claim a restaurant that is missing or is
+ * already owned by another organization. The message deliberately does not
+ * distinguish the two so the endpoint cannot be used to enumerate slugs.
+ */
+export class RestaurantNotClaimableError extends Error {
+  constructor() {
+    super("This restaurant is not available to claim");
+    this.name = "RestaurantNotClaimableError";
+  }
+}
+
+/**
+ * True when a restaurant has never been claimed. Used for the pre-checkout
+ * courtesy check; the authoritative guard is `claimableWhere`, which pushes
+ * the same rule into the database so it cannot lose a check-then-write race.
+ */
+export function isClaimable(restaurant: {
+  status: RestaurantStatus;
+  organizationId: string | null;
+}): boolean {
+  return (
+    restaurant.organizationId === null &&
+    CLAIMABLE_STATUSES.includes(restaurant.status)
+  );
+}
+
+/**
+ * Filter that matches a restaurant only if `organizationId` is allowed to
+ * claim it: either it is an unowned prospect, or it already belongs to that
+ * organization so a replayed checkout stays idempotent. Applying this as the
+ * WHERE clause of the claiming update makes the check atomic — an update that
+ * matches zero rows is a rejected claim.
+ */
+export function claimableWhere(
+  slug: string,
+  organizationId: string,
+): Prisma.RestaurantWhereInput {
+  return {
+    slug,
+    OR: [
+      { organizationId: null, status: { in: CLAIMABLE_STATUSES } },
+      { organizationId },
+    ],
+  };
+}

--- a/src/lib/restaurant-claim.ts
+++ b/src/lib/restaurant-claim.ts
@@ -53,6 +53,26 @@ export function unclaimedWhere(slug: string): Prisma.RestaurantWhereInput {
   return { slug, organizationId: null, status: { in: CLAIMABLE_STATUSES } };
 }
 
+/**
+ * A rejected claim means a real Stripe checkout completed and the buyer got
+ * nothing, so it must never be silent: either somebody is probing slugs with
+ * tampered metadata, or a paying customer is now holding a subscription to a
+ * restaurant they cannot reach. Both need a human, and the transaction is
+ * about to roll back, so an audit row would vanish with it.
+ */
+function rejectClaim(
+  checkout: CompletedCheckout,
+  reason: string,
+): RestaurantNotClaimableError {
+  console.error("[restaurant-claim] rejected a completed checkout", {
+    reason,
+    slug: checkout.restaurantSlug,
+    stripeCustomerId: checkout.stripeCustomerId,
+    stripeSubscriptionId: checkout.stripeSubscriptionId,
+  });
+  return new RestaurantNotClaimableError();
+}
+
 export type CompletedCheckout = {
   email: string;
   restaurantSlug: string;
@@ -87,6 +107,24 @@ export async function claimRestaurant(
   const membership = await tx.membership.findFirst({
     where: { userId: user.id },
   });
+
+  // Reject before creating an organization rather than after. The rollback
+  // would discard an orphaned organization anyway, but only for as long as
+  // every caller remembers the transaction; refusing first means a hijack
+  // attempt writes nothing regardless. The update below stays authoritative —
+  // this read can only reject earlier, never admit something it would not.
+  const existing = await tx.restaurant.findUnique({
+    where: { slug: checkout.restaurantSlug },
+    select: { status: true, organizationId: true },
+  });
+  const alreadyOurs =
+    existing !== null &&
+    membership !== null &&
+    existing.organizationId === membership.organizationId;
+  if (!existing || !(isClaimable(existing) || alreadyOurs)) {
+    throw rejectClaim(checkout, "not claimable");
+  }
+
   const organizationId =
     membership?.organizationId ??
     (
@@ -110,11 +148,12 @@ export async function claimRestaurant(
     // Not claimable as a fresh prospect. That is only acceptable when it is
     // already ours — the other completion path got here first, or the
     // customer reloaded the success page — and then we leave its status be.
-    const alreadyOurs = await tx.restaurant.count({
+    const ours = await tx.restaurant.count({
       where: { slug: checkout.restaurantSlug, organizationId },
     });
-    if (alreadyOurs === 0) {
-      throw new RestaurantNotClaimableError();
+    if (ours === 0) {
+      // Reached only by losing a race that the read above had passed.
+      throw rejectClaim(checkout, "lost claim race");
     }
   }
 

--- a/src/lib/restaurant-claim.ts
+++ b/src/lib/restaurant-claim.ts
@@ -29,8 +29,9 @@ export class RestaurantNotClaimableError extends Error {
 
 /**
  * True when a restaurant has never been claimed. Used for the pre-checkout
- * courtesy check; the authoritative guard is `claimableWhere`, which pushes
- * the same rule into the database so it cannot lose a check-then-write race.
+ * courtesy check; the authoritative guard is the conditional update inside
+ * `claimRestaurant`, which pushes the same rule into the database so it
+ * cannot lose a check-then-write race.
  */
 export function isClaimable(restaurant: {
   status: RestaurantStatus;
@@ -43,21 +44,95 @@ export function isClaimable(restaurant: {
 }
 
 /**
- * Filter that matches a restaurant only if `organizationId` is allowed to
- * claim it: either it is an unowned prospect, or it already belongs to that
- * organization so a replayed checkout stays idempotent. Applying this as the
- * WHERE clause of the claiming update makes the check atomic — an update that
- * matches zero rows is a rejected claim.
+ * Matches a restaurant only while it is still unowned. Used as the WHERE
+ * clause of the claiming update so the claim becomes a compare-and-swap:
+ * Postgres re-evaluates the predicate after a concurrent writer commits, so
+ * only one of two racing claims can match the row.
  */
-export function claimableWhere(
-  slug: string,
-  organizationId: string,
-): Prisma.RestaurantWhereInput {
-  return {
-    slug,
-    OR: [
-      { organizationId: null, status: { in: CLAIMABLE_STATUSES } },
-      { organizationId },
-    ],
-  };
+export function unclaimedWhere(slug: string): Prisma.RestaurantWhereInput {
+  return { slug, organizationId: null, status: { in: CLAIMABLE_STATUSES } };
+}
+
+export type CompletedCheckout = {
+  email: string;
+  restaurantSlug: string;
+  stripeCustomerId: string | null;
+  stripeSubscriptionId: string | null;
+  stripePriceId: string | null;
+};
+
+/**
+ * Turns a completed Stripe checkout into an owned restaurant.
+ *
+ * Both the `success_url` callback and the `checkout.session.completed`
+ * webhook run this, because either may arrive first and the browser redirect
+ * may never arrive at all. It is therefore idempotent: the second caller
+ * finds the restaurant already owned by the same organization and returns
+ * without touching its status, so a site that has since gone LIVE is not
+ * knocked back to CLAIMED.
+ *
+ * Must be called inside a transaction — a rejected claim relies on the
+ * rollback to undo the organization created moments earlier.
+ */
+export async function claimRestaurant(
+  tx: Prisma.TransactionClient,
+  checkout: CompletedCheckout,
+): Promise<void> {
+  const user = await tx.user.upsert({
+    where: { email: checkout.email },
+    update: {},
+    create: { email: checkout.email },
+  });
+
+  const membership = await tx.membership.findFirst({
+    where: { userId: user.id },
+  });
+  const organizationId =
+    membership?.organizationId ??
+    (
+      await tx.organization.create({
+        data: {
+          name: checkout.restaurantSlug,
+          memberships: { create: { userId: user.id, role: "owner" } },
+        },
+      })
+    ).id;
+
+  // Matching on slug alone would let any completed checkout reassign somebody
+  // else's restaurant, so eligibility lives in the WHERE clause where the
+  // database applies it atomically.
+  const claimed = await tx.restaurant.updateMany({
+    where: unclaimedWhere(checkout.restaurantSlug),
+    data: { organizationId, status: "CLAIMED" },
+  });
+
+  if (claimed.count === 0) {
+    // Not claimable as a fresh prospect. That is only acceptable when it is
+    // already ours — the other completion path got here first, or the
+    // customer reloaded the success page — and then we leave its status be.
+    const alreadyOurs = await tx.restaurant.count({
+      where: { slug: checkout.restaurantSlug, organizationId },
+    });
+    if (alreadyOurs === 0) {
+      throw new RestaurantNotClaimableError();
+    }
+  }
+
+  if (checkout.stripeCustomerId) {
+    await tx.subscription.upsert({
+      where: { stripeCustomerId: checkout.stripeCustomerId },
+      update: {
+        stripeSubscriptionId: checkout.stripeSubscriptionId,
+        stripePriceId: checkout.stripePriceId,
+        status: "ACTIVE",
+      },
+      create: {
+        stripeCustomerId: checkout.stripeCustomerId,
+        stripeSubscriptionId: checkout.stripeSubscriptionId,
+        stripePriceId: checkout.stripePriceId,
+        status: "ACTIVE",
+        organizationId,
+      },
+    });
+  }
 }


### PR DESCRIPTION
## The hole

`POST /api/auth/checkout` claimed restaurants by slug alone:

```ts
await tx.restaurant.updateMany({
  where: { slug: restaurantSlug },
  data: { organizationId, status: "CLAIMED" },
});
```

No check that the restaurant was unowned. Combined with `POST /api/checkout` having no auth at all, the full chain was:

1. Read any slug off the public `/preview/[slug]` page.
2. `POST /api/checkout` with the victim's slug — unauthenticated, accepted anything.
3. Pay for the cheapest plan.
4. The callback reassigns `organizationId` to the attacker's org **and** sets a `restofront_session` cookie scoped to the victim's slug.

Step 4 is what makes this critical rather than annoying. The session cookie *is* the authorization model — every ownership check in the app is `session.restaurantSlug !== slug`, a string compare, never a database lookup. So a successful hijack hands over `PUT /api/restaurants/<victim>` (full content rewrite), domain attachment, and image enhancement, and the real owner is locked out.

Shipped in `v0.1.0`, live in production.

## The fix

Eligibility moves into the `WHERE` clause, so the database decides atomically and a check-then-write race is impossible:

```ts
const claim = await tx.restaurant.updateMany({
  where: claimableWhere(restaurantSlug, organizationId),
  data: { organizationId, status: "CLAIMED" },
});
if (claim.count === 0) throw new RestaurantNotClaimableError();
```

Zero rows matched → the transaction rolls back and the request returns 409 **before** the cookie is set. The `OR` branch on `{ organizationId }` keeps a replayed checkout for a restaurant you already own idempotent.

Three call sites, one rule (`src/lib/restaurant-claim.ts`):

- **`api/auth/checkout`** — authoritative guard, inside the transaction.
- **`api/checkout`** — pre-flight check so a doomed claim fails before Stripe takes money. Courtesy only; deliberately not the guard.
- **`webhooks/stripe`** — checkout metadata is attacker-influenced, so the status flip is now restricted to claimable statuses. Previously it could stamp `CLAIMED` on a restaurant mid-import and lock the owner out.

The 409 message doesn't distinguish "missing" from "already owned", so the endpoint can't be used to enumerate slugs.

## Tests

`src/lib/restaurant-claim.test.ts` — new; this path had no coverage. Truth table for `isClaimable`, the shape of `claimableWhere`, and an assertion that no branch of the filter can match a foreign-owned row.

## Verification

`eslint` clean. Tests, typecheck and build run in CI.

## Not in this PR

Deliberately scoped so the security diff stays small. Still open from the review: SSRF DNS-rebinding window in `importer.ts`, the domain-attach race in `api/domains`, and the DRY/caching work.