### PR TITLE
docs: record AWS rebrand cleanup closeout

### DIFF
--- a/.agents/memory/production-deploy.md
+++ b/.agents/memory/production-deploy.md
@@ -8,6 +8,12 @@ status: durable
 Host `i-00e74422e719396c3` (us-west-1), single container `cornershopdev` behind
 `shipshit-caddy`, single-origin on `cornershop.dev`.
 
+Production application data and Workflow state both use the PostgreSQL database
+`cornershopdev` on RDS `api-shipshit-dev`. It was renamed in place from
+`restofront` on 2026-07-26; the original `restofront_app` owner was preserved
+and both encrypted SSM URLs were updated before the same v0.2.0 artifact was
+redeployed.
+
 ## Deploying is a release, never a merge
 
 `ci.yml` runs `deploy` only on `workflow_dispatch` or a **published,
@@ -72,3 +78,22 @@ Read-only inspection of the running container goes through
 `aws ssm send-command --document-name AWS-RunShellScript`. Long inline
 compound commands trip the permission classifier; write the parameters payload
 to a JSON file and pass `--parameters file://<path>` instead.
+
+## Legacy AWS cleanup completed
+
+The infrastructure side of the restofront→cornershopdev rebrand was closed out
+on 2026-07-26:
+
+- CloudFront distribution `E3GR7TCBV48UVV` was disabled, allowed to finish
+  deploying, then deleted.
+- `api.restofront.com`, `assets.restofront.com`, and the assets certificate
+  validation CNAME were deleted from Route 53.
+- The `assets.restofront.com` ACM certificate was deleted after CloudFront no
+  longer referenced it.
+- Inline IAM policy `restofront-ssm-deploy` was replaced by
+  `cornershopdev-ssm-deploy`; `restofront-aws-provision` was deleted.
+- The PostgreSQL database was renamed from `restofront` to `cornershopdev`
+  without copying or dropping data.
+
+Do not treat other `restofront.com` records as cleanup targets. Restofront is
+the active restaurant niche, and its email/DKIM records remain intentional.

--- a/.agents/sessions/2026-07-26.md
+++ b/.agents/sessions/2026-07-26.md
@@ -108,3 +108,97 @@ No application code changed this session; `v0.2.0` ships code that was already m
 - Runtime gates still open from the vertical-expansion plan: restaurant end-to-end parity against a real URL, and a beauty import against a real salon URL with Booksy/Fresha links.
 - Session 1's AWS cleanup items 1–5 remain open.
 - Known deferred: `VerticalConfig.presentation.itemBadges` receives no locale, so beauty badges render in English on French sites; provider `classificationPattern` fields are dead code.
+
+## Session 3 — AWS rebrand cleanup closeout
+
+**Duration:** ~35 minutes
+**Status:** Complete
+
+### System flow
+
+```mermaid
+flowchart LR
+    A[Create cornershopdev SSM policy] --> B[Rename PostgreSQL database in place]
+    B --> C[Update encrypted SSM URLs]
+    C --> D[Redeploy v0.2.0]
+    D --> E[Verify readiness]
+    E --> F[Disable and delete legacy CloudFront]
+    F --> G[Delete legacy DNS and ACM certificate]
+    G --> H[Delete stale IAM provisioning policy]
+```
+
+### Affected components
+
+| Layer | Components |
+|---|---|
+| Database | RDS database `restofront` → `cornershopdev` |
+| Runtime | Production container and readiness probes |
+| Configuration | `DATABASE_URL`, `WORKFLOW_POSTGRES_URL` in SSM |
+| Edge | CloudFront `E3GR7TCBV48UVV`, three Route 53 records, one ACM certificate |
+| IAM | Two legacy inline policies |
+
+### What was done
+
+- [x] Replaced `restofront-ssm-deploy` with the equivalent
+  `cornershopdev-ssm-deploy` inline policy.
+- [x] Renamed the live PostgreSQL database in place from `restofront` to
+  `cornershopdev`, preserving all data and the `restofront_app` owner.
+- [x] Updated both encrypted database URLs in SSM and redeployed the exact
+  v0.2.0 image so the regenerated environment file uses the new database name.
+- [x] Verified the container is healthy with failing streak 0 and database,
+  rate limiting, and storage all ready.
+- [x] Disabled and deleted CloudFront distribution `E3GR7TCBV48UVV`.
+- [x] Deleted the retired `api.restofront.com` A record,
+  `assets.restofront.com` CNAME, and ACM validation CNAME.
+- [x] Deleted the now-unused `assets.restofront.com` ACM certificate.
+- [x] Deleted `restofront-aws-provision`.
+- [x] Preserved unrelated Restofront niche records, including email/DKIM.
+
+### Key decisions
+
+- **Rename the database in place instead of copying it.**
+  - **Context:** The production database held live application and Workflow
+    state.
+  - **Rationale:** An owner-assisted PostgreSQL rename preserved every row and
+    avoided a divergent copy.
+- **Redeploy the same v0.2.0 artifact immediately after the rename.**
+  - **Context:** SSM changes do not alter an already-created container.
+  - **Rationale:** Re-running the installed deployment path regenerated the
+    environment file and kept the deployed application code unchanged.
+- **Keep `restofront_app` as database owner.**
+  - **Context:** The role name is internal and changing it was outside the
+    rebrand cleanup scope.
+  - **Rationale:** Preserving ownership avoided a broader privilege migration.
+
+### Files changed
+
+- `.agents/memory/production-deploy.md` — recorded the database cutover and
+  completed legacy-resource cleanup.
+- `.agents/sessions/2026-07-26.md` — recorded this closeout.
+
+### Mistakes and fixes
+
+- **Mistake:** The first IAM replacement exceeded the user's aggregate inline
+  policy size, and the compound command continued by deleting the old policy.
+  - **Fix:** Restored the same SSM command permissions immediately under
+    `cornershopdev-ssm-deploy` using a compact policy document, then verified
+    the live policy.
+  - **Prevention:** Use `set -e` or separate create/verify/delete calls for IAM
+    replacements.
+- **Mistake:** The first database cutover wrapper used zsh's reserved,
+  read-only `status` variable after dispatching the remote command.
+  - **Fix:** Reconciled the remote command and live service, restored both SSM
+    URLs explicitly, and renamed the variable to `command_status`.
+  - **Prevention:** Run `zsh -n` plus a shell-specific reserved-name check for
+    production orchestration wrappers.
+- **Mistake:** The application role owned the database but lacked permission to
+  rename it.
+  - **Fix:** Used the existing RDS master account to transfer ownership
+    temporarily, rename the database, then restore `restofront_app` ownership.
+
+### Next steps
+
+- [ ] Run restaurant end-to-end parity against a real URL.
+- [ ] Run a beauty import against a real salon URL with Booksy/Fresha links.
+- [ ] Address the known beauty badge locale and dead
+  `classificationPattern` fields when that deferred scope is scheduled.


### PR DESCRIPTION
## Summary
- record the completed in-place production database rename
- mark the retired CloudFront, Route 53, ACM, and IAM resources as removed
- preserve the remaining runtime gates and intentional Restofront email records

## Verification
- production container healthy on v0.2.0 with failing streak 0
- database, rate limiting, and storage readiness all ready
- both encrypted database URLs target `cornershopdev`
- legacy CloudFront distribution, ACM certificate, DNS records, and IAM policies confirmed absent
- `git diff --check`