### PR TITLE
feat(email): let each niche send as the domain it owns

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,7 +45,10 @@ STRIPE_GROWTH_PRICE_ID=
 # Claim links and email delivery
 CLAIM_TOKEN_SECRET=replace-with-at-least-32-random-characters
 RESEND_API_KEY=
+# The floor, not the identity. A launched niche declares its own sender in
+# `src/lib/verticals/<niche>/marketing.ts` and that always wins — these two only
+# cover a niche with no verified sending domain of its own yet.
 EMAIL_FROM=Cornershopdev <hello@cornershop.dev>
-# Where a reply to a platform email lands. EMAIL_FROM may point at a send-only
-# subdomain nobody reads; leave this unset and the header is simply omitted.
+# Where a reply lands when the fallback above was used. Leave unset and the
+# header is simply omitted.
 EMAIL_REPLY_TO=hello@cornershop.dev

--- a/src/app/api/auth/magic-link/route.ts
+++ b/src/app/api/auth/magic-link/route.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 import { getDb } from "@/lib/db";
-import { emailSender, getResend, platformReplyTo } from "@/lib/resend";
+import { emailReplyTo, emailSender, getResend } from "@/lib/resend";
 import { createSessionToken } from "@/lib/session";
+import { resolveVerticalConfig } from "@/lib/verticals/registry";
 
 const schema = z.object({ email: z.email() });
 
