### PR TITLE
fix(deploy): keep api.restofront.com served through the rename

### DIFF
--- a/deploy/aws/Caddyfile.fragment
+++ b/deploy/aws/Caddyfile.fragment
@@ -9,6 +9,23 @@ domains.cornershop.dev {
 	respond 404
 }
 
+# api.restofront.com keeps an explicit block for the length of the rename. It
+# cannot fall through to the on-demand catch-all below: that path asks the app
+# first, and the ask endpoint authorizes only factory hostnames and verified
+# customer domains, so any deploy whose PLATFORM_HOSTNAMES has moved on to
+# cornershop.dev answers 403 and Caddy aborts the handshake. Declaring the name
+# also renews its certificate without depending on the app being up at all.
+# Delete once restofront.com traffic has moved to cornershop.dev.
+#
+# domains.restofront.com is deliberately not declared. It has no DNS record, so
+# the block it used to have could never complete a challenge and only spent this
+# instance's Let's Encrypt failure budget on every other tenant's behalf.
+api.restofront.com {
+	@workflowHandlers path /.well-known/workflow/v1/flow* /.well-known/workflow/v1/step*
+	respond @workflowHandlers 404
+	reverse_proxy cornershopdev:3000
+}
+
 https:// {
 	tls {
 		on_demand


### PR DESCRIPTION
`api.restofront.com` stopped serving TLS the moment the managed Caddy block was replaced: the new fragment declares only the `cornershop.dev` hostnames, so that name fell through to the on-demand `https://` catch-all.

On-demand asks `/api/domains/authorize` before completing a handshake, and that endpoint authorizes factory hostnames plus verified customer domains. The currently deployed revision predates `isFactoryHostname` altogether, so it answers 403 for every platform hostname — Caddy then aborts with `tlsv1 alert internal error`. The pre-rename block never hit this because it declared the name explicitly.

This restores the explicit block, which also reuses the certificate already in Caddy's storage.

`domains.restofront.com` is deliberately **not** restored — it has no DNS record at all, so its old block could never complete an ACME challenge and only consumed the shared instance's Let's Encrypt failure budget. Cert storage confirms it: `api.restofront.com`, `api.cornershop.dev` and `domains.cornershop.dev` are present, that one never was.