### PR TITLE
feat(db): adopt the legacy restaurant schema without dropping a row

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ next-env.d.ts
 
 # codex audit/verification artifacts
 .codex/
+/.swc

--- a/deploy/aws/baseline-legacy-database.sql
+++ b/deploy/aws/baseline-legacy-database.sql
@@ -1,0 +1,66 @@
+-- One-time baselining for a database still on the pre-multi-vertical restaurant schema.
+--
+-- `20260724200000_init`, `20260724210000_integration_venue_id` and
+-- `20260725000000_beauty_vertical` describe a database built from scratch. A legacy database
+-- already holds their end state under the old names, so replaying them would fail on
+-- `CREATE TABLE "Site"`. `20260725190000_adopt_legacy_restaurant_schema` is what carries a
+-- legacy database forward instead, and it reproduces everything those three would have
+-- created. This script marks the three as applied so `prisma migrate deploy` skips straight
+-- to the adoption migration -- the same effect as `prisma migrate resolve --applied <name>`,
+-- expressed as SQL so it can run inside the already-deployed container, which predates the
+-- migration directories the CLI would need to read.
+--
+-- The checksums are the sha256 of each `migration.sql` and must stay in sync with them; a
+-- mismatch makes `migrate deploy` refuse to run. Verify with:
+--   shasum -a 256 prisma/migrations/<name>/migration.sql
+--
+-- Safe to run more than once, and a no-op on any database that is not the legacy shape.
+DO $$
+DECLARE
+  baseline RECORD;
+  inserted INTEGER;
+BEGIN
+  IF to_regclass('public."Restaurant"') IS NULL THEN
+    RAISE NOTICE 'No legacy "Restaurant" table -- not a legacy database, nothing to baseline.';
+    RETURN;
+  END IF;
+
+  IF to_regclass('public."Site"') IS NOT NULL THEN
+    RAISE NOTICE 'A "Site" table already exists -- this database has already been adopted.';
+    RETURN;
+  END IF;
+
+  FOR baseline IN
+    SELECT *
+    FROM (VALUES
+      ('20260724200000_init',
+       'cb1c5f2ed6f0c98efcc75a230ec951e34b91566ae86574e8f7894313c3881471'),
+      ('20260724210000_integration_venue_id',
+       '5926005243d836b055ed798a65355751f581681329adc878acc8ad90b153c463'),
+      ('20260725000000_beauty_vertical',
+       '297493cc641719cc1b020236d1d7d9b3588c928f87eaeeea8bbc59d8f03deb93')
+    ) AS candidates(migration_name, checksum)
+  LOOP
+    INSERT INTO "_prisma_migrations" (
+      id,
+      checksum,
+      migration_name,
+      started_at,
+      finished_at,
+      applied_steps_count
+    )
+    SELECT gen_random_uuid()::text, baseline.checksum, baseline.migration_name, now(), now(), 0
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM "_prisma_migrations" applied
+      WHERE applied.migration_name = baseline.migration_name
+    );
+
+    GET DIAGNOSTICS inserted = ROW_COUNT;
+    IF inserted = 1 THEN
+      RAISE NOTICE 'Baselined %.', baseline.migration_name;
+    ELSE
+      RAISE NOTICE 'Already recorded: %.', baseline.migration_name;
+    END IF;
+  END LOOP;
+END $$;

