### PR TITLE
feat: add client leads and first-party analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,43 @@ Cornershopdev turns an existing restaurant website—or just a restaurant name�
 9. Authorize the restaurant domain for on-demand TLS and show the exact DNS records.
 10. Monitor and maintain the menu, imagery, and external links from the dashboard.
 
+## Customer workspace and operator console
+
+Each claimed site has a tenant-scoped `/dashboard` workspace. Owners can edit
+their site, connect a domain, review first-party booking leads, and move each
+request from `NEW` to `CONTACTED` or `CLOSED`. Contact details are returned only
+after the session is revalidated against that site's organization membership.
+
+`/admin` is the platform operator console. It requires both a database
+`SUPERADMIN` role and an email listed in `SUPERADMIN_EMAILS`. It shows signups,
+subscriptions, request totals, portfolio traffic and conversion summaries, and
+bounded per-site operational rows. It intentionally does not expose customer
+lead contact details across tenants.
+
+## First-party analytics
+
+Analytics run only on verified customer domains. Factory pages, private preview
+routes, bots, and automated browsers are excluded. The browser creates an
+ephemeral visit UUID in `sessionStorage` and sends only:
+
+- event UUID
+- visit UUID
+- site view or CTA click
+- server-owned site identity derived from the verified request hostname
+- server timestamp
+
+Raw analytics events never store IP addresses, user-agent strings, referrers,
+paths, query strings, provider URLs, names, email addresses, phone numbers, or
+booking notes. A one-minute Redis limiter may use a transient hash derived from
+the connection address; it is not written to PostgreSQL.
+
+Booking requests remain the authoritative lead count, so a dropped analytics
+beacon cannot lose a real lead. The corresponding `LEAD_CREATED` event is
+server-owned and best effort. Client and operator workspaces expose 7, 30, and
+90-day distinct-visit, CTA-visitor, booking-lead, and conversion metrics.
+Raw analytics events are retained for 120 days and pruned daily under a
+PostgreSQL advisory lock.
+
 ## Restaurant templates
 
 Restaurant sites use Geist Sans rather than the Cornershopdev marketing display
@@ -226,5 +263,7 @@ this same container, where the rewrite fires again — an infinite loop.
 - `/claim/[slug]` — pricing and claim checkout
 - `/dashboard` — authenticated restaurant management
 - `/dashboard?demo=1` — local demo dashboard
+- `/admin` — dual-gated superadmin operator console
+- `/api/analytics/events` — first-party cookieless live-site event intake
 - `/preview/[slug]` — private full-screen restaurant preview
 - `/preview/[slug]/[locale]` — translated restaurant preview

