### PR TITLE
fix(deploy): drop api.restofront.com; platform ingress is cornershop.dev only

### DIFF
--- a/deploy/aws/Caddyfile.fragment
+++ b/deploy/aws/Caddyfile.fragment
@@ -9,22 +9,21 @@ domains.cornershop.dev {
 	respond 404
 }
 
-# api.restofront.com keeps an explicit block for the length of the rename. It
-# cannot fall through to the on-demand catch-all below: that path asks the app
-# first, and the ask endpoint authorizes only factory hostnames and verified
-# customer domains, so any deploy whose PLATFORM_HOSTNAMES has moved on to
-# cornershop.dev answers 403 and Caddy aborts the handshake. Declaring the name
-# also renews its certificate without depending on the app being up at all.
-# Delete once restofront.com traffic has moved to cornershop.dev.
+# No niche gets its own platform subdomain. Every ingress the factory operates —
+# api, domains, assets — lives under cornershop.dev, and a niche brings only the
+# storefront domain its customers actually type. So api.restofront.com and
+# domains.restofront.com are both absent by design, not by oversight:
 #
-# domains.restofront.com is deliberately not declared. It has no DNS record, so
-# the block it used to have could never complete a challenge and only spent this
-# instance's Let's Encrypt failure budget on every other tenant's behalf.
-api.restofront.com {
-	@workflowHandlers path /.well-known/workflow/v1/flow* /.well-known/workflow/v1/step*
-	respond @workflowHandlers 404
-	reverse_proxy cornershopdev:3000
-}
+#   - api.restofront.com was an alternate ingress to this same container. The app
+#     is single-origin, the deploy pipeline health-checks api.cornershop.dev, and
+#     restofront.com itself is served elsewhere, so nothing addressed it but
+#     uptime probes and vulnerability scanners.
+#   - domains.restofront.com never had a DNS record, so the block it used to have
+#     could not complete a challenge and only spent this instance's Let's Encrypt
+#     failure budget, which is shared with every other tenant on the host.
+#
+# A niche storefront still reaches the app through the on-demand block below,
+# which authorizes it via the vertical registry rather than a hardcoded name.
 
 https:// {
 	tls {


### PR DESCRIPTION
A niche brings a storefront domain, not a platform subdomain. api.restofront.com
was an alternate ingress to the same container: the app is single-origin, the
deploy pipeline health-checks api.cornershop.dev, and restofront.com is served
elsewhere, so the only clients addressing it were uptime probes and scanners.

Removing the explicit block lets the name fall through to the on-demand catch-all,
where the ask endpoint declines it and the certificate lapses on its own. Niche
storefronts keep reaching the app through that same block, authorized by the
vertical registry rather than a hardcoded hostname.
