### PR TITLE
fix(docker): ship bundled operator scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,14 @@ ENV NODE_ENV=production
 ENV WORKFLOW_TARGET_WORLD=@workflow/world-postgres
 COPY . .
 RUN bun run build
+RUN bun build scripts/grant-superadmin.ts \
+  --target=bun \
+  --packages=external \
+  --outfile=.operator-scripts/grant-superadmin.ts
+RUN bun build scripts/import-le-petit-meunier.ts \
+  --target=bun \
+  --packages=external \
+  --outfile=.operator-scripts/import-le-petit-meunier.ts
 
 FROM oven/bun:1.3.14-alpine AS runner
 WORKDIR /app
@@ -35,6 +43,7 @@ COPY --from=builder --chown=bun:bun /app/public ./public
 COPY --from=builder --chown=bun:bun /app/prisma ./prisma
 COPY --from=builder --chown=bun:bun /app/prisma.config.ts ./prisma.config.ts
 COPY --from=builder --chown=bun:bun /app/package.json ./package.json
+COPY --from=builder --chown=bun:bun /app/.operator-scripts ./scripts
 COPY --chown=bun:bun deploy/aws/container-entrypoint.sh ./deploy/aws/container-entrypoint.sh
 
 USER bun


### PR DESCRIPTION
## Summary
- bundle the superadmin grant command into the production image
- bundle the Le Petit Meunier importer into the production image
- keep runtime dependencies external so the scripts use the image's installed packages

## Verification
- production Docker image builds successfully
- both scripts are present under /app/scripts
- superadmin command reaches its usage guard
- importer reaches its database connection with a deliberately invalid URL (no module-resolution failure)
- git diff --check passes