--- a/prisma/migrations/20260726200000_client_analytics/migration.sql
+++ b/prisma/migrations/20260726200000_client_analytics/migration.sql
@@ -1,0 +1,31 @@
+-- First-party, cookieless conversion events. Privacy-sensitive request data
+-- cannot drift into this table because the schema has no IP, user-agent,
+-- referrer, URL, query-string, provider-link, metadata, or contact columns.
+CREATE TYPE "AnalyticsEventType" AS ENUM (
+  'SITE_VIEW',
+  'CTA_CLICK',
+  'LEAD_CREATED'
+);
+
+CREATE TABLE "AnalyticsEvent" (
+  "id" UUID NOT NULL,
+  "visitId" UUID NOT NULL,
+  "type" "AnalyticsEventType" NOT NULL,
+  "siteId" TEXT NOT NULL,
+  "occurredAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "AnalyticsEvent_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "AnalyticsEvent_siteId_occurredAt_type_idx"
+ON "AnalyticsEvent"("siteId", "occurredAt", "type");
+
+CREATE INDEX "AnalyticsEvent_occurredAt_idx"
+ON "AnalyticsEvent"("occurredAt");
+
+ALTER TABLE "AnalyticsEvent"
+ADD CONSTRAINT "AnalyticsEvent_siteId_fkey"
+FOREIGN KEY ("siteId")
+REFERENCES "Site"("id")
+ON DELETE CASCADE
+ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -62,6 +62,12 @@ enum PlatformRole {
   SUPERADMIN
 }
 
+enum AnalyticsEventType {
+  SITE_VIEW
+  CTA_CLICK
+  LEAD_CREATED
+}
+
 model User {
   id           String       @id @default(cuid())
   email        String       @unique
@@ -126,6 +132,7 @@ model Site {
   claimInvitations     ClaimInvitation[]
   auditEvents          AuditEvent[]
   bookingRequests      BookingRequest[]
+  analyticsEvents      AnalyticsEvent[]
 }
 
 model CatalogSection {
@@ -273,4 +280,16 @@ model BookingRequest {
   updatedAt   DateTime             @updatedAt
 
   @@index([siteId, status, createdAt])
+}
+
+model AnalyticsEvent {
+  id         String             @id @db.Uuid
+  visitId    String             @db.Uuid
+  type       AnalyticsEventType
+  siteId     String
+  site       Site               @relation(fields: [siteId], references: [id], onDelete: Cascade)
+  occurredAt DateTime           @default(now())
+
+  @@index([siteId, occurredAt, type])
+  @@index([occurredAt])
 }

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -121,7 +121,7 @@ export default async function AdminPage() {
                   <th scope="col" className="px-5 py-3 font-medium">Visits</th>
                   <th scope="col" className="px-5 py-3 font-medium">CTA visitors</th>
                   <th scope="col" className="px-5 py-3 font-medium">CTA rate</th>
-                  <th scope="col" className="px-5 py-3 font-medium">Booking leads</th>
+                  <th scope="col" className="px-5 py-3 font-medium">Live booking leads</th>
                   <th scope="col" className="px-5 py-3 font-medium">Lead conversion</th>
                 </tr>
               </thead>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -99,18 +99,54 @@ export default async function AdminPage() {
           />
           <MetricCard
             label="Needs action"
-            value={data.totals.newBookingRequests}
-            detail="New booking requests"
+            value={data.totals.pendingBookingRequests}
+            detail="Awaiting contact"
             icon={<Inbox />}
           />
         </section>
 
         <Card className="mt-6 overflow-hidden py-0">
           <CardHeader className="border-b py-5">
+            <CardTitle>Live-site performance</CardTitle>
+            <p className="text-xs text-muted-foreground">
+              Cookieless traffic from verified customer domains only. Preview
+              and factory traffic is excluded.
+            </p>
+          </CardHeader>
+          <CardContent className="overflow-x-auto p-0">
+            <table className="w-full min-w-[720px] text-left text-sm">
+              <thead className="border-b bg-muted/50 text-xs uppercase tracking-[0.12em] text-muted-foreground">
+                <tr>
+                  <th scope="col" className="px-5 py-3 font-medium">Window</th>
+                  <th scope="col" className="px-5 py-3 font-medium">Visits</th>
+                  <th scope="col" className="px-5 py-3 font-medium">CTA visitors</th>
+                  <th scope="col" className="px-5 py-3 font-medium">CTA rate</th>
+                  <th scope="col" className="px-5 py-3 font-medium">Booking leads</th>
+                  <th scope="col" className="px-5 py-3 font-medium">Lead conversion</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {data.analytics.windows.map((window) => (
+                  <tr key={window.days}>
+                    <td className="px-5 py-4 font-medium">{window.days} days</td>
+                    <td className="px-5 py-4">{formatNumber(window.visits)}</td>
+                    <td className="px-5 py-4">{formatNumber(window.ctaVisitors)}</td>
+                    <td className="px-5 py-4">{formatPercent(window.ctaRate)}</td>
+                    <td className="px-5 py-4">{formatNumber(window.bookingLeads)}</td>
+                    <td className="px-5 py-4">{formatPercent(window.leadRate)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </CardContent>
+        </Card>
+
+        <Card className="mt-6 overflow-hidden py-0">
+          <CardHeader className="border-b py-5">
             <CardTitle>All sites</CardTitle>
           </CardHeader>
           <CardContent className="overflow-x-auto p-0">
-            <table className="w-full min-w-[1050px] text-left text-sm">
+            <table className="w-full min-w-[1250px] text-left text-sm">
               <thead className="border-b bg-muted/50 text-xs uppercase tracking-[0.12em] text-muted-foreground">
                 <tr>
                   <th scope="col" className="px-5 py-3 font-medium">Business</th>
@@ -119,6 +155,8 @@ export default async function AdminPage() {
                   <th scope="col" className="px-5 py-3 font-medium">Subscription</th>
                   <th scope="col" className="px-5 py-3 font-medium">Import</th>
                   <th scope="col" className="px-5 py-3 font-medium">Booking leads</th>
+                  <th scope="col" className="px-5 py-3 font-medium">Visits · 30d</th>
+                  <th scope="col" className="px-5 py-3 font-medium">Lead conv. · 30d</th>
                   <th scope="col" className="px-5 py-3 font-medium">Created</th>
                   <th scope="col" className="px-5 py-3 text-right font-medium">Site</th>
                 </tr>
@@ -219,8 +257,17 @@ function SiteRow({ site }: { site: OperatorSiteRow }) {
       <td className="px-5 py-4">
         <p className="font-medium">{site.bookingRequestCount}</p>
         <p className="mt-1 text-xs text-muted-foreground">
-          {site.newBookingRequestCount} new
+          {site.pendingBookingRequestCount} awaiting contact
         </p>
+      </td>
+      <td className="px-5 py-4">
+        <p className="font-medium">{formatNumber(site.analytics30d.visits)}</p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          {formatNumber(site.analytics30d.ctaVisitors)} CTA visitors
+        </p>
+      </td>
+      <td className="px-5 py-4 font-medium">
+        {formatPercent(site.analytics30d.leadRate)}
       </td>
       <td className="px-5 py-4 text-muted-foreground">
         {formatDate(site.createdAt)}
@@ -248,5 +295,16 @@ function humanize(value: string): string {
 function formatDate(value: Date): string {
   return new Intl.DateTimeFormat("en", {
     dateStyle: "medium",
+  }).format(value);
+}
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat("en").format(value);
+}
+
+function formatPercent(value: number): string {
+  return new Intl.NumberFormat("en", {
+    style: "percent",
+    maximumFractionDigits: 1,
   }).format(value);
 }

--- a/src/app/api/analytics/events/route.ts
+++ b/src/app/api/analytics/events/route.ts
@@ -1,0 +1,47 @@
+import { analyticsEventInputSchema } from "@/lib/analytics-contract";
+import { isLikelyAutomatedRequest } from "@/lib/analytics-policy";
+import {
+  recordBrowserAnalyticsEvent,
+  resolveAnalyticsSiteForHeaders,
+} from "@/lib/analytics";
+import { limitAnalyticsEvent } from "@/lib/rate-limit";
+
+export const runtime = "nodejs";
+
+function emptyResponse() {
+  return new Response(null, {
+    status: 204,
+    headers: { "Cache-Control": "no-store" },
+  });
+}
+
+export async function POST(request: Request) {
+  if (isLikelyAutomatedRequest(request.headers)) return emptyResponse();
+
+  const rateLimit = await limitAnalyticsEvent(request);
+  if (!rateLimit.success) return emptyResponse();
+
+  let event;
+  try {
+    event = analyticsEventInputSchema.parse(await request.json());
+  } catch {
+    return Response.json(
+      { error: "Invalid analytics event" },
+      { status: 400, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+
+  try {
+    // Site identity comes only from the verified public hostname. The browser
+    // cannot name a tenant in its payload or turn a factory preview into traffic.
+    const site = await resolveAnalyticsSiteForHeaders(request.headers);
+    if (!site) return emptyResponse();
+    await recordBrowserAnalyticsEvent(site.id, event);
+  } catch (error) {
+    console.error("[analytics-event] dropped", {
+      error: error instanceof Error ? error.message : "unknown",
+    });
+  }
+
+  return emptyResponse();
+}

--- a/src/app/api/sites/[slug]/booking-requests/[requestId]/route.ts
+++ b/src/app/api/sites/[slug]/booking-requests/[requestId]/route.ts
@@ -1,0 +1,65 @@
+import {
+  accessFailureResponse,
+  getSiteAccess,
+} from "@/lib/authorization";
+import {
+  ownerBookingRequestStatusSchema,
+  updateBookingRequestStatus,
+} from "@/lib/booking-request-status";
+import { getDb } from "@/lib/db";
+
+type BookingRequestRouteContext = {
+  params: Promise<{ slug: string; requestId: string }>;
+};
+
+export async function PATCH(
+  request: Request,
+  { params }: BookingRequestRouteContext,
+) {
+  const { slug, requestId } = await params;
+  const access = await getSiteAccess(slug);
+  if (!access.ok) return accessFailureResponse(access);
+
+  try {
+    const body = (await request.json()) as { status?: unknown };
+    const parsed = ownerBookingRequestStatusSchema.safeParse(body.status);
+    if (!parsed.success) {
+      return Response.json(
+        { error: "Status must be CONTACTED or CLOSED" },
+        { status: 400 },
+      );
+    }
+    const status = parsed.data;
+    const updated = await updateBookingRequestStatus(
+      {
+        updateForSite: async ({ requestId: id, siteId, data }) =>
+          (
+            await getDb().bookingRequest.updateMany({
+              where: { id, siteId },
+              data,
+            })
+          ).count,
+      },
+      {
+        requestId,
+        siteId: access.site.id,
+        status,
+      },
+    );
+
+    if (!updated) {
+      return Response.json({ error: "Booking request not found" }, { status: 404 });
+    }
+    return Response.json({ ok: true, status });
+  } catch (error) {
+    console.error("[booking-request-status] update failed", {
+      slug,
+      requestId,
+      error: error instanceof Error ? error.message : "unknown",
+    });
+    return Response.json(
+      { error: "Booking request could not be updated" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/sites/[slug]/booking-requests/route.ts
+++ b/src/app/api/sites/[slug]/booking-requests/route.ts
@@ -1,5 +1,10 @@
-import { NextResponse } from "next/server";
+import { after, NextResponse } from "next/server";
 import { z } from "zod";
+import {
+  LIVE_BOOKING_REQUEST_SOURCE,
+  recordLeadCreatedEvent,
+  resolveAnalyticsSiteForHeaders,
+} from "@/lib/analytics";
 import {
   bookingRequestInputSchema,
   createBookingRequest,
@@ -44,7 +49,8 @@ export async function POST(request: Request, { params }: RouteContext) {
   }
 
   try {
-    const input = bookingRequestInputSchema.parse(await request.json());
+    const parsed = bookingRequestInputSchema.parse(await request.json());
+    const { analyticsVisitId, ...input } = parsed;
 
     if (!process.env.DATABASE_URL) {
       return NextResponse.json(
@@ -68,7 +74,40 @@ export async function POST(request: Request, { params }: RouteContext) {
       return NextResponse.json({ error: "Site not found" }, { status: 404 });
     }
 
-    const created = await createBookingRequest(site, input);
+    let liveAnalyticsSiteId: string | null = null;
+    try {
+      const analyticsSite = await resolveAnalyticsSiteForHeaders(
+        request.headers,
+      );
+      if (analyticsSite?.id === site.id) liveAnalyticsSiteId = site.id;
+    } catch (error) {
+      console.error("[booking-request] analytics host check failed", {
+        slug,
+        error: error instanceof Error ? error.message : "unknown",
+      });
+    }
+
+    const created = await createBookingRequest(
+      site,
+      input,
+      liveAnalyticsSiteId ? LIVE_BOOKING_REQUEST_SOURCE : "site-form",
+    );
+    if (liveAnalyticsSiteId && analyticsVisitId) {
+      after(async () => {
+        try {
+          await recordLeadCreatedEvent({
+            siteId: liveAnalyticsSiteId,
+            visitId: analyticsVisitId,
+          });
+        } catch (error) {
+          console.error("[booking-request] lead analytics dropped", {
+            slug,
+            bookingRequestId: created.id,
+            error: error instanceof Error ? error.message : "unknown",
+          });
+        }
+      });
+    }
     // Awaited rather than fired and forgotten: a floating promise does not
     // survive the response on serverless. It cannot fail the request — the lead
     // is already committed and the visitor is owed a success either way.

--- a/src/app/dashboard/dashboard.tsx
+++ b/src/app/dashboard/dashboard.tsx
@@ -14,14 +14,20 @@ import {
   LayoutDashboard,
   Link2,
   LoaderCircle,
+  Mail,
   MoreHorizontal,
   Plus,
   RefreshCcw,
   Save,
   Settings,
   Sparkles,
+  TrendingUp,
 } from "lucide-react";
 import { Brand } from "@/components/brand";
+import {
+  ClientAnalyticsPanel,
+  ClientBookingRequestInbox,
+} from "@/components/client-workspace";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -31,6 +37,8 @@ import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import type { BrandIdentity } from "@/lib/brand";
+import type { AnalyticsSummaryDto } from "@/lib/analytics-contract";
+import type { BookingRequestDto } from "@/lib/booking-request-inbox";
 import {
   formatPrice,
   type RestaurantDraft,
@@ -54,12 +62,16 @@ export function Dashboard({
   checkoutComplete,
   demo,
   brand,
+  analyticsSummary,
+  bookingRequests,
 }: {
   initialDraft: RestaurantDraft;
   email: string;
   checkoutComplete: boolean;
   demo: boolean;
   brand: BrandIdentity;
+  analyticsSummary: AnalyticsSummaryDto;
+  bookingRequests: BookingRequestDto[];
 }) {
   const [draft, setDraft] = useState(initialDraft);
   const [saving, setSaving] = useState(false);
@@ -219,6 +231,8 @@ export function Dashboard({
             <TabsList className="flex h-auto w-full flex-col items-stretch bg-transparent">
               {[
                 ["overview", LayoutDashboard, "Overview"],
+                ["analytics", TrendingUp, "Analytics"],
+                ["leads", Mail, "Leads"],
                 ["menu", BookOpenText, "Menu"],
                 ["imagery", ImageIcon, "Imagery"],
                 ["integrations", Link2, "Integrations"],
@@ -246,6 +260,8 @@ export function Dashboard({
           <div className="min-w-0 flex-1 p-4 md:p-7 lg:p-10">
             <TabsList className="mb-6 w-full justify-start overflow-x-auto lg:hidden">
               <TabsTrigger value="overview">Overview</TabsTrigger>
+              <TabsTrigger value="analytics">Analytics</TabsTrigger>
+              <TabsTrigger value="leads">Leads</TabsTrigger>
               <TabsTrigger value="menu">Menu</TabsTrigger>
               <TabsTrigger value="imagery">Imagery</TabsTrigger>
               <TabsTrigger value="integrations">Links</TabsTrigger>
@@ -343,6 +359,18 @@ export function Dashboard({
                 <Metric label="Preserved systems" value={`${draft.integrations.length}`} detail="No migrations required" />
                 <Metric label="Last source check" value="Just now" detail="No changes detected" />
               </div>
+            </TabsContent>
+
+            <TabsContent value="analytics" className="mt-0">
+              <ClientAnalyticsPanel summary={analyticsSummary} />
+            </TabsContent>
+
+            <TabsContent value="leads" className="mt-0">
+              <ClientBookingRequestInbox
+                siteSlug={draft.slug}
+                initialRequests={bookingRequests}
+                demo={demo}
+              />
             </TabsContent>
 
             <TabsContent value="menu" className="mt-0">

--- a/src/app/dashboard/dashboard.tsx
+++ b/src/app/dashboard/dashboard.tsx
@@ -38,7 +38,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import type { BrandIdentity } from "@/lib/brand";
 import type { AnalyticsSummaryDto } from "@/lib/analytics-contract";
-import type { BookingRequestDto } from "@/lib/booking-request-inbox";
+import type { BookingRequestInboxDto } from "@/lib/booking-request-inbox";
 import {
   formatPrice,
   type RestaurantDraft,
@@ -63,7 +63,7 @@ export function Dashboard({
   demo,
   brand,
   analyticsSummary,
-  bookingRequests,
+  bookingInbox,
 }: {
   initialDraft: RestaurantDraft;
   email: string;
@@ -71,7 +71,7 @@ export function Dashboard({
   demo: boolean;
   brand: BrandIdentity;
   analyticsSummary: AnalyticsSummaryDto;
-  bookingRequests: BookingRequestDto[];
+  bookingInbox: BookingRequestInboxDto;
 }) {
   const [draft, setDraft] = useState(initialDraft);
   const [saving, setSaving] = useState(false);
@@ -368,7 +368,7 @@ export function Dashboard({
             <TabsContent value="leads" className="mt-0">
               <ClientBookingRequestInbox
                 siteSlug={draft.slug}
-                initialRequests={bookingRequests}
+                initialInbox={bookingInbox}
                 demo={demo}
               />
             </TabsContent>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -29,13 +29,22 @@ export default async function DashboardPage({
     session?.siteSlug ? await getSiteAccess(session.siteSlug) : null;
   if (session && (!access || !access.ok)) redirect("/sign-in");
 
-  const [draft, analyticsSummary, bookingRequests] = access?.ok
+  const [draft, analyticsSummary, bookingInbox] = access?.ok
     ? await Promise.all([
         getRestaurantDraft(access.site.slug),
         getSiteAnalyticsSummary(access.site.id),
         getBookingRequestInbox(access.site.id),
       ])
-    : [sampleRestaurant, buildEmptyAnalyticsSummary(), []];
+    : [
+        sampleRestaurant,
+        buildEmptyAnalyticsSummary(),
+        {
+          requests: [],
+          total: 0,
+          awaitingContact: 0,
+          truncated: false,
+        },
+      ];
 
   return (
     <Dashboard
@@ -45,7 +54,7 @@ export default async function DashboardPage({
       demo={!session}
       brand={await resolveRequestBrand()}
       analyticsSummary={analyticsSummary}
-      bookingRequests={bookingRequests}
+      bookingInbox={bookingInbox}
     />
   );
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,7 +1,10 @@
 import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { Dashboard } from "@/app/dashboard/dashboard";
+import { getSiteAnalyticsSummary } from "@/lib/analytics";
+import { buildEmptyAnalyticsSummary } from "@/lib/analytics-contract";
 import { getSiteAccess } from "@/lib/authorization";
+import { getBookingRequestInbox } from "@/lib/booking-request-inbox";
 import { getCurrentSession } from "@/lib/current-session";
 import { getRestaurantDraft } from "@/lib/restaurants";
 import { sampleRestaurant } from "@/lib/restaurant";
@@ -26,8 +29,13 @@ export default async function DashboardPage({
     session?.siteSlug ? await getSiteAccess(session.siteSlug) : null;
   if (session && (!access || !access.ok)) redirect("/sign-in");
 
-  const draft =
-    access?.ok ? await getRestaurantDraft(access.site.slug) : sampleRestaurant;
+  const [draft, analyticsSummary, bookingRequests] = access?.ok
+    ? await Promise.all([
+        getRestaurantDraft(access.site.slug),
+        getSiteAnalyticsSummary(access.site.id),
+        getBookingRequestInbox(access.site.id),
+      ])
+    : [sampleRestaurant, buildEmptyAnalyticsSummary(), []];
 
   return (
     <Dashboard
@@ -36,6 +44,8 @@ export default async function DashboardPage({
       checkoutComplete={query.checkout === "success"}
       demo={!session}
       brand={await resolveRequestBrand()}
+      analyticsSummary={analyticsSummary}
+      bookingRequests={bookingRequests}
     />
   );
 }

--- a/src/app/preview/[slug]/[locale]/page.tsx
+++ b/src/app/preview/[slug]/[locale]/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { SiteRenderer } from "@/components/site-renderer";
 import { getSiteLocales, localizeSiteDraft } from "@/lib/site-draft";
+import { isLiveSiteSurface } from "@/lib/site-surface";
 import { findSiteView } from "@/lib/sites";
 
 type PageProps = {
@@ -43,14 +45,16 @@ export default async function LocalizedPreviewPage({ params }: PageProps) {
   if (!site) notFound();
   const locales = getSiteLocales(site.draft);
   if (!locales.includes(locale)) notFound();
+  const liveSurface = isLiveSiteSurface(await headers(), slug);
 
   return (
     <SiteRenderer
       draft={localizeSiteDraft(site.draft, locale)}
       vertical={site.vertical}
       locale={locale}
-      localeBasePath={`/preview/${slug}`}
+      localeBasePath={liveSurface ? "/" : `/preview/${slug}`}
       availableLocales={locales}
+      analyticsEnabled={liveSurface}
     />
   );
 }

--- a/src/app/preview/[slug]/page.tsx
+++ b/src/app/preview/[slug]/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { SiteRenderer } from "@/components/site-renderer";
 import { getSiteLocales } from "@/lib/site-draft";
+import { isLiveSiteSurface } from "@/lib/site-surface";
 import { findSiteView } from "@/lib/sites";
 
 type PageProps = {
@@ -36,13 +38,15 @@ export default async function PreviewPage({ params }: PageProps) {
   const { slug } = await params;
   const site = await findSiteView(slug);
   if (!site) notFound();
+  const liveSurface = isLiveSiteSurface(await headers(), slug);
   return (
     <SiteRenderer
       draft={site.draft}
       vertical={site.vertical}
       locale={site.draft.defaultLocale}
-      localeBasePath={`/preview/${slug}`}
+      localeBasePath={liveSurface ? "/" : `/preview/${slug}`}
       availableLocales={getSiteLocales(site.draft)}
+      analyticsEnabled={liveSurface}
     />
   );
 }

--- a/src/components/booking-request-form.tsx
+++ b/src/components/booking-request-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { getAnalyticsVisitId } from "@/lib/analytics-browser";
 
 export type BookingRequestFormCopy = {
   name: string;
@@ -77,6 +78,7 @@ export function BookingRequestForm({
             // typed it and read as local time by the server.
             requestedAt,
             partySize: partySize ? Number(partySize) : undefined,
+            analyticsVisitId: getAnalyticsVisitId(slug) ?? undefined,
           }),
         },
       );

--- a/src/components/client-workspace.tsx
+++ b/src/components/client-workspace.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { Check, LoaderCircle, Mail, Phone } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -9,7 +9,7 @@ import type {
   AnalyticsSummaryDto,
   AnalyticsWindowDays,
 } from "@/lib/analytics-contract";
-import type { BookingRequestDto } from "@/lib/booking-request-inbox";
+import type { BookingRequestInboxDto } from "@/lib/booking-request-inbox";
 
 export function ClientAnalyticsPanel({
   summary,
@@ -68,9 +68,9 @@ export function ClientAnalyticsPanel({
           detail={`${formatPercent(metrics.ctaRate)} of visits`}
         />
         <AnalyticsMetric
-          label="Booking leads"
+          label="Live booking leads"
           value={formatInteger(metrics.bookingLeads)}
-          detail="Durable requests received"
+          detail="Submitted on the live domain"
         />
         <AnalyticsMetric
           label="Lead conversion"
@@ -84,24 +84,19 @@ export function ClientAnalyticsPanel({
 
 export function ClientBookingRequestInbox({
   siteSlug,
-  initialRequests,
+  initialInbox,
   demo,
 }: {
   siteSlug: string;
-  initialRequests: BookingRequestDto[];
+  initialInbox: BookingRequestInboxDto;
   demo: boolean;
 }) {
-  const [requests, setRequests] = useState(initialRequests);
+  const [requests, setRequests] = useState(initialInbox.requests);
+  const [awaitingContact, setAwaitingContact] = useState(
+    initialInbox.awaitingContact,
+  );
   const [updating, setUpdating] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const openCount = useMemo(
-    () =>
-      requests.filter(
-        (request) =>
-          request.status === "NEW" || request.status === "NOTIFIED",
-      ).length,
-    [requests],
-  );
 
   async function updateStatus(
     requestId: string,
@@ -120,6 +115,7 @@ export function ClientBookingRequestInbox({
         },
       );
       if (!response.ok) throw new Error("Status update failed");
+      const previous = requests.find((request) => request.id === requestId);
       setRequests((current) =>
         current.map((request) =>
           request.id === requestId
@@ -131,6 +127,12 @@ export function ClientBookingRequestInbox({
             : request,
         ),
       );
+      if (
+        previous?.status === "NEW" ||
+        previous?.status === "NOTIFIED"
+      ) {
+        setAwaitingContact((current) => Math.max(0, current - 1));
+      }
     } catch {
       setError("The lead status could not be updated. Please try again.");
     } finally {
@@ -153,13 +155,19 @@ export function ClientBookingRequestInbox({
             analytics events.
           </p>
         </div>
-        <Badge variant={openCount > 0 ? "secondary" : "outline"}>
-          {openCount} awaiting contact
+        <Badge variant={awaitingContact > 0 ? "secondary" : "outline"}>
+          {awaitingContact} awaiting contact
         </Badge>
       </div>
       {error ? (
         <p className="mt-4 text-sm text-destructive" role="alert">
           {error}
+        </p>
+      ) : null}
+      {initialInbox.truncated ? (
+        <p className="mt-4 text-xs text-muted-foreground">
+          Showing the latest {requests.length} of {initialInbox.total} requests.
+          The awaiting-contact count includes the full inbox.
         </p>
       ) : null}
 

--- a/src/components/client-workspace.tsx
+++ b/src/components/client-workspace.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Check, LoaderCircle, Mail, Phone } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type {
+  AnalyticsSummaryDto,
+  AnalyticsWindowDays,
+} from "@/lib/analytics-contract";
+import type { BookingRequestDto } from "@/lib/booking-request-inbox";
+
+export function ClientAnalyticsPanel({
+  summary,
+}: {
+  summary: AnalyticsSummaryDto;
+}) {
+  const [days, setDays] = useState<AnalyticsWindowDays>(30);
+  const metrics =
+    summary.windows.find((window) => window.days === days) ??
+    summary.windows[0];
+
+  if (!metrics) return null;
+
+  return (
+    <div>
+      <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-end">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary">
+            Live-site analytics
+          </p>
+          <h2 className="font-display mt-2 text-4xl tracking-[-0.04em]">
+            Traffic that turns into customers.
+          </h2>
+          <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+            Cookieless counts from your verified customer domain. Factory and
+            preview traffic is excluded.
+          </p>
+        </div>
+        <div className="flex rounded-lg border bg-background p-1">
+          {summary.windows.map((window) => (
+            <button
+              key={window.days}
+              type="button"
+              onClick={() => setDays(window.days)}
+              className={`rounded-md px-3 py-1.5 text-xs font-semibold ${
+                days === window.days
+                  ? "bg-foreground text-background"
+                  : "text-muted-foreground"
+              }`}
+            >
+              {window.days} days
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-8 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <AnalyticsMetric
+          label="Visits"
+          value={formatInteger(metrics.visits)}
+          detail="Distinct live-site visits"
+        />
+        <AnalyticsMetric
+          label="CTA visitors"
+          value={formatInteger(metrics.ctaVisitors)}
+          detail={`${formatPercent(metrics.ctaRate)} of visits`}
+        />
+        <AnalyticsMetric
+          label="Booking leads"
+          value={formatInteger(metrics.bookingLeads)}
+          detail="Durable requests received"
+        />
+        <AnalyticsMetric
+          label="Lead conversion"
+          value={formatPercent(metrics.leadRate)}
+          detail="Booking leads ÷ visits"
+        />
+      </div>
+    </div>
+  );
+}
+
+export function ClientBookingRequestInbox({
+  siteSlug,
+  initialRequests,
+  demo,
+}: {
+  siteSlug: string;
+  initialRequests: BookingRequestDto[];
+  demo: boolean;
+}) {
+  const [requests, setRequests] = useState(initialRequests);
+  const [updating, setUpdating] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const openCount = useMemo(
+    () =>
+      requests.filter(
+        (request) =>
+          request.status === "NEW" || request.status === "NOTIFIED",
+      ).length,
+    [requests],
+  );
+
+  async function updateStatus(
+    requestId: string,
+    status: "CONTACTED" | "CLOSED",
+  ) {
+    if (demo) return;
+    setUpdating(requestId);
+    setError(null);
+    try {
+      const response = await fetch(
+        `/api/sites/${encodeURIComponent(siteSlug)}/booking-requests/${encodeURIComponent(requestId)}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status }),
+        },
+      );
+      if (!response.ok) throw new Error("Status update failed");
+      setRequests((current) =>
+        current.map((request) =>
+          request.id === requestId
+            ? {
+                ...request,
+                status,
+                updatedAt: new Date().toISOString(),
+              }
+            : request,
+        ),
+      );
+    } catch {
+      setError("The lead status could not be updated. Please try again.");
+    } finally {
+      setUpdating(null);
+    }
+  }
+
+  return (
+    <div>
+      <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-end">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary">
+            Lead inbox
+          </p>
+          <h2 className="font-display mt-2 text-4xl tracking-[-0.04em]">
+            Booking requests in one place.
+          </h2>
+          <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+            Contact details stay inside your workspace and are never copied into
+            analytics events.
+          </p>
+        </div>
+        <Badge variant={openCount > 0 ? "secondary" : "outline"}>
+          {openCount} awaiting contact
+        </Badge>
+      </div>
+      {error ? (
+        <p className="mt-4 text-sm text-destructive" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      <div className="mt-8 space-y-4">
+        {requests.map((request) => (
+          <Card key={request.id}>
+            <CardHeader className="gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <CardTitle>{request.name}</CardTitle>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Received {formatDateTime(request.createdAt)}
+                </p>
+              </div>
+              <Badge variant="outline">{humanize(request.status)}</Badge>
+            </CardHeader>
+            <CardContent>
+              <div className="grid gap-5 lg:grid-cols-[1fr_1fr_auto]">
+                <div className="space-y-2 text-sm">
+                  {request.email ? (
+                    <a
+                      href={`mailto:${request.email}`}
+                      className="flex items-center gap-2 font-medium"
+                    >
+                      <Mail className="size-4 text-muted-foreground" />
+                      {request.email}
+                    </a>
+                  ) : null}
+                  {request.phone ? (
+                    <a
+                      href={`tel:${request.phone}`}
+                      className="flex items-center gap-2 font-medium"
+                    >
+                      <Phone className="size-4 text-muted-foreground" />
+                      {request.phone}
+                    </a>
+                  ) : null}
+                  {request.requestedAt ? (
+                    <p className="text-muted-foreground">
+                      Preferred time: {formatDateTime(request.requestedAt)}
+                    </p>
+                  ) : null}
+                  {request.partySize ? (
+                    <p className="text-muted-foreground">
+                      Party of {request.partySize}
+                    </p>
+                  ) : null}
+                </div>
+                <p className="text-sm leading-6 text-muted-foreground">
+                  {request.notes || "No additional notes."}
+                </p>
+                <div className="flex flex-wrap items-start gap-2 lg:justify-end">
+                  {request.status !== "CONTACTED" ? (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={updating === request.id || demo}
+                      onClick={() =>
+                        void updateStatus(request.id, "CONTACTED")
+                      }
+                    >
+                      {updating === request.id ? (
+                        <LoaderCircle className="animate-spin" />
+                      ) : (
+                        <Check />
+                      )}
+                      Contacted
+                    </Button>
+                  ) : null}
+                  {request.status !== "CLOSED" ? (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={updating === request.id || demo}
+                      onClick={() => void updateStatus(request.id, "CLOSED")}
+                    >
+                      Close
+                    </Button>
+                  ) : (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={updating === request.id || demo}
+                      onClick={() =>
+                        void updateStatus(request.id, "CONTACTED")
+                      }
+                    >
+                      Reopen
+                    </Button>
+                  )}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+        {requests.length === 0 ? (
+          <Card>
+            <CardContent className="py-12 text-center">
+              <p className="font-medium">No booking requests yet.</p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                New first-party requests will appear here immediately.
+              </p>
+            </CardContent>
+          </Card>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function AnalyticsMetric({
+  label,
+  value,
+  detail,
+}: {
+  label: string;
+  value: string;
+  detail: string;
+}) {
+  return (
+    <Card>
+      <CardContent className="pt-1">
+        <p className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
+          {label}
+        </p>
+        <p className="mt-5 text-3xl font-semibold tracking-[-0.04em]">{value}</p>
+        <p className="mt-1 text-xs text-muted-foreground">{detail}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function formatInteger(value: number): string {
+  return new Intl.NumberFormat("en").format(value);
+}
+
+function formatPercent(value: number): string {
+  return new Intl.NumberFormat("en", {
+    style: "percent",
+    maximumFractionDigits: 1,
+  }).format(value);
+}
+
+function formatDateTime(value: string): string {
+  return new Intl.DateTimeFormat("en", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function humanize(value: string): string {
+  return value
+    .toLowerCase()
+    .replaceAll("_", " ")
+    .replace(/^\w/, (character) => character.toUpperCase());
+}

--- a/src/components/site-analytics.tsx
+++ b/src/components/site-analytics.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect } from "react";
+import {
+  getAnalyticsVisitId,
+  markAnalyticsViewSent,
+  sendAnalyticsEvent,
+} from "@/lib/analytics-browser";
+
+export function SiteAnalytics({ siteSlug }: { siteSlug: string }) {
+  useEffect(() => {
+    if (navigator.webdriver) return;
+    const visitId = getAnalyticsVisitId(siteSlug);
+    if (!visitId) return;
+
+    if (markAnalyticsViewSent(siteSlug)) {
+      sendAnalyticsEvent("SITE_VIEW", visitId);
+    }
+
+    const captureCta = (event: MouseEvent) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      if (!target.closest("[data-analytics-cta]")) return;
+      sendAnalyticsEvent("CTA_CLICK", visitId);
+    };
+    document.addEventListener("click", captureCta, { capture: true });
+    return () => document.removeEventListener("click", captureCta, true);
+  }, [siteSlug]);
+
+  return null;
+}

--- a/src/components/site-renderer.tsx
+++ b/src/components/site-renderer.tsx
@@ -8,12 +8,14 @@ import Image from "next/image";
 import Link from "next/link";
 import { BookingEmbed } from "@/components/booking-embed";
 import { BookingRequestForm } from "@/components/booking-request-form";
+import { SiteAnalytics } from "@/components/site-analytics";
 import { resolveBookingEmbed } from "@/lib/booking-embed";
 import {
   getSiteDictionary,
   getTemplateCopy,
   localizeIntegrationUrl,
 } from "@/lib/site-i18n";
+import { localeHref } from "@/lib/site-surface";
 import { formatPrice, type SiteDraftView } from "@/lib/site-draft";
 import { resolveVerticalConfig } from "@/lib/verticals/registry";
 import type { VerticalId } from "@/lib/verticals/types";
@@ -34,6 +36,7 @@ type SiteRendererProps = {
   locale?: string;
   localeBasePath?: string;
   availableLocales?: string[];
+  analyticsEnabled?: boolean;
 };
 
 export function SiteRenderer({
@@ -43,6 +46,7 @@ export function SiteRenderer({
   locale = draft.defaultLocale,
   localeBasePath,
   availableLocales = [draft.defaultLocale],
+  analyticsEnabled = false,
 }: SiteRendererProps) {
   const config = resolveVerticalConfig(vertical);
   const booking = draft.integrations.find(
@@ -106,6 +110,7 @@ export function SiteRenderer({
         } as React.CSSProperties
       }
     >
+      {analyticsEnabled ? <SiteAnalytics siteSlug={draft.slug} /> : null}
       <header
         className={cn(
           "z-20 grid w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-3 p-4 sm:flex sm:justify-between sm:gap-4 sm:p-5 md:p-8",
@@ -137,9 +142,11 @@ export function SiteRenderer({
                 <Link
                   key={availableLocale}
                   href={
-                    availableLocale === draft.defaultLocale
-                      ? localeBasePath
-                      : `${localeBasePath}/${availableLocale}`
+                    localeHref(
+                      localeBasePath,
+                      availableLocale,
+                      draft.defaultLocale,
+                    )
                   }
                   hrefLang={availableLocale}
                   aria-current={
@@ -162,6 +169,7 @@ export function SiteRenderer({
           {ordering ? (
             <a
               href={localizeIntegrationUrl(ordering.url, locale)}
+              data-analytics-cta
               target="_blank"
               rel="noreferrer"
               className={cn(
@@ -178,6 +186,7 @@ export function SiteRenderer({
           {booking ? (
             <a
               href={localizeIntegrationUrl(booking.url, locale)}
+              data-analytics-cta
               target="_blank"
               rel="noreferrer"
               className={cn(
@@ -337,6 +346,7 @@ export function SiteRenderer({
             {booking ? (
               <a
                 href={localizeIntegrationUrl(booking.url, locale)}
+                data-analytics-cta
                 target="_blank"
                 rel="noreferrer"
                 className="flex items-center gap-2 font-semibold opacity-100"
@@ -350,6 +360,7 @@ export function SiteRenderer({
             {ordering ? (
               <a
                 href={localizeIntegrationUrl(ordering.url, locale)}
+                data-analytics-cta
                 target="_blank"
                 rel="noreferrer"
                 className="flex items-center gap-2 font-semibold opacity-100"

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,8 +1,14 @@
 export async function register() {
-  if (
-    process.env.NEXT_RUNTIME !== "edge" &&
-    process.env.WORKFLOW_TARGET_WORLD === "@workflow/world-postgres"
-  ) {
+  if (process.env.NEXT_RUNTIME === "edge") return;
+
+  if (process.env.DATABASE_URL) {
+    const { startAnalyticsRetentionScheduler } = await import(
+      "@/lib/analytics-retention-runtime"
+    );
+    startAnalyticsRetentionScheduler();
+  }
+
+  if (process.env.WORKFLOW_TARGET_WORLD === "@workflow/world-postgres") {
     const { getWorld } = await import("workflow/runtime");
     await getWorld().start?.();
   }

--- a/src/lib/analytics-browser.ts
+++ b/src/lib/analytics-browser.ts
@@ -1,0 +1,70 @@
+const VISIT_KEY_PREFIX = "cornershopdev:analytics:visit:";
+const VIEW_KEY_PREFIX = "cornershopdev:analytics:view:";
+const fallbackVisits = new Map<string, string>();
+
+export type PublicAnalyticsEventType = "SITE_VIEW" | "CTA_CLICK";
+
+export function getAnalyticsVisitId(siteSlug: string): string | null {
+  if (typeof window === "undefined" || !globalThis.crypto?.randomUUID) {
+    return null;
+  }
+
+  const key = `${VISIT_KEY_PREFIX}${siteSlug}`;
+  try {
+    const existing = window.sessionStorage.getItem(key);
+    if (existing) return existing;
+    const created = globalThis.crypto.randomUUID();
+    window.sessionStorage.setItem(key, created);
+    return created;
+  } catch {
+    const existing = fallbackVisits.get(key);
+    if (existing) return existing;
+    const created = globalThis.crypto.randomUUID();
+    fallbackVisits.set(key, created);
+    return created;
+  }
+}
+
+export function markAnalyticsViewSent(siteSlug: string): boolean {
+  if (typeof window === "undefined") return false;
+  const key = `${VIEW_KEY_PREFIX}${siteSlug}`;
+  try {
+    if (window.sessionStorage.getItem(key)) return false;
+    window.sessionStorage.setItem(key, "1");
+    return true;
+  } catch {
+    return true;
+  }
+}
+
+export function sendAnalyticsEvent(
+  type: PublicAnalyticsEventType,
+  visitId: string,
+): void {
+  const payload = JSON.stringify({
+    id: globalThis.crypto.randomUUID(),
+    visitId,
+    type,
+  });
+
+  try {
+    if (
+      navigator.sendBeacon(
+        "/api/analytics/events",
+        new Blob([payload], { type: "application/json" }),
+      )
+    ) {
+      return;
+    }
+  } catch {
+    // The keepalive fallback below has the same fire-and-forget semantics.
+  }
+
+  void fetch("/api/analytics/events", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: payload,
+    credentials: "omit",
+    keepalive: true,
+  }).catch(() => undefined);
+}

--- a/src/lib/analytics-contract.test.ts
+++ b/src/lib/analytics-contract.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "bun:test";
+import {
+  ANALYTICS_WINDOWS,
+  analyticsEventInputSchema,
+  buildAnalyticsWindowDto,
+} from "@/lib/analytics-contract";
+
+const event = {
+  id: "5cd2b4dd-c6d5-4bfb-b453-2d12b349c27a",
+  visitId: "aa508bd0-43a1-4559-88ff-127fcf981bab",
+  type: "SITE_VIEW" as const,
+};
+
+describe("public analytics event contract", () => {
+  it("accepts only browser-owned site views and CTA clicks", () => {
+    expect(analyticsEventInputSchema.parse(event)).toEqual(event);
+    expect(
+      analyticsEventInputSchema.parse({ ...event, type: "CTA_CLICK" }),
+    ).toEqual({ ...event, type: "CTA_CLICK" });
+  });
+
+  it("rejects server-owned lead creation", () => {
+    expect(() =>
+      analyticsEventInputSchema.parse({ ...event, type: "LEAD_CREATED" }),
+    ).toThrow();
+  });
+
+  it("rejects unknown fields and malformed identifiers", () => {
+    expect(() =>
+      analyticsEventInputSchema.parse({
+        ...event,
+        referrer: "https://example.test/private?email=owner@example.test",
+      }),
+    ).toThrow();
+    expect(() =>
+      analyticsEventInputSchema.parse({ ...event, visitId: "visitor-1" }),
+    ).toThrow();
+  });
+});
+
+describe("analytics windows", () => {
+  it("offers exactly the supported reporting windows", () => {
+    expect(ANALYTICS_WINDOWS).toEqual([7, 30, 90]);
+  });
+
+  it("builds conversion rates from the same visit denominator", () => {
+    expect(
+      buildAnalyticsWindowDto({
+        days: 30,
+        visits: 20,
+        ctaVisitors: 5,
+        bookingLeads: 2,
+      }),
+    ).toEqual({
+      days: 30,
+      visits: 20,
+      ctaVisitors: 5,
+      bookingLeads: 2,
+      ctaRate: 0.25,
+      leadRate: 0.1,
+    });
+  });
+
+  it("returns zero rates when there are no visits", () => {
+    expect(
+      buildAnalyticsWindowDto({
+        days: 7,
+        visits: 0,
+        ctaVisitors: 3,
+        bookingLeads: 1,
+      }),
+    ).toMatchObject({ ctaRate: 0, leadRate: 0 });
+  });
+
+  it("preserves rates above one when a visit creates multiple outcomes", () => {
+    expect(
+      buildAnalyticsWindowDto({
+        days: 90,
+        visits: 2,
+        ctaVisitors: 4,
+        bookingLeads: 3,
+      }),
+    ).toMatchObject({ ctaRate: 2, leadRate: 1.5 });
+  });
+});

--- a/src/lib/analytics-contract.ts
+++ b/src/lib/analytics-contract.ts
@@ -1,0 +1,83 @@
+import { z } from "zod";
+
+export const ANALYTICS_WINDOWS = [7, 30, 90] as const;
+
+export type AnalyticsWindowDays = (typeof ANALYTICS_WINDOWS)[number];
+
+/**
+ * The only analytics facts an anonymous browser may assert. Lead creation is
+ * server-owned and therefore deliberately absent from this schema.
+ */
+export const analyticsEventInputSchema = z
+  .object({
+    id: z.uuid(),
+    visitId: z.uuid(),
+    type: z.enum(["SITE_VIEW", "CTA_CLICK"]),
+  })
+  .strict();
+
+export type AnalyticsEventInput = z.infer<typeof analyticsEventInputSchema>;
+
+export type AnalyticsWindowDto = {
+  days: AnalyticsWindowDays;
+  visits: number;
+  ctaVisitors: number;
+  bookingLeads: number;
+  ctaRate: number;
+  leadRate: number;
+};
+
+export type AnalyticsSummaryDto = {
+  generatedAt: string;
+  windows: AnalyticsWindowDto[];
+};
+
+export type SiteAnalyticsRowDto = {
+  visits: number;
+  ctaVisitors: number;
+  bookingLeads: number;
+  ctaRate: number;
+  leadRate: number;
+};
+
+export function buildEmptyAnalyticsSummary(
+  now = new Date(),
+): AnalyticsSummaryDto {
+  return {
+    generatedAt: now.toISOString(),
+    windows: ANALYTICS_WINDOWS.map((days) =>
+      buildAnalyticsWindowDto({
+        days,
+        visits: 0,
+        ctaVisitors: 0,
+        bookingLeads: 0,
+      }),
+    ),
+  };
+}
+
+export function buildAnalyticsWindowDto({
+  days,
+  visits,
+  ctaVisitors,
+  bookingLeads,
+}: {
+  days: AnalyticsWindowDays;
+  visits: number;
+  ctaVisitors: number;
+  bookingLeads: number;
+}): AnalyticsWindowDto {
+  return {
+    days,
+    visits,
+    ctaVisitors,
+    bookingLeads,
+    ctaRate: conversionRate(ctaVisitors, visits),
+    leadRate: conversionRate(bookingLeads, visits),
+  };
+}
+
+function conversionRate(numerator: number, denominator: number): number {
+  if (denominator <= 0 || numerator <= 0) return 0;
+  return numerator / denominator;
+}

--- a/src/lib/analytics-idempotency.test.ts
+++ b/src/lib/analytics-idempotency.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { createIdempotentAnalyticsEvent } from "@/lib/analytics-idempotency";
+
+describe("createIdempotentAnalyticsEvent", () => {
+  test("reports a successful insert", async () => {
+    expect(
+      await createIdempotentAnalyticsEvent(async () => undefined),
+    ).toBe("created");
+  });
+
+  test("treats Prisma unique conflicts as duplicate delivery", async () => {
+    expect(
+      await createIdempotentAnalyticsEvent(async () => {
+        throw { code: "P2002" };
+      }),
+    ).toBe("duplicate");
+  });
+
+  test("does not hide other storage failures", async () => {
+    expect(
+      createIdempotentAnalyticsEvent(async () => {
+        throw { code: "P2024" };
+      }),
+    ).rejects.toEqual({ code: "P2024" });
+  });
+});

--- a/src/lib/analytics-idempotency.ts
+++ b/src/lib/analytics-idempotency.ts
@@ -1,0 +1,22 @@
+export type AnalyticsCreateResult = "created" | "duplicate";
+
+export async function createIdempotentAnalyticsEvent(
+  create: () => Promise<unknown>,
+): Promise<AnalyticsCreateResult> {
+  try {
+    await create();
+    return "created";
+  } catch (error) {
+    if (hasPrismaCode(error, "P2002")) return "duplicate";
+    throw error;
+  }
+}
+
+function hasPrismaCode(error: unknown, code: string): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === code
+  );
+}

--- a/src/lib/analytics-policy.test.ts
+++ b/src/lib/analytics-policy.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "bun:test";
+import {
+  analyticsRequestHostname,
+  isLikelyAutomatedRequest,
+  resolveEligibleAnalyticsSite,
+  type AnalyticsHostLookup,
+} from "@/lib/analytics-policy";
+
+describe("analytics request hostname", () => {
+  it("prefers and normalizes the first forwarded hostname", () => {
+    const headers = new Headers({
+      "x-forwarded-host": " Customer.Example:443, proxy.internal ",
+      host: "container:3000",
+    });
+
+    expect(analyticsRequestHostname(headers)).toBe("customer.example");
+  });
+
+  it("falls back to Host when the forwarded value is blank", () => {
+    const headers = new Headers({
+      "x-forwarded-host": " ",
+      host: "Customer.Example.:3000",
+    });
+
+    expect(analyticsRequestHostname(headers)).toBe("customer.example");
+  });
+});
+
+describe("automated analytics requests", () => {
+  it("rejects prefetches without retaining their headers", () => {
+    expect(
+      isLikelyAutomatedRequest(
+        new Headers({
+          purpose: "prefetch",
+          "user-agent": "Mozilla/5.0",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isLikelyAutomatedRequest(
+        new Headers({
+          "next-router-prefetch": "1",
+          "user-agent": "Mozilla/5.0",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects known crawlers and missing user agents", () => {
+    expect(
+      isLikelyAutomatedRequest(
+        new Headers({ "user-agent": "Googlebot/2.1" }),
+      ),
+    ).toBe(true);
+    expect(isLikelyAutomatedRequest(new Headers())).toBe(true);
+  });
+
+  it("admits an ordinary browser request", () => {
+    expect(
+      isLikelyAutomatedRequest(
+        new Headers({
+          "user-agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/537.36 Safari/537.36",
+        }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("analytics host eligibility", () => {
+  it("rejects factory and niche hosts before querying tenant data", async () => {
+    let lookups = 0;
+    const lookup: AnalyticsHostLookup = async () => {
+      lookups += 1;
+      return { id: "site_1", slug: "chez-lea", verified: true };
+    };
+
+    expect(
+      await resolveEligibleAnalyticsSite({
+        hostname: "RestoFront.com:443",
+        isFactory: (hostname) => hostname === "restofront.com",
+        lookup,
+      }),
+    ).toBeNull();
+    expect(lookups).toBe(0);
+  });
+
+  it("requires the hostname lookup to return a verified site", async () => {
+    expect(
+      await resolveEligibleAnalyticsSite({
+        hostname: "Preview.Example:443",
+        isFactory: () => false,
+        lookup: async (hostname) => ({
+          id: "site_1",
+          slug: hostname,
+          verified: false,
+        }),
+      }),
+    ).toBeNull();
+  });
+
+  it("returns the verified site for a normalized customer hostname", async () => {
+    const visited: string[] = [];
+    const site = { id: "site_1", slug: "chez-lea", verified: true };
+
+    expect(
+      await resolveEligibleAnalyticsSite({
+        hostname: " WWW.Chez-Lea.Example:443 ",
+        isFactory: () => false,
+        lookup: async (hostname) => {
+          visited.push(hostname);
+          return site;
+        },
+      }),
+    ).toEqual(site);
+    expect(visited).toEqual(["www.chez-lea.example"]);
+  });
+});

--- a/src/lib/analytics-policy.ts
+++ b/src/lib/analytics-policy.ts
@@ -1,0 +1,83 @@
+export type AnalyticsHeaderReader = Pick<Headers, "get">;
+
+export type AnalyticsHostSite = {
+  id: string;
+  slug: string;
+  verified: boolean;
+};
+
+export type AnalyticsHostLookup = (
+  hostname: string,
+) => Promise<AnalyticsHostSite | null>;
+
+const automatedUserAgent =
+  /(bot|crawler|spider|slurp|bingpreview|facebookexternalhit|headlesschrome|lighthouse|pagespeed|google-inspectiontool)/i;
+
+/**
+ * Reads the public hostname before a reverse proxy can replace it with the
+ * container address. Only the first forwarded value belongs to the caller.
+ */
+export function analyticsRequestHostname(
+  headers: AnalyticsHeaderReader,
+): string {
+  const forwarded = firstHeaderValue(headers.get("x-forwarded-host"));
+  const host = forwarded || firstHeaderValue(headers.get("host"));
+  return normalizeHostname(host);
+}
+
+/**
+ * Uses request headers only as a transient rejection signal. Callers receive a
+ * boolean, not the identifying header values, so no persistence surface exists.
+ */
+export function isLikelyAutomatedRequest(
+  headers: AnalyticsHeaderReader,
+): boolean {
+  const purpose = [
+    headers.get("purpose"),
+    headers.get("sec-purpose"),
+    headers.get("x-purpose"),
+  ]
+    .filter((value): value is string => Boolean(value))
+    .join(" ");
+  if (/\b(prefetch|prerender)\b/i.test(purpose)) return true;
+  if (headers.get("next-router-prefetch") !== null) return true;
+
+  const userAgent = headers.get("user-agent")?.trim() ?? "";
+  return !userAgent || automatedUserAgent.test(userAgent);
+}
+
+/**
+ * Resolves a hostname only after excluding platform-owned domains. The lookup
+ * remains injected so the policy is pure and can be backed by a verified Domain
+ * query without importing Prisma into this module.
+ */
+export async function resolveEligibleAnalyticsSite({
+  hostname,
+  isFactory,
+  lookup,
+}: {
+  hostname: string;
+  isFactory: (hostname: string) => boolean;
+  lookup: AnalyticsHostLookup;
+}): Promise<AnalyticsHostSite | null> {
+  const normalized = normalizeHostname(hostname);
+  if (!normalized || isFactory(normalized)) return null;
+
+  const site = await lookup(normalized);
+  return site?.verified ? site : null;
+}
+
+function firstHeaderValue(value: string | null): string {
+  return value?.split(",")[0]?.trim() ?? "";
+}
+
+function normalizeHostname(value: string): string {
+  const normalized = value.trim().toLowerCase();
+  if (normalized.startsWith("[")) {
+    const closingBracket = normalized.indexOf("]");
+    return closingBracket > 0
+      ? normalized.slice(1, closingBracket)
+      : normalized;
+  }
+  return normalized.replace(/:\d+$/, "").replace(/\.$/, "");
+}

--- a/src/lib/analytics-policy.ts
+++ b/src/lib/analytics-policy.ts
@@ -1,4 +1,10 @@
-export type AnalyticsHeaderReader = Pick<Headers, "get">;
+import {
+  normalizeHostname,
+  requestHostname,
+  type HeaderReader,
+} from "@/lib/request-hostname";
+
+export type AnalyticsHeaderReader = HeaderReader;
 
 export type AnalyticsHostSite = {
   id: string;
@@ -17,13 +23,7 @@ const automatedUserAgent =
  * Reads the public hostname before a reverse proxy can replace it with the
  * container address. Only the first forwarded value belongs to the caller.
  */
-export function analyticsRequestHostname(
-  headers: AnalyticsHeaderReader,
-): string {
-  const forwarded = firstHeaderValue(headers.get("x-forwarded-host"));
-  const host = forwarded || firstHeaderValue(headers.get("host"));
-  return normalizeHostname(host);
-}
+export const analyticsRequestHostname = requestHostname;
 
 /**
  * Uses request headers only as a transient rejection signal. Callers receive a
@@ -65,19 +65,4 @@ export async function resolveEligibleAnalyticsSite({
 
   const site = await lookup(normalized);
   return site?.verified ? site : null;
-}
-
-function firstHeaderValue(value: string | null): string {
-  return value?.split(",")[0]?.trim() ?? "";
-}
-
-function normalizeHostname(value: string): string {
-  const normalized = value.trim().toLowerCase();
-  if (normalized.startsWith("[")) {
-    const closingBracket = normalized.indexOf("]");
-    return closingBracket > 0
-      ? normalized.slice(1, closingBracket)
-      : normalized;
-  }
-  return normalized.replace(/:\d+$/, "").replace(/\.$/, "");
 }

--- a/src/lib/analytics-retention-runtime.ts
+++ b/src/lib/analytics-retention-runtime.ts
@@ -1,0 +1,29 @@
+import "server-only";
+import { pruneExpiredAnalytics } from "@/lib/analytics";
+
+const DAY_MS = 24 * 60 * 60_000;
+const MAX_INITIAL_JITTER_MS = 5 * 60_000;
+
+type AnalyticsSchedulerGlobal = typeof globalThis & {
+  __cornershopAnalyticsRetentionStarted?: boolean;
+};
+
+export function startAnalyticsRetentionScheduler(): void {
+  const schedulerGlobal = globalThis as AnalyticsSchedulerGlobal;
+  if (schedulerGlobal.__cornershopAnalyticsRetentionStarted) return;
+  schedulerGlobal.__cornershopAnalyticsRetentionStarted = true;
+
+  const run = () => {
+    void pruneExpiredAnalytics().catch((error) => {
+      console.error("[analytics-retention] prune failed", {
+        error: error instanceof Error ? error.message : "unknown",
+      });
+    });
+  };
+  const initial = setTimeout(() => {
+    run();
+    const interval = setInterval(run, DAY_MS);
+    interval.unref();
+  }, Math.floor(Math.random() * MAX_INITIAL_JITTER_MS));
+  initial.unref();
+}

--- a/src/lib/analytics-retention.test.ts
+++ b/src/lib/analytics-retention.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+import {
+  ANALYTICS_RETENTION_DAYS,
+  analyticsRetentionCutoff,
+} from "@/lib/analytics-retention";
+
+describe("analytics retention", () => {
+  it("retains raw events for 120 rolling days", () => {
+    const now = new Date("2026-07-26T18:00:00.000Z");
+
+    expect(ANALYTICS_RETENTION_DAYS).toBe(120);
+    expect(analyticsRetentionCutoff(now).toISOString()).toBe(
+      "2026-03-28T18:00:00.000Z",
+    );
+  });
+
+  it("does not mutate the supplied clock", () => {
+    const now = new Date("2026-07-26T18:00:00.000Z");
+
+    analyticsRetentionCutoff(now);
+
+    expect(now.toISOString()).toBe("2026-07-26T18:00:00.000Z");
+  });
+
+  it("rejects an invalid clock", () => {
+    expect(() => analyticsRetentionCutoff(new Date("invalid"))).toThrow(
+      RangeError,
+    );
+  });
+});

--- a/src/lib/analytics-retention.ts
+++ b/src/lib/analytics-retention.ts
@@ -1,0 +1,15 @@
+export const ANALYTICS_RETENTION_DAYS = 120;
+
+const DAY_MS = 24 * 60 * 60_000;
+
+/**
+ * Raw analytics uses a rolling duration rather than calendar-day arithmetic,
+ * keeping the cutoff stable across daylight-saving and timezone boundaries.
+ */
+export function analyticsRetentionCutoff(now: Date): Date {
+  const timestamp = now.getTime();
+  if (!Number.isFinite(timestamp)) {
+    throw new RangeError("Analytics retention requires a valid date");
+  }
+  return new Date(timestamp - ANALYTICS_RETENTION_DAYS * DAY_MS);
+}

--- a/src/lib/analytics.postgres.test.ts
+++ b/src/lib/analytics.postgres.test.ts
@@ -1,0 +1,153 @@
+import { randomUUID } from "node:crypto";
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+const enabled = process.env.ANALYTICS_POSTGRES_TEST === "1";
+const now = new Date("2026-07-26T12:00:00.000Z");
+const primarySiteId = `analytics-test-${randomUUID()}`;
+const secondarySiteId = `analytics-test-${randomUUID()}`;
+const primaryRecentVisitId = randomUUID();
+let db: ReturnType<typeof import("@/lib/db").getDb>;
+let getSiteAnalyticsSummary: typeof import("@/lib/analytics").getSiteAnalyticsSummary;
+let getPortfolioAnalytics: typeof import("@/lib/analytics").getPortfolioAnalytics;
+let liveBookingRequestSource: string;
+
+describe.skipIf(!enabled)("analytics PostgreSQL integration", () => {
+  beforeAll(async () => {
+    const analytics = await import("@/lib/analytics");
+    const database = await import("@/lib/db");
+    db = database.getDb();
+    getSiteAnalyticsSummary = analytics.getSiteAnalyticsSummary;
+    getPortfolioAnalytics = analytics.getPortfolioAnalytics;
+    liveBookingRequestSource = analytics.LIVE_BOOKING_REQUEST_SOURCE;
+
+    await db.site.createMany({
+      data: [
+        {
+          id: primarySiteId,
+          slug: `analytics-primary-${randomUUID()}`,
+          name: "Analytics primary",
+        },
+        {
+          id: secondarySiteId,
+          slug: `analytics-secondary-${randomUUID()}`,
+          name: "Analytics secondary",
+        },
+      ],
+    });
+    await db.analyticsEvent.createMany({
+      data: [
+        event(primarySiteId, "SITE_VIEW", daysBefore(1), primaryRecentVisitId),
+        event(primarySiteId, "CTA_CLICK", daysBefore(1), primaryRecentVisitId),
+        event(primarySiteId, "SITE_VIEW", daysBefore(20), randomUUID()),
+        event(primarySiteId, "SITE_VIEW", daysBefore(60), randomUUID()),
+        event(secondarySiteId, "SITE_VIEW", daysBefore(1), randomUUID()),
+      ],
+    });
+    await db.bookingRequest.createMany({
+      data: [
+        {
+          siteId: primarySiteId,
+          name: "Primary lead",
+          email: "primary@example.test",
+          source: liveBookingRequestSource,
+          createdAt: daysBefore(1),
+        },
+        {
+          siteId: secondarySiteId,
+          name: "Secondary lead",
+          email: "secondary@example.test",
+          source: liveBookingRequestSource,
+          createdAt: daysBefore(1),
+        },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await db.site.deleteMany({
+      where: { id: { in: [primarySiteId, secondarySiteId] } },
+    });
+  });
+
+  test("returns executable 7/30/90-day site windows", async () => {
+    const summary = await getSiteAnalyticsSummary(primarySiteId, now);
+
+    expect(summary.windows).toEqual([
+      {
+        days: 7,
+        visits: 1,
+        ctaVisitors: 1,
+        bookingLeads: 1,
+        ctaRate: 1,
+        leadRate: 1,
+      },
+      {
+        days: 30,
+        visits: 2,
+        ctaVisitors: 1,
+        bookingLeads: 1,
+        ctaRate: 0.5,
+        leadRate: 0.5,
+      },
+      {
+        days: 90,
+        visits: 3,
+        ctaVisitors: 1,
+        bookingLeads: 1,
+        ctaRate: 1 / 3,
+        leadRate: 1 / 3,
+      },
+    ]);
+  });
+
+  test("returns portfolio windows and bounded per-site metrics", async () => {
+    const portfolio = await getPortfolioAnalytics({
+      displayedSiteIds: [primarySiteId],
+      now,
+    });
+
+    expect(portfolio.summary.windows[0]).toMatchObject({
+      days: 7,
+      visits: 2,
+      ctaVisitors: 1,
+      bookingLeads: 2,
+      ctaRate: 0.5,
+      leadRate: 1,
+    });
+    expect(portfolio.displayedSites30d.get(primarySiteId)).toEqual({
+      visits: 2,
+      ctaVisitors: 1,
+      bookingLeads: 1,
+      ctaRate: 0.5,
+      leadRate: 0.5,
+    });
+  });
+});
+
+function event(
+  siteId: string,
+  type: "SITE_VIEW" | "CTA_CLICK",
+  occurredAt: Date,
+  visitId: string,
+) {
+  return {
+    id: randomUUID(),
+    siteId,
+    visitId,
+    type,
+    occurredAt,
+  } as const;
+}
+
+function daysBefore(days: number): Date {
+  return new Date(now.getTime() - days * 24 * 60 * 60_000);
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,294 @@
+import "server-only";
+import { randomUUID } from "node:crypto";
+import { Prisma } from "@/generated/prisma/client";
+import type { AnalyticsEventType } from "@/generated/prisma/enums";
+import {
+  ANALYTICS_WINDOWS,
+  buildAnalyticsWindowDto,
+  type AnalyticsEventInput,
+  type AnalyticsSummaryDto,
+  type SiteAnalyticsRowDto,
+} from "@/lib/analytics-contract";
+import {
+  analyticsRequestHostname,
+  resolveEligibleAnalyticsSite,
+} from "@/lib/analytics-policy";
+import { createIdempotentAnalyticsEvent } from "@/lib/analytics-idempotency";
+import { analyticsRetentionCutoff } from "@/lib/analytics-retention";
+import { getDb } from "@/lib/db";
+import { isFactoryHostname } from "@/lib/hostnames";
+
+export const LIVE_BOOKING_REQUEST_SOURCE = "live-site-form";
+
+export type { AnalyticsSummaryDto, SiteAnalyticsRowDto };
+
+type MetricRow = {
+  days: number;
+  visits: number;
+  ctaVisitors: number;
+  bookingLeads: number;
+};
+
+type SiteMetricRow = {
+  siteId: string;
+  visits: number;
+  ctaVisitors: number;
+};
+
+type SiteLeadRow = {
+  siteId: string;
+  bookingLeads: number;
+};
+
+export async function resolveAnalyticsSiteForHeaders(headers: Headers) {
+  const hostname = analyticsRequestHostname(headers);
+  return resolveEligibleAnalyticsSite({
+    hostname,
+    isFactory: isFactoryHostname,
+    lookup: async (verifiedHostname) => {
+      const domain = await getDb().domain.findUnique({
+        where: { hostname: verifiedHostname },
+        select: {
+          verified: true,
+          site: { select: { id: true, slug: true } },
+        },
+      });
+      if (!domain) return null;
+      return {
+        id: domain.site.id,
+        slug: domain.site.slug,
+        verified: domain.verified,
+      };
+    },
+  });
+}
+
+export async function recordBrowserAnalyticsEvent(
+  siteId: string,
+  event: AnalyticsEventInput,
+): Promise<"created" | "duplicate"> {
+  return createAnalyticsEvent({
+    id: event.id,
+    visitId: event.visitId,
+    type: event.type,
+    siteId,
+  });
+}
+
+export async function recordLeadCreatedEvent(input: {
+  siteId: string;
+  visitId: string;
+}): Promise<"created" | "duplicate"> {
+  return createAnalyticsEvent({
+    id: randomUUID(),
+    visitId: input.visitId,
+    type: "LEAD_CREATED",
+    siteId: input.siteId,
+  });
+}
+
+async function createAnalyticsEvent(input: {
+  id: string;
+  visitId: string;
+  type: AnalyticsEventType;
+  siteId: string;
+}): Promise<"created" | "duplicate"> {
+  return createIdempotentAnalyticsEvent(() =>
+    getDb().analyticsEvent.create({ data: input }),
+  );
+}
+
+export async function getSiteAnalyticsSummary(
+  siteId: string,
+  now = new Date(),
+): Promise<AnalyticsSummaryDto> {
+  const rows = await getDb().$queryRaw<MetricRow[]>`
+    WITH windows(days) AS (
+      VALUES (7), (30), (90)
+    )
+    SELECT
+      windows.days::int AS days,
+      (
+        SELECT COUNT(DISTINCT event."visitId")::int
+        FROM "AnalyticsEvent" AS event
+        WHERE event."siteId" = ${siteId}
+          AND event."type" = 'SITE_VIEW'
+          AND event."occurredAt" >= ${now} - windows.days * INTERVAL '1 day'
+          AND event."occurredAt" < ${now}
+      ) AS visits,
+      (
+        SELECT COUNT(DISTINCT event."visitId")::int
+        FROM "AnalyticsEvent" AS event
+        WHERE event."siteId" = ${siteId}
+          AND event."type" = 'CTA_CLICK'
+          AND event."occurredAt" >= ${now} - windows.days * INTERVAL '1 day'
+          AND event."occurredAt" < ${now}
+      ) AS "ctaVisitors",
+      (
+        SELECT COUNT(*)::int
+        FROM "BookingRequest" AS lead
+        WHERE lead."siteId" = ${siteId}
+          AND lead."source" = ${LIVE_BOOKING_REQUEST_SOURCE}
+          AND lead."createdAt" >= ${now} - windows.days * INTERVAL '1 day'
+          AND lead."createdAt" < ${now}
+      ) AS "bookingLeads"
+    FROM windows
+    ORDER BY windows.days ASC
+  `;
+
+  return analyticsSummary(rows, now);
+}
+
+export async function getPortfolioAnalytics(input: {
+  displayedSiteIds: string[];
+  now?: Date;
+}): Promise<{
+  summary: AnalyticsSummaryDto;
+  displayedSites30d: Map<string, SiteAnalyticsRowDto>;
+}> {
+  const now = input.now ?? new Date();
+  const cutoff30d = new Date(now.getTime() - 30 * 24 * 60 * 60_000);
+  const db = getDb();
+  const siteFilter =
+    input.displayedSiteIds.length > 0
+      ? Prisma.sql`AND event."siteId" IN (${Prisma.join(input.displayedSiteIds)})`
+      : Prisma.sql`AND FALSE`;
+  const leadSiteFilter =
+    input.displayedSiteIds.length > 0
+      ? Prisma.sql`AND lead."siteId" IN (${Prisma.join(input.displayedSiteIds)})`
+      : Prisma.sql`AND FALSE`;
+
+  const [summaryRows, siteRows, leadRows] = await Promise.all([
+    db.$queryRaw<MetricRow[]>`
+      WITH windows(days) AS (
+        VALUES (7), (30), (90)
+      )
+      SELECT
+        windows.days::int AS days,
+        (
+          SELECT COUNT(DISTINCT (event."siteId", event."visitId"))::int
+          FROM "AnalyticsEvent" AS event
+          WHERE event."type" = 'SITE_VIEW'
+            AND event."occurredAt" >= ${now} - windows.days * INTERVAL '1 day'
+            AND event."occurredAt" < ${now}
+        ) AS visits,
+        (
+          SELECT COUNT(DISTINCT (event."siteId", event."visitId"))::int
+          FROM "AnalyticsEvent" AS event
+          WHERE event."type" = 'CTA_CLICK'
+            AND event."occurredAt" >= ${now} - windows.days * INTERVAL '1 day'
+            AND event."occurredAt" < ${now}
+        ) AS "ctaVisitors",
+        (
+          SELECT COUNT(*)::int
+          FROM "BookingRequest" AS lead
+          WHERE lead."source" = ${LIVE_BOOKING_REQUEST_SOURCE}
+            AND lead."createdAt" >= ${now} - windows.days * INTERVAL '1 day'
+            AND lead."createdAt" < ${now}
+        ) AS "bookingLeads"
+      FROM windows
+      ORDER BY windows.days ASC
+    `,
+    db.$queryRaw<SiteMetricRow[]>(Prisma.sql`
+      SELECT
+        event."siteId",
+        COUNT(DISTINCT event."visitId")
+          FILTER (WHERE event."type" = 'SITE_VIEW')::int AS visits,
+        COUNT(DISTINCT event."visitId")
+          FILTER (WHERE event."type" = 'CTA_CLICK')::int AS "ctaVisitors"
+      FROM "AnalyticsEvent" AS event
+      WHERE event."occurredAt" >= ${cutoff30d}
+        AND event."occurredAt" < ${now}
+        ${siteFilter}
+      GROUP BY event."siteId"
+    `),
+    db.$queryRaw<SiteLeadRow[]>(Prisma.sql`
+      SELECT
+        lead."siteId",
+        COUNT(*)::int AS "bookingLeads"
+      FROM "BookingRequest" AS lead
+      WHERE lead."source" = ${LIVE_BOOKING_REQUEST_SOURCE}
+        AND lead."createdAt" >= ${cutoff30d}
+        AND lead."createdAt" < ${now}
+        ${leadSiteFilter}
+      GROUP BY lead."siteId"
+    `),
+  ]);
+
+  const counts = new Map<
+    string,
+    { visits: number; ctaVisitors: number; bookingLeads: number }
+  >();
+  for (const row of siteRows) {
+    counts.set(row.siteId, {
+      visits: row.visits,
+      ctaVisitors: row.ctaVisitors,
+      bookingLeads: 0,
+    });
+  }
+  for (const row of leadRows) {
+    const current = counts.get(row.siteId) ?? {
+      visits: 0,
+      ctaVisitors: 0,
+      bookingLeads: 0,
+    };
+    current.bookingLeads = row.bookingLeads;
+    counts.set(row.siteId, current);
+  }
+
+  return {
+    summary: analyticsSummary(summaryRows, now),
+    displayedSites30d: new Map(
+      input.displayedSiteIds.map((siteId) => {
+        const value = counts.get(siteId) ?? {
+          visits: 0,
+          ctaVisitors: 0,
+          bookingLeads: 0,
+        };
+        const dto = buildAnalyticsWindowDto({ days: 30, ...value });
+        return [
+          siteId,
+          {
+            visits: dto.visits,
+            ctaVisitors: dto.ctaVisitors,
+            bookingLeads: dto.bookingLeads,
+            ctaRate: dto.ctaRate,
+            leadRate: dto.leadRate,
+          },
+        ];
+      }),
+    ),
+  };
+}
+
+export async function pruneExpiredAnalytics(now = new Date()): Promise<number> {
+  return getDb().$transaction(async (transaction) => {
+    const [lock] = await transaction.$queryRaw<Array<{ acquired: boolean }>>`
+      SELECT pg_try_advisory_xact_lock(1129333061) AS acquired
+    `;
+    if (!lock?.acquired) return 0;
+    const deleted = await transaction.analyticsEvent.deleteMany({
+      where: { occurredAt: { lt: analyticsRetentionCutoff(now) } },
+    });
+    return deleted.count;
+  });
+}
+
+function analyticsSummary(
+  rows: MetricRow[],
+  now: Date,
+): AnalyticsSummaryDto {
+  const byDays = new Map(rows.map((row) => [row.days, row]));
+  return {
+    generatedAt: now.toISOString(),
+    windows: ANALYTICS_WINDOWS.map((days) => {
+      const row = byDays.get(days);
+      return buildAnalyticsWindowDto({
+        days,
+        visits: row?.visits ?? 0,
+        ctaVisitors: row?.ctaVisitors ?? 0,
+        bookingLeads: row?.bookingLeads ?? 0,
+      });
+    }),
+  };
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -113,24 +113,33 @@ export async function getSiteAnalyticsSummary(
         FROM "AnalyticsEvent" AS event
         WHERE event."siteId" = ${siteId}
           AND event."type" = 'SITE_VIEW'
-          AND event."occurredAt" >= ${now} - windows.days * INTERVAL '1 day'
-          AND event."occurredAt" < ${now}
+          AND event."occurredAt" >=
+            (${now}::timestamptz AT TIME ZONE 'UTC')
+            - make_interval(days => windows.days)
+          AND event."occurredAt" <
+            (${now}::timestamptz AT TIME ZONE 'UTC')
       ) AS visits,
       (
         SELECT COUNT(DISTINCT event."visitId")::int
         FROM "AnalyticsEvent" AS event
         WHERE event."siteId" = ${siteId}
           AND event."type" = 'CTA_CLICK'
-          AND event."occurredAt" >= ${now} - windows.days * INTERVAL '1 day'
-          AND event."occurredAt" < ${now}
+          AND event."occurredAt" >=
+            (${now}::timestamptz AT TIME ZONE 'UTC')
+            - make_interval(days => windows.days)
+          AND event."occurredAt" <
+            (${now}::timestamptz AT TIME ZONE 'UTC')
       ) AS "ctaVisitors",
       (
         SELECT COUNT(*)::int
         FROM "BookingRequest" AS lead
         WHERE lead."siteId" = ${siteId}
           AND lead."source" = ${LIVE_BOOKING_REQUEST_SOURCE}
-          AND lead."createdAt" >= ${now} - windows.days * INTERVAL '1 day'
-          AND lead."createdAt" < ${now}
+          AND lead."createdAt" >=
+            (${now}::timestamptz AT TIME ZONE 'UTC')
+            - make_interval(days => windows.days)
+          AND lead."createdAt" <
+            (${now}::timestamptz AT TIME ZONE 'UTC')
       ) AS "bookingLeads"
     FROM windows
     ORDER BY windows.days ASC
@@ -169,22 +178,31 @@ export async function getPortfolioAnalytics(input: {
           SELECT COUNT(DISTINCT (event."siteId", event."visitId"))::int
           FROM "AnalyticsEvent" AS event
           WHERE event."type" = 'SITE_VIEW'
-            AND event."occurredAt" >= ${now} - windows.days * INTERVAL '1 day'
-            AND event."occurredAt" < ${now}
+            AND event."occurredAt" >=
+              (${now}::timestamptz AT TIME ZONE 'UTC')
+              - make_interval(days => windows.days)
+            AND event."occurredAt" <
+              (${now}::timestamptz AT TIME ZONE 'UTC')
         ) AS visits,
         (
           SELECT COUNT(DISTINCT (event."siteId", event."visitId"))::int
           FROM "AnalyticsEvent" AS event
           WHERE event."type" = 'CTA_CLICK'
-            AND event."occurredAt" >= ${now} - windows.days * INTERVAL '1 day'
-            AND event."occurredAt" < ${now}
+            AND event."occurredAt" >=
+              (${now}::timestamptz AT TIME ZONE 'UTC')
+              - make_interval(days => windows.days)
+            AND event."occurredAt" <
+              (${now}::timestamptz AT TIME ZONE 'UTC')
         ) AS "ctaVisitors",
         (
           SELECT COUNT(*)::int
           FROM "BookingRequest" AS lead
           WHERE lead."source" = ${LIVE_BOOKING_REQUEST_SOURCE}
-            AND lead."createdAt" >= ${now} - windows.days * INTERVAL '1 day'
-            AND lead."createdAt" < ${now}
+            AND lead."createdAt" >=
+              (${now}::timestamptz AT TIME ZONE 'UTC')
+              - make_interval(days => windows.days)
+            AND lead."createdAt" <
+              (${now}::timestamptz AT TIME ZONE 'UTC')
         ) AS "bookingLeads"
       FROM windows
       ORDER BY windows.days ASC
@@ -197,8 +215,10 @@ export async function getPortfolioAnalytics(input: {
         COUNT(DISTINCT event."visitId")
           FILTER (WHERE event."type" = 'CTA_CLICK')::int AS "ctaVisitors"
       FROM "AnalyticsEvent" AS event
-      WHERE event."occurredAt" >= ${cutoff30d}
-        AND event."occurredAt" < ${now}
+      WHERE event."occurredAt" >=
+          (${cutoff30d}::timestamptz AT TIME ZONE 'UTC')
+        AND event."occurredAt" <
+          (${now}::timestamptz AT TIME ZONE 'UTC')
         ${siteFilter}
       GROUP BY event."siteId"
     `),
@@ -208,8 +228,10 @@ export async function getPortfolioAnalytics(input: {
         COUNT(*)::int AS "bookingLeads"
       FROM "BookingRequest" AS lead
       WHERE lead."source" = ${LIVE_BOOKING_REQUEST_SOURCE}
-        AND lead."createdAt" >= ${cutoff30d}
-        AND lead."createdAt" < ${now}
+        AND lead."createdAt" >=
+          (${cutoff30d}::timestamptz AT TIME ZONE 'UTC')
+        AND lead."createdAt" <
+          (${now}::timestamptz AT TIME ZONE 'UTC')
         ${leadSiteFilter}
       GROUP BY lead."siteId"
     `),

--- a/src/lib/booking-request-inbox.ts
+++ b/src/lib/booking-request-inbox.ts
@@ -15,31 +15,53 @@ export type BookingRequestDto = {
   updatedAt: string;
 };
 
+export type BookingRequestInboxDto = {
+  requests: BookingRequestDto[];
+  total: number;
+  awaitingContact: number;
+  truncated: boolean;
+};
+
 export async function getBookingRequestInbox(
   siteId: string,
-): Promise<BookingRequestDto[]> {
-  const requests = await getDb().bookingRequest.findMany({
-    where: { siteId },
-    orderBy: [{ createdAt: "desc" }, { id: "desc" }],
-    take: 100,
-    select: {
-      id: true,
-      name: true,
-      email: true,
-      phone: true,
-      requestedAt: true,
-      partySize: true,
-      notes: true,
-      status: true,
-      createdAt: true,
-      updatedAt: true,
-    },
-  });
+): Promise<BookingRequestInboxDto> {
+  const db = getDb();
+  const [requests, total, awaitingContact] = await Promise.all([
+    db.bookingRequest.findMany({
+      where: { siteId },
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      take: 100,
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        phone: true,
+        requestedAt: true,
+        partySize: true,
+        notes: true,
+        status: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    }),
+    db.bookingRequest.count({ where: { siteId } }),
+    db.bookingRequest.count({
+      where: {
+        siteId,
+        status: { in: ["NEW", "NOTIFIED"] },
+      },
+    }),
+  ]);
 
-  return requests.map((request) => ({
-    ...request,
-    requestedAt: request.requestedAt?.toISOString() ?? null,
-    createdAt: request.createdAt.toISOString(),
-    updatedAt: request.updatedAt.toISOString(),
-  }));
+  return {
+    requests: requests.map((request) => ({
+      ...request,
+      requestedAt: request.requestedAt?.toISOString() ?? null,
+      createdAt: request.createdAt.toISOString(),
+      updatedAt: request.updatedAt.toISOString(),
+    })),
+    total,
+    awaitingContact,
+    truncated: total > requests.length,
+  };
 }

--- a/src/lib/booking-request-inbox.ts
+++ b/src/lib/booking-request-inbox.ts
@@ -1,0 +1,45 @@
+import "server-only";
+import type { BookingRequestStatus } from "@/generated/prisma/enums";
+import { getDb } from "@/lib/db";
+
+export type BookingRequestDto = {
+  id: string;
+  name: string;
+  email: string | null;
+  phone: string | null;
+  requestedAt: string | null;
+  partySize: number | null;
+  notes: string | null;
+  status: BookingRequestStatus;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export async function getBookingRequestInbox(
+  siteId: string,
+): Promise<BookingRequestDto[]> {
+  const requests = await getDb().bookingRequest.findMany({
+    where: { siteId },
+    orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+    take: 100,
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      phone: true,
+      requestedAt: true,
+      partySize: true,
+      notes: true,
+      status: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+
+  return requests.map((request) => ({
+    ...request,
+    requestedAt: request.requestedAt?.toISOString() ?? null,
+    createdAt: request.createdAt.toISOString(),
+    updatedAt: request.updatedAt.toISOString(),
+  }));
+}

--- a/src/lib/booking-request-status.test.ts
+++ b/src/lib/booking-request-status.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "bun:test";
+import {
+  updateBookingRequestStatus,
+  type BookingRequestStatusStore,
+} from "@/lib/booking-request-status";
+
+describe("booking request status updates", () => {
+  it("updates only a request owned by the accessed site", async () => {
+    const rows = new Map([
+      ["lead_a", { siteId: "site_a", status: "NEW" }],
+      ["lead_b", { siteId: "site_b", status: "NEW" }],
+    ]);
+    const store = memoryStore(rows);
+
+    expect(
+      await updateBookingRequestStatus(store, {
+        requestId: "lead_b",
+        siteId: "site_a",
+        status: "CLOSED",
+      }),
+    ).toBe(false);
+    expect(rows.get("lead_b")?.status).toBe("NEW");
+  });
+
+  it("sets lifecycle timestamps and clears closedAt when reopened", async () => {
+    const rows = new Map([
+      [
+        "lead_a",
+        {
+          siteId: "site_a",
+          status: "CLOSED",
+          closedAt: new Date("2026-07-01T00:00:00.000Z"),
+        },
+      ],
+    ]);
+    const store = memoryStore(rows);
+    const now = new Date("2026-07-26T12:00:00.000Z");
+
+    expect(
+      await updateBookingRequestStatus(store, {
+        requestId: "lead_a",
+        siteId: "site_a",
+        status: "CONTACTED",
+        now,
+      }),
+    ).toBe(true);
+    expect(rows.get("lead_a")).toMatchObject({
+      status: "CONTACTED",
+      contactedAt: now,
+      closedAt: null,
+    });
+  });
+});
+
+function memoryStore(
+  rows: Map<
+    string,
+    {
+      siteId: string;
+      status: string;
+      contactedAt?: Date;
+      closedAt?: Date | null;
+    }
+  >,
+): BookingRequestStatusStore {
+  return {
+    updateForSite: async ({ requestId, siteId, data }) => {
+      const row = rows.get(requestId);
+      if (!row || row.siteId !== siteId) return 0;
+      rows.set(requestId, { ...row, ...data });
+      return 1;
+    },
+  };
+}

--- a/src/lib/booking-request-status.ts
+++ b/src/lib/booking-request-status.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+
+export const ownerBookingRequestStatusSchema = z.enum([
+  "CONTACTED",
+  "CLOSED",
+]);
+
+export type OwnerBookingRequestStatus = z.infer<
+  typeof ownerBookingRequestStatusSchema
+>;
+
+export type BookingRequestStatusStore = {
+  updateForSite: (input: {
+    requestId: string;
+    siteId: string;
+    data: {
+      status: OwnerBookingRequestStatus;
+      contactedAt?: Date;
+      closedAt?: Date | null;
+    };
+  }) => Promise<number>;
+};
+
+/**
+ * The site id is part of the mutation predicate, not merely checked before it.
+ * A valid tenant session holding another tenant's request id therefore receives
+ * the same not-found result as a random id and changes no row.
+ */
+export async function updateBookingRequestStatus(
+  store: BookingRequestStatusStore,
+  input: {
+    requestId: string;
+    siteId: string;
+    status: OwnerBookingRequestStatus;
+    now?: Date;
+  },
+): Promise<boolean> {
+  const now = input.now ?? new Date();
+  const data =
+    input.status === "CONTACTED"
+      ? {
+          status: input.status,
+          contactedAt: now,
+          // Reopening a closed request preserves its history in `contactedAt`
+          // while making the current lifecycle state unambiguous.
+          closedAt: null,
+        }
+      : { status: input.status, closedAt: now };
+
+  return (
+    (await store.updateForSite({
+      requestId: input.requestId,
+      siteId: input.siteId,
+      data,
+    })) === 1
+  );
+}

--- a/src/lib/booking-requests.ts
+++ b/src/lib/booking-requests.ts
@@ -41,6 +41,7 @@ export const bookingRequestInputSchema = z
     requestedAt: requestedAtSchema.optional(),
     partySize: z.number().int().min(1).max(200).optional(),
     notes: z.string().trim().max(1000).optional(),
+    analyticsVisitId: z.uuid().optional(),
   })
   .superRefine((value, ctx) => {
     if (!value.email && !value.phone) {

--- a/src/lib/hostnames.test.ts
+++ b/src/lib/hostnames.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { isFactoryHostname, platformHostnames } from "@/lib/hostnames";
+import {
+  isFactoryHostname,
+  platformHostnames,
+  requestHostname,
+} from "@/lib/hostnames";
 
 // Every call passes the override explicitly. Omitting it reads
 // `process.env.PLATFORM_HOSTNAMES`, which would make these assertions depend on
@@ -21,6 +25,26 @@ describe("platformHostnames", () => {
     expect([...platformHostnames(" Staging.Example.com , ")]).toEqual([
       "staging.example.com",
     ]);
+  });
+});
+
+describe("requestHostname", () => {
+  it("prefers the first forwarded hostname and normalizes it", () => {
+    expect(
+      requestHostname(
+        new Headers({
+          host: "internal:3000",
+          "x-forwarded-host": " BISTRO.EXAMPLE:443, proxy.internal ",
+        }),
+      ),
+    ).toBe("bistro.example");
+  });
+
+  it("falls back to host and rejects an absent value", () => {
+    expect(requestHostname(new Headers({ host: "Cafe.Example:443" }))).toBe(
+      "cafe.example",
+    );
+    expect(requestHostname(new Headers())).toBe("");
   });
 });
 

--- a/src/lib/hostnames.ts
+++ b/src/lib/hostnames.ts
@@ -1,4 +1,5 @@
 import { resolveVerticalByHostname } from "@/lib/verticals/registry";
+export { requestHostname } from "@/lib/request-hostname";
 
 /**
  * The factory's own hostnames, overridable so a staging box can answer for its
@@ -18,20 +19,6 @@ export function platformHostnames(
       .map((hostname) => hostname.trim().toLowerCase())
       .filter(Boolean),
   );
-}
-
-/**
- * Normalizes the original public hostname at the reverse-proxy boundary.
- * Caddy supplies `x-forwarded-host`; the first value is authoritative when
- * multiple proxies have appended entries.
- */
-export function requestHostname(headers: Headers): string {
-  const forwardedHost = headers.get("x-forwarded-host");
-  return (forwardedHost ?? headers.get("host") ?? "")
-    .split(",")[0]
-    .trim()
-    .split(":")[0]
-    .toLowerCase();
 }
 
 /**

--- a/src/lib/hostnames.ts
+++ b/src/lib/hostnames.ts
@@ -21,6 +21,20 @@ export function platformHostnames(
 }
 
 /**
+ * Normalizes the original public hostname at the reverse-proxy boundary.
+ * Caddy supplies `x-forwarded-host`; the first value is authoritative when
+ * multiple proxies have appended entries.
+ */
+export function requestHostname(headers: Headers): string {
+  const forwardedHost = headers.get("x-forwarded-host");
+  return (forwardedHost ?? headers.get("host") ?? "")
+    .split(",")[0]
+    .trim()
+    .split(":")[0]
+    .toLowerCase();
+}
+
+/**
  * Whether a hostname belongs to the factory itself — its own domains, or the
  * marketing domain of a registered niche — as opposed to a customer's.
  *

--- a/src/lib/operator-dashboard.ts
+++ b/src/lib/operator-dashboard.ts
@@ -5,6 +5,11 @@ import type {
   SubscriptionStatus,
   Vertical,
 } from "@/generated/prisma/enums";
+import {
+  getPortfolioAnalytics,
+  type AnalyticsSummaryDto,
+  type SiteAnalyticsRowDto,
+} from "@/lib/analytics";
 import { getDb } from "@/lib/db";
 
 export type OperatorSiteRow = {
@@ -19,8 +24,9 @@ export type OperatorSiteRow = {
   latestImportStatus: ImportStatus | null;
   latestImportAt: Date | null;
   bookingRequestCount: number;
-  newBookingRequestCount: number;
+  pendingBookingRequestCount: number;
   verifiedDomain: string | null;
+  analytics30d: SiteAnalyticsRowDto;
 };
 
 export type OperatorDashboardData = {
@@ -29,8 +35,9 @@ export type OperatorDashboardData = {
     signedUpSites: number;
     activeSubscriptions: number;
     bookingRequests: number;
-    newBookingRequests: number;
+    pendingBookingRequests: number;
   };
+  analytics: AnalyticsSummaryDto;
   sites: OperatorSiteRow[];
 };
 
@@ -45,7 +52,7 @@ export async function getOperatorDashboardData(): Promise<OperatorDashboardData>
     signedUpSiteCount,
     activeSubscriptionCount,
     bookingRequestCount,
-    newBookingRequestCount,
+    pendingBookingRequestCount,
     sites,
   ] = await Promise.all([
     db.site.count(),
@@ -56,7 +63,9 @@ export async function getOperatorDashboardData(): Promise<OperatorDashboardData>
     }),
     db.subscription.count({ where: { status: "ACTIVE" } }),
     db.bookingRequest.count(),
-    db.bookingRequest.count({ where: { status: "NEW" } }),
+    db.bookingRequest.count({
+      where: { status: { in: ["NEW", "NOTIFIED"] } },
+    }),
     db.site.findMany({
       orderBy: { createdAt: "desc" },
       take: 200,
@@ -92,16 +101,21 @@ export async function getOperatorDashboardData(): Promise<OperatorDashboardData>
       },
     }),
   ]);
-  const newBookingRequestsBySite = await db.bookingRequest.groupBy({
-    by: ["siteId"],
-    where: {
-      status: "NEW",
-      siteId: { in: sites.map((site) => site.id) },
-    },
-    _count: { _all: true },
-  });
-  const newBookingRequestCounts = new Map(
-    newBookingRequestsBySite.map((row) => [row.siteId, row._count._all]),
+  const [pendingBookingRequestsBySite, analytics] = await Promise.all([
+    db.bookingRequest.groupBy({
+      by: ["siteId"],
+      where: {
+        status: { in: ["NEW", "NOTIFIED"] },
+        siteId: { in: sites.map((site) => site.id) },
+      },
+      _count: { _all: true },
+    }),
+    getPortfolioAnalytics({
+      displayedSiteIds: sites.map((site) => site.id),
+    }),
+  ]);
+  const pendingBookingRequestCounts = new Map(
+    pendingBookingRequestsBySite.map((row) => [row.siteId, row._count._all]),
   );
 
   return {
@@ -110,8 +124,9 @@ export async function getOperatorDashboardData(): Promise<OperatorDashboardData>
       signedUpSites: signedUpSiteCount,
       activeSubscriptions: activeSubscriptionCount,
       bookingRequests: bookingRequestCount,
-      newBookingRequests: newBookingRequestCount,
+      pendingBookingRequests: pendingBookingRequestCount,
     },
+    analytics: analytics.summary,
     sites: sites.map((site) => ({
       id: site.id,
       slug: site.slug,
@@ -124,8 +139,16 @@ export async function getOperatorDashboardData(): Promise<OperatorDashboardData>
       latestImportStatus: site.importJobs[0]?.status ?? null,
       latestImportAt: site.importJobs[0]?.createdAt ?? null,
       bookingRequestCount: site._count.bookingRequests,
-      newBookingRequestCount: newBookingRequestCounts.get(site.id) ?? 0,
+      pendingBookingRequestCount:
+        pendingBookingRequestCounts.get(site.id) ?? 0,
       verifiedDomain: site.domains[0]?.hostname ?? null,
+      analytics30d: analytics.displayedSites30d.get(site.id) ?? {
+        visits: 0,
+        ctaVisitors: 0,
+        bookingLeads: 0,
+        ctaRate: 0,
+        leadRate: 0,
+      },
     })),
   };
 }

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -114,3 +114,18 @@ export function limitBookingRequest(
     windowMs,
   });
 }
+
+/**
+ * Analytics has a deliberately generous, short bucket. A limiter outage or a
+ * full bucket makes the ingest route drop the event with a successful empty
+ * response; customer navigation never inherits Redis availability.
+ */
+export function limitAnalyticsEvent(
+  request: Request,
+): Promise<RateLimitResult> {
+  return limitByIp(request, {
+    namespace: "analytics-event",
+    limit: 120,
+    windowMs: 60_000,
+  });
+}

--- a/src/lib/request-hostname.ts
+++ b/src/lib/request-hostname.ts
@@ -1,0 +1,22 @@
+export type HeaderReader = Pick<Headers, "get">;
+
+export function requestHostname(headers: HeaderReader): string {
+  const forwarded = firstHeaderValue(headers.get("x-forwarded-host"));
+  const host = forwarded || firstHeaderValue(headers.get("host"));
+  return normalizeHostname(host);
+}
+
+export function normalizeHostname(value: string): string {
+  const normalized = value.trim().toLowerCase();
+  if (normalized.startsWith("[")) {
+    const closingBracket = normalized.indexOf("]");
+    return closingBracket > 0
+      ? normalized.slice(1, closingBracket)
+      : normalized;
+  }
+  return normalized.replace(/:\d+$/, "").replace(/\.$/, "");
+}
+
+function firstHeaderValue(value: string | null): string {
+  return value?.split(",")[0]?.trim() ?? "";
+}

--- a/src/lib/site-surface.test.ts
+++ b/src/lib/site-surface.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "bun:test";
+import {
+  isLiveSiteSurface,
+  LIVE_SITE_SLUG_HEADER,
+  localeHref,
+} from "@/lib/site-surface";
+
+describe("live site surfaces", () => {
+  it("requires the proxy-attested slug", () => {
+    const headers = new Headers({
+      [LIVE_SITE_SLUG_HEADER]: "chez-lea",
+    });
+
+    expect(isLiveSiteSurface(headers, "chez-lea")).toBe(true);
+    expect(isLiveSiteSurface(headers, "another-site")).toBe(false);
+    expect(isLiveSiteSurface(new Headers(), "chez-lea")).toBe(false);
+  });
+
+  it("keeps live locale links on the customer hostname", () => {
+    expect(localeHref("/", "en", "en")).toBe("/");
+    expect(localeHref("/", "fr", "en")).toBe("/fr");
+  });
+
+  it("keeps private preview locale links under the preview path", () => {
+    expect(localeHref("/preview/chez-lea", "en", "en")).toBe(
+      "/preview/chez-lea",
+    );
+    expect(localeHref("/preview/chez-lea", "fr", "en")).toBe(
+      "/preview/chez-lea/fr",
+    );
+  });
+});

--- a/src/lib/site-surface.ts
+++ b/src/lib/site-surface.ts
@@ -1,0 +1,17 @@
+export const LIVE_SITE_SLUG_HEADER = "x-cornershop-live-site-slug";
+
+export function isLiveSiteSurface(
+  headers: Pick<Headers, "get">,
+  siteSlug: string,
+): boolean {
+  return headers.get(LIVE_SITE_SLUG_HEADER) === siteSlug;
+}
+
+export function localeHref(
+  basePath: string,
+  locale: string,
+  defaultLocale: string,
+): string {
+  if (locale === defaultLocale) return basePath;
+  return `${basePath.replace(/\/$/, "")}/${locale}`;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,7 +1,8 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
-import { platformHostnames } from "@/lib/hostnames";
+import { platformHostnames, requestHostname } from "@/lib/hostnames";
+import { LIVE_SITE_SLUG_HEADER } from "@/lib/site-surface";
 import {
   listEmbedFrameOrigins,
   resolveVerticalByHostname,
@@ -30,27 +31,25 @@ function withEmbedFrameCsp(response: NextResponse) {
   return response;
 }
 
-function requestHostname(request: NextRequest) {
-  const forwardedHost = request.headers.get("x-forwarded-host");
-  return (forwardedHost ?? request.headers.get("host") ?? "")
-    .split(",")[0]
-    .trim()
-    .split(":")[0]
-    .toLowerCase();
-}
-
 export async function proxy(request: NextRequest) {
+  const upstreamHeaders = new Headers(request.headers);
+  // Never trust a caller-supplied surface marker. Only the verified-domain
+  // branch below may add it for the rewritten Server Component request.
+  upstreamHeaders.delete(LIVE_SITE_SLUG_HEADER);
+
   // A `/preview` URL is already the rendered site, whatever hostname asked for
   // it, so it is passed through with the frame policy attached and never
   // resolved against the domain table. Handling it before the hostname branch
   // keeps custom-domain behaviour on these paths exactly as it was.
   if (request.nextUrl.pathname.startsWith("/preview/")) {
-    return withEmbedFrameCsp(NextResponse.next());
+    return withEmbedFrameCsp(
+      NextResponse.next({ request: { headers: upstreamHeaders } }),
+    );
   }
 
-  const hostname = requestHostname(request);
+  const hostname = requestHostname(request.headers);
   if (!hostname || platformHostnames().has(hostname)) {
-    return NextResponse.next();
+    return NextResponse.next({ request: { headers: upstreamHeaders } });
   }
 
   // A niche's own marketing domain — restofront.com today, a nails or barber
@@ -65,6 +64,7 @@ export async function proxy(request: NextRequest) {
     // serves the same page rather than 404ing on a URL a visitor may well try.
     return NextResponse.rewrite(
       new URL(`/niche/${verticalSlug(niche)}`, request.url),
+      { request: { headers: upstreamHeaders } },
     );
   }
 
@@ -78,11 +78,14 @@ export async function proxy(request: NextRequest) {
   const destination = locale
     ? `/preview/${domain.site.slug}/${locale.toLowerCase()}`
     : `/preview/${domain.site.slug}`;
+  upstreamHeaders.set(LIVE_SITE_SLUG_HEADER, domain.site.slug);
   // The rewrite target is a preview route, so the frame policy rides along here
   // too — the visitor's URL never says `/preview`, but the page it gets is the
   // one that may embed a booking widget.
   return withEmbedFrameCsp(
-    NextResponse.rewrite(new URL(destination, request.url)),
+    NextResponse.rewrite(new URL(destination, request.url), {
+      request: { headers: upstreamHeaders },
+    }),
   );
 }
 


### PR DESCRIPTION
Closes #56

## What ships
- tenant-scoped customer lead inbox with CONTACTED/CLOSED lifecycle actions
- cookieless first-party SITE_VIEW and CTA_CLICK tracking on verified customer domains only
- server-owned lead attribution with BookingRequest as the durable source of truth
- 7/30/90-day client and superadmin visit, CTA, lead, and conversion metrics
- additive AnalyticsEvent migration plus 120-day retention scheduler
- bounded operator portfolio rows with no cross-tenant lead contact details

## Privacy and safety
- preview, factory, niche, and likely bot traffic are excluded
- analytics stores no IP, user-agent, referrer, path, query string, provider URL, or contact data
- lead status writes include siteId in the mutation predicate
- raw event delivery is UUID-idempotent and public callers cannot assert LEAD_CREATED

## Verification
- Prisma validate: pass
- TypeScript: pass
- Bun tests: 140 pass (conditional PostgreSQL integration suite skipped in the default run)
- PostgreSQL 16 integration: all 6 migrations applied; 2/2 analytics query tests pass with seeded 7/30/90 windows
- ESLint: 0 errors; one pre-existing generated workflow warning
- webpack app compilation and TypeScript: pass; local page-data collection remains blocked by the pre-existing generated Workflow route without its build-time environment
- independent Opus exact-head review of a7af4b8: PASS