### PR TITLE
feat(publish): add safe draft and live snapshots

### DIFF
--- a/prisma/migrations/20260726230000_safe_draft_publish/migration.sql
+++ b/prisma/migrations/20260726230000_safe_draft_publish/migration.sql
@@ -1,0 +1,434 @@
+-- Draft state remains editable on Site and its normalized child rows. Published
+-- state is selected through one pointer to an immutable SiteVersion snapshot.
+ALTER TABLE "Site"
+ADD COLUMN "draftTheme" JSONB NOT NULL DEFAULT '{}',
+ADD COLUMN "draftThemeVersion" TEXT NOT NULL DEFAULT 'legacy-v1',
+ADD COLUMN "draftPalette" JSONB NOT NULL DEFAULT '{}',
+ADD COLUMN "publishedSiteVersionId" TEXT;
+
+ALTER TABLE "SiteVersion"
+ADD COLUMN "vertical" "Vertical" NOT NULL DEFAULT 'RESTAURANT',
+ADD COLUMN "themeVersion" TEXT NOT NULL DEFAULT 'legacy-v1',
+ADD COLUMN "palette" JSONB NOT NULL DEFAULT '{}',
+ADD COLUMN "translations" JSONB NOT NULL DEFAULT '[]',
+ADD COLUMN "integrations" JSONB NOT NULL DEFAULT '[]',
+ADD COLUMN "publishedBy" TEXT,
+ADD COLUMN "changeSummary" TEXT;
+
+-- Preserve every historical payload before turning the old `theme` column
+-- (which used to contain only the palette) into a pinned theme selection.
+UPDATE "SiteVersion" AS version
+SET
+  "vertical" = site."vertical",
+  "palette" = CASE
+    WHEN jsonb_typeof(version."content" -> 'palette') = 'object'
+      THEN version."content" -> 'palette'
+    WHEN jsonb_typeof(version."theme") = 'object'
+      AND version."theme" ? 'background'
+      AND version."theme" ? 'foreground'
+      AND version."theme" ? 'accent'
+      THEN version."theme"
+    WHEN site."vertical" = 'BEAUTY'
+      THEN '{"background":"#f7f4f1","foreground":"#211d1b","accent":"#9a6f52"}'::jsonb
+    ELSE '{"background":"#f4efe5","foreground":"#1d241f","accent":"#a5482d"}'::jsonb
+  END,
+  "translations" = CASE
+    WHEN jsonb_typeof(version."content" -> 'translations') = 'array'
+      THEN version."content" -> 'translations'
+    ELSE site."translations"
+  END,
+  "integrations" = CASE
+    WHEN jsonb_typeof(version."content" -> 'integrations') = 'array'
+      THEN version."content" -> 'integrations'
+    ELSE '[]'::jsonb
+  END,
+  "themeVersion" = 'legacy-v1',
+  "theme" = jsonb_build_object(
+    'id',
+    CASE
+      WHEN site."vertical" = 'BEAUTY' THEN
+        COALESCE(version."content" -> 'attributes' ->> 'serviceStyle', 'classic-salon')
+      WHEN COALESCE(version."content" -> 'attributes' ->> 'cuisine', '') ~*
+        'french|française|gastronom|bistro|brasserie|tradition'
+        THEN 'heritage'
+      WHEN COALESCE(version."content" -> 'attributes' ->> 'cuisine', '') ~*
+        'healthy|vegan|vegetarian|organic|salad|juice|wellness'
+        THEN 'fresh'
+      WHEN COALESCE(version."content" -> 'attributes' ->> 'cuisine', '') ~*
+        'american|burger|barbecue|bbq|steak|diner|tex.?mex|hot dog'
+        THEN 'bold'
+      WHEN COALESCE(version."content" -> 'attributes' ->> 'cuisine', '') ~*
+        'japanese|sushi|ramen|izakaya|korean|omakase'
+        THEN 'nocturne'
+      WHEN COALESCE(version."content" -> 'attributes' ->> 'cuisine', '') ~*
+        'seafood|fish|oyster|coastal|maritime'
+        THEN 'coastal'
+      ELSE 'warm'
+    END
+  )
+FROM "Site" AS site
+WHERE site."id" = version."siteId";
+
+-- Draft palette and theme are now first-class editable state. Use the newest
+-- stored payload to preserve the exact pre-migration private preview.
+WITH latest_version AS (
+  SELECT DISTINCT ON ("siteId")
+    "siteId",
+    "palette",
+    "theme",
+    "themeVersion"
+  FROM "SiteVersion"
+  ORDER BY "siteId", "version" DESC
+)
+UPDATE "Site" AS site
+SET
+  "draftPalette" = latest_version."palette",
+  "draftTheme" = latest_version."theme",
+  "draftThemeVersion" = latest_version."themeVersion"
+FROM latest_version
+WHERE latest_version."siteId" = site."id";
+
+UPDATE "Site"
+SET
+  "draftPalette" = CASE
+    WHEN "vertical" = 'BEAUTY'
+      THEN '{"background":"#f7f4f1","foreground":"#211d1b","accent":"#9a6f52"}'::jsonb
+    ELSE '{"background":"#f4efe5","foreground":"#1d241f","accent":"#a5482d"}'::jsonb
+  END
+WHERE jsonb_typeof("draftPalette") <> 'object'
+   OR NOT ("draftPalette" ?& ARRAY['background', 'foreground', 'accent']);
+
+UPDATE "Site"
+SET "draftTheme" = jsonb_build_object(
+  'id',
+  CASE
+    WHEN "vertical" = 'BEAUTY'
+      THEN COALESCE("attributes" ->> 'serviceStyle', 'classic-salon')
+    WHEN COALESCE("attributes" ->> 'cuisine', '') ~*
+      'french|française|gastronom|bistro|brasserie|tradition'
+      THEN 'heritage'
+    WHEN COALESCE("attributes" ->> 'cuisine', '') ~*
+      'healthy|vegan|vegetarian|organic|salad|juice|wellness'
+      THEN 'fresh'
+    WHEN COALESCE("attributes" ->> 'cuisine', '') ~*
+      'american|burger|barbecue|bbq|steak|diner|tex.?mex|hot dog'
+      THEN 'bold'
+    WHEN COALESCE("attributes" ->> 'cuisine', '') ~*
+      'japanese|sushi|ramen|izakaya|korean|omakase'
+      THEN 'nocturne'
+    WHEN COALESCE("attributes" ->> 'cuisine', '') ~*
+      'seafood|fish|oyster|coastal|maritime'
+      THEN 'coastal'
+    ELSE 'warm'
+  END
+)
+WHERE jsonb_typeof("draftTheme") <> 'object'
+   OR NOT ("draftTheme" ? 'id');
+
+-- Existing live sites must not disappear during the rollout. Prefer the newest
+-- already-valid generic snapshot. Legacy rows are handled by the bootstrap
+-- insert below.
+WITH latest_valid_snapshot AS (
+  SELECT DISTINCT ON (version."siteId")
+    version."siteId",
+    version."id"
+  FROM "SiteVersion" AS version
+  WHERE jsonb_typeof(version."content") = 'object'
+    AND jsonb_typeof(version."content" -> 'attributes') = 'object'
+    AND jsonb_typeof(version."content" -> 'catalogSections') = 'array'
+    AND jsonb_typeof(version."content" -> 'integrations') = 'array'
+    AND jsonb_typeof(version."content" -> 'palette') = 'object'
+  ORDER BY version."siteId", version."version" DESC
+)
+UPDATE "Site" AS site
+SET "publishedSiteVersionId" = snapshot."id"
+FROM latest_valid_snapshot AS snapshot
+WHERE snapshot."siteId" = site."id"
+  AND (
+    site."status" = 'LIVE'
+    OR EXISTS (
+      SELECT 1
+      FROM "Domain"
+      WHERE "Domain"."siteId" = site."id"
+        AND "Domain"."verified" = TRUE
+    )
+  );
+
+-- A database adopted from the legacy restaurant schema can have only flat
+-- SiteVersion payloads. Rebuild one validated generic snapshot from the current
+-- normalized draft for any already-public site that still lacks a pointer.
+WITH public_sites AS (
+  SELECT site.*
+  FROM "Site" AS site
+  WHERE site."publishedSiteVersionId" IS NULL
+    AND (
+      site."status" = 'LIVE'
+      OR EXISTS (
+        SELECT 1
+        FROM "Domain"
+        WHERE "Domain"."siteId" = site."id"
+          AND "Domain"."verified" = TRUE
+      )
+    )
+    AND EXISTS (
+      SELECT 1 FROM "CatalogSection"
+      WHERE "CatalogSection"."siteId" = site."id"
+    )
+),
+next_versions AS (
+  SELECT
+    site."id" AS "siteId",
+    COALESCE(MAX(version."version"), 0) + 1 AS "version"
+  FROM public_sites AS site
+  LEFT JOIN "SiteVersion" AS version ON version."siteId" = site."id"
+  GROUP BY site."id"
+),
+bootstrap AS (
+  SELECT
+    'migration-published-' || md5(site."id") AS "id",
+    next_versions."version",
+    site."vertical",
+    site."draftTheme" AS "theme",
+    site."draftThemeVersion" AS "themeVersion",
+    site."draftPalette" AS "palette",
+    site."translations",
+    COALESCE((
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'type', lower(integration."type"::text),
+          'label', integration."label",
+          'provider', integration."provider",
+          'url', integration."url",
+          'venueId', integration."venueId"
+        )
+        ORDER BY integration."position", integration."createdAt", integration."id"
+      )
+      FROM "Integration" AS integration
+      WHERE integration."siteId" = site."id"
+        AND integration."type" <> 'ANALYTICS'
+    ), '[]'::jsonb) AS "integrations",
+    site."id" AS "siteId",
+    jsonb_build_object(
+      'slug', site."slug",
+      'name', site."name",
+      'eyebrow', COALESCE(site."eyebrow", ''),
+      'description', COALESCE(
+        site."description",
+        CASE
+          WHEN site."vertical" = 'BEAUTY'
+            THEN 'An independent studio taking appointments for cuts, colour and care.'
+          ELSE 'An independent restaurant serving its neighbourhood.'
+        END
+      ),
+      'address', COALESCE(site."address", ''),
+      'phone', COALESCE(site."phone", ''),
+      'sourceUrl', site."sourceUrl",
+      'heroImageUrl', site."heroImageUrl",
+      'heroOriginalImageUrl', site."heroOriginalImageUrl",
+      'heroImageProvenance', CASE
+        WHEN site."heroImageProvenance" IS NULL THEN NULL
+        ELSE replace(lower(site."heroImageProvenance"::text), '_', '-')
+      END,
+      'palette', site."draftPalette",
+      'attributes', site."attributes",
+      'autoEnhanceImages', site."autoEnhanceImages",
+      'defaultLocale', site."defaultLocale",
+      'translations', site."translations",
+      'catalogSections', COALESCE((
+        SELECT jsonb_agg(
+          jsonb_build_object(
+            'name', section."name",
+            'description', COALESCE(section."description", ''),
+            'items', COALESCE((
+              SELECT jsonb_agg(
+                jsonb_build_object(
+                  'name', item."name",
+                  'description', COALESCE(item."description", ''),
+                  'price', item."price",
+                  'currency', item."currency",
+                  'attributes', item."attributes",
+                  'imageUrl', item."imageUrl",
+                  'originalImageUrl', item."originalImageUrl",
+                  'imageProvenance', CASE
+                    WHEN item."imageProvenance" IS NULL THEN NULL
+                    ELSE replace(lower(item."imageProvenance"::text), '_', '-')
+                  END
+                )
+                ORDER BY item."position", item."id"
+              )
+              FROM "CatalogItem" AS item
+              WHERE item."sectionId" = section."id"
+            ), '[]'::jsonb)
+          )
+          ORDER BY section."position", section."id"
+        )
+        FROM "CatalogSection" AS section
+        WHERE section."siteId" = site."id"
+      ), '[]'::jsonb),
+      'integrations', COALESCE((
+        SELECT jsonb_agg(
+          jsonb_build_object(
+            'type', lower(integration."type"::text),
+            'label', integration."label",
+            'provider', integration."provider",
+            'url', integration."url",
+            'venueId', integration."venueId"
+          )
+          ORDER BY integration."position", integration."createdAt", integration."id"
+        )
+        FROM "Integration" AS integration
+        WHERE integration."siteId" = site."id"
+          AND integration."type" <> 'ANALYTICS'
+      ), '[]'::jsonb)
+    ) AS "content"
+  FROM public_sites AS site
+  JOIN next_versions ON next_versions."siteId" = site."id"
+)
+INSERT INTO "SiteVersion" (
+  "id",
+  "version",
+  "vertical",
+  "theme",
+  "themeVersion",
+  "palette",
+  "content",
+  "translations",
+  "integrations",
+  "publishedAt",
+  "publishedBy",
+  "changeSummary",
+  "siteId",
+  "createdAt"
+)
+SELECT
+  bootstrap."id",
+  bootstrap."version",
+  bootstrap."vertical",
+  bootstrap."theme",
+  bootstrap."themeVersion",
+  bootstrap."palette",
+  bootstrap."content",
+  bootstrap."translations",
+  bootstrap."integrations",
+  CURRENT_TIMESTAMP,
+  'system:migration',
+  'Existing live site snapshot',
+  bootstrap."siteId",
+  CURRENT_TIMESTAMP
+FROM bootstrap;
+
+UPDATE "Site" AS site
+SET "publishedSiteVersionId" = version."id"
+FROM "SiteVersion" AS version
+WHERE version."siteId" = site."id"
+  AND version."id" = 'migration-published-' || md5(site."id")
+  AND site."publishedSiteVersionId" IS NULL;
+
+UPDATE "SiteVersion" AS version
+SET
+  "publishedAt" = COALESCE(version."publishedAt", version."createdAt"),
+  "publishedBy" = COALESCE(version."publishedBy", 'system:migration'),
+  "changeSummary" = COALESCE(
+    version."changeSummary",
+    'Existing live site snapshot'
+  )
+FROM "Site" AS site
+WHERE site."publishedSiteVersionId" = version."id";
+
+INSERT INTO "AuditEvent" (
+  "id",
+  "type",
+  "actor",
+  "metadata",
+  "siteId",
+  "createdAt"
+)
+SELECT
+  'migration-publish-audit-' || md5(site."id"),
+  'site.published',
+  version."publishedBy",
+  jsonb_build_object(
+    'siteVersionId', version."id",
+    'version', version."version",
+    'changeSummary', version."changeSummary",
+    'themeId', version."theme" ->> 'id',
+    'themeVersion', version."themeVersion"
+  ),
+  site."id",
+  version."publishedAt"
+FROM "Site" AS site
+JOIN "SiteVersion" AS version
+  ON version."id" = site."publishedSiteVersionId";
+
+CREATE UNIQUE INDEX "Site_publishedSiteVersionId_key"
+ON "Site"("publishedSiteVersionId");
+
+ALTER TABLE "Site"
+ADD CONSTRAINT "Site_publishedSiteVersionId_fkey"
+FOREIGN KEY ("publishedSiteVersionId")
+REFERENCES "SiteVersion"("id")
+ON DELETE SET NULL
+ON UPDATE CASCADE;
+
+-- The pointer may only target a published snapshot owned by the same site.
+CREATE FUNCTION enforce_site_published_version()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW."publishedSiteVersionId" IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1
+      FROM "SiteVersion"
+      WHERE "SiteVersion"."id" = NEW."publishedSiteVersionId"
+        AND "SiteVersion"."siteId" = NEW."id"
+        AND "SiteVersion"."publishedAt" IS NOT NULL
+    )
+  THEN
+    RAISE EXCEPTION
+      'publishedSiteVersionId must reference a published version of the same site'
+      USING ERRCODE = '23514';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER "Site_enforce_published_version"
+BEFORE INSERT OR UPDATE OF "publishedSiteVersionId"
+ON "Site"
+FOR EACH ROW
+EXECUTE FUNCTION enforce_site_published_version();
+
+-- Published snapshots are append-only. Rollback (#54) must create a new
+-- version rather than rewriting or deleting history.
+CREATE FUNCTION prevent_published_site_version_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  -- A whole-site cascade is an explicit lifecycle deletion, not history
+  -- rewriting. During that cascade the parent row is already absent.
+  IF OLD."publishedAt" IS NOT NULL
+    AND (
+      TG_OP <> 'DELETE'
+      OR EXISTS (
+        SELECT 1 FROM "Site" WHERE "Site"."id" = OLD."siteId"
+      )
+    )
+  THEN
+    RAISE EXCEPTION 'Published site versions are immutable'
+      USING ERRCODE = '55000';
+  END IF;
+  RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+END;
+$$;
+
+CREATE TRIGGER "SiteVersion_prevent_published_update"
+BEFORE UPDATE ON "SiteVersion"
+FOR EACH ROW
+EXECUTE FUNCTION prevent_published_site_version_mutation();
+
+CREATE TRIGGER "SiteVersion_prevent_published_delete"
+BEFORE DELETE ON "SiteVersion"
+FOR EACH ROW
+EXECUTE FUNCTION prevent_published_site_version_mutation();

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -100,39 +100,44 @@ model Membership {
 }
 
 model Site {
-  id                   String            @id @default(cuid())
-  slug                 String            @unique
-  name                 String
-  eyebrow              String?
-  description          String?
-  address              String?
-  phone                String?
-  email                String?
-  sourceUrl            String?
-  sourceKey            String?           @unique
-  logoUrl              String?
-  heroImageUrl         String?
-  heroOriginalImageUrl String?
-  heroImageProvenance  ImageProvenance?
-  autoEnhanceImages    Boolean           @default(true)
-  defaultLocale        String            @default("en")
-  translations         Json              @default("[]")
-  vertical             Vertical          @default(RESTAURANT)
-  attributes           Json              @default("{}")
-  status               SiteStatus        @default(PROSPECT)
-  organizationId       String?
-  organization         Organization?     @relation(fields: [organizationId], references: [id], onDelete: SetNull)
-  createdAt            DateTime          @default(now())
-  updatedAt            DateTime          @updatedAt
-  catalogSections      CatalogSection[]
-  integrations         Integration[]
-  importJobs           ImportJob[]
-  domains              Domain[]
-  siteVersions         SiteVersion[]
-  claimInvitations     ClaimInvitation[]
-  auditEvents          AuditEvent[]
-  bookingRequests      BookingRequest[]
-  analyticsEvents      AnalyticsEvent[]
+  id                     String            @id @default(cuid())
+  slug                   String            @unique
+  name                   String
+  eyebrow                String?
+  description            String?
+  address                String?
+  phone                  String?
+  email                  String?
+  sourceUrl              String?
+  sourceKey              String?           @unique
+  logoUrl                String?
+  heroImageUrl           String?
+  heroOriginalImageUrl   String?
+  heroImageProvenance    ImageProvenance?
+  autoEnhanceImages      Boolean           @default(true)
+  defaultLocale          String            @default("en")
+  translations           Json              @default("[]")
+  draftTheme             Json              @default("{}")
+  draftThemeVersion      String            @default("legacy-v1")
+  draftPalette           Json              @default("{}")
+  vertical               Vertical          @default(RESTAURANT)
+  attributes             Json              @default("{}")
+  status                 SiteStatus        @default(PROSPECT)
+  publishedSiteVersionId String?           @unique
+  publishedSiteVersion   SiteVersion?      @relation("PublishedSiteVersion", fields: [publishedSiteVersionId], references: [id], onDelete: SetNull)
+  organizationId         String?
+  organization           Organization?     @relation(fields: [organizationId], references: [id], onDelete: SetNull)
+  createdAt              DateTime          @default(now())
+  updatedAt              DateTime          @updatedAt
+  catalogSections        CatalogSection[]
+  integrations           Integration[]
+  importJobs             ImportJob[]
+  domains                Domain[]
+  siteVersions           SiteVersion[]
+  claimInvitations       ClaimInvitation[]
+  auditEvents            AuditEvent[]
+  bookingRequests        BookingRequest[]
+  analyticsEvents        AnalyticsEvent[]
 }
 
 model CatalogSection {
@@ -162,12 +167,12 @@ model CatalogItem {
 }
 
 model Integration {
-  id       String          @id @default(cuid())
-  type     IntegrationType
-  provider String?
-  label    String
-  url      String
-  position Int             @default(0)
+  id        String          @id @default(cuid())
+  type      IntegrationType
+  provider  String?
+  label     String
+  url       String
+  position  Int             @default(0)
   /// Owner's id inside the provider (an OpenTable `rid`). Only consumed after the
   /// provider's own anchored `idPattern` matches it — see `src/lib/booking-embed.ts`.
   venueId   String?
@@ -199,14 +204,22 @@ model ImportJob {
 }
 
 model SiteVersion {
-  id          String    @id @default(cuid())
-  version     Int
-  theme       Json
-  content     Json
-  publishedAt DateTime?
-  siteId      String
-  site        Site      @relation(fields: [siteId], references: [id], onDelete: Cascade)
-  createdAt   DateTime  @default(now())
+  id               String    @id @default(cuid())
+  version          Int
+  vertical         Vertical  @default(RESTAURANT)
+  theme            Json
+  themeVersion     String    @default("legacy-v1")
+  palette          Json      @default("{}")
+  content          Json
+  translations     Json      @default("[]")
+  integrations     Json      @default("[]")
+  publishedAt      DateTime?
+  publishedBy      String?
+  changeSummary    String?
+  siteId           String
+  site             Site      @relation(fields: [siteId], references: [id], onDelete: Cascade)
+  publishedForSite Site?     @relation("PublishedSiteVersion")
+  createdAt        DateTime  @default(now())
 
   @@unique([siteId, version])
 }

--- a/scripts/import-le-petit-meunier.ts
+++ b/scripts/import-le-petit-meunier.ts
@@ -101,7 +101,7 @@ async function main() {
       verified._count.catalogSections !== draft.catalogSections.length ||
       verifiedItemCount !== expectedItemCount ||
       verified._count.integrations !== draft.integrations.length ||
-      verified._count.siteVersions !== 1
+      verified._count.siteVersions !== 0
     ) {
       throw new Error("Imported site failed its database verification");
     }

--- a/src/app/api/sites/[slug]/publish/route.ts
+++ b/src/app/api/sites/[slug]/publish/route.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+import {
+  accessFailureResponse,
+  getSiteAccess,
+} from "@/lib/authorization";
+import {
+  publishSiteDraft,
+  SitePublicationStateError,
+} from "@/lib/site-publication";
+
+const publishRequestSchema = z.object({
+  changeSummary: z.string().trim().min(3).max(280),
+});
+
+export async function POST(
+  request: Request,
+  { params }: RouteContext<"/api/sites/[slug]/publish">,
+) {
+  const { slug } = await params;
+  const access = await getSiteAccess(slug);
+  if (!access.ok) return accessFailureResponse(access);
+
+  const parsed = publishRequestSchema.safeParse(
+    await request.json().catch(() => null),
+  );
+  if (!parsed.success) {
+    return Response.json(
+      { error: "Describe the changes in 3 to 280 characters" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const published = await publishSiteDraft({
+      siteId: access.site.id,
+      slug: access.site.slug,
+      vertical: access.site.vertical,
+      actor: access.user,
+      changeSummary: parsed.data.changeSummary,
+    });
+    return Response.json({ ok: true, published });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      console.error("[site-publish] persisted draft validation failed", {
+        slug,
+        issues: error.issues,
+      });
+      return Response.json(
+        { error: "Fix the invalid draft fields before publishing" },
+        { status: 422 },
+      );
+    }
+    if (error instanceof SitePublicationStateError) {
+      return Response.json({ error: error.message }, { status: 409 });
+    }
+
+    console.error("[site-publish] failed", {
+      slug,
+      actorId: access.user.id,
+      error: error instanceof Error ? error.message : "unknown",
+    });
+    return Response.json(
+      { error: "Site could not be published" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/dashboard/dashboard.tsx
+++ b/src/app/dashboard/dashboard.tsx
@@ -18,6 +18,7 @@ import {
   MoreHorizontal,
   Plus,
   RefreshCcw,
+  Rocket,
   Save,
   Settings,
   Sparkles,
@@ -76,15 +77,19 @@ export function Dashboard({
   const [draft, setDraft] = useState(initialDraft);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
+  const [publishing, setPublishing] = useState(false);
+  const [publishedVersion, setPublishedVersion] = useState<number | null>(null);
+  const [publishError, setPublishError] = useState<string | null>(null);
   const [domain, setDomain] = useState("");
   const [domainSetup, setDomainSetup] = useState<DomainSetup | null>(null);
   const [domainError, setDomainError] = useState<string | null>(null);
   const [domainLoading, setDomainLoading] = useState(false);
   const [imageLoading, setImageLoading] = useState(false);
 
-  async function save() {
+  async function save(): Promise<boolean> {
     setSaving(true);
     setSaved(false);
+    setPublishError(null);
     try {
       if (!demo) {
         const response = await fetch(`/api/sites/${draft.slug}`, {
@@ -95,8 +100,66 @@ export function Dashboard({
         if (!response.ok) throw new Error("Save failed");
       }
       setSaved(true);
+      setPublishedVersion(null);
+      return true;
+    } catch (caught) {
+      setPublishError(
+        caught instanceof Error ? caught.message : "Save failed",
+      );
+      return false;
     } finally {
       setSaving(false);
+    }
+  }
+
+  async function publish() {
+    const changeSummary = window
+      .prompt(
+        "Summarize what will change on the public site:",
+        "Publish approved draft",
+      )
+      ?.trim();
+    if (!changeSummary) return;
+    if (changeSummary.length < 3 || changeSummary.length > 280) {
+      setPublishError("Use a change summary between 3 and 280 characters");
+      return;
+    }
+    if (
+      !window.confirm(
+        "Publish this saved draft to the connected public domain now?",
+      )
+    ) {
+      return;
+    }
+
+    setPublishing(true);
+    setPublishError(null);
+    try {
+      if (!(await save())) return;
+      if (demo) {
+        setPublishedVersion(1);
+        return;
+      }
+
+      const response = await fetch(`/api/sites/${draft.slug}/publish`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ changeSummary }),
+      });
+      const result = (await response.json()) as {
+        error?: string;
+        published?: { version: number };
+      };
+      if (!response.ok || !result.published) {
+        throw new Error(result.error ?? "Publish failed");
+      }
+      setPublishedVersion(result.published.version);
+    } catch (caught) {
+      setPublishError(
+        caught instanceof Error ? caught.message : "Publish failed",
+      );
+    } finally {
+      setPublishing(false);
     }
   }
 
@@ -201,14 +264,34 @@ export function Dashboard({
           <Button
             size="sm"
             onClick={() => void save()}
-            disabled={saving}
+            disabled={saving || publishing}
           >
             {saving ? <LoaderCircle className="animate-spin" /> : <Save />}
             {saved ? "Saved" : "Save"}
           </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => void publish()}
+            disabled={saving || publishing}
+          >
+            {publishing ? (
+              <LoaderCircle className="animate-spin" />
+            ) : (
+              <Rocket />
+            )}
+            {publishedVersion
+              ? `Published v${publishedVersion}`
+              : "Publish"}
+          </Button>
         </div>
       </header>
 
+      {publishError ? (
+        <div className="border-b border-red-200 bg-red-50 px-5 py-3 text-center text-sm text-red-800">
+          {publishError}
+        </div>
+      ) : null}
       {checkoutComplete ? (
         <div className="border-b border-emerald-200 bg-emerald-50 px-5 py-3 text-center text-sm text-emerald-800">
           <CircleCheck className="mr-2 inline size-4" />

--- a/src/app/preview/[slug]/[locale]/page.tsx
+++ b/src/app/preview/[slug]/[locale]/page.tsx
@@ -4,7 +4,10 @@ import { notFound } from "next/navigation";
 import { SiteRenderer } from "@/components/site-renderer";
 import { getSiteLocales, localizeSiteDraft } from "@/lib/site-draft";
 import { isLiveSiteSurface } from "@/lib/site-surface";
-import { findSiteView } from "@/lib/sites";
+import {
+  findPublishedSiteView,
+  findSiteView,
+} from "@/lib/sites";
 
 type PageProps = {
   params: Promise<{ slug: string; locale: string }>;
@@ -14,25 +17,39 @@ export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
   const { slug, locale } = await params;
-  const site = await findSiteView(slug);
+  const liveSurface = isLiveSiteSurface(await headers(), slug);
+  const site = liveSurface
+    ? await findPublishedSiteView(slug)
+    : await findSiteView(slug);
   if (!site) notFound();
   const locales = getSiteLocales(site.draft);
   if (!locales.includes(locale)) notFound();
 
   return {
-    title: `${site.draft.name} — Private preview`,
-    robots: { index: false, follow: false },
+    title: liveSurface
+      ? site.draft.name
+      : `${site.draft.name} — Private preview`,
+    robots: liveSurface
+      ? { index: true, follow: true }
+      : { index: false, follow: false },
     alternates: {
-      canonical:
-        locale === site.draft.defaultLocale
+      canonical: liveSurface
+        ? locale === site.draft.defaultLocale
+          ? "/"
+          : `/${locale}`
+        : locale === site.draft.defaultLocale
           ? `/preview/${slug}`
           : `/preview/${slug}/${locale}`,
       languages: Object.fromEntries(
         locales.map((availableLocale) => [
           availableLocale,
-          availableLocale === site.draft.defaultLocale
-            ? `/preview/${slug}`
-            : `/preview/${slug}/${availableLocale}`,
+          liveSurface
+            ? availableLocale === site.draft.defaultLocale
+              ? "/"
+              : `/${availableLocale}`
+            : availableLocale === site.draft.defaultLocale
+              ? `/preview/${slug}`
+              : `/preview/${slug}/${availableLocale}`,
         ]),
       ),
     },
@@ -41,16 +58,19 @@ export async function generateMetadata({
 
 export default async function LocalizedPreviewPage({ params }: PageProps) {
   const { slug, locale } = await params;
-  const site = await findSiteView(slug);
+  const liveSurface = isLiveSiteSurface(await headers(), slug);
+  const site = liveSurface
+    ? await findPublishedSiteView(slug)
+    : await findSiteView(slug);
   if (!site) notFound();
   const locales = getSiteLocales(site.draft);
   if (!locales.includes(locale)) notFound();
-  const liveSurface = isLiveSiteSurface(await headers(), slug);
 
   return (
     <SiteRenderer
       draft={localizeSiteDraft(site.draft, locale)}
       vertical={site.vertical}
+      theme={site.theme}
       locale={locale}
       localeBasePath={liveSurface ? "/" : `/preview/${slug}`}
       availableLocales={locales}

--- a/src/app/preview/[slug]/page.tsx
+++ b/src/app/preview/[slug]/page.tsx
@@ -4,7 +4,10 @@ import { notFound } from "next/navigation";
 import { SiteRenderer } from "@/components/site-renderer";
 import { getSiteLocales } from "@/lib/site-draft";
 import { isLiveSiteSurface } from "@/lib/site-surface";
-import { findSiteView } from "@/lib/sites";
+import {
+  findPublishedSiteView,
+  findSiteView,
+} from "@/lib/sites";
 
 type PageProps = {
   params: Promise<{ slug: string }>;
@@ -14,20 +17,31 @@ export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
   const { slug } = await params;
-  const site = await findSiteView(slug);
+  const liveSurface = isLiveSiteSurface(await headers(), slug);
+  const site = liveSurface
+    ? await findPublishedSiteView(slug)
+    : await findSiteView(slug);
   if (!site) notFound();
   const locales = getSiteLocales(site.draft);
   return {
-    title: `${site.draft.name} — Private preview`,
-    robots: { index: false, follow: false },
+    title: liveSurface
+      ? site.draft.name
+      : `${site.draft.name} — Private preview`,
+    robots: liveSurface
+      ? { index: true, follow: true }
+      : { index: false, follow: false },
     alternates: {
-      canonical: `/preview/${slug}`,
+      canonical: liveSurface ? "/" : `/preview/${slug}`,
       languages: Object.fromEntries(
         locales.map((locale) => [
           locale,
-          locale === site.draft.defaultLocale
-            ? `/preview/${slug}`
-            : `/preview/${slug}/${locale}`,
+          liveSurface
+            ? locale === site.draft.defaultLocale
+              ? "/"
+              : `/${locale}`
+            : locale === site.draft.defaultLocale
+              ? `/preview/${slug}`
+              : `/preview/${slug}/${locale}`,
         ]),
       ),
     },
@@ -36,13 +50,16 @@ export async function generateMetadata({
 
 export default async function PreviewPage({ params }: PageProps) {
   const { slug } = await params;
-  const site = await findSiteView(slug);
-  if (!site) notFound();
   const liveSurface = isLiveSiteSurface(await headers(), slug);
+  const site = liveSurface
+    ? await findPublishedSiteView(slug)
+    : await findSiteView(slug);
+  if (!site) notFound();
   return (
     <SiteRenderer
       draft={site.draft}
       vertical={site.vertical}
+      theme={site.theme}
       locale={site.draft.defaultLocale}
       localeBasePath={liveSurface ? "/" : `/preview/${slug}`}
       availableLocales={getSiteLocales(site.draft)}

--- a/src/components/site-renderer.tsx
+++ b/src/components/site-renderer.tsx
@@ -16,7 +16,11 @@ import {
   localizeIntegrationUrl,
 } from "@/lib/site-i18n";
 import { localeHref } from "@/lib/site-surface";
-import { formatPrice, type SiteDraftView } from "@/lib/site-draft";
+import {
+  formatPrice,
+  type SiteDraftView,
+  type SiteThemeView,
+} from "@/lib/site-draft";
 import { resolveVerticalConfig } from "@/lib/verticals/registry";
 import type { VerticalId } from "@/lib/verticals/types";
 import { cn } from "@/lib/utils";
@@ -37,6 +41,7 @@ type SiteRendererProps = {
   localeBasePath?: string;
   availableLocales?: string[];
   analyticsEnabled?: boolean;
+  theme?: SiteThemeView;
 };
 
 export function SiteRenderer({
@@ -47,6 +52,7 @@ export function SiteRenderer({
   localeBasePath,
   availableLocales = [draft.defaultLocale],
   analyticsEnabled = false,
+  theme,
 }: SiteRendererProps) {
   const config = resolveVerticalConfig(vertical);
   const booking = draft.integrations.find(
@@ -55,7 +61,10 @@ export function SiteRenderer({
   const ordering = draft.integrations.find((integration) =>
     ["ordering", "delivery"].includes(integration.type),
   );
-  const template = config.templates.resolve(draft.attributes);
+  const resolvedTemplate = config.templates.resolve(draft.attributes);
+  const template = theme
+    ? (config.templates.definitions[theme.id] ?? resolvedTemplate)
+    : resolvedTemplate;
   const capabilities = config.rendererCapabilities(draft.attributes);
   const bookingEmbed = booking ? resolveBookingEmbed(vertical, booking) : null;
   // A site with no booking tool at all always gets the form — otherwise its only
@@ -94,6 +103,7 @@ export function SiteRenderer({
     <article
       lang={locale}
       data-site-template={template.id}
+      data-site-theme-version={theme?.version}
       className={cn(
         "font-sans",
         embedded

--- a/src/lib/site-draft.ts
+++ b/src/lib/site-draft.ts
@@ -14,6 +14,22 @@ export type SitePaletteView = {
   accent: string;
 };
 
+export const LEGACY_THEME_VERSION = "legacy-v1";
+
+/**
+ * The renderer identity pinned independently from the editable content.
+ *
+ * `selection` deliberately remains an open JSON-shaped record. Issue #19 will
+ * add bounded automatic/manual selection metadata there without another
+ * publish-schema migration, while `id` and `version` stay the stable contract
+ * this renderer needs today.
+ */
+export type SiteThemeView = {
+  id: string;
+  version: string;
+  selection: Record<string, unknown>;
+};
+
 export type SiteCatalogItemView = {
   name: string;
   description: string;

--- a/src/lib/site-persistence.ts
+++ b/src/lib/site-persistence.ts
@@ -1,6 +1,7 @@
 import { Prisma } from "@/generated/prisma/client";
 import { Vertical } from "@/generated/prisma/enums";
 import { getDb } from "@/lib/db";
+import { LEGACY_THEME_VERSION } from "@/lib/site-draft";
 import {
   buildImportUrls,
   importFailureMessage,
@@ -287,7 +288,6 @@ export async function persistSiteImport<TDraft extends PersistableSiteDraft>(inp
                 select: { id: true, slug: true },
               });
 
-          await createNextSiteVersion(tx, site.id, draft);
           await tx.auditEvent.create({
             data: {
               type: existing ? "site.import.updated" : "site.import.created",
@@ -398,7 +398,6 @@ export async function createOperatorSiteImport<
             select: { id: true, slug: true },
           });
 
-          await createNextSiteVersion(tx, site.id, draft);
           await tx.auditEvent.create({
             data: {
               type: "site.import.created",
@@ -468,7 +467,7 @@ export async function createOperatorSiteImport<
             itemCount !== expectedItemCount ||
             integrationRows.length !== draft.integrations.length ||
             !integrationOrderMatches ||
-            versionCount !== 1
+            versionCount !== 0
           ) {
             throw new Error(
               "The operator import failed its atomic fidelity check",
@@ -516,15 +515,13 @@ export async function updateSiteDraft(
     try {
       await db.$transaction(
         async (tx) => {
-          const site = await tx.site.update({
-            where: { slug },
+          await tx.site.update({
+            where: { slug, vertical },
             data: {
               ...editableSiteScalarData(parsed, vertical),
               ...siteRelationReplaceData(parsed, vertical),
             },
-            select: { id: true },
           });
-          await createNextSiteVersion(tx, site.id, parsed);
         },
         { isolationLevel: "Serializable" },
       );
@@ -582,6 +579,8 @@ function editableSiteScalarData(
   vertical: VerticalId,
 ) {
   const config = resolveVerticalConfig(vertical);
+  const attributes = config.attributesSchema.parse(draft.attributes);
+  const theme = config.templates.resolve(attributes);
   return {
     name: draft.name,
     eyebrow: draft.eyebrow,
@@ -594,9 +593,10 @@ function editableSiteScalarData(
     // Parsed on the way in as well as on the way out: the attributes bag is the
     // only place vertical-specific data lives, so an unvalidated write here is a
     // read-path crash later.
-    attributes: config.attributesSchema.parse(
-      draft.attributes,
-    ) as Prisma.InputJsonValue,
+    attributes: attributes as Prisma.InputJsonValue,
+    draftTheme: { id: theme.id } as Prisma.InputJsonValue,
+    draftThemeVersion: LEGACY_THEME_VERSION,
+    draftPalette: draft.palette as Prisma.InputJsonValue,
     autoEnhanceImages: draft.autoEnhanceImages,
     defaultLocale: draft.defaultLocale,
     translations: draft.translations as Prisma.InputJsonValue,
@@ -612,27 +612,6 @@ function integrationCreateData(draft: PersistableSiteDraft) {
     venueId: integration.venueId ?? null,
     position,
   }));
-}
-
-async function createNextSiteVersion(
-  tx: Prisma.TransactionClient,
-  siteId: string,
-  draft: PersistableSiteDraft,
-): Promise<void> {
-  const latest = await tx.siteVersion.findFirst({
-    where: { siteId },
-    orderBy: { version: "desc" },
-    select: { version: true },
-  });
-
-  await tx.siteVersion.create({
-    data: {
-      siteId,
-      version: (latest?.version ?? 0) + 1,
-      theme: draft.palette as Prisma.InputJsonValue,
-      content: draft as Prisma.InputJsonValue,
-    },
-  });
 }
 
 function catalogSectionCreateData(

--- a/src/lib/site-publication.postgres.test.ts
+++ b/src/lib/site-publication.postgres.test.ts
@@ -1,0 +1,381 @@
+import { randomUUID } from "node:crypto";
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+const enabled = process.env.SITE_PUBLICATION_POSTGRES_TEST === "1";
+const siteId = `site-publication-${randomUUID()}`;
+const organizationId = `site-publication-org-${randomUUID()}`;
+const userId = `site-publication-user-${randomUUID()}`;
+const slug = `site-publication-${randomUUID()}`;
+const actor = { id: userId, email: `${userId}@example.test` };
+
+let db: ReturnType<typeof import("@/lib/db").getDb>;
+let sampleSiteDraft: typeof import("@/lib/restaurant").sampleSiteDraft;
+let publishSiteDraft: typeof import("@/lib/site-publication").publishSiteDraft;
+let updateSiteDraft: typeof import("@/lib/site-persistence").updateSiteDraft;
+let findPublishedSiteView: typeof import("@/lib/sites").findPublishedSiteView;
+let findSiteView: typeof import("@/lib/sites").findSiteView;
+let Vertical: typeof import("@/generated/prisma/enums").Vertical;
+
+describe.skipIf(!enabled)("safe draft and publish PostgreSQL integration", () => {
+  beforeAll(async () => {
+    const database = await import("@/lib/db");
+    const restaurant = await import("@/lib/restaurant");
+    const publication = await import("@/lib/site-publication");
+    const persistence = await import("@/lib/site-persistence");
+    const sites = await import("@/lib/sites");
+    const enums = await import("@/generated/prisma/enums");
+
+    db = database.getDb();
+    sampleSiteDraft = restaurant.sampleSiteDraft;
+    publishSiteDraft = publication.publishSiteDraft;
+    updateSiteDraft = persistence.updateSiteDraft;
+    findPublishedSiteView = sites.findPublishedSiteView;
+    findSiteView = sites.findSiteView;
+    Vertical = enums.Vertical;
+
+    await db.user.create({
+      data: {
+        id: userId,
+        email: actor.email,
+        memberships: {
+          create: {
+            organization: {
+              create: {
+                id: organizationId,
+                name: "Publication integration",
+              },
+            },
+          },
+        },
+      },
+    });
+    await db.site.create({
+      data: {
+        id: siteId,
+        slug,
+        name: sampleSiteDraft.name,
+        eyebrow: sampleSiteDraft.eyebrow,
+        description: sampleSiteDraft.description,
+        address: sampleSiteDraft.address,
+        phone: sampleSiteDraft.phone,
+        sourceUrl: sampleSiteDraft.sourceUrl,
+        heroImageUrl: sampleSiteDraft.heroImageUrl,
+        heroOriginalImageUrl: sampleSiteDraft.heroOriginalImageUrl,
+        heroImageProvenance: "OWNER",
+        draftTheme: { id: "warm" },
+        draftThemeVersion: "legacy-v1",
+        draftPalette: sampleSiteDraft.palette,
+        attributes: sampleSiteDraft.attributes,
+        autoEnhanceImages: sampleSiteDraft.autoEnhanceImages,
+        defaultLocale: sampleSiteDraft.defaultLocale,
+        translations: sampleSiteDraft.translations,
+        vertical: "RESTAURANT",
+        status: "CLAIMED",
+        organizationId,
+        integrations: {
+          create: sampleSiteDraft.integrations.map(
+            (integration, position) => ({
+              type: integration.type.toUpperCase() as
+                | "BOOKING"
+                | "ORDERING"
+                | "DELIVERY"
+                | "SOCIAL",
+              label: integration.label,
+              provider: integration.provider,
+              url: integration.url,
+              venueId: integration.venueId,
+              position,
+            }),
+          ),
+        },
+        catalogSections: {
+          create: sampleSiteDraft.catalogSections.map(
+            (section, sectionPosition) => ({
+              name: section.name,
+              description: section.description,
+              position: sectionPosition,
+              items: {
+                create: section.items.map((item, itemPosition) => ({
+                  name: item.name,
+                  description: item.description,
+                  price: item.price,
+                  currency: item.currency,
+                  imageUrl: item.imageUrl,
+                  originalImageUrl: item.originalImageUrl,
+                  imageProvenance: item.imageProvenance?.toUpperCase() as
+                    | "OFFICIAL"
+                    | "OWNER"
+                    | undefined,
+                  attributes: item.attributes,
+                  position: itemPosition,
+                })),
+              },
+            }),
+          ),
+        },
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await db.site.deleteMany({ where: { id: siteId } });
+    await db.organization.deleteMany({ where: { id: organizationId } });
+    await db.user.deleteMany({ where: { id: userId } });
+  });
+
+  test("does not let Publish bypass a paused lifecycle state", async () => {
+    await db.site.update({
+      where: { id: siteId },
+      data: { status: "PAUSED" },
+    });
+
+    await expect(
+      publishSiteDraft({
+        siteId,
+        slug,
+        vertical: Vertical.RESTAURANT,
+        actor,
+        changeSummary: "Attempt to bypass pause",
+      }),
+    ).rejects.toThrow("Only claimed or live sites can be published");
+    expect(
+      await db.site.findUniqueOrThrow({
+        where: { id: siteId },
+        select: {
+          publishedSiteVersionId: true,
+          _count: { select: { siteVersions: true, auditEvents: true } },
+        },
+      }),
+    ).toEqual({
+      publishedSiteVersionId: null,
+      _count: { siteVersions: 0, auditEvents: 0 },
+    });
+
+    await db.site.update({
+      where: { id: siteId },
+      data: { status: "CLAIMED" },
+    });
+  });
+
+  test("publishes a validated immutable snapshot and audits the actor", async () => {
+    const published = await publishSiteDraft({
+      siteId,
+      slug,
+      vertical: Vertical.RESTAURANT,
+      actor,
+      changeSummary: "Initial customer launch",
+      now: new Date("2026-07-26T20:00:00.000Z"),
+    });
+
+    expect(published).toMatchObject({
+      version: 1,
+      theme: { id: "warm", version: "legacy-v1" },
+    });
+    const site = await db.site.findUnique({
+      where: { id: siteId },
+      select: {
+        status: true,
+        publishedSiteVersionId: true,
+        publishedSiteVersion: {
+          select: {
+            content: true,
+            translations: true,
+            integrations: true,
+            palette: true,
+            publishedBy: true,
+            changeSummary: true,
+          },
+        },
+        auditEvents: {
+          where: { type: "site.published" },
+          select: { actor: true, metadata: true },
+        },
+      },
+    });
+
+    expect(site?.status).toBe("LIVE");
+    expect(site?.publishedSiteVersionId).toBe(published.id);
+    expect(site?.publishedSiteVersion).toMatchObject({
+      publishedBy: actor.id,
+      changeSummary: "Initial customer launch",
+      palette: sampleSiteDraft.palette,
+      translations: sampleSiteDraft.translations,
+      integrations: sampleSiteDraft.integrations,
+    });
+    expect(site?.publishedSiteVersion?.content).toMatchObject({
+      slug,
+      name: sampleSiteDraft.name,
+      palette: sampleSiteDraft.palette,
+    });
+    expect(site?.auditEvents).toEqual([
+      {
+        actor: actor.id,
+        metadata: expect.objectContaining({
+          siteVersionId: published.id,
+          version: 1,
+          changeSummary: "Initial customer launch",
+          actorEmail: actor.email,
+        }),
+      },
+    ]);
+  });
+
+  test("keeps Save private until a later atomic publish", async () => {
+    const firstPointer = (
+      await db.site.findUniqueOrThrow({
+        where: { id: siteId },
+        select: { publishedSiteVersionId: true },
+      })
+    ).publishedSiteVersionId;
+    const changedDraft = {
+      ...sampleSiteDraft,
+      slug,
+      name: "Private draft name",
+      description:
+        "This description is visible in the owner preview but not on the public domain.",
+      palette: {
+        background: "#101010",
+        foreground: "#f5f5f5",
+        accent: "#dd5544",
+      },
+      attributes: {
+        ...sampleSiteDraft.attributes,
+        cuisine: "Japanese omakase",
+      },
+    };
+
+    await updateSiteDraft(slug, changedDraft, Vertical.RESTAURANT);
+
+    const afterSave = await db.site.findUniqueOrThrow({
+      where: { id: siteId },
+      select: {
+        publishedSiteVersionId: true,
+        siteVersions: { select: { id: true } },
+      },
+    });
+    const [privateView, publicView] = await Promise.all([
+      findSiteView(slug),
+      findPublishedSiteView(slug),
+    ]);
+    expect(afterSave.publishedSiteVersionId).toBe(firstPointer);
+    expect(afterSave.siteVersions).toHaveLength(1);
+    expect(privateView?.draft.name).toBe("Private draft name");
+    expect(privateView?.theme.id).toBe("nocturne");
+    expect(publicView?.draft.name).toBe(sampleSiteDraft.name);
+    expect(publicView?.draft.palette).toEqual(sampleSiteDraft.palette);
+    expect(publicView?.theme).toMatchObject({
+      id: "warm",
+      version: "legacy-v1",
+    });
+
+    const second = await publishSiteDraft({
+      siteId,
+      slug,
+      vertical: Vertical.RESTAURANT,
+      actor,
+      changeSummary: "Publish private copy and palette",
+    });
+    expect(second.version).toBe(2);
+    expect(second.theme).toEqual({ id: "nocturne", version: "legacy-v1" });
+    expect(second.id).not.toBe(firstPointer);
+    expect((await findPublishedSiteView(slug))?.draft).toMatchObject({
+      name: changedDraft.name,
+      palette: changedDraft.palette,
+    });
+  });
+
+  test("leaves the live pointer untouched when persisted draft validation fails", async () => {
+    const before = await db.site.findUniqueOrThrow({
+      where: { id: siteId },
+      select: {
+        publishedSiteVersionId: true,
+        _count: { select: { siteVersions: true, auditEvents: true } },
+      },
+    });
+    await db.site.update({
+      where: { id: siteId },
+      data: {
+        translations: [
+          {
+            locale: "fr",
+            catalogSections: [],
+            integrationLabels: [],
+          },
+        ],
+      },
+    });
+
+    await expect(
+      publishSiteDraft({
+        siteId,
+        slug,
+        vertical: Vertical.RESTAURANT,
+        actor,
+        changeSummary: "This publish must fail",
+      }),
+    ).rejects.toThrow();
+
+    const after = await db.site.findUniqueOrThrow({
+      where: { id: siteId },
+      select: {
+        publishedSiteVersionId: true,
+        _count: { select: { siteVersions: true, auditEvents: true } },
+      },
+    });
+    expect(after).toEqual(before);
+    await db.site.update({
+      where: { id: siteId },
+      data: { translations: [] },
+    });
+  });
+
+  test("serializes concurrent publishes and never mutates published history", async () => {
+    const results = await Promise.all([
+      publishSiteDraft({
+        siteId,
+        slug,
+        vertical: Vertical.RESTAURANT,
+        actor,
+        changeSummary: "Concurrent publish A",
+      }),
+      publishSiteDraft({
+        siteId,
+        slug,
+        vertical: Vertical.RESTAURANT,
+        actor,
+        changeSummary: "Concurrent publish B",
+      }),
+    ]);
+    const versions = await db.siteVersion.findMany({
+      where: { siteId },
+      orderBy: { version: "asc" },
+      select: { id: true, version: true },
+    });
+    const pointer = await db.site.findUniqueOrThrow({
+      where: { id: siteId },
+      select: { publishedSiteVersionId: true },
+    });
+
+    expect(results.map((result) => result.version).sort()).toEqual([3, 4]);
+    expect(versions.map((version) => version.version)).toEqual([1, 2, 3, 4]);
+    expect(pointer.publishedSiteVersionId).toBe(versions.at(-1)?.id);
+
+    await expect(
+      Promise.resolve(
+        db.siteVersion.update({
+          where: { id: versions[0].id },
+          data: { changeSummary: "Tampered history" },
+        }),
+      ),
+    ).rejects.toThrow("Published site versions are immutable");
+  });
+});

--- a/src/lib/site-publication.ts
+++ b/src/lib/site-publication.ts
@@ -1,0 +1,175 @@
+import "server-only";
+import { Prisma } from "@/generated/prisma/client";
+import { getDb } from "@/lib/db";
+import {
+  projectSiteDraft,
+  siteDraftRelations,
+} from "@/lib/sites";
+import type { VerticalId } from "@/lib/verticals/types";
+
+const retryablePublishCodes = new Set(["P2002", "P2034"]);
+
+export type PublishSiteDraftInput = {
+  siteId: string;
+  slug: string;
+  vertical: VerticalId;
+  actor: {
+    id: string;
+    email: string;
+  };
+  changeSummary: string;
+  now?: Date;
+};
+
+export type PublishedSiteVersion = {
+  id: string;
+  version: number;
+  publishedAt: Date;
+  theme: {
+    id: string;
+    version: string;
+  };
+};
+
+export class SitePublicationStateError extends Error {
+  constructor() {
+    super("Only claimed or live sites can be published");
+    this.name = "SitePublicationStateError";
+  }
+}
+
+/**
+ * Validates the persisted private draft, appends an immutable snapshot, moves
+ * the live pointer, and records the audit event in one serializable transaction.
+ *
+ * A caller cannot publish a request body directly: only the draft already owned
+ * by this site can cross the boundary, which keeps preview and publish on the
+ * same validated representation and makes Save-before-Publish explicit.
+ */
+export async function publishSiteDraft(
+  input: PublishSiteDraftInput,
+): Promise<PublishedSiteVersion> {
+  const changeSummary = input.changeSummary.trim();
+  if (changeSummary.length < 3 || changeSummary.length > 280) {
+    throw new Error("Change summary must be between 3 and 280 characters");
+  }
+  if (!process.env.DATABASE_URL) {
+    throw new Error("Site publishing is temporarily unavailable");
+  }
+
+  const db = getDb();
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      return await db.$transaction(
+        async (tx) => {
+          const site = await tx.site.findFirst({
+            where: {
+              id: input.siteId,
+              slug: input.slug,
+              vertical: input.vertical,
+            },
+            include: siteDraftRelations,
+          });
+          if (!site) throw new Error("Site not found");
+          if (site.status !== "CLAIMED" && site.status !== "LIVE") {
+            // Publishing must not resurrect a prospect or bypass an operator or
+            // billing pause by changing PAUSED back to LIVE.
+            throw new SitePublicationStateError();
+          }
+
+          // `projectSiteDraft` is the private-preview projection. Parsing it
+          // here before any write means validation failure cannot create a
+          // version, move the pointer, change status, or write an audit row.
+          const loaded = projectSiteDraft(site);
+          const draft = loaded.draft as Prisma.InputJsonValue;
+          const latest = await tx.siteVersion.findFirst({
+            where: { siteId: input.siteId },
+            orderBy: { version: "desc" },
+            select: { version: true },
+          });
+          const publishedAt = input.now ?? new Date();
+          const version = await tx.siteVersion.create({
+            data: {
+              siteId: input.siteId,
+              version: (latest?.version ?? 0) + 1,
+              vertical: loaded.vertical,
+              theme: loaded.theme.selection as Prisma.InputJsonValue,
+              themeVersion: loaded.theme.version,
+              palette: (
+                loaded.draft as { palette: Prisma.InputJsonValue }
+              ).palette,
+              content: draft,
+              translations: (
+                loaded.draft as { translations: Prisma.InputJsonValue }
+              ).translations,
+              integrations: (
+                loaded.draft as { integrations: Prisma.InputJsonValue }
+              ).integrations,
+              publishedAt,
+              publishedBy: input.actor.id,
+              changeSummary,
+            },
+            select: { id: true, version: true },
+          });
+
+          const moved = await tx.site.updateMany({
+            where: {
+              id: input.siteId,
+              slug: input.slug,
+              vertical: input.vertical,
+            },
+            data: {
+              publishedSiteVersionId: version.id,
+              status: "LIVE",
+            },
+          });
+          if (moved.count !== 1) {
+            throw new Error("Site could not be published");
+          }
+
+          await tx.auditEvent.create({
+            data: {
+              type: "site.published",
+              actor: input.actor.id,
+              siteId: input.siteId,
+              metadata: {
+                siteVersionId: version.id,
+                version: version.version,
+                changeSummary,
+                actorEmail: input.actor.email,
+                themeId: loaded.theme.id,
+                themeVersion: loaded.theme.version,
+              },
+            },
+          });
+
+          return {
+            id: version.id,
+            version: version.version,
+            publishedAt,
+            theme: {
+              id: loaded.theme.id,
+              version: loaded.theme.version,
+            },
+          };
+        },
+        { isolationLevel: "Serializable" },
+      );
+    } catch (error) {
+      if (attempt < 2 && isRetryablePublishError(error)) continue;
+      throw error;
+    }
+  }
+
+  throw new Error("Site could not be published");
+}
+
+function isRetryablePublishError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    typeof error.code === "string" &&
+    retryablePublishCodes.has(error.code)
+  );
+}

--- a/src/lib/sites.ts
+++ b/src/lib/sites.ts
@@ -1,7 +1,13 @@
+import { Prisma } from "@/generated/prisma/client";
 import { Vertical } from "@/generated/prisma/enums";
 import { getDb } from "@/lib/db";
 import { leadSiteDrafts } from "@/lib/lead-drafts";
-import type { SiteDraftView } from "@/lib/site-draft";
+import type {
+  SiteDraftView,
+  SitePaletteView,
+  SiteThemeView,
+} from "@/lib/site-draft";
+import { LEGACY_THEME_VERSION } from "@/lib/site-draft";
 import { sampleSiteDraft } from "@/lib/verticals/restaurant/schema";
 import {
   resolveVerticalConfig,
@@ -9,56 +15,47 @@ import {
 } from "@/lib/verticals/registry";
 import type { VerticalId } from "@/lib/verticals/types";
 
+export const siteDraftRelations = {
+  integrations: {
+    orderBy: [{ position: "asc" }, { createdAt: "asc" }],
+  },
+  catalogSections: {
+    orderBy: { position: "asc" },
+    include: { items: { orderBy: { position: "asc" } } },
+  },
+} satisfies Prisma.SiteInclude;
+
+export type PersistedSiteDraftRecord = Prisma.SiteGetPayload<{
+  include: typeof siteDraftRelations;
+}>;
+
 export type LoadedSite = {
   vertical: VerticalId;
   config: ErasedVerticalConfig;
   draft: unknown;
+  theme: SiteThemeView;
 };
 
 /**
  * What a page needs to render a site: the draft in its structural form plus the
- * vertical it belongs to, so the renderer can resolve its own config.
+ * vertical and pinned theme identity that own it.
  */
 export type SiteView = {
   vertical: VerticalId;
   draft: SiteDraftView;
+  theme: SiteThemeView;
 };
 
 /**
- * The vertical-agnostic read path: load a `Site` row and project it back through
- * the owning vertical's own schemas. Nothing here knows what a menu, a cuisine or
- * a dietary label is — those live in the `attributes` bags and are re-validated on
- * the way out, so a bad write surfaces here rather than in the renderer.
+ * Projects editable Site rows through the owning vertical's schemas.
  *
- * Returns `null` when the database is not configured or the slug is unknown; the
- * in-code fixture fallbacks are layered on by `findSiteView` below rather than by
- * this storage read.
+ * This function is shared with the publish transaction so the private preview
+ * and the snapshot being published cannot drift into separate serialization
+ * formats.
  */
-export async function findSiteDraft(slug: string): Promise<LoadedSite | null> {
-  if (!process.env.DATABASE_URL) return null;
-
-  const site = await getDb().site.findUnique({
-    where: { slug },
-    include: {
-      integrations: {
-        orderBy: [{ position: "asc" }, { createdAt: "asc" }],
-      },
-      catalogSections: {
-        orderBy: { position: "asc" },
-        include: { items: { orderBy: { position: "asc" } } },
-      },
-      siteVersions: { orderBy: { version: "desc" }, take: 1 },
-    },
-  });
-
-  if (!site) return null;
-
+export function projectSiteDraft(site: PersistedSiteDraftRecord): LoadedSite {
   const config = resolveVerticalConfig(site.vertical);
   const attributes = config.attributesSchema.parse(site.attributes);
-  const latestTheme = site.siteVersions[0]?.theme as
-    | { background: string; foreground: string; accent: string }
-    | undefined;
-
   const draft = config.draftSchema.parse({
     slug: site.slug,
     name: site.name,
@@ -73,8 +70,13 @@ export async function findSiteDraft(slug: string): Promise<LoadedSite | null> {
     sourceUrl: site.sourceUrl,
     heroImageUrl: site.heroImageUrl,
     heroOriginalImageUrl: site.heroOriginalImageUrl,
-    heroImageProvenance: fromDatabaseImageProvenance(site.heroImageProvenance),
-    palette: latestTheme ?? config.presentation.fallbackPalette,
+    heroImageProvenance: fromDatabaseImageProvenance(
+      site.heroImageProvenance,
+    ),
+    palette: storedPalette(
+      site.draftPalette,
+      config.presentation.fallbackPalette,
+    ),
     attributes,
     autoEnhanceImages: site.autoEnhanceImages,
     defaultLocale: site.defaultLocale,
@@ -102,30 +104,105 @@ export async function findSiteDraft(slug: string): Promise<LoadedSite | null> {
     })),
   });
 
-  return { vertical: site.vertical, config, draft };
+  return {
+    vertical: site.vertical,
+    config,
+    draft,
+    theme: editableTheme(config, attributes, site.draftTheme, site.draftThemeVersion),
+  };
 }
 
 /**
- * The loader every rendering page uses. It adds the demo-mode fixture fallbacks on
- * top of the storage read: without `DATABASE_URL` the app still serves the seeded
- * lead drafts and the sample site, which is what makes `bun run dev` work with no
- * infrastructure. Those fixtures are restaurant drafts today — when a second
- * vertical ships fixtures they move behind the registry, not into this branch.
+ * Loads only editable draft state. Private previews and owner dashboards use
+ * this path; custom domains never do.
+ */
+export async function findSiteDraft(slug: string): Promise<LoadedSite | null> {
+  if (!process.env.DATABASE_URL) return null;
+
+  const site = await getDb().site.findUnique({
+    where: { slug },
+    include: siteDraftRelations,
+  });
+
+  return site ? projectSiteDraft(site) : null;
+}
+
+/**
+ * Dereferences the site's one live pointer and validates the immutable snapshot
+ * before rendering it. Mutable Site columns and child rows are intentionally not
+ * selected, so a Save cannot leak into a public custom domain.
+ */
+export async function findPublishedSiteView(
+  slug: string,
+): Promise<SiteView | null> {
+  if (!process.env.DATABASE_URL) return null;
+
+  const site = await getDb().site.findUnique({
+    where: { slug },
+    select: {
+      publishedSiteVersion: {
+        select: {
+          vertical: true,
+          theme: true,
+          themeVersion: true,
+          palette: true,
+          content: true,
+          translations: true,
+          integrations: true,
+          publishedAt: true,
+        },
+      },
+    },
+  });
+  const version = site?.publishedSiteVersion;
+  if (!version?.publishedAt) return null;
+
+  const config = resolveVerticalConfig(version.vertical);
+  const content = jsonRecord(version.content);
+  const draft = config.draftSchema.parse({
+    ...content,
+    palette: version.palette,
+    translations: version.translations,
+    integrations: version.integrations,
+  }) as SiteDraftView;
+  const theme = publishedTheme(config, version.theme, version.themeVersion);
+  if (!theme) return null;
+
+  return { vertical: version.vertical, draft, theme };
+}
+
+/**
+ * The loader every private rendering page uses. It adds demo fixtures on top of
+ * the editable storage read; live custom-domain requests switch to
+ * `findPublishedSiteView` in the page before this is called.
  */
 export async function findSiteView(slug: string): Promise<SiteView | null> {
   if (!process.env.DATABASE_URL) {
-    const leadDraft = leadSiteDrafts[slug];
-    if (leadDraft) return { vertical: Vertical.RESTAURANT, draft: leadDraft };
-    return slug === sampleSiteDraft.slug
-      ? { vertical: Vertical.RESTAURANT, draft: sampleSiteDraft }
-      : null;
+    const draft =
+      leadSiteDrafts[slug] ??
+      (slug === sampleSiteDraft.slug ? sampleSiteDraft : null);
+    if (!draft) return null;
+    const config = resolveVerticalConfig(Vertical.RESTAURANT);
+    const attributes = config.attributesSchema.parse(draft.attributes);
+    return {
+      vertical: Vertical.RESTAURANT,
+      draft,
+      theme: editableTheme(
+        config,
+        attributes,
+        {},
+        LEGACY_THEME_VERSION,
+      ),
+    };
   }
 
   const site = await findSiteDraft(slug);
   if (!site) return null;
-  // `findSiteDraft` already parsed the draft with the vertical's own schema, and
-  // every vertical draft extends the base shape the view type describes.
-  return { vertical: site.vertical, draft: site.draft as SiteDraftView };
+  return {
+    vertical: site.vertical,
+    draft: site.draft as SiteDraftView,
+    theme: site.theme,
+  };
 }
 
 /**
@@ -133,12 +210,73 @@ export async function findSiteView(slug: string): Promise<SiteView | null> {
  * slug so surfaces that must always render something (the dashboard) have a draft.
  */
 export async function getSiteView(slug: string): Promise<SiteView> {
-  return (
-    (await findSiteView(slug)) ?? {
-      vertical: Vertical.RESTAURANT,
-      draft: { ...sampleSiteDraft, slug },
-    }
-  );
+  const site = await findSiteView(slug);
+  if (site) return site;
+
+  const config = resolveVerticalConfig(Vertical.RESTAURANT);
+  const draft = { ...sampleSiteDraft, slug };
+  const attributes = config.attributesSchema.parse(draft.attributes);
+  return {
+    vertical: Vertical.RESTAURANT,
+    draft,
+    theme: editableTheme(config, attributes, {}, LEGACY_THEME_VERSION),
+  };
+}
+
+function editableTheme(
+  config: ErasedVerticalConfig,
+  attributes: Record<string, unknown>,
+  value: Prisma.JsonValue,
+  version: string,
+): SiteThemeView {
+  const selection = jsonRecord(value);
+  const storedId = typeof selection.id === "string" ? selection.id : null;
+  const resolvedId = config.templates.resolve(attributes).id;
+  const id =
+    storedId && storedId in config.templates.definitions
+      ? storedId
+      : resolvedId;
+  return {
+    id,
+    version: version || LEGACY_THEME_VERSION,
+    selection: { ...selection, id },
+  };
+}
+
+function publishedTheme(
+  config: ErasedVerticalConfig,
+  value: Prisma.JsonValue,
+  version: string,
+): SiteThemeView | null {
+  const selection = jsonRecord(value);
+  const id = typeof selection.id === "string" ? selection.id : null;
+  if (!id || !(id in config.templates.definitions) || !version) return null;
+  return { id, version, selection };
+}
+
+function storedPalette(
+  value: Prisma.JsonValue,
+  fallback: SitePaletteView,
+): SitePaletteView {
+  const palette = jsonRecord(value);
+  if (
+    typeof palette.background !== "string" ||
+    typeof palette.foreground !== "string" ||
+    typeof palette.accent !== "string"
+  ) {
+    return fallback;
+  }
+  return {
+    background: palette.background,
+    foreground: palette.foreground,
+    accent: palette.accent,
+  };
+}
+
+function jsonRecord(value: Prisma.JsonValue): Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
 }
 
 function fromDatabaseImageProvenance(

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -70,9 +70,18 @@ export async function proxy(request: NextRequest) {
 
   const domain = await getDb().domain.findFirst({
     where: { hostname, verified: true },
-    select: { site: { select: { slug: true } } },
+    select: {
+      site: {
+        select: {
+          slug: true,
+          publishedSiteVersionId: true,
+        },
+      },
+    },
   });
-  if (!domain) return new NextResponse("Not found", { status: 404 });
+  if (!domain?.site.publishedSiteVersionId) {
+    return new NextResponse("Not found", { status: 404 });
+  }
 
   const locale = request.nextUrl.pathname.match(/^\/([a-z]{2})\/?$/i)?.[1];
   const destination = locale


### PR DESCRIPTION
## Summary

- Store editable draft theme, palette, content, translations, and integrations independently from the public site.
- Append validated immutable snapshots and move one live pointer atomically with the publish audit event.
- Route private previews to draft state and verified custom domains only to the published pointer.
- Add an authorized Publish action with change summary and explicit confirmation.
- Backfill and audit already-live sites without replacing their visible snapshot.

## Related issue

Closes #18.

This is the storage and rendering foundation for #19 theme selection/version pinning and #54 restore-by-new-version.

## Scope

- Additive Prisma/PostgreSQL migration only; no destructive column or table changes.
- Published snapshots contain content, translations, integrations, palette, vertical, theme ID/version, actor, timestamp, and change summary.
- Database triggers reject cross-site/unpublished pointers and update/delete of published history.
- Save no longer creates a SiteVersion or moves the public pointer.
- Publish allows CLAIMED/LIVE sites only; PAUSED sites cannot self-resurrect.
- History browsing and rollback UI remain out of scope.

## Verification

- `bun run test` - 140 pass, 11 database-gated skips, 0 fail.
- Real PostgreSQL 18 publication suite - 5 pass, 25 assertions covering lifecycle guard, audit, Save isolation, pinned theme/palette, invalid validation rollback, concurrent serialization, and immutability.
- Fresh PostgreSQL 18 `prisma migrate deploy` - pass.
- Seeded pre-issue live-site migration - existing pointer, `warm@legacy-v1`, exact palette, and `system:migration` audit preserved.
- Prisma database-to-schema drift check - no difference.
- `bun run lint` - 0 errors; one pre-existing generated workflow warning.
- `bun run build` - pass.
- `git diff --check` - pass.

## Screenshots

Not captured. The visible change is a minimal authenticated dashboard Publish control; rendering and route behavior are covered by build and PostgreSQL integration verification.

## Checklist

- [x] I reviewed the final diff for unrelated changes.
- [x] I ran the relevant focused checks.
- [x] No documentation change is required beyond the migration and PR contract.
- [x] The additive migration, release behavior, and external gates are documented here.
- [x] I did not include secrets, credentials, personal data, customer data, or generated build output.

## Cross-provider run record

- Planner: Fable via `~/.claude-genfeedai`, high - failed before inference: `Not logged in`.
- Planning fallback: Opus via `~/.claude-genfeedai`, high - failed before inference: `Not logged in`.
- Planning status: `planning_degraded`; Sol proceeded from a repo-grounded acceptance plan.
- Implementation head: `9380cabd3fada4ac33178ee58fa022b0a567fd5b`.
- Exact-head Opus verification: unavailable at `9380cabd3fada4ac33178ee58fa022b0a567fd5b`; the required profile failed before inference with `Not logged in` (exit 1). This is not a PASS, so the PR remains unmerged.
- CI: `verify` PASS; deploy correctly skipped for the PR; CodeRabbit SUCCESS.

