### PR TITLE
fix(deploy): survive the restofront to cornershopdev host rename

### DIFF
--- a/deploy/aws/bootstrap-host.sh
+++ b/deploy/aws/bootstrap-host.sh
@@ -19,11 +19,25 @@ temporary_body="$(mktemp /etc/caddy/Caddyfile.body.XXXXXX)"
 temporary_caddyfile="$(mktemp /etc/caddy/Caddyfile.XXXXXX)"
 trap 'rm -f "$temporary_body" "$temporary_caddyfile"' EXIT
 
+# RESTOFRONT is the marker an earlier revision of this script wrote. A host
+# bootstrapped before the rename still carries that block, and the fragment we
+# append declares the same catch-all `https://` address, so dropping only the
+# current marker leaves two blocks claiming it and `caddy validate` rejects the
+# file. Keep matching the old name until no host is running the old bootstrap.
 awk '
-  /^# BEGIN CORNERSHOPDEV$/ { in_cornershopdev = 1; next }
-  /^# END CORNERSHOPDEV$/ { in_cornershopdev = 0; next }
-  !in_cornershopdev { print }
+  /^# BEGIN (CORNERSHOPDEV|RESTOFRONT)$/ { managed = 1; next }
+  /^# END (CORNERSHOPDEV|RESTOFRONT)$/ { managed = 0; next }
+  !managed { print }
 ' "$caddyfile" >"$temporary_body"
+
+# The global options block sits outside those markers, so the pre-rename run
+# left an ask endpoint naming a container this script is about to rename away.
+# Caddy denies every on-demand certificate when that endpoint stops resolving,
+# which would cost each customer domain its issuance and renewal. Retarget only
+# the exact line the old bootstrap wrote and leave operator edits untouched.
+sed -i \
+  's#ask http://restofront:3000/api/domains/authorize#ask http://cornershopdev:3000/api/domains/authorize#' \
+  "$temporary_body"
 
 {
   if ! grep -q "on_demand_tls" "$temporary_body"; then


### PR DESCRIPTION
Two defects in `bootstrap-host.sh` that block the cornershopdev migration on the existing production host.

**1. Marker mismatch aborts the bootstrap.** The awk filter strips only `# BEGIN CORNERSHOPDEV` / `# END CORNERSHOPDEV`. The live host was bootstrapped before the rename, so it carries `# BEGIN RESTOFRONT` / `# END RESTOFRONT` instead. That block survives the filter, and `Caddyfile.fragment` then appends a second `https://` catch-all site address. Caddy rejects duplicate site addresses, so `caddy validate` fails and the bootstrap exits before installing anything.

The failure is safe — validation runs in a throwaway container ahead of the write, so the live Caddyfile is never touched — but the migration cannot proceed at all until this is fixed.

**2. Stale on-demand TLS ask silently breaks customer domains.** The global options block is written *outside* the markers, so it is not part of the managed region. The `grep -q "on_demand_tls"` guard sees the pre-rename block, decides one already exists, and skips emitting a new one. The surviving block keeps asking `http://restofront:3000/api/domains/authorize` — a container the rename removes. Caddy denies on-demand certificates whenever the ask endpoint is unreachable, so every customer custom domain loses both new issuance and renewal. Unlike defect 1 this fails open into production rather than aborting.

## Changes

- awk matches `(CORNERSHOPDEV|RESTOFRONT)` so a pre-rename host is cleaned up correctly. The legacy name stays until no host runs the old bootstrap.
- A targeted `sed` retargets the exact ask line the previous revision of this script wrote, leaving any operator-authored global block untouched. The `grep -q` guard still covers a fresh host with no global block.

## Verification

`bash -n` clean. Behaviour is exercised by `caddy validate`, which the script runs twice — once in a throwaway container before writing, once against the live config before reload — so a regression here aborts rather than reaching production.