### PR TITLE
feat(claim): verify restaurant ownership

### DIFF
--- a/.agents/sessions/2026-07-26.md
+++ b/.agents/sessions/2026-07-26.md
@@ -292,3 +292,53 @@ issue #19 + theme research + 3 code patterns
   the repaired head.
 - Stack owner theme selection on the issue #18 draft/publish persistence
   boundary.
+
+## Session 5 — Secure restaurant ownership claiming (#13)
+
+### Flow
+
+```mermaid
+flowchart LR
+  A["Public claim page"] --> B{"Exact business email proof?"}
+  B -->|yes| C["Hashed 48-hour invitation"]
+  B -->|ambiguous| D["Dual-gated operator approval"]
+  D --> C
+  C --> E["Token opened from URL fragment"]
+  E --> F["Rate-limited invitation verification"]
+  F --> G["Invitation-bound Stripe Checkout"]
+  G --> H["Signed webhook or success callback"]
+  H --> I["Atomic invitation acceptance + site ownership + audit"]
+```
+
+### What was done
+
+- [x] Replaced public email-to-checkout with exact domain-email proof or
+  dual-gated operator approval.
+- [x] Added random 256-bit invitations stored only as SHA-256 hashes, expiring
+  after 48 hours and revoked when superseded or undeliverable.
+- [x] Kept raw tokens in email URL fragments, copied them into memory, and
+  removed the fragment before embedded preview assets could receive a referrer.
+- [x] Bound checkout and account activation to the invitation ID, Stripe
+  session ID, site, and normalized intended email.
+- [x] Made same-session completion replay idempotent while rejecting cross-site,
+  cross-email, cross-session, expired, revoked, duplicate, and already-owned
+  claims.
+- [x] Recorded invitation creation, verification, checkout start, acceptance,
+  and rejection in `AuditEvent`.
+- [x] Added focused ownership, replay, origin, hashing, email-proof, and
+  invitation-email tests.
+
+### Key decisions
+
+- Self-serve proof requires imported email equality or an email domain equal to
+  the exact normalized source hostname. Registrable-domain guessing is unsafe.
+- One invitation is active per site, enforced by serializable issuance and a
+  PostgreSQL partial unique index.
+- Stripe subscription provisioning remains downstream in #8.
+
+### Verification
+
+- `bun test` — 146 pass, 4 PostgreSQL-gated analytics tests skipped.
+- `bun run lint` — zero errors; one generated workflow warning.
+- `bunx next typegen && bunx tsc --noEmit` — pass.
+- `bunx --bun prisma validate` and `git diff --check` — pass.

--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ Cornershopdev turns an existing restaurant website—or just a restaurant name�
 5. Detect the source language, preserve it as canonical, and generate a complete English translation during the same structured AI pass.
 6. Preserve first-party photography and optionally enhance exposure, colour, crop, noise, and clarity without changing the food or venue.
 7. Save a private preview through a durable PostgreSQL-backed Workflow.
-8. Claim the restaurant through Stripe Checkout; the completed checkout creates the prefilled owner account.
-9. Authorize the restaurant domain for on-demand TLS and show the exact DNS records.
-10. Monitor and maintain the menu, imagery, and external links from the dashboard.
+8. Verify ownership through a one-time business-domain email invitation or a concierge-approved owner email.
+9. Claim the restaurant through invitation-bound Stripe Checkout; the completed checkout creates the prefilled owner account.
+10. Authorize the restaurant domain for on-demand TLS and show the exact DNS records.
+11. Monitor and maintain the menu, imagery, and external links from the dashboard.
 
 ## Customer workspace and operator console
 
@@ -258,6 +259,15 @@ this same container, where the rewrite fires again — an infinite loop.
 - AI output is validated with Zod before it enters the product.
 - Existing booking and ordering links are extracted from source material and override model-generated links.
 - Stripe webhooks verify the raw body signature.
+- Restaurant claims require a hashed, expiring invitation bound to one site,
+  intended email, and Stripe Checkout session. Raw invitation tokens are kept
+  in URL fragments so embedded preview assets cannot receive them as referrers.
+- Self-serve claims require the exact imported business email or an address on
+  the exact source hostname. Ambiguous ownership requires a dual-gated
+  superadmin approval from the operator console.
+- Claim invitation requests and checkout attempts use isolated Redis rate-limit
+  buckets and fail closed in production. Creation, verification, checkout,
+  acceptance, and rejection events are recorded without tokens or contact data.
 - Dashboard sessions are HMAC-signed, HTTP-only, same-site cookies.
 - Restaurant mutations require a session matching the restaurant slug.
 - Image enhancement and domain management require that same restaurant-scoped session.

--- a/prisma/migrations/20260726220000_secure_claim_invitations/migration.sql
+++ b/prisma/migrations/20260726220000_secure_claim_invitations/migration.sql
@@ -1,0 +1,19 @@
+CREATE TYPE "ClaimProofMethod" AS ENUM ('DOMAIN_EMAIL', 'OPERATOR_APPROVAL');
+
+ALTER TABLE "ClaimInvitation"
+ADD COLUMN "proofMethod" "ClaimProofMethod" NOT NULL DEFAULT 'DOMAIN_EMAIL',
+ADD COLUMN "verifiedAt" TIMESTAMP(3),
+ADD COLUMN "revokedAt" TIMESTAMP(3),
+ADD COLUMN "checkoutSessionId" TEXT;
+
+DROP INDEX "ClaimInvitation_siteId_email_idx";
+
+CREATE UNIQUE INDEX "ClaimInvitation_checkoutSessionId_key"
+ON "ClaimInvitation"("checkoutSessionId");
+
+CREATE UNIQUE INDEX "ClaimInvitation_one_active_per_site_key"
+ON "ClaimInvitation"("siteId")
+WHERE "acceptedAt" IS NULL AND "revokedAt" IS NULL;
+
+CREATE INDEX "ClaimInvitation_siteId_email_expiresAt_idx"
+ON "ClaimInvitation"("siteId", "email", "expiresAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -68,6 +68,11 @@ enum AnalyticsEventType {
   LEAD_CREATED
 }
 