--- a/prisma/migrations/20260725190000_adopt_legacy_restaurant_schema/migration.sql
+++ b/prisma/migrations/20260725190000_adopt_legacy_restaurant_schema/migration.sql
@@ -1,0 +1,197 @@
+-- Adopts a database still on the pre-multi-vertical restaurant schema (everything up to
+-- `20260723221500_persist_import_identity`) without dropping a row.
+--
+-- Databases created by `20260724200000_init` are already in the target shape, so the whole
+-- body is skipped when the legacy `Restaurant` table is absent. That makes this migration a
+-- no-op on fresh databases and on any database that has already been adopted.
+--
+-- The legacy database is baselined with `prisma migrate resolve --applied` for
+-- `20260724200000_init`, `20260724210000_integration_venue_id` and
+-- `20260725000000_beauty_vertical` before `migrate deploy` runs, so this file also has to
+-- carry what those three would have created: the `Vertical` enum with both values,
+-- `Integration.venueId`, and `ImportJob.vertical`.
+DO $$
+DECLARE
+  constraint_rename RECORD;
+BEGIN
+  IF to_regclass('public."Restaurant"') IS NULL THEN
+    RETURN;
+  END IF;
+
+  -- Enums. `RestaurantStatus` and `SiteStatus` carry identical values, so a rename keeps
+  -- every existing column binding intact.
+  ALTER TYPE "RestaurantStatus" RENAME TO "SiteStatus";
+  CREATE TYPE "Vertical" AS ENUM ('RESTAURANT', 'BEAUTY');
+  CREATE TYPE "BookingRequestStatus" AS ENUM ('NEW', 'NOTIFIED', 'CONTACTED', 'CLOSED');
+
+  -- Tables. Postgres leaves constraint and index names untouched by a table rename, so each
+  -- one is renamed explicitly to match what `20260724200000_init` would have produced.
+  ALTER TABLE "Restaurant" RENAME TO "Site";
+  ALTER TABLE "MenuSection" RENAME TO "CatalogSection";
+  ALTER TABLE "MenuItem" RENAME TO "CatalogItem";
+
+  ALTER TABLE "Site" RENAME CONSTRAINT "Restaurant_pkey" TO "Site_pkey";
+  ALTER TABLE "Site" RENAME CONSTRAINT "Restaurant_organizationId_fkey" TO "Site_organizationId_fkey";
+  ALTER INDEX "Restaurant_slug_key" RENAME TO "Site_slug_key";
+  ALTER INDEX "Restaurant_sourceKey_key" RENAME TO "Site_sourceKey_key";
+
+  ALTER TABLE "CatalogSection" RENAME CONSTRAINT "MenuSection_pkey" TO "CatalogSection_pkey";
+  ALTER TABLE "CatalogItem" RENAME CONSTRAINT "MenuItem_pkey" TO "CatalogItem_pkey";
+  ALTER TABLE "CatalogItem" RENAME CONSTRAINT "MenuItem_sectionId_fkey" TO "CatalogItem_sectionId_fkey";
+
+  -- Foreign keys onto the renamed owner table.
+  ALTER TABLE "CatalogSection" RENAME COLUMN "restaurantId" TO "siteId";
+  ALTER TABLE "CatalogSection" RENAME CONSTRAINT "MenuSection_restaurantId_fkey" TO "CatalogSection_siteId_fkey";
+
+  ALTER TABLE "Integration" RENAME COLUMN "restaurantId" TO "siteId";
+  ALTER TABLE "Integration" RENAME CONSTRAINT "Integration_restaurantId_fkey" TO "Integration_siteId_fkey";
+
+  ALTER TABLE "ImportJob" RENAME COLUMN "restaurantId" TO "siteId";
+  ALTER TABLE "ImportJob" RENAME CONSTRAINT "ImportJob_restaurantId_fkey" TO "ImportJob_siteId_fkey";
+
+  ALTER TABLE "SiteVersion" RENAME COLUMN "restaurantId" TO "siteId";
+  ALTER TABLE "SiteVersion" RENAME CONSTRAINT "SiteVersion_restaurantId_fkey" TO "SiteVersion_siteId_fkey";
+  ALTER INDEX "SiteVersion_restaurantId_version_key" RENAME TO "SiteVersion_siteId_version_key";
+
+  ALTER TABLE "Domain" RENAME COLUMN "restaurantId" TO "siteId";
+  ALTER TABLE "Domain" RENAME CONSTRAINT "Domain_restaurantId_fkey" TO "Domain_siteId_fkey";
+
+  ALTER TABLE "ClaimInvitation" RENAME COLUMN "restaurantId" TO "siteId";
+  ALTER TABLE "ClaimInvitation" RENAME CONSTRAINT "ClaimInvitation_restaurantId_fkey" TO "ClaimInvitation_siteId_fkey";
+  ALTER INDEX "ClaimInvitation_restaurantId_email_idx" RENAME TO "ClaimInvitation_siteId_email_idx";
+
+  ALTER TABLE "AuditEvent" RENAME COLUMN "restaurantId" TO "siteId";
+  ALTER TABLE "AuditEvent" RENAME CONSTRAINT "AuditEvent_restaurantId_fkey" TO "AuditEvent_siteId_fkey";
+  ALTER INDEX "AuditEvent_restaurantId_createdAt_idx" RENAME TO "AuditEvent_siteId_createdAt_idx";
+
+  -- New columns. Every legacy row is a restaurant, so the enum defaults are already correct.
+  ALTER TABLE "Site" ADD COLUMN "vertical" "Vertical" NOT NULL DEFAULT 'RESTAURANT';
+  ALTER TABLE "Site" ADD COLUMN "attributes" JSONB NOT NULL DEFAULT '{}';
+  ALTER TABLE "CatalogItem" ADD COLUMN "attributes" JSONB NOT NULL DEFAULT '{}';
+  ALTER TABLE "Integration" ADD COLUMN "venueId" TEXT;
+  ALTER TABLE "ImportJob" ADD COLUMN "vertical" "Vertical" NOT NULL DEFAULT 'RESTAURANT';
+
+  -- Fold the food-only columns into the restaurant vertical's attribute bags. The shapes
+  -- mirror `restaurantAttributesSchema` and `restaurantItemAttributesSchema`, whose defaults
+  -- are `cuisine: ""` and `dietaryLabels: []`.
+  UPDATE "Site"
+  SET "attributes" = jsonb_build_object(
+    'cuisine', to_jsonb(COALESCE("cuisine", '')),
+    'showMenuImages', to_jsonb("showMenuImages")
+  );
+  ALTER TABLE "Site" DROP COLUMN "cuisine";
+  ALTER TABLE "Site" DROP COLUMN "showMenuImages";
+
+  UPDATE "CatalogItem"
+  SET "attributes" = jsonb_build_object(
+    'dietaryLabels', to_jsonb(COALESCE("dietaryLabels", ARRAY[]::TEXT[]))
+  );
+  ALTER TABLE "CatalogItem" DROP COLUMN "dietaryLabels";
+
+  -- Reshape the translation overlays. Renaming the tables is not enough: the JSONB payload
+  -- itself moved from the flat restaurant shape to the generic site shape, and
+  -- `findSiteDraft` hands this column straight to the vertical's Zod draft schema.
+  --   {locale, cuisine, eyebrow, description, menuSections:[{name, description,
+  --      items:[{name, description, dietaryLabels}]}], integrationLabels}
+  -- becomes
+  --   {locale, eyebrow, description, attributes:{cuisine}, catalogSections:[{name,
+  --      description, items:[{name, description, attributes:{dietaryLabels}}]}],
+  --    integrationLabels}
+  UPDATE "Site"
+  SET "translations" = COALESCE((
+    SELECT jsonb_agg(
+      jsonb_build_object(
+        'locale', translation -> 'locale',
+        'eyebrow', translation -> 'eyebrow',
+        'description', translation -> 'description',
+        'attributes', jsonb_build_object(
+          'cuisine', COALESCE(translation -> 'cuisine', '""'::jsonb)
+        ),
+        'catalogSections', COALESCE((
+          SELECT jsonb_agg(
+            jsonb_build_object(
+              'name', section -> 'name',
+              'description', section -> 'description',
+              'items', COALESCE((
+                SELECT jsonb_agg(
+                  jsonb_build_object(
+                    'name', item -> 'name',
+                    'description', item -> 'description',
+                    'attributes', jsonb_build_object(
+                      'dietaryLabels', COALESCE(item -> 'dietaryLabels', '[]'::jsonb)
+                    )
+                  )
+                  ORDER BY item_position
+                )
+                FROM jsonb_array_elements(
+                  COALESCE(section -> 'items', '[]'::jsonb)
+                ) WITH ORDINALITY AS item_rows(item, item_position)
+              ), '[]'::jsonb)
+            )
+            ORDER BY section_position
+          )
+          FROM jsonb_array_elements(
+            COALESCE(translation -> 'menuSections', '[]'::jsonb)
+          ) WITH ORDINALITY AS section_rows(section, section_position)
+        ), '[]'::jsonb),
+        'integrationLabels', COALESCE(translation -> 'integrationLabels', '[]'::jsonb)
+      )
+      ORDER BY translation_position
+    )
+    FROM jsonb_array_elements("translations") WITH ORDINALITY AS translation_rows(translation, translation_position)
+  ), '[]'::jsonb)
+  WHERE jsonb_typeof("translations") = 'array'
+    AND jsonb_array_length("translations") > 0;
+
+  -- Lead capture for sites with no booking provider of their own.
+  CREATE TABLE "BookingRequest" (
+    "id" TEXT NOT NULL,
+    "siteId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT,
+    "phone" TEXT,
+    "requestedAt" TIMESTAMP(3),
+    "partySize" INTEGER,
+    "notes" TEXT,
+    "status" "BookingRequestStatus" NOT NULL DEFAULT 'NEW',
+    "notifiedAt" TIMESTAMP(3),
+    "contactedAt" TIMESTAMP(3),
+    "closedAt" TIMESTAMP(3),
+    "source" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "BookingRequest_pkey" PRIMARY KEY ("id")
+  );
+
+  CREATE INDEX "BookingRequest_siteId_status_createdAt_idx" ON "BookingRequest"("siteId", "status", "createdAt");
+
+  ALTER TABLE "BookingRequest" ADD CONSTRAINT "BookingRequest_siteId_fkey" FOREIGN KEY ("siteId") REFERENCES "Site"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+  -- Postgres 18 gives every NOT NULL its own named constraint, and neither a table nor a
+  -- column rename touches those names -- an adopted database would keep carrying
+  -- `Restaurant_id_not_null` on "Site" forever. Prisma does not model the names, so this is
+  -- cosmetic, but normalising them keeps a raw dump of an adopted database identical to a
+  -- dump of a fresh one. Driven off the catalog rather than a hardcoded list because the
+  -- legacy names depend on how the database reached PG18 (created there vs `pg_upgrade`d),
+  -- and a single wrong name in an explicit `RENAME CONSTRAINT` would abort the migration.
+  FOR constraint_rename IN
+    SELECT c.conrelid::regclass::text AS table_ref,
+           c.conname AS current_name,
+           t.relname || '_' || a.attname || '_not_null' AS target_name
+    FROM pg_constraint c
+    JOIN pg_class t ON t.oid = c.conrelid
+    JOIN pg_namespace n ON n.oid = t.relnamespace
+    JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = c.conkey[1]
+    WHERE n.nspname = 'public'
+      AND c.contype = 'n'
+      AND c.conname IS DISTINCT FROM t.relname || '_' || a.attname || '_not_null'
+  LOOP
+    EXECUTE format(
+      'ALTER TABLE %s RENAME CONSTRAINT %I TO %I',
+      constraint_rename.table_ref,
+      constraint_rename.current_name,
+      constraint_rename.target_name
+    );
+  END LOOP;
+END $$;