@@ -39,15 +40,20 @@ export async function POST(request: Request) {
     const appUrl =
       process.env.NEXT_PUBLIC_APP_URL ?? new URL(request.url).origin;
     const verifyUrl = `${appUrl}/api/auth/verify?token=${encodeURIComponent(token)}`;
+    // The niche that sold this site owns the whole message — sender, reply
+    // address and the name in the copy. The factory's name appearing here would
+    // introduce a brand the recipient has never bought from, in the one email
+    // they must trust enough to click.
+    const brand = resolveVerticalConfig(site.vertical).marketing.brand;
     const { error } = await getResend().emails.send(
       {
-        from: emailSender(),
+        from: emailSender(site.vertical),
         to: email,
-        replyTo: platformReplyTo(),
-        subject: `Open ${site.name} in Cornershopdev`,
+        replyTo: emailReplyTo(site.vertical),
+        subject: `Open ${site.name} in ${brand.name}`,
         html: `<div style="font-family:Arial,sans-serif;background:#f4efe5;padding:40px">
           <div style="max-width:520px;margin:auto;background:white;border-radius:18px;padding:32px">
-            <p style="font-size:13px;color:#a5482d;font-weight:700">CORNERSHOPDEV</p>
+            <p style="font-size:13px;color:#a5482d;font-weight:700">${brand.name.toUpperCase()}</p>
             <h1 style="font-size:30px;line-height:1.05;margin:18px 0">Your site is ready.</h1>
             <p style="color:#5e5b55;line-height:1.6">Use the secure link below to open the ${site.name} dashboard. It expires in 20 minutes.</p>
             <p style="margin:28px 0"><a href="${verifyUrl}" style="background:#a5482d;color:white;text-decoration:none;padding:13px 20px;border-radius:10px;font-weight:700">Open dashboard</a></p>
@@ -68,7 +74,9 @@ export async function POST(request: Request) {
     return Response.json(
       {
         error:
-          error instanceof Error ? error.message : "Sign-in link could not be sent",
+          error instanceof Error
+            ? error.message
+            : "Sign-in link could not be sent",
       },
       { status: 400 },
     );

--- a/src/app/api/sites/[slug]/booking-requests/route.ts
+++ b/src/app/api/sites/[slug]/booking-requests/route.ts
@@ -55,7 +55,14 @@ export async function POST(request: Request, { params }: RouteContext) {
 
     const site = await getDb().site.findUnique({
       where: { slug },
-      select: { id: true, name: true, slug: true, organizationId: true },
+      select: {
+        id: true,
+        name: true,
+        slug: true,
+        organizationId: true,
+        // Decides which niche the owner's notification is sent as.
+        vertical: true,
+      },
     });
     if (!site) {
       return NextResponse.json({ error: "Site not found" }, { status: 404 });

--- a/src/lib/booking-requests.ts
+++ b/src/lib/booking-requests.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 import { getDb } from "@/lib/db";
 import { emailSender, getResend } from "@/lib/resend";
+import { resolveVerticalConfig } from "@/lib/verticals/registry";
+import type { VerticalId } from "@/lib/verticals/types";
 
 const YEAR_MS = 365 * 24 * 60 * 60_000;
 
@@ -57,6 +59,8 @@ export type BookingRequestSite = {
   name: string;
   slug: string;
   organizationId: string | null;
+  /** Which niche's identity this site's mail goes out under. */
+  vertical: VerticalId;
 };
 
 export type CreatedBookingRequest = {
@@ -161,10 +165,11 @@ export async function notifyOwnerOfBookingRequest(
 
   const { error } = await getResend().emails.send(
     {
-      from: emailSender(),
+      from: emailSender(site.vertical),
       to: recipients,
-      // Deliberately not falling back to the platform address: an owner hitting
-      // reply expects the diner, and reaching us instead would read as one.
+      // Deliberately not falling back to the niche's own address: an owner
+      // hitting reply expects the diner, and reaching us instead would read as
+      // one.
       replyTo: request.email ?? undefined,
       subject: `New booking request for ${site.name}`,
       html: bookingRequestEmailHtml(site, request),
@@ -207,9 +212,14 @@ function bookingRequestEmailHtml(
     )
     .join("");
 
+  // The niche the owner bought from, not the factory that built it. This lands
+  // beside the sender address, so a mismatch between the two is the thing that
+  // makes an otherwise ordinary notification look forged.
+  const brand = resolveVerticalConfig(site.vertical).marketing.brand;
+
   return `<div style="font-family:Arial,sans-serif;background:#f4efe5;padding:40px">
   <div style="max-width:520px;margin:0 auto;background:#fffdf8;border-radius:16px;padding:32px">
-    <p style="margin:0 0 8px;letter-spacing:0.18em;text-transform:uppercase;font-size:11px;color:#a5482d">CORNERSHOPDEV</p>
+    <p style="margin:0 0 8px;letter-spacing:0.18em;text-transform:uppercase;font-size:11px;color:#a5482d">${escapeHtml(brand.name.toUpperCase())}</p>
     <h1 style="margin:0 0 16px;font-size:22px;color:#2f2a24">New booking request</h1>
     <p style="margin:0 0 24px;font-size:15px;color:#5c5147">Someone asked to book with ${escapeHtml(site.name)} through your website.</p>
     <table style="border-collapse:collapse">${body}</table>

--- a/src/lib/resend.test.ts
+++ b/src/lib/resend.test.ts
@@ -1,32 +1,71 @@
 import { describe, expect, it } from "bun:test";
-import { emailSender, platformReplyTo } from "@/lib/resend";
+import { Vertical } from "@/generated/prisma/enums";
+import { emailReplyTo, emailSender } from "@/lib/resend";
+import { restaurantMarketing } from "@/lib/verticals/restaurant/marketing";
 
+/**
+ * Who a customer hears from. Every customer arrives through a niche storefront,
+ * so the niche that sold the site owns the envelope — the factory's identity
+ * reaching a restaurant's inbox is the failure these cover.
+ */
 describe("emailSender", () => {
-  it("sends as the configured identity", () => {
+  it("sends as the niche that owns the site", () => {
+    expect(emailSender(Vertical.RESTAURANT)).toBe(
+      restaurantMarketing.email!.from,
+    );
+  });
+
+  /**
+   * The precedence that matters: EMAIL_FROM is a floor for niches without their
+   * own verified domain, never an override. A deploy-wide value must not be able
+   * to put one niche's address on another niche's mail.
+   */
+  it("prefers the niche's identity over the deploy-wide one", () => {
     expect(
-      emailSender({ EMAIL_FROM: "Vincent <vincent@send.cornershop.dev>" }),
-    ).toBe("Vincent <vincent@send.cornershop.dev>");
+      emailSender(Vertical.RESTAURANT, { EMAIL_FROM: "Someone <a@b.test>" }),
+    ).toBe(restaurantMarketing.email!.from);
+  });
+
+  it("falls back to EMAIL_FROM for a niche that has not launched a sender", () => {
+    expect(
+      emailSender(Vertical.BEAUTY, { EMAIL_FROM: "Floor <a@b.test>" }),
+    ).toBe("Floor <a@b.test>");
+    expect(emailSender(null, { EMAIL_FROM: "Floor <a@b.test>" })).toBe(
+      "Floor <a@b.test>",
+    );
   });
 
   it("falls back to the shared domain when unset or blank", () => {
     // deploy.sh drops empty parameters, but a half-filled local `.env` would
     // otherwise hand Resend an empty `from` and fail every send.
-    expect(emailSender({})).toBe("Cornershopdev <onboarding@resend.dev>");
-    expect(emailSender({ EMAIL_FROM: "" })).toBe(
+    expect(emailSender(Vertical.BEAUTY, {})).toBe(
+      "Cornershopdev <onboarding@resend.dev>",
+    );
+    expect(emailSender(Vertical.BEAUTY, { EMAIL_FROM: "" })).toBe(
       "Cornershopdev <onboarding@resend.dev>",
     );
   });
 });
 
-describe("platformReplyTo", () => {
-  it("points replies at a mailbox a human reads", () => {
-    expect(platformReplyTo({ EMAIL_REPLY_TO: "vincent@cornershop.dev" })).toBe(
-      "vincent@cornershop.dev",
+describe("emailReplyTo", () => {
+  it("points replies at a mailbox the niche reads", () => {
+    expect(emailReplyTo(Vertical.RESTAURANT)).toBe(
+      restaurantMarketing.email!.replyTo,
     );
   });
 
+  it("falls back to EMAIL_REPLY_TO for a niche without its own", () => {
+    expect(
+      emailReplyTo(Vertical.BEAUTY, {
+        EMAIL_REPLY_TO: "vincent@cornershop.dev",
+      }),
+    ).toBe("vincent@cornershop.dev");
+  });
+
   it("stays undefined when unset, leaving the header off", () => {
-    expect(platformReplyTo({})).toBeUndefined();
-    expect(platformReplyTo({ EMAIL_REPLY_TO: "" })).toBeUndefined();
+    expect(emailReplyTo(Vertical.BEAUTY, {})).toBeUndefined();
+    expect(
+      emailReplyTo(Vertical.BEAUTY, { EMAIL_REPLY_TO: "" }),
+    ).toBeUndefined();
   });
 });

--- a/src/lib/resend.ts
+++ b/src/lib/resend.ts
@@ -1,4 +1,6 @@
 import { Resend } from "resend";
+import { resolveVerticalConfig } from "@/lib/verticals/registry";
+import type { VerticalId } from "@/lib/verticals/types";
 
 let resend: Resend | undefined;
 
@@ -12,30 +14,55 @@ export function getResend(): Resend {
 }
 
 /**
- * The sending identity every outbound message shares, so one verified domain
- * covers all of them. The resend.dev fallback only reaches a developer machine;
- * deployments set EMAIL_FROM. A blank value counts as unset — Resend rejects an
- * empty `from` outright, and a half-filled `.env` should not break sign-in.
- */
-export function emailSender(environment: EmailEnvironment = process.env): string {
-  return environment.EMAIL_FROM || "Cornershopdev <onboarding@resend.dev>";
-}
-
-/**
- * Where a reply to a platform email lands. EMAIL_FROM points at a send-only
- * subdomain nobody reads, so without this a recipient who hits reply is talking
- * to a black hole. Unset leaves the header off, which is the prior behaviour.
- */
-export function platformReplyTo(
-  environment: EmailEnvironment = process.env,
-): string | undefined {
-  return environment.EMAIL_REPLY_TO || undefined;
-}
-
-/**
  * Reads EMAIL_FROM and EMAIL_REPLY_TO. Deliberately an index signature rather
  * than those two names: `process.env` is a weak type under bun-types, so a
  * type listing only optional keys it does not declare is not assignable to it.
  * Same shape `platform-readiness` uses for the same reason.
  */
 type EmailEnvironment = Record<string, string | undefined>;
+
+/**
+ * The niche's declared sending identity, or null when it has not launched one.
+ * An absent vertical — a caller with no site in hand — resolves the same way, so
+ * the environment fallback below covers both without a second branch.
+ */
+function nicheEmail(vertical: VerticalId | null | undefined) {
+  return vertical ? resolveVerticalConfig(vertical).marketing.email : null;
+}
+
+/**
+ * The address a message goes out as, resolved from the niche that owns the site
+ * it concerns rather than from one platform-wide identity. A restaurant bought
+ * Restofront, so Restofront is who writes to it — the same rule the wordmark
+ * already follows, applied to the envelope.
+ *
+ * EMAIL_FROM survives only as the floor for a niche with no verified sending
+ * domain of its own. The resend.dev fallback beneath it reaches a developer
+ * machine and nothing else; a blank value counts as unset, because Resend
+ * rejects an empty `from` outright and a half-filled `.env` should not break
+ * sign-in.
+ */
+export function emailSender(
+  vertical?: VerticalId | null,
+  environment: EmailEnvironment = process.env,
+): string {
+  return (
+    nicheEmail(vertical)?.from ||
+    environment.EMAIL_FROM ||
+    "Cornershopdev <onboarding@resend.dev>"
+  );
+}
+
+/**
+ * Where a reply lands. Senders are send-only subdomains nobody reads, so without
+ * this a recipient who hits reply is talking to a black hole. Undefined leaves
+ * the header off, which is the prior behaviour.
+ */
+export function emailReplyTo(
+  vertical?: VerticalId | null,
+  environment: EmailEnvironment = process.env,
+): string | undefined {
+  return (
+    nicheEmail(vertical)?.replyTo || environment.EMAIL_REPLY_TO || undefined
+  );
+}

--- a/src/lib/verticals/beauty/marketing.ts
+++ b/src/lib/verticals/beauty/marketing.ts
@@ -14,6 +14,9 @@ export const beautyMarketing = {
   hostnames: [],
   domain: null,
   brand: { name: "Salonfront", initials: "SF" },
+  // No domain yet, so no sending domain to verify either. Launching means a DNS
+  // record, a verified sender, and these two strings — in that order.
+  email: null,
   audience: "salons and barbers",
   tagline: "A service list and a booking button, always up to date.",
   heroVisual: "none",

--- a/src/lib/verticals/registry.test.ts
+++ b/src/lib/verticals/registry.test.ts
@@ -124,7 +124,9 @@ describe("vertical registry", () => {
     );
 
     expect(draft.attributes).toEqual(beautyConfig.attributeDefaults);
-    expect(draft.catalogSections[0]?.name).toBe(beautyConfig.vocabulary.catalog);
+    expect(draft.catalogSections[0]?.name).toBe(
+      beautyConfig.vocabulary.catalog,
+    );
   });
 });
 
@@ -199,6 +201,26 @@ describe("niche routing", () => {
     const launched = ordered.map((id) =>
       Boolean(resolveVerticalConfig(id).marketing.domain),
     );
-    expect(launched).toEqual([...launched].sort((a, b) => Number(b) - Number(a)));
+    expect(launched).toEqual(
+      [...launched].sort((a, b) => Number(b) - Number(a)),
+    );
+  });
+
+  /**
+   * The two halves of launching a niche, tied together. A niche with a domain is
+   * selling, and a selling niche writes to its customers — if it has no sender of
+   * its own, `emailSender` falls through to the deploy-wide `EMAIL_FROM` and a
+   * salon owner gets their sign-in link from Restofront. Adding the domain and
+   * forgetting the sender is exactly the omission that produces that, so it fails
+   * here instead of in someone's inbox.
+   */
+  it("gives every launched niche a sender of its own", () => {
+    for (const id of listVerticalIds()) {
+      const { domain, email } = resolveVerticalConfig(id).marketing;
+      if (!domain) continue;
+      expect(email).not.toBeNull();
+      expect(email?.from).toContain("@");
+      expect(email?.replyTo).toContain("@");
+    }
   });
 });

--- a/src/lib/verticals/restaurant/marketing.ts
+++ b/src/lib/verticals/restaurant/marketing.ts
@@ -10,6 +10,12 @@ export const restaurantMarketing = {
   hostnames: ["restofront.com", "www.restofront.com"],
   domain: "restofront.com",
   brand: { name: "Restofront", initials: "RF" },
+  // send.restofront.com is the verified sending domain; nobody reads it, so
+  // replies are pointed at the bare domain instead.
+  email: {
+    from: "Vincent from Restofront <vincent@send.restofront.com>",
+    replyTo: "vincent@restofront.com",
+  },
   audience: "restaurants",
   tagline: "Menus, bookings and hours that stay current on their own.",
   heroVisual: "transformation",

--- a/src/lib/verticals/types.ts
+++ b/src/lib/verticals/types.ts
@@ -10,10 +10,7 @@ export type CatalogVocabulary = {
 };
 
 export type IntegrationLinkType =
-  | "booking"
-  | "ordering"
-  | "delivery"
-  | "social";
+  "booking" | "ordering" | "delivery" | "social";
 
 /**
  * How a provider's own booking widget is embedded on a generated site.
@@ -94,12 +91,7 @@ export type LinkClassificationHint = {
  * mapping, so an unmapped name is a build error rather than a blank square.
  */
 export type MarketingIconName =
-  | "catalog"
-  | "imagery"
-  | "booking"
-  | "refresh"
-  | "shield"
-  | "cursor";
+  "catalog" | "imagery" | "booking" | "refresh" | "shield" | "cursor";
 
 export type MarketingPlan = {
   name: string;
@@ -130,6 +122,19 @@ export type VerticalMarketing = {
   /** Bare domain printed as the niche's public identity, or null while unlaunched. */
   domain: string | null;
   brand: { name: string; initials: string };
+  /**
+   * The address this niche's mail goes out as, and where a reply to it lands.
+   * Every customer arrives through a niche storefront, so every customer email
+   * is a niche email: a restaurant that bought Restofront must never receive a
+   * sign-in link from a factory address it has never heard of.
+   *
+   * Null until the niche's sending domain is verified with the mail provider.
+   * That is not a soft default — a niche cannot send as a domain it does not
+   * own, and borrowing a launched niche's address would put Restofront's name
+   * on a salon's mail. So this gates launch alongside `domain`: a niche is
+   * live when it has both, and until then `EMAIL_FROM` covers the stragglers.
+   */
+  email: { from: string; replyTo: string } | null;
   /** Plural noun for the businesses served: "restaurants", "salons and barbers". */
   audience: string;
   /** One line under the niche's name on the factory homepage. */


### PR DESCRIPTION
## Why

A customer never buys from the factory. They land on `restofront.com`, pay Restofront — and then got their sign-in link from a **Cornershopdev** address, with `CORNERSHOPDEV` printed above the button they were being asked to click. The one email whose entire job is to look legitimate was introducing a brand the recipient had never heard of.

## What changed

**The sending identity lives in the vertical's marketing block**, beside the domain and wordmark it has to match — not in an env var. A new niche is a config entry, not an SSM write plus a redeploy.

```ts
// restaurant
email: {
  from: "Vincent from Restofront <vincent@send.restofront.com>",
  replyTo: "vincent@restofront.com",
}

// beauty — no domain yet, so no sending domain to verify either
email: null,
```

**`null` is a launch gate, not a soft default.** A niche cannot send as a domain it does not own, and borrowing a launched niche's address would put Restofront's name on a salon's mail. So `EMAIL_FROM` is demoted from *the* platform identity to the floor for niches without a verified sender of their own.

**Resolution is free.** Every send site already holds the site, and `Site.vertical` is a required column, so `emailSender(vertical)` / `emailReplyTo(vertical)` (was `platformReplyTo`) always have what they need. No new queries — just `vertical: true` added to one existing `select`.

**Same fix for the body copy.** Both templates hardcoded the factory brand where the niche's belongs; both now resolve it. A brand mismatch between the envelope and the letterhead is exactly what makes an ordinary notification read as forged.

## Precedence

| | sender |
|---|---|
| launched niche | its own `email.from` — wins over `EMAIL_FROM` |
| unlaunched niche / no site in hand | `EMAIL_FROM` |
| neither set | `onboarding@resend.dev` (reaches a dev machine and nothing else) |

Blank counts as unset throughout: Resend rejects an empty `from` outright, and a half-filled local `.env` should not break sign-in.

## Tests

`resend.test.ts` covers each rung of that table, including that `EMAIL_FROM` cannot override a launched niche. `registry.test.ts` gains the invariant that ties the two halves of launching together — **add a domain without a sender and it fails in CI, not in an owner's inbox.**

## Not in scope

`NEXT_PUBLIC_APP_URL` still sends a Restofront owner to `cornershop.dev` for the magic-link redirect and Stripe checkout. Same leak, different axis; separate PR.