+enum ClaimProofMethod {
+  DOMAIN_EMAIL
+  OPERATOR_APPROVAL
+}
+
 model User {
   id           String       @id @default(cuid())
   email        String       @unique
@@ -237,16 +242,20 @@ model Domain {
 }
 
 model ClaimInvitation {
-  id         String    @id @default(cuid())
-  email      String
-  tokenHash  String    @unique
-  expiresAt  DateTime
-  acceptedAt DateTime?
-  siteId     String
-  site       Site      @relation(fields: [siteId], references: [id], onDelete: Cascade)
-  createdAt  DateTime  @default(now())
+  id                    String           @id @default(cuid())
+  email                 String
+  tokenHash             String           @unique
+  proofMethod           ClaimProofMethod @default(DOMAIN_EMAIL)
+  expiresAt             DateTime
+  verifiedAt            DateTime?
+  acceptedAt            DateTime?
+  revokedAt             DateTime?
+  checkoutSessionId     String?          @unique
+  siteId                String
+  site                  Site             @relation(fields: [siteId], references: [id], onDelete: Cascade)
+  createdAt             DateTime         @default(now())
 
-  @@index([siteId, email])
+  @@index([siteId, email, expiresAt])
 }
 
 model Subscription {

--- a/src/app/admin/claim-invitation-form.tsx
+++ b/src/app/admin/claim-invitation-form.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState } from "react";
+import { Check, LoaderCircle, Send } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+export function ClaimInvitationForm({ siteSlug }: { siteSlug: string }) {
+  const [email, setEmail] = useState("");
+  const [sending, setSending] = useState(false);
+  const [sent, setSent] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function approve() {
+    setSending(true);
+    setSent(false);
+    setError(null);
+    try {
+      const response = await fetch("/api/admin/claim-invitations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ siteSlug, email }),
+      });
+      const result = (await response.json()) as {
+        ok?: boolean;
+        error?: string;
+      };
+      if (!response.ok || !result.ok) {
+        throw new Error(result.error ?? "Invitation could not be sent.");
+      }
+      setSent(true);
+    } catch (caught) {
+      setError(
+        caught instanceof Error ? caught.message : "Invitation could not be sent.",
+      );
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <div className="min-w-56">
+      <div className="flex gap-2">
+        <Input
+          aria-label={`Approved owner email for ${siteSlug}`}
+          type="email"
+          value={email}
+          onChange={(event) => {
+            setEmail(event.target.value);
+            setSent(false);
+          }}
+          placeholder="approved@business.com"
+          className="h-8 min-w-44"
+        />
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={!email || sending}
+          onClick={() => void approve()}
+        >
+          {sending ? (
+            <LoaderCircle className="animate-spin" />
+          ) : sent ? (
+            <Check />
+          ) : (
+            <Send />
+          )}
+          {sent ? "Sent" : "Approve"}
+        </Button>
+      </div>
+      {error ? (
+        <p className="mt-1 max-w-64 text-[11px] text-destructive">{error}</p>
+      ) : (
+        <p className="mt-1 text-[11px] text-muted-foreground">
+          Sends a 48-hour one-time claim link.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -8,6 +8,7 @@ import {
   Inbox,
   Users,
 } from "lucide-react";
+import { ClaimInvitationForm } from "@/app/admin/claim-invitation-form";
 import { Brand } from "@/components/brand";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -65,8 +66,9 @@ export default async function AdminPage() {
               Leads, customers and requests.
             </h1>
             <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
-              A read-only platform view across every generated site. Customer
-              contact details stay inside the tenant record.
+              A platform view across every generated site. Customer contact
+              details stay inside the tenant record; operators can approve a
+              specific concierge claim email without exposing stored contacts.
             </p>
           </div>
           <Badge variant="secondary">Latest 200 sites</Badge>
@@ -146,7 +148,7 @@ export default async function AdminPage() {
             <CardTitle>All sites</CardTitle>
           </CardHeader>
           <CardContent className="overflow-x-auto p-0">
-            <table className="w-full min-w-[1250px] text-left text-sm">
+            <table className="w-full min-w-[1500px] text-left text-sm">
               <thead className="border-b bg-muted/50 text-xs uppercase tracking-[0.12em] text-muted-foreground">
                 <tr>
                   <th scope="col" className="px-5 py-3 font-medium">Business</th>
@@ -158,6 +160,7 @@ export default async function AdminPage() {
                   <th scope="col" className="px-5 py-3 font-medium">Visits · 30d</th>
                   <th scope="col" className="px-5 py-3 font-medium">Lead conv. · 30d</th>
                   <th scope="col" className="px-5 py-3 font-medium">Created</th>
+                  <th scope="col" className="px-5 py-3 font-medium">Concierge claim</th>
                   <th scope="col" className="px-5 py-3 text-right font-medium">Site</th>
                 </tr>
               </thead>
@@ -271,6 +274,13 @@ function SiteRow({ site }: { site: OperatorSiteRow }) {
       </td>
       <td className="px-5 py-4 text-muted-foreground">
         {formatDate(site.createdAt)}
+      </td>
+      <td className="px-5 py-4">
+        {site.ownerCount === 0 ? (
+          <ClaimInvitationForm siteSlug={site.slug} />
+        ) : (
+          <span className="text-muted-foreground">Owned</span>
+        )}
       </td>
       <td className="px-5 py-4 text-right">
         <Button

--- a/src/app/api/admin/claim-invitations/route.ts
+++ b/src/app/api/admin/claim-invitations/route.ts
@@ -1,0 +1,97 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getSuperadminAccess } from "@/lib/authorization";
+import {
+  ClaimFlowError,
+  deliverClaimInvitation,
+  issueClaimInvitation,
+  recordClaimRejection,
+  revokeUndeliveredInvitation,
+} from "@/lib/claim-invitations";
+import { limitOperatorClaimInvitation } from "@/lib/rate-limit";
+import { isSameOriginMutation } from "@/lib/request-origin";
+
+export const runtime = "nodejs";
+
+const requestSchema = z.object({
+  siteSlug: z.string().trim().min(2).max(80),
+  email: z.email().max(320),
+});
+
+export async function POST(request: Request) {
+  if (!isSameOriginMutation(request, { requireOrigin: true })) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const operator = await getSuperadminAccess();
+  if (!operator) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const rateLimit = await limitOperatorClaimInvitation(request);
+  if (!rateLimit.success) {
+    return NextResponse.json(
+      {
+        error:
+          rateLimit.reason === "unavailable"
+            ? "Claim approvals are temporarily unavailable."
+            : "Too many claim approvals. Try again later.",
+      },
+      { status: rateLimit.reason === "unavailable" ? 503 : 429 },
+    );
+  }
+
+  let siteSlug = "unknown";
+  try {
+    const input = requestSchema.parse(await request.json());
+    siteSlug = input.siteSlug;
+    const invitation = await issueClaimInvitation({
+      siteSlug,
+      email: input.email,
+      proofMethod: "OPERATOR_APPROVAL",
+      actor: `operator:${operator.id}`,
+    });
+    try {
+      await deliverClaimInvitation(
+        invitation,
+        process.env.NEXT_PUBLIC_APP_URL ?? new URL(request.url).origin,
+      );
+    } catch (error) {
+      await revokeUndeliveredInvitation(invitation);
+      throw error;
+    }
+
+    return NextResponse.json(
+      { ok: true, expiresAt: invitation.expiresAt.toISOString() },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: error.issues[0]?.message ?? "Check the invitation details." },
+        { status: 400 },
+      );
+    }
+    if (error instanceof ClaimFlowError) {
+      await recordClaimRejection({
+        siteSlug,
+        reason: error.code,
+        actor: `operator:${operator.id}`,
+      });
+      return NextResponse.json(
+        { error: error.message },
+        { status: error.status },
+      );
+    }
+
+    console.error("[operator-claim-invitation] failed", {
+      siteSlug,
+      operatorId: operator.id,
+      error: error instanceof Error ? error.message : "unknown",
+    });
+    return NextResponse.json(
+      { error: "The claim invitation could not be sent." },
+      { status: 503 },
+    );
+  }
+}

--- a/src/app/api/auth/checkout/route.ts
+++ b/src/app/api/auth/checkout/route.ts
@@ -1,5 +1,6 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { recordClaimRejection } from "@/lib/claim-invitations";
 import { getDb } from "@/lib/db";
 import { claimSite, SiteNotClaimableError } from "@/lib/site-claim";
 import { createSessionToken, SESSION_COOKIE } from "@/lib/session";
@@ -18,7 +19,16 @@ export async function GET(request: Request) {
 
   const email = checkout.customer_details?.email ?? checkout.customer_email;
   const siteSlug = checkout.metadata?.siteSlug;
-  if (!email || !siteSlug) {
+  const claimInvitationId = checkout.metadata?.claimInvitationId;
+  if (!email || !siteSlug || !claimInvitationId) {
+    if (siteSlug) {
+      await recordClaimRejection({
+        siteSlug,
+        reason: "checkout_metadata_missing",
+        actor: "system:stripe-callback",
+        invitationId: claimInvitationId,
+      });
+    }
     return Response.json(
       { error: "Checkout is missing account details" },
       { status: 400 },
@@ -51,6 +61,8 @@ export async function GET(request: Request) {
       claimSite(tx, {
         email,
         siteSlug,
+        claimInvitationId,
+        stripeCheckoutSessionId: checkout.id,
         stripeCustomerId:
           typeof checkout.customer === "string" ? checkout.customer : null,
         stripeSubscriptionId:
@@ -62,6 +74,12 @@ export async function GET(request: Request) {
     );
   } catch (error) {
     if (error instanceof SiteNotClaimableError) {
+      await recordClaimRejection({
+        siteSlug,
+        reason: "checkout_completion_rejected",
+        actor: "system:stripe-callback",
+        invitationId: claimInvitationId,
+      });
       return Response.json({ error: error.message }, { status: 409 });
     }
     throw error;

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -3,6 +3,7 @@ import {
   authorizeClaimInvitationForCheckout,
   bindClaimInvitationToCheckout,
   ClaimFlowError,
+  MIN_CLAIM_CHECKOUT_TTL_MS,
   recordClaimRejection,
 } from "@/lib/claim-invitations";
 import { limitClaimCheckout } from "@/lib/rate-limit";
@@ -67,9 +68,55 @@ export async function POST(request: Request) {
     const appUrl =
       process.env.NEXT_PUBLIC_APP_URL ?? new URL(request.url).origin;
     const stripe = getStripe();
+    const previousSessionId = invitation.checkoutSessionId;
+    if (previousSessionId) {
+      const previousSession =
+        await stripe.checkout.sessions.retrieve(previousSessionId);
+      if (
+        previousSession.status === "open" &&
+        previousSession.metadata?.plan === plan &&
+        previousSession.url
+      ) {
+        return Response.json({ url: previousSession.url });
+      }
+      if (previousSession.status === "complete") {
+        throw new ClaimFlowError(
+          "invitation_used",
+          409,
+          "This checkout is already complete. Refresh to continue to your account.",
+        );
+      }
+      if (
+        invitation.expiresAt.getTime() - Date.now() <
+        MIN_CLAIM_CHECKOUT_TTL_MS
+      ) {
+        throw new ClaimFlowError(
+          "invalid_invitation",
+          403,
+          "This ownership link is near expiry. Continue the existing checkout or request a new email after it expires.",
+        );
+      }
+      if (previousSession.status === "open") {
+        try {
+          await stripe.checkout.sessions.expire(previousSession.id);
+        } catch (error) {
+          // Concurrent retries can both observe an open session. Continue only
+          // when the other request successfully expired it.
+          const refreshed = await stripe.checkout.sessions.retrieve(
+            previousSession.id,
+          );
+          if (refreshed.status !== "expired") throw error;
+        }
+      }
+    }
+
     const session = await stripe.checkout.sessions.create(
       {
         mode: "subscription",
+        expires_at: Math.min(
+          Math.floor(Date.now() / 1000) + 24 * 60 * 60,
+          Math.floor(invitation.expiresAt.getTime() / 1000),
+        ),
         line_items: [{ price: priceId, quantity: 1 }],
         allow_promotion_codes: true,
         customer_email: invitation.email,
@@ -92,13 +139,38 @@ export async function POST(request: Request) {
         cancel_url: `${appUrl}/claim/${siteSlug}?checkout=canceled`,
       },
       {
-        idempotencyKey: `claim-${invitation.id}-${plan}`,
+        // Including the previously observed binding yields one Stripe session
+        // per lifecycle step. Retrying a request is idempotent, while an
+        // expired/cancelled session can be replaced without Stripe returning
+        // the old session for its 24-hour idempotency window.
+        idempotencyKey: `claim-${invitation.id}-${plan}-${previousSessionId ?? "initial"}`,
       },
     );
-    await bindClaimInvitationToCheckout({
-      invitation,
-      stripeCheckoutSessionId: session.id,
-    });
+    try {
+      await bindClaimInvitationToCheckout({
+        invitation,
+        stripeCheckoutSessionId: session.id,
+        expectedCheckoutSessionId: previousSessionId,
+      });
+    } catch (error) {
+      // Never leave an unbound payment path open: Stripe could otherwise
+      // collect money for a checkout that claimSite must reject.
+      if (session.status === "open") {
+        try {
+          await stripe.checkout.sessions.expire(session.id);
+        } catch (cleanupError) {
+          console.error("[checkout] failed to expire unbound session", {
+            siteSlug,
+            stripeCheckoutSessionId: session.id,
+            error:
+              cleanupError instanceof Error
+                ? cleanupError.message
+                : "unknown",
+          });
+        }
+      }
+      throw error;
+    }
 
     return Response.json({ url: session.url });
   } catch (error) {

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import {
   authorizeClaimInvitationForCheckout,
   bindClaimInvitationToCheckout,
+  buildClaimCheckoutIdempotencyKey,
   ClaimFlowError,
   MIN_CLAIM_CHECKOUT_TTL_MS,
   recordClaimRejection,
@@ -110,13 +111,14 @@ export async function POST(request: Request) {
       }
     }
 
+    const checkoutExpiresAt = Math.min(
+      Math.floor(Date.now() / 1000) + 24 * 60 * 60,
+      Math.floor(invitation.expiresAt.getTime() / 1000),
+    );
     const session = await stripe.checkout.sessions.create(
       {
         mode: "subscription",
-        expires_at: Math.min(
-          Math.floor(Date.now() / 1000) + 24 * 60 * 60,
-          Math.floor(invitation.expiresAt.getTime() / 1000),
-        ),
+        expires_at: checkoutExpiresAt,
         line_items: [{ price: priceId, quantity: 1 }],
         allow_promotion_codes: true,
         customer_email: invitation.email,
@@ -139,19 +141,41 @@ export async function POST(request: Request) {
         cancel_url: `${appUrl}/claim/${siteSlug}?checkout=canceled`,
       },
       {
-        // Including the previously observed binding yields one Stripe session
-        // per lifecycle step. Retrying a request is idempotent, while an
-        // expired/cancelled session can be replaced without Stripe returning
-        // the old session for its 24-hour idempotency window.
-        idempotencyKey: `claim-${invitation.id}-${plan}-${previousSessionId ?? "initial"}`,
+        // expires_at is part of the key because it is part of Stripe's
+        // idempotency comparison. Requests in the same second are identical;
+        // later/concurrent sessions are reconciled by the database CAS below.
+        idempotencyKey: buildClaimCheckoutIdempotencyKey({
+          invitationId: invitation.id,
+          plan,
+          previousSessionId,
+          expiresAt: checkoutExpiresAt,
+        }),
       },
     );
     try {
-      await bindClaimInvitationToCheckout({
+      const boundSessionId = await bindClaimInvitationToCheckout({
         invitation,
         stripeCheckoutSessionId: session.id,
         expectedCheckoutSessionId: previousSessionId,
       });
+      if (boundSessionId !== session.id) {
+        if (session.status === "open") {
+          await stripe.checkout.sessions.expire(session.id);
+        }
+        const winner = await stripe.checkout.sessions.retrieve(boundSessionId);
+        if (
+          winner.status === "open" &&
+          winner.metadata?.plan === plan &&
+          winner.url
+        ) {
+          return Response.json({ url: winner.url });
+        }
+        throw new ClaimFlowError(
+          "invitation_used",
+          409,
+          "Another checkout replaced this one. Reopen the ownership email and try again.",
+        );
+      }
     } catch (error) {
       // Never leave an unbound payment path open: Stripe could otherwise
       // collect money for a checkout that claimSite must reject.

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -1,19 +1,49 @@
 import { z } from "zod";
-import { getDb } from "@/lib/db";
-import { isClaimable } from "@/lib/site-claim";
+import {
+  authorizeClaimInvitationForCheckout,
+  bindClaimInvitationToCheckout,
+  ClaimFlowError,
+  recordClaimRejection,
+} from "@/lib/claim-invitations";
+import { limitClaimCheckout } from "@/lib/rate-limit";
+import { isSameOriginMutation } from "@/lib/request-origin";
 import { getStripe } from "@/lib/stripe";
 
 const requestSchema = z.object({
   plan: z.enum(["starter", "growth"]),
   siteSlug: z.string().trim().min(2).max(80),
-  email: z.email().optional(),
+  invitationToken: z
+    .string()
+    .min(32)
+    .max(128)
+    .regex(/^[A-Za-z0-9_-]+$/),
 });
 
 export async function POST(request: Request) {
-  try {
-    const { plan, siteSlug, email } = requestSchema.parse(
-      await request.json(),
+  const rateLimit = await limitClaimCheckout(request);
+  if (!rateLimit.success) {
+    return Response.json(
+      {
+        error:
+          rateLimit.reason === "unavailable"
+            ? "Claim checkout is temporarily unavailable."
+            : "Too many claim attempts. Try again later.",
+      },
+      { status: rateLimit.reason === "unavailable" ? 503 : 429 },
     );
+  }
+  if (!isSameOriginMutation(request)) {
+    return Response.json(
+      { error: "Cross-site checkout requests are not allowed." },
+      { status: 403 },
+    );
+  }
+
+  let siteSlug = "unknown";
+  try {
+    const input = requestSchema.parse(await request.json());
+    const { plan, invitationToken } = input;
+    siteSlug = input.siteSlug;
     const priceId =
       plan === "starter"
         ? process.env.STRIPE_STARTER_PRICE_ID
@@ -23,37 +53,51 @@ export async function POST(request: Request) {
       throw new Error(`Stripe price for the ${plan} plan is not configured`);
     }
 
-    // Fail before taking money for a claim that cannot succeed. This is a
-    // courtesy check only — the authoritative, race-free guard runs inside the
-    // checkout callback's transaction in `api/auth/checkout`.
-    if (process.env.DATABASE_URL) {
-      const site = await getDb().site.findUnique({
-        where: { slug: siteSlug },
-        select: { status: true, organizationId: true },
-      });
-      if (!site || !isClaimable(site)) {
-        return Response.json(
-          { error: "This site is not available to claim" },
-          { status: 409 },
-        );
-      }
+    if (!process.env.DATABASE_URL) {
+      return Response.json(
+        { error: "Claim checkout is temporarily unavailable." },
+        { status: 503 },
+      );
     }
+    const invitation = await authorizeClaimInvitationForCheckout({
+      siteSlug,
+      token: invitationToken,
+    });
 
     const appUrl =
       process.env.NEXT_PUBLIC_APP_URL ?? new URL(request.url).origin;
     const stripe = getStripe();
-    const session = await stripe.checkout.sessions.create({
-      mode: "subscription",
-      line_items: [{ price: priceId, quantity: 1 }],
-      allow_promotion_codes: true,
-      customer_email: email,
-      client_reference_id: siteSlug,
-      metadata: { siteSlug, plan, priceId },
-      subscription_data: {
-        metadata: { siteSlug, plan, priceId },
+    const session = await stripe.checkout.sessions.create(
+      {
+        mode: "subscription",
+        line_items: [{ price: priceId, quantity: 1 }],
+        allow_promotion_codes: true,
+        customer_email: invitation.email,
+        client_reference_id: siteSlug,
+        metadata: {
+          siteSlug,
+          plan,
+          priceId,
+          claimInvitationId: invitation.id,
+        },
+        subscription_data: {
+          metadata: {
+            siteSlug,
+            plan,
+            priceId,
+            claimInvitationId: invitation.id,
+          },
+        },
+        success_url: `${appUrl}/api/auth/checkout?session_id={CHECKOUT_SESSION_ID}`,
+        cancel_url: `${appUrl}/claim/${siteSlug}?checkout=canceled`,
       },
-      success_url: `${appUrl}/api/auth/checkout?session_id={CHECKOUT_SESSION_ID}`,
-      cancel_url: `${appUrl}/claim/${siteSlug}?checkout=canceled`,
+      {
+        idempotencyKey: `claim-${invitation.id}-${plan}`,
+      },
+    );
+    await bindClaimInvitationToCheckout({
+      invitation,
+      stripeCheckoutSessionId: session.id,
     });
 
     return Response.json({ url: session.url });
@@ -64,12 +108,24 @@ export async function POST(request: Request) {
         { status: 400 },
       );
     }
+    if (error instanceof ClaimFlowError) {
+      await recordClaimRejection({
+        siteSlug,
+        reason: error.code,
+        actor: "claimant:checkout",
+      });
+      return Response.json(
+        { error: error.message },
+        { status: error.status },
+      );
+    }
 
     // Everything else is ours, not the caller's: an unset price ID, a Stripe
     // outage, a database that will not answer. Returning `error.message` here
     // named our own environment variables to anyone who could POST malformed
     // input, and reported a server fault as a 400 the client could not fix.
     console.error("[checkout] failed", {
+      siteSlug,
       error: error instanceof Error ? error.message : "unknown",
     });
     return Response.json(

--- a/src/app/api/claim-invitations/route.ts
+++ b/src/app/api/claim-invitations/route.ts
@@ -1,0 +1,109 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import {
+  ClaimFlowError,
+  deliverClaimInvitation,
+  issueClaimInvitation,
+  recordClaimRejection,
+  revokeUndeliveredInvitation,
+} from "@/lib/claim-invitations";
+import { limitClaimInvitationRequest } from "@/lib/rate-limit";
+import { isSameOriginMutation } from "@/lib/request-origin";
+
+export const runtime = "nodejs";
+
+const requestSchema = z.object({
+  siteSlug: z.string().trim().min(2).max(80),
+  email: z.email().max(320),
+});
+
+export async function POST(request: Request) {
+  const rateLimit = await limitClaimInvitationRequest(request);
+  if (!rateLimit.success) {
+    return NextResponse.json(
+      {
+        error:
+          rateLimit.reason === "unavailable"
+            ? "Ownership verification is temporarily unavailable."
+            : "Too many claim attempts. Try again later.",
+      },
+      {
+        status: rateLimit.reason === "unavailable" ? 503 : 429,
+        headers: rateLimitHeaders(rateLimit),
+      },
+    );
+  }
+  if (!isSameOriginMutation(request)) {
+    return NextResponse.json(
+      { error: "Cross-site claim requests are not allowed." },
+      { status: 403 },
+    );
+  }
+
+  let siteSlug = "unknown";
+  try {
+    const input = requestSchema.parse(await request.json());
+    siteSlug = input.siteSlug;
+    if (!process.env.DATABASE_URL || !process.env.RESEND_API_KEY) {
+      throw new Error("Claim services are not configured");
+    }
+
+    const invitation = await issueClaimInvitation({
+      siteSlug,
+      email: input.email,
+      proofMethod: "DOMAIN_EMAIL",
+      actor: "claimant:self-serve",
+    });
+    try {
+      await deliverClaimInvitation(
+        invitation,
+        process.env.NEXT_PUBLIC_APP_URL ?? new URL(request.url).origin,
+      );
+    } catch (error) {
+      await revokeUndeliveredInvitation(invitation);
+      throw error;
+    }
+
+    return NextResponse.json(
+      { ok: true },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: error.issues[0]?.message ?? "Check the claim details." },
+        { status: 400 },
+      );
+    }
+    if (error instanceof ClaimFlowError) {
+      await recordClaimRejection({
+        siteSlug,
+        reason: error.code,
+        actor: "claimant:self-serve",
+      });
+      return NextResponse.json(
+        { error: error.message },
+        { status: error.status, headers: { "Cache-Control": "no-store" } },
+      );
+    }
+
+    console.error("[claim-invitation] request failed", {
+      siteSlug,
+      error: error instanceof Error ? error.message : "unknown",
+    });
+    return NextResponse.json(
+      { error: "Ownership verification could not be sent. Try again shortly." },
+      { status: 503 },
+    );
+  }
+}
+
+function rateLimitHeaders(result: {
+  remaining: number;
+  reset: number;
+}): Record<string, string> {
+  return {
+    "X-RateLimit-Remaining": String(result.remaining),
+    "X-RateLimit-Reset": String(result.reset),
+  };
+}

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -1,4 +1,5 @@
 import type Stripe from "stripe";
+import { recordClaimRejection } from "@/lib/claim-invitations";
 import { getDb } from "@/lib/db";
 import {
   claimSite,
@@ -37,8 +38,17 @@ export async function POST(request: Request) {
   if (event.type === "checkout.session.completed") {
     const session = event.data.object;
     const slug = session.metadata?.siteSlug;
+    const claimInvitationId = session.metadata?.claimInvitationId;
     const email = session.customer_details?.email ?? session.customer_email;
-    if (slug && email) {
+    if (slug && (!email || !claimInvitationId)) {
+      await recordClaimRejection({
+        siteSlug: slug,
+        reason: "checkout_metadata_missing",
+        actor: "system:stripe-webhook",
+        invitationId: claimInvitationId,
+      });
+    }
+    if (slug && email && claimInvitationId) {
       // Stripe routinely delivers this before the browser follows success_url,
       // and may be the only completion signal we ever get if the customer
       // closes the tab. So the webhook performs the whole claim rather than
@@ -49,6 +59,8 @@ export async function POST(request: Request) {
           claimSite(tx, {
             email,
             siteSlug: slug,
+            claimInvitationId,
+            stripeCheckoutSessionId: session.id,
             stripeCustomerId:
               typeof session.customer === "string" ? session.customer : null,
             stripeSubscriptionId:
@@ -60,6 +72,12 @@ export async function POST(request: Request) {
         );
       } catch (error) {
         if (!(error instanceof SiteNotClaimableError)) throw error;
+        await recordClaimRejection({
+          siteSlug: slug,
+          reason: "checkout_completion_rejected",
+          actor: "system:stripe-webhook",
+          invitationId: claimInvitationId,
+        });
         // Checkout metadata is attacker-influenced, so a slug pointing at
         // somebody else's site is expected here. Acknowledge it: no
         // amount of retrying will make that site claimable.

--- a/src/app/claim/[slug]/claim-panel.tsx
+++ b/src/app/claim/[slug]/claim-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import {
   ArrowRight,
@@ -56,17 +56,72 @@ export function ClaimPanel({
   const [plan, setPlan] = useState<"starter" | "growth">("growth");
   const [email, setEmail] = useState("");
   const [loading, setLoading] = useState(false);
+  const [invitationSent, setInvitationSent] = useState(false);
+  const [invitationToken, setInvitationToken] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  async function checkout() {
+  useEffect(() => {
+    const fragment = new URLSearchParams(window.location.hash.slice(1));
+    const token = fragment.get("claim_token");
+    let revealToken: number | undefined;
+    if (token && /^[A-Za-z0-9_-]{32,128}$/.test(token)) {
+      revealToken = window.setTimeout(() => setInvitationToken(token), 0);
+    }
+    if (window.location.hash) {
+      window.history.replaceState(
+        null,
+        "",
+        `${window.location.pathname}${window.location.search}`,
+      );
+    }
+    return () => {
+      if (revealToken !== undefined) window.clearTimeout(revealToken);
+    };
+  }, []);
+
+  async function requestInvitation() {
     if (!email) return;
+    setLoading(true);
+    setInvitationSent(false);
+    setError(null);
+    try {
+      const response = await fetch("/api/claim-invitations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ siteSlug: slug, email }),
+      });
+      const result = (await response.json()) as {
+        ok?: boolean;
+        error?: string;
+      };
+      if (!response.ok || !result.ok) {
+        throw new Error(result.error ?? "Ownership verification could not be sent");
+      }
+      setInvitationSent(true);
+    } catch (caught) {
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "Ownership verification could not be sent",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function checkout() {
+    if (!invitationToken) return;
     setLoading(true);
     setError(null);
     try {
       const response = await fetch("/api/checkout", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ plan, siteSlug: slug, email }),
+        body: JSON.stringify({
+          plan,
+          siteSlug: slug,
+          invitationToken,
+        }),
       });
       const result = (await response.json()) as {
         url?: string;
@@ -120,7 +175,10 @@ export function ClaimPanel({
       <aside className="flex items-center px-5 py-12 sm:px-10 lg:px-14">
         <div className="mx-auto w-full max-w-xl">
           <Badge variant="secondary" className="rounded-full">
-            <ShieldCheck /> Nothing publishes before payment
+            <ShieldCheck />
+            {invitationToken
+              ? "One-time ownership link attached"
+              : "Ownership proof required before payment"}
           </Badge>
           <h2 className="font-display text-balance mt-5 text-5xl leading-[0.92] tracking-[-0.045em]">
             Keep this site current.
@@ -175,17 +233,42 @@ export function ClaimPanel({
             ))}
           </div>
 
-          <label className="mt-7 block text-xs font-medium" htmlFor="email">
-            Owner email
-          </label>
-          <Input
-            id="email"
-            type="email"
-            value={email}
-            onChange={(event) => setEmail(event.target.value)}
-            placeholder="owner@restaurant.com"
-            className="mt-2 h-11"
-          />
+          {invitationToken ? (
+            <div className="mt-7 rounded-xl border border-primary/30 bg-primary/5 p-4">
+              <p className="text-sm font-medium">Ownership link ready</p>
+              <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                Checkout will verify that this one-time link belongs to this
+                site and the email approved for it.
+              </p>
+            </div>
+          ) : (
+            <>
+              <label className="mt-7 block text-xs font-medium" htmlFor="email">
+                Business owner email
+              </label>
+              <Input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(event) => {
+                  setEmail(event.target.value);
+                  setInvitationSent(false);
+                }}
+                placeholder="owner@restaurant.com"
+                className="mt-2 h-11"
+              />
+              <p className="mt-2 text-[11px] leading-5 text-muted-foreground">
+                Use the email shown on the source website or an address on that
+                exact domain. Concierge-approved owners can use the address the
+                operator approved.
+              </p>
+            </>
+          )}
+          {invitationSent ? (
+            <p className="mt-3 rounded-lg bg-primary/8 px-3 py-2 text-xs text-primary">
+              Check that inbox for the 48-hour one-time ownership link.
+            </p>
+          ) : null}
           {error ? (
             <p className="mt-3 rounded-lg bg-destructive/8 px-3 py-2 text-xs text-destructive">
               {error}
@@ -194,22 +277,32 @@ export function ClaimPanel({
           <Button
             size="lg"
             className="mt-4 h-12 w-full"
-            disabled={!email || loading}
-            onClick={() => void checkout()}
+            disabled={(!invitationToken && !email) || loading}
+            onClick={() =>
+              void (invitationToken ? checkout() : requestInvitation())
+            }
           >
             {loading ? (
               <>
-                <LoaderCircle className="animate-spin" /> Opening secure checkout
+                <LoaderCircle className="animate-spin" />
+                {invitationToken
+                  ? "Opening secure checkout"
+                  : "Sending ownership link"}
+              </>
+            ) : invitationToken ? (
+              <>
+                Claim and continue <ArrowRight />
               </>
             ) : (
               <>
-                Claim and continue <ArrowRight />
+                Verify ownership by email <ArrowRight />
               </>
             )}
           </Button>
           <p className="mt-3 text-center text-[11px] leading-5 text-muted-foreground">
-            Secure subscription checkout by Stripe. Cancel any time. Domain
-            connection happens after the account is created.
+            {invitationToken
+              ? "Secure subscription checkout by Stripe. The invitation is accepted only after checkout completes."
+              : "No checkout or owner account can start until the approved email opens its one-time link."}
           </p>
         </div>
       </aside>

--- a/src/lib/claim-invitation-email.test.ts
+++ b/src/lib/claim-invitation-email.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "bun:test";
+import { buildClaimInvitationEmail } from "@/lib/claim-invitation-email";
+
+describe("claim invitation email", () => {
+  it("uses the site niche and escapes stored business names", () => {
+    const email = buildClaimInvitationEmail({
+      claimUrl:
+        "https://cornershop.dev/claim/chez-lea#claim_token=secret&next=<bad>",
+      siteName: 'Chez <Léa> "Bistro"',
+      vertical: "RESTAURANT",
+      expiresAt: new Date("2026-07-28T12:00:00.000Z"),
+    });
+
+    expect(email.from).toContain("Restofront");
+    expect(email.subject).toBe('Verify ownership of Chez <Léa> "Bistro"');
+    expect(email.html).toContain("Chez &lt;Léa&gt; &quot;Bistro&quot;");
+    expect(email.html).not.toContain("next=<bad>");
+    expect(email.html).toContain("claim_token=secret&amp;next=&lt;bad&gt;");
+  });
+});

--- a/src/lib/claim-invitation-email.ts
+++ b/src/lib/claim-invitation-email.ts
@@ -1,0 +1,50 @@
+import { emailReplyTo, emailSender } from "@/lib/resend";
+import { resolveVerticalConfig } from "@/lib/verticals/registry";
+import type { VerticalId } from "@/lib/verticals/types";
+
+export type ClaimInvitationEmail = {
+  from: string;
+  replyTo: string | undefined;
+  subject: string;
+  html: string;
+};
+
+export function buildClaimInvitationEmail(input: {
+  claimUrl: string;
+  siteName: string;
+  vertical: VerticalId;
+  expiresAt: Date;
+}): ClaimInvitationEmail {
+  const brand = resolveVerticalConfig(input.vertical).marketing.brand;
+  const siteName = escapeHtml(input.siteName);
+  const claimUrl = escapeHtml(input.claimUrl);
+  const expiry = new Intl.DateTimeFormat("en", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "UTC",
+  }).format(input.expiresAt);
+
+  return {
+    from: emailSender(input.vertical),
+    replyTo: emailReplyTo(input.vertical),
+    subject: `Verify ownership of ${input.siteName}`,
+    html: `<div style="font-family:Arial,sans-serif;background:#f4efe5;padding:40px">
+      <div style="max-width:520px;margin:auto;background:white;border-radius:18px;padding:32px">
+        <p style="font-size:13px;color:#a5482d;font-weight:700">${brand.name.toUpperCase()}</p>
+        <h1 style="font-size:30px;line-height:1.05;margin:18px 0">Verify ${siteName}.</h1>
+        <p style="color:#5e5b55;line-height:1.6">This one-time link proves access to the approved owner email before subscription checkout can begin.</p>
+        <p style="margin:28px 0"><a href="${claimUrl}" style="background:#a5482d;color:white;text-decoration:none;padding:13px 20px;border-radius:10px;font-weight:700">Continue secure claim</a></p>
+        <p style="font-size:12px;color:#858079">The link expires ${expiry} UTC. If you did not request it, ignore this email.</p>
+      </div>
+    </div>`,
+  };
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}

--- a/src/lib/claim-invitations.test.ts
+++ b/src/lib/claim-invitations.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "bun:test";
+import {
+  hasDomainEmailOwnershipProof,
+  hashClaimInvitationToken,
+} from "@/lib/claim-invitations";
+
+describe("claim invitation secrets", () => {
+  it("stores a fixed SHA-256 digest rather than the bearer token", () => {
+    const token = "a-private-one-time-token";
+    const digest = hashClaimInvitationToken(token);
+
+    expect(digest).toHaveLength(64);
+    expect(digest).not.toContain(token);
+    expect(hashClaimInvitationToken(token)).toBe(digest);
+    expect(hashClaimInvitationToken(`${token}-other`)).not.toBe(digest);
+  });
+});
+
+describe("self-serve domain email proof", () => {
+  it("accepts the exact imported contact email", () => {
+    expect(
+      hasDomainEmailOwnershipProof(
+        {
+          sourceUrl: null,
+          email: "Bookings@Chez-Lea.test",
+        },
+        " bookings@chez-lea.TEST ",
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts the exact source hostname after removing leading www", () => {
+    expect(
+      hasDomainEmailOwnershipProof(
+        {
+          sourceUrl: "https://www.chez-lea.test/menu",
+          email: null,
+        },
+        "owner@chez-lea.test",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not guess parent, sibling or registrable domains", () => {
+    const site = {
+      sourceUrl: "https://restaurant.example.co.uk",
+      email: null,
+    };
+
+    expect(
+      hasDomainEmailOwnershipProof(site, "owner@example.co.uk"),
+    ).toBe(false);
+    expect(
+      hasDomainEmailOwnershipProof(site, "owner@shop.example.co.uk"),
+    ).toBe(false);
+    expect(
+      hasDomainEmailOwnershipProof(site, "owner@restaurant.example.co.uk"),
+    ).toBe(true);
+  });
+
+  it("fails closed for malformed imported identity data", () => {
+    expect(
+      hasDomainEmailOwnershipProof(
+        { sourceUrl: "not a URL", email: "not an email" },
+        "owner@example.test",
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/lib/claim-invitations.test.ts
+++ b/src/lib/claim-invitations.test.ts
@@ -41,6 +41,18 @@ describe("self-serve domain email proof", () => {
     ).toBe(true);
   });
 
+  it("does not strip www from the candidate email domain", () => {
+    expect(
+      hasDomainEmailOwnershipProof(
+        {
+          sourceUrl: "https://example.test/menu",
+          email: null,
+        },
+        "owner@www.example.test",
+      ),
+    ).toBe(false);
+  });
+
   it("does not guess parent, sibling or registrable domains", () => {
     const site = {
       sourceUrl: "https://restaurant.example.co.uk",

--- a/src/lib/claim-invitations.test.ts
+++ b/src/lib/claim-invitations.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+  buildClaimCheckoutIdempotencyKey,
   hasDomainEmailOwnershipProof,
   hashClaimInvitationToken,
 } from "@/lib/claim-invitations";
@@ -13,6 +14,27 @@ describe("claim invitation secrets", () => {
     expect(digest).not.toContain(token);
     expect(hashClaimInvitationToken(token)).toBe(digest);
     expect(hashClaimInvitationToken(`${token}-other`)).not.toBe(digest);
+  });
+});
+
+describe("claim checkout idempotency", () => {
+  it("binds the exact Stripe expiry to the idempotency key", () => {
+    const input = {
+      invitationId: "invite_1",
+      plan: "growth" as const,
+      previousSessionId: "cs_previous",
+      expiresAt: 1_800_000_000,
+    };
+
+    expect(buildClaimCheckoutIdempotencyKey(input)).toBe(
+      buildClaimCheckoutIdempotencyKey({ ...input }),
+    );
+    expect(
+      buildClaimCheckoutIdempotencyKey({
+        ...input,
+        expiresAt: input.expiresAt + 1,
+      }),
+    ).not.toBe(buildClaimCheckoutIdempotencyKey(input));
   });
 });
 

--- a/src/lib/claim-invitations.ts
+++ b/src/lib/claim-invitations.ts
@@ -48,6 +48,21 @@ export function hashClaimInvitationToken(token: string): string {
   return createHash("sha256").update(token, "utf8").digest("hex");
 }
 
+export function buildClaimCheckoutIdempotencyKey(input: {
+  invitationId: string;
+  plan: "starter" | "growth";
+  previousSessionId: string | null;
+  expiresAt: number;
+}): string {
+  return [
+    "claim",
+    input.invitationId,
+    input.plan,
+    input.previousSessionId ?? "initial",
+    input.expiresAt,
+  ].join("-");
+}
+
 /**
  * Intentionally conservative. A mailbox proves self-serve ownership only when
  * it is the exact imported business email or lives on the exact source website
@@ -344,9 +359,9 @@ export async function bindClaimInvitationToCheckout(input: {
   stripeCheckoutSessionId: string;
   expectedCheckoutSessionId: string | null;
   now?: Date;
-}): Promise<void> {
+}): Promise<string> {
   const now = input.now ?? new Date();
-  await getDb().$transaction(async (tx) => {
+  return getDb().$transaction(async (tx) => {
     const bound = await tx.claimInvitation.updateMany({
       where: {
         id: input.invitation.id,
@@ -363,6 +378,24 @@ export async function bindClaimInvitationToCheckout(input: {
       data: { checkoutSessionId: input.stripeCheckoutSessionId },
     });
     if (bound.count !== 1) {
+      const current = await tx.claimInvitation.findUnique({
+        where: { id: input.invitation.id },
+        select: {
+          acceptedAt: true,
+          revokedAt: true,
+          expiresAt: true,
+          checkoutSessionId: true,
+        },
+      });
+      if (
+        current &&
+        !current.acceptedAt &&
+        !current.revokedAt &&
+        current.expiresAt > now &&
+        current.checkoutSessionId
+      ) {
+        return current.checkoutSessionId;
+      }
       throw new ClaimFlowError(
         "invitation_used",
         409,
@@ -377,6 +410,7 @@ export async function bindClaimInvitationToCheckout(input: {
         siteId: input.invitation.siteId,
       },
     });
+    return input.stripeCheckoutSessionId;
   });
 }
 

--- a/src/lib/claim-invitations.ts
+++ b/src/lib/claim-invitations.ts
@@ -1,0 +1,457 @@
+import { createHash, randomBytes } from "node:crypto";
+import { domainToASCII } from "node:url";
+import { normalizeAccountEmail } from "@/lib/account-email";
+import { buildClaimInvitationEmail } from "@/lib/claim-invitation-email";
+import { getDb } from "@/lib/db";
+import { getResend } from "@/lib/resend";
+import { isClaimable } from "@/lib/site-claim";
+import type { VerticalId } from "@/lib/verticals/types";
+
+export const CLAIM_INVITATION_TTL_MS = 48 * 60 * 60_000;
+const retryableInvitationCodes = new Set(["P2002", "P2034"]);
+
+export type ClaimProofMethodValue =
+  | "DOMAIN_EMAIL"
+  | "OPERATOR_APPROVAL";
+
+export type ClaimFlowErrorCode =
+  | "invalid_invitation"
+  | "invalid_ownership_proof"
+  | "invitation_used"
+  | "not_claimable";
+
+export class ClaimFlowError extends Error {
+  constructor(
+    public readonly code: ClaimFlowErrorCode,
+    public readonly status: 403 | 409,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ClaimFlowError";
+  }
+}
+
+type ClaimSite = {
+  id: string;
+  slug: string;
+  name: string;
+  vertical: VerticalId;
+  sourceUrl: string | null;
+  email: string | null;
+  status: "PROSPECT" | "PREVIEW_READY" | "CLAIMED" | "LIVE" | "PAUSED";
+  organizationId: string | null;
+};
+
+export function hashClaimInvitationToken(token: string): string {
+  return createHash("sha256").update(token, "utf8").digest("hex");
+}
+
+/**
+ * Intentionally conservative. A mailbox proves self-serve ownership only when
+ * it is the exact imported business email or lives on the exact source website
+ * hostname after removing a leading `www.`. We do not guess registrable domains
+ * (`co.uk`, hosted subdomains, etc.); ambiguous prospects use operator approval.
+ */
+export function hasDomainEmailOwnershipProof(
+  site: Pick<ClaimSite, "sourceUrl" | "email">,
+  candidateEmail: string,
+): boolean {
+  const email = normalizeAccountEmail(candidateEmail);
+  if (site.email) {
+    try {
+      if (normalizeAccountEmail(site.email) === email) return true;
+    } catch {
+      // Imported contact data can be malformed; it must never widen proof.
+    }
+  }
+
+  if (!site.sourceUrl) return false;
+  try {
+    const sourceDomain = normalizeDomain(new URL(site.sourceUrl).hostname);
+    const emailDomain = normalizeDomain(email.slice(email.lastIndexOf("@") + 1));
+    return sourceDomain.length > 0 && sourceDomain === emailDomain;
+  } catch {
+    return false;
+  }
+}
+
+function normalizeDomain(value: string): string {
+  const ascii = domainToASCII(value.trim().toLowerCase().replace(/\.$/, ""));
+  return ascii.replace(/^www\./, "");
+}
+
+export type IssuedClaimInvitation = {
+  id: string;
+  token: string;
+  email: string;
+  expiresAt: Date;
+  site: {
+    id: string;
+    slug: string;
+    name: string;
+    vertical: VerticalId;
+  };
+};
+
+export async function issueClaimInvitation(input: {
+  siteSlug: string;
+  email: string;
+  proofMethod: ClaimProofMethodValue;
+  actor: string;
+  now?: Date;
+}): Promise<IssuedClaimInvitation> {
+  const email = normalizeAccountEmail(input.email);
+  const now = input.now ?? new Date();
+  const expiresAt = new Date(now.getTime() + CLAIM_INVITATION_TTL_MS);
+  const token = randomBytes(32).toString("base64url");
+  const tokenHash = hashClaimInvitationToken(token);
+  const db = getDb();
+
+  let issued:
+    | {
+        id: string;
+        site: {
+          id: string;
+          slug: string;
+          name: string;
+          vertical: VerticalId;
+        };
+      }
+    | undefined;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      issued = await db.$transaction(
+        async (tx) => {
+          const site = await tx.site.findUnique({
+            where: { slug: input.siteSlug },
+            select: {
+              id: true,
+              slug: true,
+              name: true,
+              vertical: true,
+              sourceUrl: true,
+              email: true,
+              status: true,
+              organizationId: true,
+            },
+          });
+          if (!site || !isClaimable(site)) throw notClaimable();
+          if (
+            input.proofMethod === "DOMAIN_EMAIL" &&
+            !hasDomainEmailOwnershipProof(site, email)
+          ) {
+            throw new ClaimFlowError(
+              "invalid_ownership_proof",
+              403,
+              "Use the business email shown on the source website, or ask for concierge approval.",
+            );
+          }
+
+          // Revoke every earlier unaccepted path, not only invitations for the
+          // same email. Combined with the partial unique index, exactly one
+          // bearer token can authorize this site at a time.
+          await tx.claimInvitation.updateMany({
+            where: {
+              siteId: site.id,
+              acceptedAt: null,
+              revokedAt: null,
+            },
+            data: { revokedAt: now },
+          });
+          const invitation = await tx.claimInvitation.create({
+            data: {
+              siteId: site.id,
+              email,
+              tokenHash,
+              proofMethod: input.proofMethod,
+              expiresAt,
+            },
+            select: { id: true },
+          });
+          await tx.auditEvent.create({
+            data: {
+              type: "claim.invitation.created",
+              actor: input.actor,
+              metadata: {
+                invitationId: invitation.id,
+                proofMethod: input.proofMethod,
+                expiresAt: expiresAt.toISOString(),
+              },
+              siteId: site.id,
+            },
+          });
+
+          return {
+            id: invitation.id,
+            site: {
+              id: site.id,
+              slug: site.slug,
+              name: site.name,
+              vertical: site.vertical,
+            },
+          };
+        },
+        { isolationLevel: "Serializable" },
+      );
+      break;
+    } catch (error) {
+      if (attempt < 2 && isRetryableInvitationError(error)) continue;
+      throw error;
+    }
+  }
+  if (!issued) throw new Error("Claim invitation could not be issued");
+
+  return { ...issued, token, email, expiresAt };
+}
+
+export type CheckoutClaimInvitation = {
+  id: string;
+  email: string;
+  siteId: string;
+  siteSlug: string;
+};
+
+/**
+ * Validates the bearer token immediately before Stripe Checkout. Verification
+ * and its audit row are atomic; repeated reads stay idempotent and do not flood
+ * the audit trail.
+ */
+export async function authorizeClaimInvitationForCheckout(input: {
+  siteSlug: string;
+  token: string;
+  now?: Date;
+}): Promise<CheckoutClaimInvitation> {
+  const now = input.now ?? new Date();
+  const tokenHash = hashClaimInvitationToken(input.token);
+
+  return getDb().$transaction(async (tx) => {
+    const invitation = await tx.claimInvitation.findUnique({
+      where: { tokenHash },
+      select: {
+        id: true,
+        email: true,
+        expiresAt: true,
+        verifiedAt: true,
+        acceptedAt: true,
+        revokedAt: true,
+        siteId: true,
+        site: {
+          select: {
+            slug: true,
+            status: true,
+            organizationId: true,
+          },
+        },
+      },
+    });
+    if (!invitation || invitation.site.slug !== input.siteSlug) {
+      throw invalidInvitation();
+    }
+    if (!isClaimable(invitation.site)) throw notClaimable();
+    if (invitation.acceptedAt) {
+      throw new ClaimFlowError(
+        "invitation_used",
+        409,
+        "This invitation has already been accepted.",
+      );
+    }
+    if (invitation.revokedAt || invitation.expiresAt <= now) {
+      throw invalidInvitation();
+    }
+
+    if (!invitation.verifiedAt) {
+      const verified = await tx.claimInvitation.updateMany({
+        where: {
+          id: invitation.id,
+          verifiedAt: null,
+          acceptedAt: null,
+          revokedAt: null,
+          expiresAt: { gt: now },
+        },
+        data: { verifiedAt: now },
+      });
+      if (verified.count !== 1) throw invalidInvitation();
+      await tx.auditEvent.create({
+        data: {
+          type: "claim.invitation.verified",
+          actor: "claimant:invitation",
+          metadata: { invitationId: invitation.id },
+          siteId: invitation.siteId,
+        },
+      });
+    }
+
+    return {
+      id: invitation.id,
+      email: invitation.email,
+      siteId: invitation.siteId,
+      siteSlug: invitation.site.slug,
+    };
+  });
+}
+
+/**
+ * Stores the Stripe session ID after the network call. A repeated request may
+ * bind the same idempotently-created Stripe session, but no different session
+ * can replace it.
+ */
+export async function bindClaimInvitationToCheckout(input: {
+  invitation: CheckoutClaimInvitation;
+  stripeCheckoutSessionId: string;
+  now?: Date;
+}): Promise<void> {
+  const now = input.now ?? new Date();
+  await getDb().$transaction(async (tx) => {
+    const bound = await tx.claimInvitation.updateMany({
+      where: {
+        id: input.invitation.id,
+        siteId: input.invitation.siteId,
+        email: input.invitation.email,
+        acceptedAt: null,
+        revokedAt: null,
+        expiresAt: { gt: now },
+        OR: [
+          { checkoutSessionId: null },
+          { checkoutSessionId: input.stripeCheckoutSessionId },
+        ],
+      },
+      data: { checkoutSessionId: input.stripeCheckoutSessionId },
+    });
+    if (bound.count !== 1) {
+      throw new ClaimFlowError(
+        "invitation_used",
+        409,
+        "This invitation is already attached to another checkout.",
+      );
+    }
+    await tx.auditEvent.create({
+      data: {
+        type: "claim.checkout.started",
+        actor: "claimant:invitation",
+        metadata: { invitationId: input.invitation.id },
+        siteId: input.invitation.siteId,
+      },
+    });
+  });
+}
+
+export async function deliverClaimInvitation(
+  invitation: IssuedClaimInvitation,
+  appOrigin: string,
+): Promise<void> {
+  const claimUrl = new URL(`/claim/${encodeURIComponent(invitation.site.slug)}`, appOrigin);
+  // The fragment is never sent in HTTP requests or Referer headers. The claim
+  // page reads it into memory and removes it immediately, preventing embedded
+  // third-party imagery in the preview from learning the bearer token.
+  claimUrl.hash = new URLSearchParams({
+    claim_token: invitation.token,
+  }).toString();
+  const message = buildClaimInvitationEmail({
+    claimUrl: claimUrl.toString(),
+    siteName: invitation.site.name,
+    vertical: invitation.site.vertical,
+    expiresAt: invitation.expiresAt,
+  });
+  const { error } = await getResend().emails.send(
+    {
+      from: message.from,
+      to: invitation.email,
+      replyTo: message.replyTo,
+      subject: message.subject,
+      html: message.html,
+    },
+    {
+      headers: {
+        "Idempotency-Key": `claim-invitation-${invitation.id}`,
+      },
+    },
+  );
+  if (error) throw new Error(error.message);
+}
+
+/**
+ * Rejections are recorded outside any transaction that throws. Metadata never
+ * includes the raw token or claimant email.
+ */
+export async function recordClaimRejection(input: {
+  siteSlug: string;
+  reason: string;
+  actor: string;
+  invitationId?: string;
+}): Promise<void> {
+  if (!process.env.DATABASE_URL) return;
+  try {
+    const db = getDb();
+    const site = await db.site.findUnique({
+      where: { slug: input.siteSlug },
+      select: { id: true },
+    });
+    if (!site) return;
+    await db.auditEvent.create({
+      data: {
+        type: "claim.invitation.rejected",
+        actor: input.actor,
+        metadata: {
+          reason: input.reason,
+          invitationId: input.invitationId ?? null,
+        },
+        siteId: site.id,
+      },
+    });
+  } catch (error) {
+    console.error("[claim-invitation] rejection audit failed", {
+      siteSlug: input.siteSlug,
+      reason: input.reason,
+      error: error instanceof Error ? error.message : "unknown",
+    });
+  }
+}
+
+export async function revokeUndeliveredInvitation(
+  invitation: IssuedClaimInvitation,
+): Promise<void> {
+  const now = new Date();
+  await getDb().$transaction(async (tx) => {
+    await tx.claimInvitation.updateMany({
+      where: { id: invitation.id, acceptedAt: null, revokedAt: null },
+      data: { revokedAt: now },
+    });
+    await tx.auditEvent.create({
+      data: {
+        type: "claim.invitation.rejected",
+        actor: "system:email",
+        metadata: {
+          reason: "delivery_failed",
+          invitationId: invitation.id,
+        },
+        siteId: invitation.site.id,
+      },
+    });
+  });
+}
+
+function invalidInvitation(): ClaimFlowError {
+  return new ClaimFlowError(
+    "invalid_invitation",
+    403,
+    "This claim invitation is invalid or expired.",
+  );
+}
+
+function notClaimable(): ClaimFlowError {
+  return new ClaimFlowError(
+    "not_claimable",
+    409,
+    "This site already has an owner or is not available to claim.",
+  );
+}
+
+function isRetryableInvitationError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    typeof error.code === "string" &&
+    retryableInvitationCodes.has(error.code)
+  );
+}

--- a/src/lib/claim-invitations.ts
+++ b/src/lib/claim-invitations.ts
@@ -8,6 +8,7 @@ import { isClaimable } from "@/lib/site-claim";
 import type { VerticalId } from "@/lib/verticals/types";
 
 export const CLAIM_INVITATION_TTL_MS = 48 * 60 * 60_000;
+export const MIN_CLAIM_CHECKOUT_TTL_MS = 31 * 60_000;
 const retryableInvitationCodes = new Set(["P2002", "P2034"]);
 
 export type ClaimProofMethodValue =
@@ -15,6 +16,7 @@ export type ClaimProofMethodValue =
   | "OPERATOR_APPROVAL";
 
 export type ClaimFlowErrorCode =
+  | "checkout_in_progress"
   | "invalid_invitation"
   | "invalid_ownership_proof"
   | "invitation_used"
@@ -67,7 +69,10 @@ export function hasDomainEmailOwnershipProof(
 
   if (!site.sourceUrl) return false;
   try {
-    const sourceDomain = normalizeDomain(new URL(site.sourceUrl).hostname);
+    const sourceDomain = normalizeDomain(
+      new URL(site.sourceUrl).hostname,
+      true,
+    );
     const emailDomain = normalizeDomain(email.slice(email.lastIndexOf("@") + 1));
     return sourceDomain.length > 0 && sourceDomain === emailDomain;
   } catch {
@@ -75,9 +80,9 @@ export function hasDomainEmailOwnershipProof(
   }
 }
 
-function normalizeDomain(value: string): string {
+function normalizeDomain(value: string, stripLeadingWww = false): string {
   const ascii = domainToASCII(value.trim().toLowerCase().replace(/\.$/, ""));
-  return ascii.replace(/^www\./, "");
+  return stripLeadingWww ? ascii.replace(/^www\./, "") : ascii;
 }
 
 export type IssuedClaimInvitation = {
@@ -147,14 +152,40 @@ export async function issueClaimInvitation(input: {
             );
           }
 
+          const checkoutInProgress = await tx.claimInvitation.findFirst({
+            where: {
+              siteId: site.id,
+              acceptedAt: null,
+              revokedAt: null,
+              expiresAt: { gt: now },
+              checkoutSessionId: { not: null },
+            },
+            select: { id: true },
+          });
+          if (checkoutInProgress) {
+            throw new ClaimFlowError(
+              "checkout_in_progress",
+              409,
+              "Checkout already started. Reopen the ownership email to continue or change plans.",
+            );
+          }
+
           // Revoke every earlier unaccepted path, not only invitations for the
           // same email. Combined with the partial unique index, exactly one
-          // bearer token can authorize this site at a time.
+          // bearer token can authorize this site at a time. A checkout-bound
+          // invitation is never silently revoked: the checkout route owns its
+          // Stripe session lifecycle.
           await tx.claimInvitation.updateMany({
             where: {
               siteId: site.id,
               acceptedAt: null,
               revokedAt: null,
+              OR: [
+                { checkoutSessionId: null },
+                // Checkout sessions are explicitly capped at the invitation
+                // expiry, so an expired binding is safe to retire.
+                { expiresAt: { lte: now } },
+              ],
             },
             data: { revokedAt: now },
           });
@@ -209,6 +240,8 @@ export type CheckoutClaimInvitation = {
   email: string;
   siteId: string;
   siteSlug: string;
+  checkoutSessionId: string | null;
+  expiresAt: Date;
 };
 
 /**
@@ -234,6 +267,7 @@ export async function authorizeClaimInvitationForCheckout(input: {
         verifiedAt: true,
         acceptedAt: true,
         revokedAt: true,
+        checkoutSessionId: true,
         siteId: true,
         site: {
           select: {
@@ -256,6 +290,13 @@ export async function authorizeClaimInvitationForCheckout(input: {
       );
     }
     if (invitation.revokedAt || invitation.expiresAt <= now) {
+      throw invalidInvitation();
+    }
+    if (
+      !invitation.checkoutSessionId &&
+      invitation.expiresAt.getTime() - now.getTime() <
+        MIN_CLAIM_CHECKOUT_TTL_MS
+    ) {
       throw invalidInvitation();
     }
 
@@ -286,18 +327,22 @@ export async function authorizeClaimInvitationForCheckout(input: {
       email: invitation.email,
       siteId: invitation.siteId,
       siteSlug: invitation.site.slug,
+      checkoutSessionId: invitation.checkoutSessionId,
+      expiresAt: invitation.expiresAt,
     };
   });
 }
 
 /**
- * Stores the Stripe session ID after the network call. A repeated request may
- * bind the same idempotently-created Stripe session, but no different session
- * can replace it.
+ * Stores the Stripe session ID after the network call. Rebinding is a
+ * compare-and-swap: only the session observed before the Stripe call can be
+ * replaced, while a concurrent request that created the same idempotent Stripe
+ * session remains safe.
  */
 export async function bindClaimInvitationToCheckout(input: {
   invitation: CheckoutClaimInvitation;
   stripeCheckoutSessionId: string;
+  expectedCheckoutSessionId: string | null;
   now?: Date;
 }): Promise<void> {
   const now = input.now ?? new Date();
@@ -311,7 +356,7 @@ export async function bindClaimInvitationToCheckout(input: {
         revokedAt: null,
         expiresAt: { gt: now },
         OR: [
-          { checkoutSessionId: null },
+          { checkoutSessionId: input.expectedCheckoutSessionId },
           { checkoutSessionId: input.stripeCheckoutSessionId },
         ],
       },
@@ -321,7 +366,7 @@ export async function bindClaimInvitationToCheckout(input: {
       throw new ClaimFlowError(
         "invitation_used",
         409,
-        "This invitation is already attached to another checkout.",
+        "Another checkout replaced this one. Reopen the ownership email and try again.",
       );
     }
     await tx.auditEvent.create({

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -129,3 +129,33 @@ export function limitAnalyticsEvent(
     windowMs: 60_000,
   });
 }
+
+export function limitClaimInvitationRequest(
+  request: Request,
+): Promise<RateLimitResult> {
+  return limitByIp(request, {
+    namespace: "claim-invitation",
+    limit: 5,
+    windowMs,
+  });
+}
+
+export function limitClaimCheckout(
+  request: Request,
+): Promise<RateLimitResult> {
+  return limitByIp(request, {
+    namespace: "claim-checkout",
+    limit: 10,
+    windowMs,
+  });
+}
+
+export function limitOperatorClaimInvitation(
+  request: Request,
+): Promise<RateLimitResult> {
+  return limitByIp(request, {
+    namespace: "operator-claim-invitation",
+    limit: 30,
+    windowMs,
+  });
+}

--- a/src/lib/request-origin.test.ts
+++ b/src/lib/request-origin.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { isSameOriginMutation } from "@/lib/request-origin";
+
+describe("mutation origin policy", () => {
+  it("accepts the request origin and the configured public origin", () => {
+    expect(
+      isSameOriginMutation(
+        request("https://internal.example/api/claim", {
+          origin: "https://cornershop.dev",
+        }),
+        {
+          environment: {
+            NEXT_PUBLIC_APP_URL: "https://cornershop.dev/dashboard",
+          },
+        },
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects explicit cross-site requests", () => {
+    expect(
+      isSameOriginMutation(
+        request("https://cornershop.dev/api/claim", {
+          origin: "https://attacker.test",
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isSameOriginMutation(
+        request("https://cornershop.dev/api/claim", {
+          "sec-fetch-site": "cross-site",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("requires an Origin header for cookie-authorized operator writes", () => {
+    expect(
+      isSameOriginMutation(request("https://cornershop.dev/api/admin"), {
+        requireOrigin: true,
+      }),
+    ).toBe(false);
+  });
+});
+
+function request(url: string, headers: Record<string, string> = {}) {
+  return new Request(url, { method: "POST", headers });
+}

--- a/src/lib/request-origin.ts
+++ b/src/lib/request-origin.ts
@@ -1,0 +1,39 @@
+type OriginEnvironment = Record<string, string | undefined>;
+
+/**
+ * Browser mutations may carry an authenticated operator cookie or a bearer
+ * invitation token. Rejecting an explicit cross-origin request prevents either
+ * credential from being exercised by another site. Non-browser clients without
+ * Origin remain valid for public bearer-token routes; operator routes opt into
+ * requiring Origin because their cookie is ambient authority.
+ */
+export function isSameOriginMutation(
+  request: Request,
+  options: {
+    requireOrigin?: boolean;
+    environment?: OriginEnvironment;
+  } = {},
+): boolean {
+  if (request.headers.get("sec-fetch-site") === "cross-site") return false;
+
+  const origin = request.headers.get("origin");
+  if (!origin) return !options.requireOrigin;
+
+  const allowedOrigins = new Set([new URL(request.url).origin]);
+  const configuredUrl = (
+    options.environment ?? process.env
+  ).NEXT_PUBLIC_APP_URL;
+  if (configuredUrl) {
+    try {
+      allowedOrigins.add(new URL(configuredUrl).origin);
+    } catch {
+      return false;
+    }
+  }
+
+  try {
+    return allowedOrigins.has(new URL(origin).origin);
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/site-claim.test.ts
+++ b/src/lib/site-claim.test.ts
@@ -10,34 +10,18 @@ import {
 } from "@/lib/site-claim";
 
 describe("site claim eligibility", () => {
-  it("accepts an unowned prospect", () => {
+  it("admits only unowned prospects", () => {
     expect(isClaimable({ status: "PROSPECT", organizationId: null })).toBe(true);
     expect(isClaimable({ status: "PREVIEW_READY", organizationId: null })).toBe(
       true,
     );
-  });
-
-  it("rejects a site that already belongs to an organization", () => {
-    expect(isClaimable({ status: "PROSPECT", organizationId: "org_a" })).toBe(
+    expect(isClaimable({ status: "CLAIMED", organizationId: null })).toBe(false);
+    expect(isClaimable({ status: "PROSPECT", organizationId: "org_1" })).toBe(
       false,
     );
   });
 
-  it("rejects a site that has moved past the prospect stage", () => {
-    for (const status of ["CLAIMED", "LIVE", "PAUSED"] as const) {
-      expect(isClaimable({ status, organizationId: null })).toBe(false);
-    }
-  });
-
-  it("never treats a live or claimed site as claimable", () => {
-    expect(CLAIMABLE_STATUSES).not.toContain("CLAIMED");
-    expect(CLAIMABLE_STATUSES).not.toContain("LIVE");
-    expect(CLAIMABLE_STATUSES).not.toContain("PAUSED");
-  });
-});
-
-describe("unclaimedWhere", () => {
-  it("pins the update to the requested slug and to unowned prospects", () => {
+  it("pins the compare-and-swap to slug, ownership and lifecycle", () => {
     expect(unclaimedWhere("chez-lea")).toEqual({
       slug: "chez-lea",
       organizationId: null,
@@ -46,98 +30,131 @@ describe("unclaimedWhere", () => {
   });
 });
 
-describe("claimSite", () => {
-  it("hands an unowned prospect to the buyer and records the subscription", async () => {
-    const { state, tx } = createFakeTx([
-      { slug: "chez-lea", status: "PREVIEW_READY", organizationId: null },
-    ]);
+describe("invitation-bound site claim", () => {
+  it("atomically accepts the invitation, assigns ownership and audits it", async () => {
+    const { state, tx } = fixture();
 
-    await claimSite(tx, completedCheckout());
+    const access = await claimSite(tx, completedCheckout());
 
-    const site = state.sites[0];
-    expect(site.status).toBe("CLAIMED");
-    expect(site.organizationId).toBe(state.organizations[0].id);
-    expect(state.subscriptions).toEqual([
-      {
-        stripeCustomerId: "cus_1",
-        stripeSubscriptionId: "sub_1",
-        stripePriceId: "price_1",
-        status: "ACTIVE",
-        organizationId: state.organizations[0].id,
-      },
-    ]);
-  });
-
-  it("refuses a site owned by another organization", async () => {
-    const { state, tx } = createFakeTx([
-      { slug: "chez-lea", status: "CLAIMED", organizationId: "org_someone" },
-    ]);
-
-    const reported = await expectClaimRejected(tx);
-
-    expect(reported).toMatchObject({
-      slug: "chez-lea",
-      stripeSubscriptionId: "sub_1",
+    expect(state.invitations[0].acceptedAt).toBeInstanceOf(Date);
+    expect(state.sites[0]).toMatchObject({
+      status: "CLAIMED",
+      organizationId: access.organizationId,
     });
-    expect(state.sites[0].organizationId).toBe("org_someone");
-    expect(state.subscriptions).toHaveLength(0);
-    // A hijack attempt writes nothing, without relying on the caller having
-    // wrapped this in a transaction that rolls the organization back.
-    expect(state.organizations).toHaveLength(0);
-    expect(state.memberships).toHaveLength(0);
-  });
-
-  it("refuses a slug that does not exist", async () => {
-    const { state, tx } = createFakeTx([]);
-
-    await expectClaimRejected(tx);
-
-    expect(state.organizations).toHaveLength(0);
-  });
-
-  it("refuses an owned site whose organization was deleted", async () => {
-    // `onDelete: SetNull` leaves a real customer's site at
-    // {CLAIMED, organizationId: null}. Treating that as claimable would hand
-    // it to whoever checks out next, so it stays off limits.
-    const { state, tx } = createFakeTx([
-      { slug: "chez-lea", status: "CLAIMED", organizationId: null },
-    ]);
-
-    await expectClaimRejected(tx);
-
-    expect(state.sites[0].organizationId).toBeNull();
-    expect(state.organizations).toHaveLength(0);
-  });
-
-  it("is idempotent when the other completion path already claimed it", async () => {
-    const { state, tx } = createFakeTx([
-      { slug: "chez-lea", status: "PROSPECT", organizationId: null },
-    ]);
-
-    await claimSite(tx, completedCheckout());
-    const organizationId = state.organizations[0].id;
-    // The site has gone live since the first claim; a replayed webhook or a
-    // reloaded success page must not knock it back to CLAIMED.
-    state.sites[0].status = "LIVE";
-
-    await claimSite(tx, completedCheckout());
-
-    expect(state.sites[0].status).toBe("LIVE");
-    expect(state.sites[0].organizationId).toBe(organizationId);
-    expect(state.organizations).toHaveLength(1);
     expect(state.subscriptions).toHaveLength(1);
+    expect(state.auditEvents).toEqual([
+      expect.objectContaining({
+        type: "claim.invitation.accepted",
+        siteId: "site_1",
+        metadata: {
+          invitationId: "invite_1",
+          proofMethod: "DOMAIN_EMAIL",
+        },
+      }),
+    ]);
   });
 
-  it("reuses the buyer's existing organization for a second site", async () => {
-    const { state, tx } = createFakeTx([
-      { slug: "chez-lea", status: "PROSPECT", organizationId: null },
-      { slug: "chez-max", status: "PROSPECT", organizationId: null },
-    ]);
+  it("replays the same completed Stripe session idempotently", async () => {
+    const { state, tx } = fixture();
+
+    const first = await claimSite(tx, completedCheckout());
+    state.sites[0].status = "LIVE";
+    const replay = await claimSite(tx, completedCheckout());
+
+    expect(replay).toEqual(first);
+    expect(state.sites[0].status).toBe("LIVE");
+    expect(state.organizations).toHaveLength(1);
+    expect(state.auditEvents).toHaveLength(1);
+  });
+
+  it("rejects cross-site, cross-email and cross-session use", async () => {
+    for (const checkout of [
+      completedCheckout({ siteSlug: "another-site" }),
+      completedCheckout({ email: "attacker@example.test" }),
+      completedCheckout({ stripeCheckoutSessionId: "cs_other" }),
+    ]) {
+      const { state, tx } = fixture();
+      await expectRejected(tx, checkout);
+      expect(state.sites[0].organizationId).toBeNull();
+      expect(state.invitations[0].acceptedAt).toBeNull();
+    }
+  });
+
+  it("rejects expired and revoked invitations", async () => {
+    for (const invitation of [
+      { expiresAt: new Date("2020-01-01"), revokedAt: null },
+      { expiresAt: new Date("2099-01-01"), revokedAt: new Date() },
+    ]) {
+      const { state, tx } = fixture({ invitation });
+      await expectRejected(tx);
+      expect(state.sites[0].organizationId).toBeNull();
+    }
+  });
+
+  it("does not transfer a site that already has an owner", async () => {
+    const { state, tx } = fixture({
+      site: { status: "CLAIMED", organizationId: "org_someone" },
+    });
+
+    await expectRejected(tx);
+
+    expect(state.sites[0].organizationId).toBe("org_someone");
+    expect(state.invitations[0].acceptedAt).toBeNull();
+    expect(state.organizations).toHaveLength(0);
+  });
+
+  it("does not accept another invitation after ownership was established", async () => {
+    const { state, tx } = fixture({
+      invitations: [
+        invitation(),
+        invitation({
+          id: "invite_2",
+          email: "second@chez-lea.test",
+          checkoutSessionId: "cs_second",
+        }),
+      ],
+    });
+    await claimSite(tx, completedCheckout());
+
+    await expectRejected(
+      tx,
+      completedCheckout({
+        email: "second@chez-lea.test",
+        claimInvitationId: "invite_2",
+        stripeCheckoutSessionId: "cs_second",
+      }),
+    );
+
+    expect(state.sites[0].organizationId).toBe(state.organizations[0].id);
+    expect(state.invitations[1].acceptedAt).toBeNull();
+  });
+
+  it("reuses an existing buyer organization for another invited site", async () => {
+    const { state, tx } = fixture({
+      sites: [
+        site(),
+        site({ id: "site_2", slug: "chez-max" }),
+      ],
+      invitations: [
+        invitation(),
+        invitation({
+          id: "invite_2",
+          siteId: "site_2",
+          checkoutSessionId: "cs_second",
+        }),
+      ],
+    });
 
     await claimSite(tx, completedCheckout());
     await claimSite(
       tx,
-      completedCheckout({ siteSlug: "chez-max" }),
+      completedCheckout({
+        siteSlug: "chez-max",
+        claimInvitationId: "invite_2",
+        stripeCheckoutSessionId: "cs_second",
+        stripeCustomerId: "cus_2",
+        stripeSubscriptionId: "sub_2",
+      }),
     );
 
     expect(state.organizations).toHaveLength(1);
@@ -146,64 +163,39 @@ describe("claimSite", () => {
       state.organizations[0].id,
     ]);
   });
-
-  it("normalizes Stripe email before creating account identity", async () => {
-    const { state, tx } = createFakeTx([
-      { slug: "chez-lea", status: "PREVIEW_READY", organizationId: null },
-    ]);
-
-    await claimSite(
-      tx,
-      completedCheckout({ email: " Owner@Chez-Lea.TEST " }),
-    );
-
-    expect(state.users[0].email).toBe("owner@chez-lea.test");
-  });
 });
 
 describe("SiteNotClaimableError", () => {
-  it("does not reveal whether the slug exists", () => {
+  it("does not expose ownership or invitation internals", () => {
     const error = new SiteNotClaimableError();
-    expect(error.name).toBe("SiteNotClaimableError");
     expect(error.message).toBe("This site is not available to claim");
-    expect(error.message).not.toContain("not found");
+    expect(error.message).not.toContain("invitation");
   });
 });
 
-/**
- * Asserts a claim is refused *and* that it left a trace. A rejected claim
- * means a real payment completed with nothing to show for it, so silence is
- * itself a bug — the log line is the only signal a human gets, since the
- * transaction rolls back before an audit row could survive. Spying also keeps
- * the expected error out of the CI output.
- */
-async function expectClaimRejected(
+async function expectRejected(
   tx: Prisma.TransactionClient,
   checkout: CompletedCheckout = completedCheckout(),
-): Promise<Record<string, unknown>> {
+) {
   const logged = spyOn(console, "error").mockImplementation(() => {});
   try {
     await expect(claimSite(tx, checkout)).rejects.toBeInstanceOf(
       SiteNotClaimableError,
     );
     expect(logged).toHaveBeenCalledTimes(1);
-    return logged.mock.calls[0][1] as Record<string, unknown>;
   } finally {
     logged.mockRestore();
   }
 }
 
-/**
- * Typed against the exported `CompletedCheckout` rather than inferred from this
- * fixture, so a field added to the real checkout payload fails to compile here
- * instead of leaving the tests asserting against a shape Stripe no longer sends.
- */
 function completedCheckout(
   overrides: Partial<CompletedCheckout> = {},
 ): CompletedCheckout {
   return {
     email: "owner@chez-lea.test",
     siteSlug: "chez-lea",
+    claimInvitationId: "invite_1",
+    stripeCheckoutSessionId: "cs_1",
     stripeCustomerId: "cus_1",
     stripeSubscriptionId: "sub_1",
     stripePriceId: "price_1",
@@ -212,9 +204,22 @@ function completedCheckout(
 }
 
 type SiteRow = {
+  id: string;
   slug: string;
   status: string;
   organizationId: string | null;
+};
+
+type InvitationRow = {
+  id: string;
+  email: string;
+  proofMethod: string;
+  expiresAt: Date;
+  verifiedAt: Date | null;
+  acceptedAt: Date | null;
+  revokedAt: Date | null;
+  checkoutSessionId: string | null;
+  siteId: string;
 };
 
 type SubscriptionRow = {
@@ -225,70 +230,155 @@ type SubscriptionRow = {
   organizationId: string;
 };
 
-/**
- * A tiny in-memory stand-in for a Prisma transaction. `updateMany` and `count`
- * apply the real WHERE clause the way Postgres would — every field ANDed, `in`
- * treated as set membership — so a guard that stops narrowing the update
- * shows up here as a test failure rather than a passing snapshot.
- */
-function createFakeTx(sites: SiteRow[]) {
+function site(overrides: Partial<SiteRow> = {}): SiteRow {
+  return {
+    id: "site_1",
+    slug: "chez-lea",
+    status: "PREVIEW_READY",
+    organizationId: null,
+    ...overrides,
+  };
+}
+
+function invitation(
+  overrides: Partial<InvitationRow> = {},
+): InvitationRow {
+  return {
+    id: "invite_1",
+    email: "owner@chez-lea.test",
+    proofMethod: "DOMAIN_EMAIL",
+    expiresAt: new Date("2099-01-01"),
+    verifiedAt: new Date(),
+    acceptedAt: null,
+    revokedAt: null,
+    checkoutSessionId: "cs_1",
+    siteId: "site_1",
+    ...overrides,
+  };
+}
+
+function fixture(
+  overrides: {
+    site?: Partial<SiteRow>;
+    sites?: SiteRow[];
+    invitation?: Partial<InvitationRow>;
+    invitations?: InvitationRow[];
+  } = {},
+) {
   const state = {
-    sites,
+    sites: overrides.sites ?? [site(overrides.site)],
+    invitations:
+      overrides.invitations ?? [invitation(overrides.invitation)],
     users: [] as Array<{ id: string; email: string }>,
     organizations: [] as Array<{ id: string; name: string }>,
     memberships: [] as Array<{ userId: string; organizationId: string }>,
     subscriptions: [] as SubscriptionRow[],
+    auditEvents: [] as Array<Record<string, unknown>>,
   };
-
   let sequence = 0;
   const nextId = (prefix: string) => `${prefix}_${(sequence += 1)}`;
 
   const fake = {
+    claimInvitation: {
+      findUnique: async ({ where }: { where: { id: string } }) => {
+        const row = state.invitations.find((item) => item.id === where.id);
+        if (!row) return null;
+        const ownedSite = state.sites.find((item) => item.id === row.siteId);
+        return ownedSite ? { ...row, site: { ...ownedSite } } : null;
+      },
+      updateMany: async ({
+        where,
+        data,
+      }: {
+        where: WhereClause;
+        data: Partial<InvitationRow>;
+      }) => {
+        const rows = state.invitations.filter((row) => matches(row, where));
+        for (const row of rows) Object.assign(row, data);
+        return { count: rows.length };
+      },
+    },
     user: {
-      upsert: async ({ where, create }: UpsertUserArgs) => {
-        const existing = state.users.find((user) => user.email === where.email);
-        if (existing) return existing;
-        const user = { id: nextId("user"), email: create.email };
-        state.users.push(user);
-        return user;
+      upsert: async ({
+        where,
+        create,
+      }: {
+        where: { email: string };
+        create: { email: string };
+      }) => {
+        const found = state.users.find((user) => user.email === where.email);
+        if (found) return found;
+        const created = { id: nextId("user"), email: create.email };
+        state.users.push(created);
+        return created;
       },
     },
     membership: {
-      findFirst: async ({ where }: { where: { userId: string } }) =>
+      findFirst: async ({
+        where,
+      }: {
+        where: { userId: string; organizationId?: string };
+      }) =>
         state.memberships.find(
-          (membership) => membership.userId === where.userId,
+          (row) =>
+            row.userId === where.userId &&
+            (!where.organizationId ||
+              row.organizationId === where.organizationId),
         ) ?? null,
     },
     organization: {
-      create: async ({ data }: CreateOrganizationArgs) => {
-        const organization = { id: nextId("org"), name: data.name };
-        state.organizations.push(organization);
+      create: async ({
+        data,
+      }: {
+        data: {
+          name: string;
+          memberships: { create: { userId: string } };
+        };
+      }) => {
+        const created = { id: nextId("org"), name: data.name };
+        state.organizations.push(created);
         state.memberships.push({
           userId: data.memberships.create.userId,
-          organizationId: organization.id,
+          organizationId: created.id,
         });
-        return organization;
+        return created;
       },
     },
     site: {
-      findUnique: async ({ where }: { where: { slug: string } }) =>
-        state.sites.find((row) => row.slug === where.slug) ?? null,
-      updateMany: async ({ where, data }: UpdateSitesArgs) => {
-        const matched = state.sites.filter((row) => matches(row, where));
-        for (const row of matched) Object.assign(row, data);
-        return { count: matched.length };
+      updateMany: async ({
+        where,
+        data,
+      }: {
+        where: WhereClause;
+        data: Partial<SiteRow>;
+      }) => {
+        const rows = state.sites.filter((row) => matches(row, where));
+        for (const row of rows) Object.assign(row, data);
+        return { count: rows.length };
       },
-      count: async ({ where }: { where: WhereClause }) =>
-        state.sites.filter((row) => matches(row, where)).length,
     },
     subscription: {
-      upsert: async ({ where, update, create }: UpsertSubscriptionArgs) => {
-        const existing = state.subscriptions.find(
+      upsert: async ({
+        where,
+        update,
+        create,
+      }: {
+        where: { stripeCustomerId: string };
+        update: Partial<SubscriptionRow>;
+        create: SubscriptionRow;
+      }) => {
+        const found = state.subscriptions.find(
           (row) => row.stripeCustomerId === where.stripeCustomerId,
         );
-        if (existing) return Object.assign(existing, update);
+        if (found) return Object.assign(found, update);
         state.subscriptions.push(create);
         return create;
+      },
+    },
+    auditEvent: {
+      create: async ({ data }: { data: Record<string, unknown> }) => {
+        state.auditEvents.push(data);
+        return data;
       },
     },
   };
@@ -298,34 +388,22 @@ function createFakeTx(sites: SiteRow[]) {
 
 type WhereClause = Record<string, unknown>;
 
-type UpsertUserArgs = {
-  where: { email: string };
-  create: { email: string };
-};
-
-type CreateOrganizationArgs = {
-  data: {
-    name: string;
-    memberships: { create: { userId: string; role: string } };
-  };
-};
-
-type UpdateSitesArgs = {
-  where: WhereClause;
-  data: Partial<SiteRow>;
-};
-
-type UpsertSubscriptionArgs = {
-  where: { stripeCustomerId: string };
-  update: Partial<SubscriptionRow>;
-  create: SubscriptionRow;
-};
-
-function matches(row: SiteRow, where: WhereClause): boolean {
+function matches(row: object, where: WhereClause): boolean {
   return Object.entries(where).every(([field, condition]) => {
+    if (field === "OR") {
+      return (condition as WhereClause[]).some((branch) => matches(row, branch));
+    }
     const value = (row as Record<string, unknown>)[field];
-    if (condition !== null && typeof condition === "object" && "in" in condition) {
-      return (condition as { in: unknown[] }).in.includes(value);
+    if (condition !== null && typeof condition === "object") {
+      if ("in" in condition) {
+        return (condition as { in: unknown[] }).in.includes(value);
+      }
+      if ("gt" in condition) {
+        return (
+          value instanceof Date &&
+          value > (condition as { gt: Date }).gt
+        );
+      }
     }
     return value === condition;
   });

--- a/src/lib/site-claim.ts
+++ b/src/lib/site-claim.ts
@@ -2,25 +2,11 @@ import type { Prisma } from "@/generated/prisma/client";
 import { SiteStatus } from "@/generated/prisma/enums";
 import { normalizeAccountEmail } from "@/lib/account-email";
 
-/**
- * A site may only be claimed while it is still an unowned prospect. Once it
- * belongs to an organization, only that organization may act on it — a
- * completed checkout must never be able to reassign somebody else's site just
- * because the caller supplied its slug.
- *
- * Mirrors the equivalent guard on the import path in `site-persistence.ts`,
- * which the claim path was missing.
- */
 export const CLAIMABLE_STATUSES: SiteStatus[] = [
   SiteStatus.PROSPECT,
   SiteStatus.PREVIEW_READY,
 ];
 
-/**
- * Raised when a checkout tries to claim a site that is missing or is already
- * owned by another organization. The message deliberately does not distinguish
- * the two so the endpoint cannot be used to enumerate slugs.
- */
 export class SiteNotClaimableError extends Error {
   constructor() {
     super("This site is not available to claim");
@@ -28,12 +14,6 @@ export class SiteNotClaimableError extends Error {
   }
 }
 
-/**
- * True when a site has never been claimed. Used for the pre-checkout courtesy
- * check; the authoritative guard is the conditional update inside `claimSite`,
- * which pushes the same rule into the database so it cannot lose a
- * check-then-write race.
- */
 export function isClaimable(site: {
   status: SiteStatus;
   organizationId: string | null;
@@ -43,23 +23,10 @@ export function isClaimable(site: {
   );
 }
 
-/**
- * Matches a site only while it is still unowned. Used as the WHERE clause of
- * the claiming update so the claim becomes a compare-and-swap: Postgres
- * re-evaluates the predicate after a concurrent writer commits, so only one of
- * two racing claims can match the row.
- */
 export function unclaimedWhere(slug: string): Prisma.SiteWhereInput {
   return { slug, organizationId: null, status: { in: CLAIMABLE_STATUSES } };
 }
 
-/**
- * A rejected claim means a real Stripe checkout completed and the buyer got
- * nothing, so it must never be silent: either somebody is probing slugs with
- * tampered metadata, or a paying customer is now holding a subscription to a
- * site they cannot reach. Both need a human, and the transaction is about to
- * roll back, so an audit row would vanish with it.
- */
 function rejectClaim(
   checkout: CompletedCheckout,
   reason: string,
@@ -67,6 +34,8 @@ function rejectClaim(
   console.error("[site-claim] rejected a completed checkout", {
     reason,
     slug: checkout.siteSlug,
+    claimInvitationId: checkout.claimInvitationId,
+    stripeCheckoutSessionId: checkout.stripeCheckoutSessionId,
     stripeCustomerId: checkout.stripeCustomerId,
     stripeSubscriptionId: checkout.stripeSubscriptionId,
   });
@@ -76,6 +45,8 @@ function rejectClaim(
 export type CompletedCheckout = {
   email: string;
   siteSlug: string;
+  claimInvitationId: string;
+  stripeCheckoutSessionId: string;
   stripeCustomerId: string | null;
   stripeSubscriptionId: string | null;
   stripePriceId: string | null;
@@ -87,49 +58,84 @@ export type ClaimedSiteAccess = {
 };
 
 /**
- * Turns a completed Stripe checkout into an owned site.
+ * Accepts one invitation and assigns its site in the same transaction.
  *
- * Both the `success_url` callback and the `checkout.session.completed` webhook
- * run this, because either may arrive first and the browser redirect may never
- * arrive at all. It is therefore idempotent: the second caller finds the site
- * already owned by the same organization and returns without touching its
- * status, so a site that has since gone LIVE is not knocked back to CLAIMED.
- *
- * Must be called inside a transaction — a rejected claim relies on the
- * rollback to undo the organization created moments earlier.
+ * The raw token is deliberately absent: checkout creation already proved it
+ * and bound the invitation to one Stripe session ID. Completion must match the
+ * invitation, session, site and normalized intended email. The same completed
+ * Stripe session may replay idempotently; no other session can reuse it.
  */
 export async function claimSite(
   tx: Prisma.TransactionClient,
   checkout: CompletedCheckout,
 ): Promise<ClaimedSiteAccess> {
   const email = normalizeAccountEmail(checkout.email);
+  const now = new Date();
+  const invitation = await tx.claimInvitation.findUnique({
+    where: { id: checkout.claimInvitationId },
+    select: {
+      id: true,
+      email: true,
+      proofMethod: true,
+      expiresAt: true,
+      acceptedAt: true,
+      revokedAt: true,
+      checkoutSessionId: true,
+      siteId: true,
+      site: {
+        select: {
+          slug: true,
+          status: true,
+          organizationId: true,
+        },
+      },
+    },
+  });
+
+  if (
+    !invitation ||
+    invitation.site.slug !== checkout.siteSlug ||
+    invitation.checkoutSessionId !== checkout.stripeCheckoutSessionId ||
+    normalizeAccountEmail(invitation.email) !== email ||
+    invitation.revokedAt
+  ) {
+    throw rejectClaim(checkout, "invitation binding mismatch");
+  }
+
+  if (invitation.acceptedAt) {
+    return resolveAcceptedClaim(tx, checkout, email);
+  }
+  if (invitation.expiresAt <= now || !isClaimable(invitation.site)) {
+    throw rejectClaim(checkout, "invitation expired or site not claimable");
+  }
+
+  // First completion wins the invitation row. A concurrent delivery of the
+  // same Stripe event waits on this update, then resolves through the accepted
+  // replay path after the winner commits.
+  const accepted = await tx.claimInvitation.updateMany({
+    where: {
+      id: invitation.id,
+      siteId: invitation.siteId,
+      email,
+      checkoutSessionId: checkout.stripeCheckoutSessionId,
+      acceptedAt: null,
+      revokedAt: null,
+      expiresAt: { gt: now },
+    },
+    data: { acceptedAt: now },
+  });
+  if (accepted.count !== 1) {
+    return resolveAcceptedClaim(tx, checkout, email);
+  }
+
   const user = await tx.user.upsert({
     where: { email },
     update: {},
     create: { email },
   });
-
   const membership = await tx.membership.findFirst({
     where: { userId: user.id },
   });
-
-  // Reject before creating an organization rather than after. The rollback
-  // would discard an orphaned organization anyway, but only for as long as
-  // every caller remembers the transaction; refusing first means a hijack
-  // attempt writes nothing regardless. The update below stays authoritative —
-  // this read can only reject earlier, never admit something it would not.
-  const existing = await tx.site.findUnique({
-    where: { slug: checkout.siteSlug },
-    select: { status: true, organizationId: true },
-  });
-  const alreadyOurs =
-    existing !== null &&
-    membership !== null &&
-    existing.organizationId === membership.organizationId;
-  if (!existing || !(isClaimable(existing) || alreadyOurs)) {
-    throw rejectClaim(checkout, "not claimable");
-  }
-
   const organizationId =
     membership?.organizationId ??
     (
@@ -141,44 +147,100 @@ export async function claimSite(
       })
     ).id;
 
-  // Matching on slug alone would let any completed checkout reassign somebody
-  // else's site, so eligibility lives in the WHERE clause where the database
-  // applies it atomically.
   const claimed = await tx.site.updateMany({
     where: unclaimedWhere(checkout.siteSlug),
     data: { organizationId, status: "CLAIMED" },
   });
-
-  if (claimed.count === 0) {
-    // Not claimable as a fresh prospect. That is only acceptable when it is
-    // already ours — the other completion path got here first, or the
-    // customer reloaded the success page — and then we leave its status be.
-    const ours = await tx.site.count({
-      where: { slug: checkout.siteSlug, organizationId },
-    });
-    if (ours === 0) {
-      // Reached only by losing a race that the read above had passed.
-      throw rejectClaim(checkout, "lost claim race");
-    }
+  if (claimed.count !== 1) {
+    throw rejectClaim(checkout, "lost ownership race");
   }
 
-  if (checkout.stripeCustomerId) {
-    await tx.subscription.upsert({
-      where: { stripeCustomerId: checkout.stripeCustomerId },
-      update: {
-        stripeSubscriptionId: checkout.stripeSubscriptionId,
-        stripePriceId: checkout.stripePriceId,
-        status: "ACTIVE",
+  await upsertSubscription(tx, checkout, organizationId);
+  await tx.auditEvent.create({
+    data: {
+      type: "claim.invitation.accepted",
+      actor: `user:${user.id}`,
+      metadata: {
+        invitationId: invitation.id,
+        proofMethod: invitation.proofMethod,
       },
-      create: {
-        stripeCustomerId: checkout.stripeCustomerId,
-        stripeSubscriptionId: checkout.stripeSubscriptionId,
-        stripePriceId: checkout.stripePriceId,
-        status: "ACTIVE",
-        organizationId,
-      },
-    });
-  }
+      siteId: invitation.siteId,
+    },
+  });
 
   return { userId: user.id, organizationId };
+}
+
+async function resolveAcceptedClaim(
+  tx: Prisma.TransactionClient,
+  checkout: CompletedCheckout,
+  email: string,
+): Promise<ClaimedSiteAccess> {
+  const accepted = await tx.claimInvitation.findUnique({
+    where: { id: checkout.claimInvitationId },
+    select: {
+      acceptedAt: true,
+      checkoutSessionId: true,
+      site: {
+        select: {
+          slug: true,
+          organizationId: true,
+        },
+      },
+    },
+  });
+  if (
+    !accepted?.acceptedAt ||
+    accepted.checkoutSessionId !== checkout.stripeCheckoutSessionId ||
+    accepted.site.slug !== checkout.siteSlug ||
+    !accepted.site.organizationId
+  ) {
+    throw rejectClaim(checkout, "accepted invitation mismatch");
+  }
+
+  const user = await tx.user.upsert({
+    where: { email },
+    update: {},
+    create: { email },
+  });
+  const membership = await tx.membership.findFirst({
+    where: {
+      userId: user.id,
+      organizationId: accepted.site.organizationId,
+    },
+  });
+  if (!membership) throw rejectClaim(checkout, "accepted owner mismatch");
+
+  await upsertSubscription(
+    tx,
+    checkout,
+    accepted.site.organizationId,
+  );
+  return {
+    userId: user.id,
+    organizationId: accepted.site.organizationId,
+  };
+}
+
+async function upsertSubscription(
+  tx: Prisma.TransactionClient,
+  checkout: CompletedCheckout,
+  organizationId: string,
+): Promise<void> {
+  if (!checkout.stripeCustomerId) return;
+  await tx.subscription.upsert({
+    where: { stripeCustomerId: checkout.stripeCustomerId },
+    update: {
+      stripeSubscriptionId: checkout.stripeSubscriptionId,
+      stripePriceId: checkout.stripePriceId,
+      status: "ACTIVE",
+    },
+    create: {
+      stripeCustomerId: checkout.stripeCustomerId,
+      stripeSubscriptionId: checkout.stripeSubscriptionId,
+      stripePriceId: checkout.stripePriceId,
+      status: "ACTIVE",
+      organizationId,
+    },
+  });
 }


### PR DESCRIPTION
## Summary
- require a hashed, expiring, one-time invitation before Stripe Checkout or owner activation
- support exact business-domain email proof and dual-gated operator concierge approval
- bind invitation acceptance to one site, intended email, and Stripe Checkout session
- prevent cross-site, cross-email, cross-session, replay, concurrent issuance, and duplicate ownership races
- isolate claim rate limits and audit creation, verification, checkout, acceptance, and rejection without tokens or contact data

## Acceptance mapping
- Public previews cannot start checkout without an approved invitation.
- Only SHA-256 token hashes are persisted; 256-bit raw tokens stay in email URL fragments and expire after 48 hours.
- Accepted or revoked invitations cannot start another checkout; the same completed Stripe session replays idempotently.
- Existing ownership returns HTTP 409 and the compare-and-swap never transfers a site.
- The operator console exposes a SUPERADMIN role + email-allowlist protected concierge approval form.
- Self-serve proof accepts only the exact imported business email or exact normalized source hostname.
- Public request/checkout and operator approval paths have isolated Redis limits and fail closed in production.

## Verification
- `bun test`: 146 pass, 4 existing PostgreSQL-gated analytics tests skipped
- `bun run lint`: zero errors, one pre-existing generated workflow warning
- `bunx next typegen && bunx tsc --noEmit`: pass
- `bunx --bun prisma validate`: pass
- `git diff --check`: pass
- local `bun run build` remained active without diagnostics for more than four minutes and was stopped; PR CI is the authoritative clean-build gate

## Dependencies
- Establishes the claim authorization boundary required by #8; subscription lifecycle reconciliation and Customer Portal remain in #8.
- #18 shares the audit table but does not block or overlap this implementation.
- Adds migration `20260726220000_secure_claim_invitations`; no production migration or deploy is performed by this PR.

## Provider review
Planning is recorded as `planning_degraded`: both required planning calls through `~/.claude-genfeedai` returned `Not logged in`. Exact-head Opus verification remains a required pre-merge gate and provider failure is not approval.

Closes #13
