### PR TITLE
chore: point the source link at the renamed cornershopdev repo

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,7 +33,7 @@ import {
  * here goes through a niche first.
  */
 
-const REPO_URL = "https://github.com/VincentShipsIt/restofront";
+const REPO_URL = "https://github.com/VincentShipsIt/cornershopdev";
 
 export const metadata: Metadata = {
   title: "Cornershopdev — the website factory for small business",


### PR DESCRIPTION
The GitHub repository was renamed `VincentShipsIt/restofront` → `VincentShipsIt/cornershopdev`: the repo is the factory, and Restofront is the first niche it ships, not the thing the codebase is.

`REPO_URL` on the factory homepage was the last place in the tree still naming the old path. GitHub redirects it, so nothing was broken — but the redirect is the kind of leftover that outlives the rename and quietly becomes the only record of the old name.

Repo metadata updated alongside this: homepage `restofront.com` → `cornershop.dev`, and the description now describes the factory rather than the restaurant niche.

## Verification
- `bun run lint` — clean
- `bun test` — 54 pass, 0 fail