### PR TITLE
fix(deploy): execute immutable release script

### DIFF
--- a/.agents/memory/production-deploy.md
+++ b/.agents/memory/production-deploy.md
@@ -38,6 +38,13 @@ Related: an unhealthy candidate **aborts the deploy and rolls back**
 (`wait_for_health` returns immediately on `unhealthy`), so a readiness
 regression blocks the whole release. Worth pre-flighting before cutting one.
 
+The host does not keep a mutable copy of this deploy logic. GitHub uploads
+`deploy.sh` beside the image under the same immutable commit SHA. The stable
+`/usr/local/bin/deploy-cornershopdev` launcher downloads that exact script,
+checks its workflow-supplied SHA-256 digest, and emits a verification sentinel
+before executing it. The workflow requires that sentinel, so a stale launcher
+or unverified script fails closed instead of producing a false-green deploy.
+
 ## Gotcha 2 — the OIDC trust policy embeds the repo name
 
 `cornershopdev-github-production-deploy` is assumed via GitHub OIDC. GitHub

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
       - run: bun run test
       - run: bun run lint
       - run: bun run build
+      - run: shellcheck deploy/aws/*.sh
+      - run: bash deploy/aws/test-host-launcher.sh
 
   deploy:
     # Ships on a manual dispatch or when a stable GitHub release is published.

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -40,19 +40,33 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ env.ROLE_ARN }}
 
-      - name: Upload immutable image artifact
+      - name: Upload immutable deployment artifacts
+        id: artifacts
         run: |
+          deploy_script_sha256="$(sha256sum deploy/aws/deploy.sh | awk '{print $1}')"
           aws s3 cp \
             cornershopdev.tar.gz \
             "s3://${ARTIFACT_BUCKET}/images/${GITHUB_SHA}.tar.gz" \
             --sse AES256 \
             --only-show-errors
+          aws s3 cp \
+            deploy/aws/deploy.sh \
+            "s3://${ARTIFACT_BUCKET}/images/${GITHUB_SHA}.deploy.sh" \
+            --sse AES256 \
+            --only-show-errors
+          aws s3 cp \
+            deploy/aws/host-launcher.sh \
+            "s3://${ARTIFACT_BUCKET}/images/${GITHUB_SHA}.host-launcher.sh" \
+            --sse AES256 \
+            --only-show-errors
+          echo "deploy_script_sha256=${deploy_script_sha256}" >>"$GITHUB_OUTPUT"
 
       - name: Deploy through Systems Manager
         id: deploy
         run: |
           artifact_uri="s3://${ARTIFACT_BUCKET}/images/${GITHUB_SHA}.tar.gz"
-          command="sudo /usr/local/bin/deploy-cornershopdev '${artifact_uri}' 'cornershopdev:${GITHUB_SHA}'"
+          deploy_script_sha256="${{ steps.artifacts.outputs.deploy_script_sha256 }}"
+          command="sudo /usr/local/bin/deploy-cornershopdev '${artifact_uri}' 'cornershopdev:${GITHUB_SHA}' '${deploy_script_sha256}'"
           parameters="$(jq -cn --arg command "$command" '{commands: [$command]}')"
           command_id="$(
             aws ssm send-command \
@@ -75,7 +89,7 @@ jobs:
                 --output text
             )"
             case "$status" in
-              Success) exit 0 ;;
+              Success) break ;;
               Cancelled|Cancelling|Failed|TimedOut)
                 echo "Deployment command ended with ${status}" >&2
                 exit 1
@@ -83,8 +97,23 @@ jobs:
             esac
             sleep 10
           done
-          echo "Deployment command did not finish within 15 minutes" >&2
-          exit 1
+          if [[ "$status" != "Success" ]]; then
+            echo "Deployment command did not finish within 15 minutes" >&2
+            exit 1
+          fi
+          output="$(
+            aws ssm get-command-invocation \
+              --region "$AWS_REGION" \
+              --command-id "$command_id" \
+              --instance-id "$INSTANCE_ID" \
+              --query StandardOutputContent \
+              --output text
+          )"
+          sentinel="deploy-script verified sha256=${deploy_script_sha256}"
+          if ! grep -Fxq "$sentinel" <<<"$output"; then
+            echo "Deployment host did not verify the exact deploy script" >&2
+            exit 1
+          fi
 
       - name: Print deployment result
         if: always() && steps.deploy.outputs.command_id

--- a/deploy/aws/bootstrap-host.sh
+++ b/deploy/aws/bootstrap-host.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-deploy_script_source="${1:-}"
+host_launcher_source="${1:-}"
 caddy_fragment_source="${2:-}"
-if [[ ! -f "$deploy_script_source" || ! -f "$caddy_fragment_source" ]]; then
-  echo "Usage: bootstrap-host.sh <deploy-script> <caddy-fragment>" >&2
+if [[ ! -f "$host_launcher_source" || ! -f "$caddy_fragment_source" ]]; then
+  echo "Usage: bootstrap-host.sh <host-launcher> <caddy-fragment>" >&2
   exit 2
 fi
 
-install -m 755 "$deploy_script_source" /usr/local/bin/deploy-cornershopdev
+install -m 755 "$host_launcher_source" /usr/local/bin/deploy-cornershopdev
 install -d -m 700 /etc/cornershopdev /var/lib/cornershopdev
 
 caddyfile="/etc/caddy/Caddyfile"

--- a/deploy/aws/host-launcher.sh
+++ b/deploy/aws/host-launcher.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+artifact_uri="${1:-}"
+image_name="${2:-}"
+expected_sha256="${3:-}"
+
+if [[ ! "$artifact_uri" =~ ^s3://cornershopdev-production-deploy-[a-z0-9-]+/images/([0-9a-f]{40})\.tar\.gz$ ]]; then
+  echo "Invalid deployment artifact URI" >&2
+  exit 2
+fi
+deploy_sha="${BASH_REMATCH[1]}"
+if [[ "$image_name" != "cornershopdev:${deploy_sha}" ]]; then
+  echo "Deployment image does not match artifact SHA" >&2
+  exit 2
+fi
+if [[ ! "$expected_sha256" =~ ^[0-9a-f]{64}$ ]]; then
+  echo "Invalid deployment script checksum" >&2
+  exit 2
+fi
+
+state_directory="${CORNERSHOPDEV_DEPLOY_STATE_DIR:-/var/lib/cornershopdev}"
+install -d -m 700 "$state_directory"
+umask 077
+deploy_script="$(mktemp "${state_directory}/deploy.XXXXXX.sh")"
+trap 'rm -f "$deploy_script"' EXIT
+
+script_uri="${artifact_uri%.tar.gz}.deploy.sh"
+aws s3 cp \
+  "$script_uri" \
+  "$deploy_script" \
+  --region us-west-1 \
+  --only-show-errors
+
+actual_sha256="$(sha256sum "$deploy_script" | awk '{print $1}')"
+if [[ "$actual_sha256" != "$expected_sha256" ]]; then
+  echo "Deployment script checksum mismatch" >&2
+  exit 1
+fi
+
+chmod 500 "$deploy_script"
+echo "deploy-script verified sha256=${actual_sha256}"
+"$deploy_script" "$artifact_uri" "$image_name"

--- a/deploy/aws/test-host-launcher.sh
+++ b/deploy/aws/test-host-launcher.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+root="$(mktemp -d)"
+trap 'rm -rf "$root"' EXIT
+fake_bin="${root}/bin"
+state_directory="${root}/state"
+mkdir -p "$fake_bin"
+
+cat >"${fake_bin}/aws" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+if [[ "$1" != "s3" || "$2" != "cp" ]]; then
+  echo "Unexpected aws invocation" >&2
+  exit 2
+fi
+cp "$FAKE_AWS_SOURCE" "$4"
+EOF
+chmod +x "${fake_bin}/aws"
+
+fake_deployer="${root}/deploy.sh"
+cat >"$fake_deployer" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+printf '%s\n' "$1" "$2" >"$FAKE_DEPLOY_RECORD"
+EOF
+chmod +x "$fake_deployer"
+
+launcher="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/host-launcher.sh"
+artifact_uri="s3://cornershopdev-production-deploy-test/images/0123456789abcdef0123456789abcdef01234567.tar.gz"
+image_name="cornershopdev:0123456789abcdef0123456789abcdef01234567"
+record="${root}/record"
+checksum="$(sha256sum "$fake_deployer" | awk '{print $1}')"
+
+if CORNERSHOPDEV_DEPLOY_STATE_DIR="$state_directory" "$launcher" >/dev/null 2>&1; then
+  echo "Launcher accepted missing arguments" >&2
+  exit 1
+fi
+
+if PATH="${fake_bin}:$PATH" \
+  FAKE_AWS_SOURCE="$fake_deployer" \
+  FAKE_DEPLOY_RECORD="$record" \
+  CORNERSHOPDEV_DEPLOY_STATE_DIR="$state_directory" \
+  "$launcher" "$artifact_uri" "$image_name" \
+  0000000000000000000000000000000000000000000000000000000000000000 \
+  >/dev/null 2>&1; then
+  echo "Launcher accepted a checksum mismatch" >&2
+  exit 1
+fi
+if [[ -e "$record" ]]; then
+  echo "Launcher executed an unverified deploy script" >&2
+  exit 1
+fi
+
+output="$(
+  PATH="${fake_bin}:$PATH" \
+    FAKE_AWS_SOURCE="$fake_deployer" \
+    FAKE_DEPLOY_RECORD="$record" \
+    CORNERSHOPDEV_DEPLOY_STATE_DIR="$state_directory" \
+    "$launcher" "$artifact_uri" "$image_name" "$checksum"
+)"
+grep -Fxq "deploy-script verified sha256=${checksum}" <<<"$output"
+expected_record="$(printf '%s\n%s' "$artifact_uri" "$image_name")"
+if [[ "$(cat "$record")" != "$expected_record" ]]; then
+  echo "Launcher changed the deploy script arguments" >&2
+  exit 1
+fi
+
+echo "host launcher tests passed"


### PR DESCRIPTION
## Summary
- replace the stale host deployer with a stable checksum-verifying launcher
- upload the exact deploy script beside every immutable image artifact
- require an exact SHA-256 verification sentinel before a deployment can pass
- add shellcheck and fail-closed launcher regression coverage

## Incident fixed
Production had the new SUPERADMIN_EMAILS parameter in SSM and in the tracked deploy script, but the EC2 host executed an older one-time-installed copy. The deployment stayed green while silently omitting the variable.

## Verification
- actionlint on both changed workflows
- shellcheck on deploy/aws scripts
- host launcher regression test
- git diff check
- AWS role policies verified: both writer and reader already permit the chosen images artifact prefix