### PR DESCRIPTION
## Why

The multi-vertical refactor (#27, #28, #29) shipped `20260724200000_init` as a clean-slate schema, on the assumption there was no production data to preserve. There is. The live database still runs the pre-refactor restaurant schema (`Restaurant`, `MenuSection`, `MenuItem`, `restaurantId` FKs), and its `_prisma_migrations` table holds the five v0.1.0 migrations this repo deleted.

**`main` is currently not deployable to production.** `migrate deploy` would try to create tables that already exist under different names. This migration is the forward path — no reset, no data loss.

## What it does

| | |
|---|---|
| Tables | `Restaurant`→`Site`, `MenuSection`→`CatalogSection`, `MenuItem`→`CatalogItem` |
| Enums | `RestaurantStatus`→`SiteStatus`; creates `Vertical`, `BookingRequestStatus` |
| FKs | `restaurantId`→`siteId` on Integration, ImportJob, SiteVersion, Domain, ClaimInvitation, AuditEvent, CatalogSection |
| Columns | adds `Site.vertical`, `Site.attributes`, `CatalogItem.attributes`, `Integration.venueId`, `ImportJob.vertical` |
| Attribute bags | folds `cuisine` + `showMenuImages` into `Site.attributes`, `dietaryLabels` into `CatalogItem.attributes` |
| Translations | reshapes the JSONB overlay from the flat restaurant shape to the generic site shape |
| New | `BookingRequest` table, index and FK |

Three details worth review:

1. **Constraint and index names.** `ALTER TABLE ... RENAME TO` renames neither, so an adopted database would silently keep `Restaurant_pkey` on `"Site"`. All 17 are renamed explicitly.
2. **Postgres 18 named NOT NULL constraints.** PG18 materialises every `NOT NULL` as its own `pg_constraint` row, and no rename touches those names. Normalised with a catalog-driven loop rather than a hardcoded list — `RENAME CONSTRAINT` has no `IF EXISTS`, and the legacy names depend on how the database reached 18 (created there vs `pg_upgrade`d), so one wrong guess would abort the migration.
3. **Baselining coupling.** Production gets the three prior migrations marked applied-without-executing, so this file must itself create the `Vertical` enum with *both* values (not `ADD VALUE`), add `Integration.venueId` and add `ImportJob.vertical`. Documented in the file header so the coupling isn't lost.

A `to_regclass('public."Restaurant"') IS NULL → RETURN` guard makes the entire body a no-op on fresh databases and on already-adopted ones, so one migrations folder serves every case.

## Verification

Run against local Postgres 18.4 (matching production's engine version) with a seeded copy of the legacy schema — two sites (one fully populated with two-locale translations, one sparse with NULL cuisine and `[]` translations), three catalog items, an orphaned ImportJob, and every dependent table.

- **Schema equivalence** — adopted database vs a freshly-`init`ed one: **271/271 catalog objects identical** (columns, constraints, indexes, enums), compared by name so column-ordinal gaps don't produce false positives.
- **Drift** — `prisma migrate diff` against `schema.prisma`: *No difference detected.*
- **Data** — every row and relation survives. `attributes` backfills to `{"cuisine":"French bistro","showMenuImages":true}` and `{"cuisine":"","showMenuImages":false}` for the sparse row; `dietaryLabels` carry through with their accents; the orphaned ImportJob keeps its NULL `siteId`.
- **Translations** — reshaped to `attributes.cuisine` / `catalogSections[].items[].attributes.dietaryLabels`, with locale, section and item ordering preserved and `description: null` intact. The sparse site's `[]` stays `[]`.
- **Idempotency** — re-running against an adopted database is a clean no-op; so is running against a fresh one.
- **Hand-off rehearsal** — on databases reproducing production exactly (legacy schema + the five orphaned `_prisma_migrations` rows), both hand-off routes were rehearsed: `migrate resolve --applied` ×3, and the SQL baseline script below. Each is followed by `migrate deploy` running **only** this migration, exit 0. **The orphaned history rows do not block it** — no `DELETE FROM "_prisma_migrations"` is needed.
- **Baseline script** — Prisma's checksum is the plain sha256 of `migration.sql`, confirmed by comparing `shasum -a 256` against the rows Prisma itself wrote during the CLI rehearsal. Prisma accepts the SQL-written rows without a modified-after-apply error. Running the script twice reports `Already recorded` the second time; both guards (`Restaurant` absent, `Site` present) fire correctly. The `docker exec` transport — `pg` client, SQL on stdin, `notice` handler — was executed against a real database and relays the NOTICE output shown below.

`bun run lint` clean (one pre-existing unrelated warning). Typecheck/tests/build via CI per repo policy.

## Production hand-off

**Correcting an earlier version of this description:** `deploy/aws/deploy.sh` has no migration step, but `deploy/aws/container-entrypoint.sh` does — it runs `bun run db:migrate:deploy` under `set -eu` on every container start. Migrations are **automatic**, not manual.

That changes what the operator has to do, and what happens if they forget.

**If this merges and deploys with production un-baselined:** `20260724200000_init` tries `CREATE TABLE "Site"` against a database that already has `Restaurant`, the entrypoint aborts, and the candidate container exits. `wait_for_health restofront-candidate` sees `exited`, dumps 120 log lines and returns non-zero — before the rename/cutover block. The live container is never touched. **That is a failed deploy, not data loss**, but it is avoidable.

**The one manual step is baselining, and it must happen before the new image starts.** It writes only `_prisma_migrations` rows and executes no DDL, so it is safe against the live database while the current image keeps serving.

`prisma migrate resolve --applied` can't do it: it reads the migration directory to compute a checksum, and production's deployed image predates those directories. `deploy/aws/baseline-legacy-database.sql` performs the identical three ledger writes as SQL, so it can run inside the container that is already there — which has `pg` as a runtime dependency and the production `DATABASE_URL`. Checksums are the sha256 of each `migration.sql`, verified against what Prisma itself writes.

Copy `deploy/aws/baseline-legacy-database.sql` to the deploy host (`scp` it, or paste it into a heredoc — it is 66 lines and depends on nothing), then, before merging:

```bash
docker exec -i restofront bun -e '
const { Client } = require("pg");
const client = new Client({ connectionString: process.env.DATABASE_URL });
client.on("notice", (n) => console.log(n.message));
await client.connect();
await client.query(await Bun.stdin.text());
await client.end();
' < baseline-legacy-database.sql
```

Expected output:

```
NOTICE:  Baselined 20260724200000_init.
NOTICE:  Baselined 20260724210000_integration_venue_id.
NOTICE:  Baselined 20260725000000_beauty_vertical.
```

Then merge and deploy; the entrypoint applies `20260725190000_adopt_legacy_restaurant_schema` and nothing else.

**Order: RDS snapshot → run the baseline script → merge → deploy.**

The script is guarded on `Restaurant` present and `Site` absent, and skips per-migration rows that already exist, so re-running it — or running it against a fresh or already-adopted database — is a no-op.

Also included: `/.swc` added to `.gitignore` (Next's SWC cache dir).
