### PR TITLE
feat(storage): give every niche its own folder in the shared asset bucket

### DIFF
--- a/src/app/api/images/enhance/route.ts
+++ b/src/app/api/images/enhance/route.ts
@@ -66,6 +66,7 @@ export async function POST(request: Request) {
     const originalImage = await fetchPublicImage(sourceImageUrl);
     const originalUrl = await storeSiteImage({
       siteSlug,
+      vertical,
       data: originalImage.data,
       mediaType: originalImage.mediaType,
       purpose: "original-hero",
@@ -84,6 +85,7 @@ export async function POST(request: Request) {
     );
     const url = await storeSiteImage({
       siteSlug,
+      vertical,
       data: image.data,
       mediaType: image.mediaType,
       purpose: "hero",

--- a/src/lib/platform-readiness.test.ts
+++ b/src/lib/platform-readiness.test.ts
@@ -11,7 +11,7 @@ const configuredEnvironment = {
   NODE_ENV: "production",
   DATABASE_URL: "postgresql://preview.example.test/cornershopdev",
   REDIS_URL: "redis://redis.example.test:6379",
-  S3_BUCKET: "cornershopdev-images",
+  S3_BUCKET: "assets.cornershop.dev",
   S3_PUBLIC_BASE_URL: "https://assets.cornershopdev.example.test",
   AWS_REGION: "us-west-1",
 };
@@ -111,9 +111,7 @@ describe("checkPlatformReadiness", () => {
       message:
         "Configured but unreachable. Check provider status and credentials.",
     });
-    expect(serialized).not.toContain(
-      configuredEnvironment.REDIS_URL,
-    );
+    expect(serialized).not.toContain(configuredEnvironment.REDIS_URL);
     expect(serialized).not.toContain(configuredEnvironment.S3_BUCKET);
     expect(serialized).not.toContain(configuredEnvironment.DATABASE_URL);
   });
@@ -146,9 +144,12 @@ describe("checkPlatformReadiness", () => {
 
 describe("platform readiness endpoint protection", () => {
   it("fails closed without a configured token", () => {
-    const request = new Request("https://cornershopdev.example/api/health/ready", {
-      headers: { Authorization: "Bearer supplied-token" },
-    });
+    const request = new Request(
+      "https://cornershopdev.example/api/health/ready",
+      {
+        headers: { Authorization: "Bearer supplied-token" },
+      },
+    );
 
     expect(isPlatformReadinessAuthorized(request, "")).toBe(false);
   });
@@ -189,10 +190,7 @@ describe("platform readiness endpoint protection", () => {
       ttlMs: 5_000,
     });
 
-    const [first, second] = await Promise.all([
-      getReadiness(),
-      getReadiness(),
-    ]);
+    const [first, second] = await Promise.all([getReadiness(), getReadiness()]);
     const cached = await getReadiness();
 
     expect(first).toBe(readiness);

--- a/src/lib/storage/images.test.ts
+++ b/src/lib/storage/images.test.ts
@@ -9,22 +9,22 @@ describe("image storage configuration", () => {
     expect(
       getImageStorageConfig({
         AWS_REGION: "us-west-1",
-        S3_BUCKET: "cornershopdev-images",
+        S3_BUCKET: "assets.cornershop.dev",
         S3_PUBLIC_BASE_URL: "https://assets.cornershop.dev/",
       }),
     ).toEqual({
       region: "us-west-1",
-      bucket: "cornershopdev-images",
+      bucket: "assets.cornershop.dev",
       publicBaseUrl: "https://assets.cornershop.dev",
     });
   });
 
   it("requires every runtime value", () => {
-    expect(imageStorageIsConfigured({ S3_BUCKET: "cornershopdev-images" })).toBe(
-      false,
-    );
+    expect(
+      imageStorageIsConfigured({ S3_BUCKET: "assets.cornershop.dev" }),
+    ).toBe(false);
     expect(() =>
-      getImageStorageConfig({ S3_BUCKET: "cornershopdev-images" }),
+      getImageStorageConfig({ S3_BUCKET: "assets.cornershop.dev" }),
     ).toThrow("S3_BUCKET, S3_PUBLIC_BASE_URL, and AWS_REGION");
   });
 });

--- a/src/lib/storage/images.ts
+++ b/src/lib/storage/images.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { verticalAssetNamespace } from "@/lib/verticals/registry";
+import type { VerticalId } from "@/lib/verticals/types";
 
 type Environment = Record<string, string | undefined>;
 
@@ -21,6 +23,7 @@ export function imageStorageIsConfigured(env: Environment = process.env) {
 
 export async function storeSiteImage(input: {
   siteSlug: string;
+  vertical: VerticalId;
   data: Uint8Array;
   mediaType: string;
   purpose: "hero" | "catalog" | "original-hero";
@@ -28,9 +31,11 @@ export async function storeSiteImage(input: {
   const { bucket, publicBaseUrl, region } = getImageStorageConfig();
   const extension =
     input.mediaType.split("/")[1]?.replace("jpeg", "jpg") ?? "png";
-  // Keys are only ever written here and stored whole; changing the prefix leaves
-  // any object written under the old one reachable by its already-stored URL.
-  const key = `sites/${input.siteSlug}/${input.purpose}-${randomUUID()}.${extension}`;
+  // One bucket serves every niche, so the niche's own folder comes first and a
+  // site slug only has to be unique within it. Keys are only ever written here
+  // and stored whole; changing the prefix leaves any object written under the
+  // old one reachable by its already-stored URL.
+  const key = `${verticalAssetNamespace(input.vertical)}/sites/${input.siteSlug}/${input.purpose}-${randomUUID()}.${extension}`;
   const s3 = new S3Client({ region });
   await s3.send(
     new PutObjectCommand({

--- a/src/lib/verticals/registry.test.ts
+++ b/src/lib/verticals/registry.test.ts
@@ -13,6 +13,7 @@ import {
   resolveVerticalByHostname,
   resolveVerticalBySlug,
   resolveVerticalConfig,
+  verticalAssetNamespace,
   verticalSlug,
 } from "@/lib/verticals/registry";
 import { restaurantConfig } from "@/lib/verticals/restaurant/config";
@@ -124,7 +125,9 @@ describe("vertical registry", () => {
     );
 
     expect(draft.attributes).toEqual(beautyConfig.attributeDefaults);
-    expect(draft.catalogSections[0]?.name).toBe(beautyConfig.vocabulary.catalog);
+    expect(draft.catalogSections[0]?.name).toBe(
+      beautyConfig.vocabulary.catalog,
+    );
   });
 });
 
@@ -180,6 +183,23 @@ describe("niche routing", () => {
     expect(resolveVerticalByHostname("")).toBeNull();
   });
 
+  /**
+   * Every niche writes into the one `assets.cornershop.dev` bucket, so a
+   * collision here would let two niches overwrite each other's images.
+   */
+  it("gives every niche its own asset folder, named after its domain", () => {
+    expect(verticalAssetNamespace(Vertical.RESTAURANT)).toBe("restofrontcom");
+    expect(verticalAssetNamespace(Vertical.BEAUTY)).toBe(
+      verticalSlug(Vertical.BEAUTY),
+    );
+
+    const namespaces = listVerticalIds().map(verticalAssetNamespace);
+    expect(new Set(namespaces).size).toBe(namespaces.length);
+    for (const namespace of namespaces) {
+      expect(namespace).toMatch(/^[a-z0-9]+$/);
+    }
+  });
+
   it("lets no two verticals register the same hostname", () => {
     const claimed = listVerticalIds().flatMap(
       (id) => resolveVerticalConfig(id).marketing.hostnames,
@@ -199,6 +219,8 @@ describe("niche routing", () => {
     const launched = ordered.map((id) =>
       Boolean(resolveVerticalConfig(id).marketing.domain),
     );
-    expect(launched).toEqual([...launched].sort((a, b) => Number(b) - Number(a)));
+    expect(launched).toEqual(
+      [...launched].sort((a, b) => Number(b) - Number(a)),
+    );
   });
 });

--- a/src/lib/verticals/registry.ts
+++ b/src/lib/verticals/registry.ts
@@ -52,6 +52,27 @@ export function verticalSlug(id: VerticalId): string {
 }
 
 /**
+ * The niche's own folder inside the shared asset bucket. `assets.cornershop.dev`
+ * holds every niche's images, so an object key has to name the niche that wrote
+ * it — otherwise two niches that both generated a site called `luigi` would
+ * write over each other, and no operator looking at the bucket could tell whose
+ * files were whose.
+ *
+ * Derived from the niche's public domain with the separators dropped, so
+ * restofront.com owns `restofrontcom/`: the folder reads as the storefront it
+ * belongs to rather than as an internal enum member. An unlaunched niche has no
+ * domain and falls back to its slug, which is the only stable name it has; when
+ * it later gets a domain, objects already written keep their stored URLs, since
+ * keys are only ever composed at write time.
+ */
+export function verticalAssetNamespace(id: VerticalId): string {
+  const { domain } = resolveVerticalConfig(id).marketing;
+  return domain
+    ? domain.toLowerCase().replace(/[^a-z0-9]+/g, "")
+    : verticalSlug(id);
+}
+
+/**
  * The inverse, for a slug that arrived from a URL or a form field and is
  * therefore untrusted. Returns null rather than throwing so callers decide
  * between a 404 and a silent fall back to the default vertical.
@@ -79,7 +100,8 @@ export function resolveVerticalByHostname(hostname: string): VerticalId | null {
     // yields the union of the concrete configs, and `includes` on a union of array
     // types demands an argument assignable to every element type at once — which
     // is `never` the moment one vertical registers no hostnames.
-    if (resolveVerticalConfig(id).marketing.hostnames.includes(wanted)) return id;
+    if (resolveVerticalConfig(id).marketing.hostnames.includes(wanted))
+      return id;
   }
   return null;
 }

--- a/src/workflows/site-import.ts
+++ b/src/workflows/site-import.ts
@@ -190,6 +190,7 @@ async function enhanceDraftImages(
     const originalImage = await fetchPublicImage(originalUrl);
     const storedOriginalUrl = await storeSiteImage({
       siteSlug: draft.slug,
+      vertical,
       data: originalImage.data,
       mediaType: originalImage.mediaType,
       purpose: "original-hero",
@@ -203,6 +204,7 @@ async function enhanceDraftImages(
     );
     const heroImageUrl = await storeSiteImage({
       siteSlug: draft.slug,
+      vertical,
       data: image.data,
       mediaType: image.mediaType,
       purpose: "hero",


### PR DESCRIPTION
## What

Object keys written to the shared asset bucket now open with the niche's own folder. `restofront.com` owns `restofrontcom/`, so a hero image lands at:

```
restofrontcom/sites/<slug>/hero-<uuid>.jpg
```

## Why

`assets.cornershop.dev` is one bucket for the whole factory. A key that starts at `sites/<slug>/` says nothing about which niche wrote it — two niches that both generate a site called `luigi` overwrite each other, and no operator looking at the bucket can tell whose files are whose.

## How

`verticalAssetNamespace()` derives the folder from the niche's own `marketing.domain` with the separators dropped, rather than declaring it anywhere. A new niche gets a folder by registering, there is no second list to keep in sync, and the folder reads as the storefront it belongs to instead of as an internal enum member. An unlaunched niche (beauty, no domain yet) falls back to its slug.

Keys are only ever composed at write time and stored whole, so this cannot strand an object: anything already written stays reachable by the URL recorded against it.

## Verification

- `bun test` — 54 pass, 0 fail
- `bun run lint` — clean
- `bun x tsc --noEmit` — no new errors (two pre-existing ones in `src/lib/site-claim.test.ts` are untouched)
- New registry test asserts the restaurant folder is `restofrontcom`, that no two niches collide, and that every folder is a bare `[a-z0-9]+` path segment