### PR TITLE
fix(checkout): stop returning internal failures to the caller

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ generation endpoint.
 Configure the webhook endpoint as:
 
 ```text
-https://api.cornershop.dev/api/webhooks/stripe
+https://cornershop.dev/api/webhooks/stripe
 ```
 
 ### Owner sign-in

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -58,12 +58,23 @@ export async function POST(request: Request) {
 
     return Response.json({ url: session.url });
   } catch (error) {
+    if (error instanceof z.ZodError) {
+      return Response.json(
+        { error: error.issues[0]?.message ?? "Check your details and retry" },
+        { status: 400 },
+      );
+    }
+
+    // Everything else is ours, not the caller's: an unset price ID, a Stripe
+    // outage, a database that will not answer. Returning `error.message` here
+    // named our own environment variables to anyone who could POST malformed
+    // input, and reported a server fault as a 400 the client could not fix.
+    console.error("[checkout] failed", {
+      error: error instanceof Error ? error.message : "unknown",
+    });
     return Response.json(
-      {
-        error:
-          error instanceof Error ? error.message : "Checkout could not start",
-      },
-      { status: 400 },
+      { error: "Checkout could not start. Try again in a moment." },
+      { status: 500 },
     );
   }
 }


### PR DESCRIPTION
## What

`POST /api/checkout` returned `error.message` verbatim for every failure, at status 400.

- **Leak:** a caller who POSTed anything reaching the price lookup got back `Stripe price for the growth plan is not configured` — our own environment variable names, to an unauthenticated client. A Stripe or Prisma error would have surfaced its own internals the same way.
- **Wrong status:** a Stripe outage or an unreachable database was reported as a 400, which tells the client to fix a request that has nothing wrong with it.

## Change

Split the branch the way `api/sites/[slug]/booking-requests` already does:

- `z.ZodError` → 400 with the first issue's message (the caller's problem, and actionable).
- Everything else → logged server-side, answered with a generic 500.

The claim panel reads `result.error` on any non-ok response, so the visitor-facing message is unchanged.

Also points the README's Stripe webhook URL at `https://cornershop.dev/api/webhooks/stripe` — the apex, where the live endpoint is configured. Both hostnames are served and both reject unsigned payloads with 400; the `api.` form was leftover split-deployment framing.

## Verification

- `bun test` — 85 pass, 0 fail
- `bunx tsc --noEmit` — clean