### PR TITLE
feat(restaurant): add owner theme workspace

### DIFF
--- a/src/app/api/sites/[slug]/rollback/route.ts
+++ b/src/app/api/sites/[slug]/rollback/route.ts
@@ -1,0 +1,65 @@
+import { z } from "zod";
+import {
+  accessFailureResponse,
+  getSiteAccess,
+} from "@/lib/authorization";
+import {
+  rollbackPublishedSiteVersion,
+  SitePublicationStateError,
+} from "@/lib/site-publication";
+
+const rollbackRequestSchema = z
+  .object({
+    siteVersionId: z.string().trim().min(1).max(128),
+  })
+  .strict();
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await params;
+  const access = await getSiteAccess(slug);
+  if (!access.ok) return accessFailureResponse(access);
+
+  const parsed = rollbackRequestSchema.safeParse(
+    await request.json().catch(() => null),
+  );
+  if (!parsed.success) {
+    return Response.json(
+      { error: "Choose a valid published version" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const published = await rollbackPublishedSiteVersion({
+      siteId: access.site.id,
+      slug: access.site.slug,
+      vertical: access.site.vertical,
+      targetSiteVersionId: parsed.data.siteVersionId,
+      actor: access.user,
+    });
+    return Response.json({ ok: true, published });
+  } catch (error) {
+    if (error instanceof SitePublicationStateError) {
+      return Response.json({ error: error.message }, { status: 409 });
+    }
+    if (
+      error instanceof Error &&
+      error.message === "Published site version not found"
+    ) {
+      return Response.json({ error: error.message }, { status: 404 });
+    }
+
+    console.error("[site-rollback] failed", {
+      slug,
+      actorId: access.user.id,
+      error: error instanceof Error ? error.message : "unknown",
+    });
+    return Response.json(
+      { error: "Site could not be rolled back" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/dashboard/dashboard.tsx
+++ b/src/app/dashboard/dashboard.tsx
@@ -10,6 +10,7 @@ import {
   Copy,
   CreditCard,
   ExternalLink,
+  Eye,
   Globe2,
   ImageIcon,
   LayoutDashboard,
@@ -18,7 +19,9 @@ import {
   Mail,
   MoreHorizontal,
   Plus,
+  Palette,
   RefreshCcw,
+  RotateCcw,
   Rocket,
   Save,
   Settings,
@@ -42,6 +45,13 @@ import type { BrandIdentity } from "@/lib/brand";
 import type { AnalyticsSummaryDto } from "@/lib/analytics-contract";
 import type { BookingRequestInboxDto } from "@/lib/booking-request-inbox";
 import type { BillingAccess } from "@/lib/billing-access";
+import type { SitePublicationHistoryItem } from "@/lib/site-publication";
+import { listRestaurantThemeManifests } from "@/lib/site-themes/restaurant/registry";
+import {
+  parseRestaurantThemeSelection,
+  restoreAutomaticRestaurantTheme,
+  selectOwnerRestaurantTheme,
+} from "@/lib/site-themes/restaurant/selection";
 import {
   formatPrice,
   type RestaurantDraft,
@@ -52,6 +62,13 @@ type DomainSetup = {
   attached: boolean;
   verified: boolean;
   records: Array<{ type: string; name: string; value: string }>;
+};
+
+type ClientPublicationHistoryItem = Omit<
+  SitePublicationHistoryItem,
+  "publishedAt"
+> & {
+  publishedAt: string;
 };
 
 /**
@@ -68,6 +85,7 @@ export function Dashboard({
   analyticsSummary,
   bookingInbox,
   billingAccess,
+  publicationHistory: initialPublicationHistory,
 }: {
   initialDraft: RestaurantDraft;
   email: string;
@@ -77,6 +95,7 @@ export function Dashboard({
   analyticsSummary: AnalyticsSummaryDto;
   bookingInbox: BookingRequestInboxDto;
   billingAccess: BillingAccess | null;
+  publicationHistory: ClientPublicationHistoryItem[];
 }) {
   const [draft, setDraft] = useState(initialDraft);
   const [saving, setSaving] = useState(false);
@@ -90,6 +109,19 @@ export function Dashboard({
   const [domainLoading, setDomainLoading] = useState(false);
   const [imageLoading, setImageLoading] = useState(false);
   const [portalLoading, setPortalLoading] = useState(false);
+  const [themeDirty, setThemeDirty] = useState(false);
+  const [rollbackLoading, setRollbackLoading] = useState<string | null>(null);
+  const [publicationHistory, setPublicationHistory] = useState(
+    initialPublicationHistory,
+  );
+
+  const themeManifests = listRestaurantThemeManifests();
+  const currentThemeSelection = parseRestaurantThemeSelection(
+    draft.themeSelection,
+  );
+  const automaticThemeSelection = restoreAutomaticRestaurantTheme(
+    draft.designProfile,
+  );
 
   async function save(): Promise<boolean> {
     setSaving(true);
@@ -105,6 +137,7 @@ export function Dashboard({
         if (!response.ok) throw new Error("Save failed");
       }
       setSaved(true);
+      setThemeDirty(false);
       setPublishedVersion(null);
       return true;
     } catch (caught) {
@@ -153,18 +186,113 @@ export function Dashboard({
       });
       const result = (await response.json()) as {
         error?: string;
-        published?: { version: number };
+        published?: {
+          id: string;
+          version: number;
+          publishedAt: string;
+          theme: { id: string; version: string };
+        };
       };
       if (!response.ok || !result.published) {
         throw new Error(result.error ?? "Publish failed");
       }
       setPublishedVersion(result.published.version);
+      setPublicationHistory((current) => [
+        {
+          id: result.published!.id,
+          version: result.published!.version,
+          publishedAt: result.published!.publishedAt,
+          changeSummary,
+          current: true,
+          theme: result.published!.theme,
+        },
+        ...current.map((item) => ({ ...item, current: false })),
+      ]);
     } catch (caught) {
       setPublishError(
         caught instanceof Error ? caught.message : "Publish failed",
       );
     } finally {
       setPublishing(false);
+    }
+  }
+
+  function selectTheme(themeId: Parameters<typeof selectOwnerRestaurantTheme>[1]) {
+    const selection = selectOwnerRestaurantTheme(
+      draft.designProfile,
+      themeId,
+    );
+    setDraft((current) => ({ ...current, themeSelection: selection }));
+    setSaved(false);
+    setThemeDirty(true);
+    setPublishedVersion(null);
+    setPublishError(null);
+  }
+
+  function restoreAutomaticTheme() {
+    setDraft((current) => ({
+      ...current,
+      themeSelection: restoreAutomaticRestaurantTheme(
+        current.designProfile,
+      ),
+    }));
+    setSaved(false);
+    setThemeDirty(true);
+    setPublishedVersion(null);
+    setPublishError(null);
+  }
+
+  async function rollback(siteVersionId: string) {
+    const target = publicationHistory.find(
+      (item) => item.id === siteVersionId,
+    );
+    if (!target || target.current) return;
+    if (
+      !window.confirm(
+        `Restore the public site to version ${target.version}? Your private draft will not change.`,
+      )
+    ) {
+      return;
+    }
+
+    setRollbackLoading(siteVersionId);
+    setPublishError(null);
+    try {
+      const response = await fetch(`/api/sites/${draft.slug}/rollback`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ siteVersionId }),
+      });
+      const result = (await response.json()) as {
+        error?: string;
+        published?: {
+          id: string;
+          version: number;
+          publishedAt: string;
+          theme: { id: string; version: string };
+        };
+      };
+      if (!response.ok || !result.published) {
+        throw new Error(result.error ?? "Rollback failed");
+      }
+      setPublishedVersion(result.published.version);
+      setPublicationHistory((current) => [
+        {
+          id: result.published!.id,
+          version: result.published!.version,
+          publishedAt: result.published!.publishedAt,
+          changeSummary: `Rollback to v${target.version}: ${target.changeSummary}`,
+          current: true,
+          theme: result.published!.theme,
+        },
+        ...current.map((item) => ({ ...item, current: false })),
+      ]);
+    } catch (caught) {
+      setPublishError(
+        caught instanceof Error ? caught.message : "Rollback failed",
+      );
+    } finally {
+      setRollbackLoading(null);
     }
   }
 
@@ -377,6 +505,7 @@ export function Dashboard({
                 ["overview", LayoutDashboard, "Overview"],
                 ["analytics", TrendingUp, "Analytics"],
                 ["leads", Mail, "Leads"],
+                ["design", Palette, "Design"],
                 ["menu", BookOpenText, "Menu"],
                 ["imagery", ImageIcon, "Imagery"],
                 ["integrations", Link2, "Integrations"],
@@ -406,6 +535,7 @@ export function Dashboard({
               <TabsTrigger value="overview">Overview</TabsTrigger>
               <TabsTrigger value="analytics">Analytics</TabsTrigger>
               <TabsTrigger value="leads">Leads</TabsTrigger>
+              <TabsTrigger value="design">Design</TabsTrigger>
               <TabsTrigger value="menu">Menu</TabsTrigger>
               <TabsTrigger value="imagery">Imagery</TabsTrigger>
               <TabsTrigger value="integrations">Links</TabsTrigger>
@@ -515,6 +645,216 @@ export function Dashboard({
                 initialInbox={bookingInbox}
                 demo={demo}
               />
+            </TabsContent>
+
+            <TabsContent value="design" className="mt-0">
+              <PageHeading
+                eyebrow="Website design"
+                title="Choose the right service experience."
+                copy="Preview every compatible renderer with your restaurant content. A choice changes only the private draft until you Save and Publish."
+                action={
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={restoreAutomaticTheme}
+                    disabled={
+                      currentThemeSelection !== null &&
+                      currentThemeSelection.source !== "owner"
+                    }
+                  >
+                    <RotateCcw />
+                    {currentThemeSelection
+                      ? "Restore automatic"
+                      : "Use automatic match"}
+                  </Button>
+                }
+              />
+
+              <Card className="mt-8">
+                <CardContent className="flex flex-col gap-4 pt-6 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                      Current private draft
+                    </p>
+                    <p className="mt-2 text-lg font-semibold">
+                      {currentThemeSelection
+                        ? themeManifests.find(
+                            (theme) =>
+                              theme.id === currentThemeSelection.themeId,
+                          )?.name
+                        : "Legacy restaurant design"}
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {currentThemeSelection
+                        ? `${currentThemeSelection.source === "owner" ? "Owner selected" : "Automatically matched"} · immutable renderer v${currentThemeSelection.rendererVersion}`
+                        : `Automatic match available: ${
+                            themeManifests.find(
+                              (theme) =>
+                                theme.id === automaticThemeSelection.themeId,
+                            )?.name
+                          }`}
+                    </p>
+                  </div>
+                  {themeDirty ? (
+                    <Badge variant="outline">Save to keep this choice</Badge>
+                  ) : (
+                    <Badge className="bg-emerald-600 text-white">
+                      Stored private draft
+                    </Badge>
+                  )}
+                </CardContent>
+              </Card>
+
+              <div className="mt-5 grid gap-5 xl:grid-cols-3">
+                {themeManifests.map((manifest) => {
+                  const selected =
+                    currentThemeSelection?.themeId === manifest.id;
+                  const automatic =
+                    automaticThemeSelection.themeId === manifest.id;
+                  return (
+                    <Card
+                      key={manifest.id}
+                      className={
+                        selected
+                          ? "overflow-hidden border-primary ring-2 ring-primary/15"
+                          : "overflow-hidden"
+                      }
+                    >
+                      <div
+                        className="relative aspect-[16/9] border-b bg-cover bg-center"
+                        style={{
+                          backgroundColor:
+                            manifest.safeDefaultTokens.colors.background,
+                          backgroundImage: `url("/themes/restaurant/${manifest.id}.webp")`,
+                        }}
+                      >
+                        <div className="absolute inset-0 bg-gradient-to-t from-black/65 to-transparent" />
+                        <div className="absolute inset-x-4 bottom-4 flex items-end justify-between gap-3 text-white">
+                          <div>
+                            <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-white/70">
+                              renderer v{manifest.rendererVersion}
+                            </p>
+                            <h2 className="mt-1 text-xl font-semibold">
+                              {manifest.name}
+                            </h2>
+                          </div>
+                          {selected ? <Badge>Selected</Badge> : null}
+                        </div>
+                      </div>
+                      <CardContent className="space-y-5 pt-6">
+                        <p className="text-sm leading-6 text-muted-foreground">
+                          {manifest.description}
+                        </p>
+                        <div className="flex flex-wrap gap-2">
+                          <Badge variant="secondary">
+                            {manifest.experience.primaryIntent}-led
+                          </Badge>
+                          <Badge variant="secondary">
+                            {manifest.experience.menuExperience} menu
+                          </Badge>
+                          {automatic ? (
+                            <Badge variant="outline">Automatic match</Badge>
+                          ) : null}
+                        </div>
+                        <div className="grid grid-cols-2 gap-2">
+                          <Button
+                            render={
+                              <Link
+                                href={`/dashboard/themes/${manifest.id}`}
+                                target="_blank"
+                              />
+                            }
+                            nativeButton={false}
+                            variant="outline"
+                            size="sm"
+                          >
+                            <Eye /> Preview
+                          </Button>
+                          <Button
+                            size="sm"
+                            onClick={() => selectTheme(manifest.id)}
+                            disabled={
+                              selected &&
+                              currentThemeSelection?.source === "owner"
+                            }
+                          >
+                            <Check />
+                            {selected ? "Selected" : "Use theme"}
+                          </Button>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  );
+                })}
+              </div>
+
+              <Card className="mt-8">
+                <CardHeader>
+                  <CardTitle className="text-base">
+                    Published history
+                  </CardTitle>
+                  <p className="text-xs leading-5 text-muted-foreground">
+                    Rollback creates a new immutable version from a previous
+                    snapshot. Your private draft remains untouched.
+                  </p>
+                </CardHeader>
+                <CardContent>
+                  {publicationHistory.length > 0 ? (
+                    <div className="divide-y">
+                      {publicationHistory.map((item) => (
+                        <div
+                          key={item.id}
+                          className="flex flex-col gap-3 py-4 sm:flex-row sm:items-center sm:justify-between"
+                        >
+                          <div>
+                            <div className="flex flex-wrap items-center gap-2">
+                              <p className="text-sm font-semibold">
+                                Version {item.version}
+                              </p>
+                              {item.current ? (
+                                <Badge className="bg-emerald-600 text-white">
+                                  Live
+                                </Badge>
+                              ) : null}
+                              <Badge variant="outline">
+                                {item.theme.id} · {item.theme.version}
+                              </Badge>
+                            </div>
+                            <p className="mt-1 text-xs text-muted-foreground">
+                              {item.changeSummary} ·{" "}
+                              {new Intl.DateTimeFormat(undefined, {
+                                dateStyle: "medium",
+                                timeStyle: "short",
+                              }).format(new Date(item.publishedAt))}
+                            </p>
+                          </div>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            disabled={
+                              item.current ||
+                              rollbackLoading !== null ||
+                              demo
+                            }
+                            onClick={() => void rollback(item.id)}
+                          >
+                            {rollbackLoading === item.id ? (
+                              <LoaderCircle className="animate-spin" />
+                            ) : (
+                              <RotateCcw />
+                            )}
+                            {item.current ? "Currently live" : "Rollback"}
+                          </Button>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">
+                      Publish the site once to start immutable version history.
+                    </p>
+                  )}
+                </CardContent>
+              </Card>
             </TabsContent>
 
             <TabsContent value="menu" className="mt-0">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -9,6 +9,7 @@ import { getSiteBillingAccess } from "@/lib/billing-access";
 import { getCurrentSession } from "@/lib/current-session";
 import { getRestaurantDraft } from "@/lib/restaurants";
 import { sampleRestaurant } from "@/lib/restaurant";
+import { getSitePublicationHistory } from "@/lib/site-publication";
 import { resolveRequestBrand } from "@/lib/verticals/request-site";
 
 export const metadata: Metadata = {
@@ -30,12 +31,19 @@ export default async function DashboardPage({
     session?.siteSlug ? await getSiteAccess(session.siteSlug) : null;
   if (session && (!access || !access.ok)) redirect("/sign-in");
 
-  const [draft, analyticsSummary, bookingInbox, billingAccess] = access?.ok
+  const [
+    draft,
+    analyticsSummary,
+    bookingInbox,
+    billingAccess,
+    publicationHistory,
+  ] = access?.ok
     ? await Promise.all([
         getRestaurantDraft(access.site.slug),
         getSiteAnalyticsSummary(access.site.id),
         getBookingRequestInbox(access.site.id),
         getSiteBillingAccess(access.site.id),
+        getSitePublicationHistory(access.site.id),
       ])
     : [
         sampleRestaurant,
@@ -47,6 +55,7 @@ export default async function DashboardPage({
           truncated: false,
         },
         null,
+        [],
       ];
 
   return (
@@ -59,6 +68,10 @@ export default async function DashboardPage({
       analyticsSummary={analyticsSummary}
       bookingInbox={bookingInbox}
       billingAccess={billingAccess}
+      publicationHistory={publicationHistory.map((item) => ({
+        ...item,
+        publishedAt: item.publishedAt.toISOString(),
+      }))}
     />
   );
 }

--- a/src/app/dashboard/themes/[themeId]/[locale]/page.tsx
+++ b/src/app/dashboard/themes/[themeId]/[locale]/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import { OwnerThemePreview } from "@/app/dashboard/themes/[themeId]/owner-theme-preview";
+
+export const metadata: Metadata = {
+  title: "Owner theme preview",
+  robots: { index: false, follow: false },
+};
+
+export default async function LocalizedOwnerThemePreviewPage({
+  params,
+}: {
+  params: Promise<{ themeId: string; locale: string }>;
+}) {
+  const { themeId, locale } = await params;
+  return <OwnerThemePreview themeId={themeId} locale={locale} />;
+}

--- a/src/app/dashboard/themes/[themeId]/owner-theme-preview.tsx
+++ b/src/app/dashboard/themes/[themeId]/owner-theme-preview.tsx
@@ -1,0 +1,87 @@
+import { Vertical } from "@/generated/prisma/enums";
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { SiteRenderer } from "@/components/site-renderer";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { getSiteLocales, localizeSiteDraft } from "@/lib/site-draft";
+import {
+  restaurantDesignProfileSchema,
+  restaurantThemeIdSchema,
+} from "@/lib/site-themes/restaurant/contracts";
+import { selectOwnerRestaurantTheme } from "@/lib/site-themes/restaurant/selection";
+import { getSiteAccess } from "@/lib/authorization";
+import { getCurrentSession } from "@/lib/current-session";
+import { findSiteView } from "@/lib/sites";
+
+export async function OwnerThemePreview({
+  themeId,
+  locale,
+}: {
+  themeId: string;
+  locale?: string;
+}) {
+  const parsedThemeId = restaurantThemeIdSchema.safeParse(themeId);
+  if (!parsedThemeId.success) notFound();
+
+  const session = await getCurrentSession();
+  if (!session?.siteSlug) redirect("/sign-in");
+  const access = await getSiteAccess(session.siteSlug);
+  if (!access.ok) redirect("/sign-in");
+  if (access.site.vertical !== Vertical.RESTAURANT) notFound();
+
+  const site = await findSiteView(access.site.slug);
+  if (!site) notFound();
+  const profile = restaurantDesignProfileSchema.safeParse(
+    site.draft.attributes.designProfile,
+  ).data;
+  const selection = selectOwnerRestaurantTheme(
+    profile,
+    parsedThemeId.data,
+  );
+  const previewDraft = {
+    ...site.draft,
+    attributes: {
+      ...site.draft.attributes,
+      themeSelection: selection,
+    },
+  };
+  const locales = getSiteLocales(previewDraft);
+  const activeLocale = locale ?? previewDraft.defaultLocale;
+  if (!locales.includes(activeLocale)) notFound();
+
+  return (
+    <main className="min-h-screen bg-[#2b2b2b]">
+      <div className="sticky top-0 z-50 flex flex-wrap items-center justify-between gap-3 border-b border-white/15 bg-[#202020]/95 px-4 py-3 text-white backdrop-blur">
+        <div className="flex flex-wrap items-center gap-3">
+          <Badge className="bg-amber-300 text-black">Preview only</Badge>
+          <p className="text-sm text-white/75">
+            This theme has not been saved or published.
+          </p>
+        </div>
+        <Button
+          render={<Link href="/dashboard" />}
+          nativeButton={false}
+          variant="secondary"
+          size="sm"
+        >
+          Back to Design
+        </Button>
+      </div>
+      <div className="p-2 md:p-4">
+        <SiteRenderer
+          draft={localizeSiteDraft(previewDraft, activeLocale)}
+          vertical={site.vertical}
+          theme={{
+            id: selection.themeId,
+            version: `restaurant-renderer-v${selection.rendererVersion}`,
+            selection,
+          }}
+          locale={activeLocale}
+          localeBasePath={`/dashboard/themes/${selection.themeId}`}
+          availableLocales={locales}
+        />
+      </div>
+    </main>
+  );
+}

--- a/src/app/dashboard/themes/[themeId]/page.tsx
+++ b/src/app/dashboard/themes/[themeId]/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import { OwnerThemePreview } from "@/app/dashboard/themes/[themeId]/owner-theme-preview";
+
+export const metadata: Metadata = {
+  title: "Owner theme preview",
+  robots: { index: false, follow: false },
+};
+
+export default async function OwnerThemePreviewPage({
+  params,
+}: {
+  params: Promise<{ themeId: string }>;
+}) {
+  const { themeId } = await params;
+  return <OwnerThemePreview themeId={themeId} />;
+}

--- a/src/lib/site-persistence.ts
+++ b/src/lib/site-persistence.ts
@@ -2,6 +2,7 @@ import { Prisma } from "@/generated/prisma/client";
 import { Vertical } from "@/generated/prisma/enums";
 import { getDb } from "@/lib/db";
 import { LEGACY_THEME_VERSION } from "@/lib/site-draft";
+import { restaurantSiteTheme } from "@/lib/site-themes/restaurant/configuration";
 import {
   buildImportUrls,
   importFailureMessage,
@@ -581,6 +582,7 @@ function editableSiteScalarData(
   const config = resolveVerticalConfig(vertical);
   const attributes = config.attributesSchema.parse(draft.attributes);
   const theme = config.templates.resolve(attributes);
+  const registeredTheme = restaurantSiteTheme(vertical, attributes);
   return {
     name: draft.name,
     eyebrow: draft.eyebrow,
@@ -594,8 +596,11 @@ function editableSiteScalarData(
     // only place vertical-specific data lives, so an unvalidated write here is a
     // read-path crash later.
     attributes: attributes as Prisma.InputJsonValue,
-    draftTheme: { id: theme.id } as Prisma.InputJsonValue,
-    draftThemeVersion: LEGACY_THEME_VERSION,
+    draftTheme: (registeredTheme?.selection ?? {
+      id: theme.id,
+    }) as Prisma.InputJsonValue,
+    draftThemeVersion:
+      registeredTheme?.version ?? LEGACY_THEME_VERSION,
     draftPalette: draft.palette as Prisma.InputJsonValue,
     autoEnhanceImages: draft.autoEnhanceImages,
     defaultLocale: draft.defaultLocale,

--- a/src/lib/site-publication.postgres.test.ts
+++ b/src/lib/site-publication.postgres.test.ts
@@ -20,9 +20,13 @@ const actor = { id: userId, email: `${userId}@example.test` };
 let db: ReturnType<typeof import("@/lib/db").getDb>;
 let sampleSiteDraft: typeof import("@/lib/restaurant").sampleSiteDraft;
 let publishSiteDraft: typeof import("@/lib/site-publication").publishSiteDraft;
+let rollbackPublishedSiteVersion: typeof import("@/lib/site-publication").rollbackPublishedSiteVersion;
 let updateSiteDraft: typeof import("@/lib/site-persistence").updateSiteDraft;
 let findPublishedSiteView: typeof import("@/lib/sites").findPublishedSiteView;
 let findSiteView: typeof import("@/lib/sites").findSiteView;
+let localizeSiteDraft: typeof import("@/lib/site-draft").localizeSiteDraft;
+let restaurantThemeFixtures: typeof import("@/lib/site-themes/restaurant/fixtures").restaurantThemeFixtures;
+let selectOwnerRestaurantTheme: typeof import("@/lib/site-themes/restaurant/selection").selectOwnerRestaurantTheme;
 let Vertical: typeof import("@/generated/prisma/enums").Vertical;
 
 describe.skipIf(!enabled)("safe draft and publish PostgreSQL integration", () => {
@@ -32,14 +36,27 @@ describe.skipIf(!enabled)("safe draft and publish PostgreSQL integration", () =>
     const publication = await import("@/lib/site-publication");
     const persistence = await import("@/lib/site-persistence");
     const sites = await import("@/lib/sites");
+    const siteDraft = await import("@/lib/site-draft");
+    const themeFixtures = await import(
+      "@/lib/site-themes/restaurant/fixtures"
+    );
+    const themeSelection = await import(
+      "@/lib/site-themes/restaurant/selection"
+    );
     const enums = await import("@/generated/prisma/enums");
 
     db = database.getDb();
     sampleSiteDraft = restaurant.sampleSiteDraft;
     publishSiteDraft = publication.publishSiteDraft;
+    rollbackPublishedSiteVersion =
+      publication.rollbackPublishedSiteVersion;
     updateSiteDraft = persistence.updateSiteDraft;
     findPublishedSiteView = sites.findPublishedSiteView;
     findSiteView = sites.findSiteView;
+    localizeSiteDraft = siteDraft.localizeSiteDraft;
+    restaurantThemeFixtures = themeFixtures.restaurantThemeFixtures;
+    selectOwnerRestaurantTheme =
+      themeSelection.selectOwnerRestaurantTheme;
     Vertical = enums.Vertical;
 
     await db.user.create({
@@ -377,5 +394,132 @@ describe.skipIf(!enabled)("safe draft and publish PostgreSQL integration", () =>
         }),
       ),
     ).rejects.toThrow("Published site versions are immutable");
+  });
+
+  test("preserves an owner theme through save, reload, locale, publish and rollback", async () => {
+    const fixture = restaurantThemeFixtures["counter-service"];
+    const ownerSelection = selectOwnerRestaurantTheme(
+      fixture.profile,
+      "after-dark",
+    );
+    const ownerDraft = {
+      ...fixture,
+      slug,
+      attributes: {
+        ...fixture.attributes,
+        themeSelection: ownerSelection,
+      },
+      translations: [
+        {
+          locale: "fr",
+          attributes: { cuisine: "Comptoir italien" },
+          eyebrow: "Des parts, des pizzas entières, sans détour",
+          description:
+            "Un comptoir de quartier pour des pizzas au levain, des boissons fraîches et une collecte rapide.",
+          catalogSections: fixture.catalogSections.map((section) => ({
+            name: section.name,
+            description: section.description,
+            items: section.items.map((item) => ({
+              name: item.name,
+              description: item.description,
+              attributes: item.attributes,
+            })),
+          })),
+          integrationLabels: fixture.integrations.map(
+            (integration) => integration.label,
+          ),
+        },
+      ],
+    };
+
+    await updateSiteDraft(slug, ownerDraft, Vertical.RESTAURANT);
+    const reloaded = await findSiteView(slug);
+    expect(reloaded?.theme).toEqual({
+      id: "after-dark",
+      version: "restaurant-renderer-v1",
+      selection: ownerSelection,
+    });
+    expect(reloaded?.draft.attributes.themeSelection).toEqual(ownerSelection);
+    expect(
+      localizeSiteDraft(reloaded!.draft, "fr").attributes.themeSelection,
+    ).toEqual(ownerSelection);
+
+    const ownerPublished = await publishSiteDraft({
+      siteId,
+      slug,
+      vertical: Vertical.RESTAURANT,
+      actor,
+      changeSummary: "Publish owner-selected after-dark theme",
+    });
+    expect(ownerPublished.theme).toEqual({
+      id: "after-dark",
+      version: "restaurant-renderer-v1",
+    });
+    const storedOwnerVersion = await db.siteVersion.findUniqueOrThrow({
+      where: { id: ownerPublished.id },
+      select: {
+        theme: true,
+        themeVersion: true,
+        translations: true,
+      },
+    });
+    expect(storedOwnerVersion).toMatchObject({
+      theme: ownerSelection,
+      themeVersion: "restaurant-renderer-v1",
+      translations: ownerDraft.translations,
+    });
+
+    const nextSelection = selectOwnerRestaurantTheme(
+      fixture.profile,
+      "terroir-editorial",
+    );
+    await updateSiteDraft(
+      slug,
+      {
+        ...ownerDraft,
+        attributes: {
+          ...ownerDraft.attributes,
+          themeSelection: nextSelection,
+        },
+      },
+      Vertical.RESTAURANT,
+    );
+    await publishSiteDraft({
+      siteId,
+      slug,
+      vertical: Vertical.RESTAURANT,
+      actor,
+      changeSummary: "Publish a later owner theme",
+    });
+
+    const rolledBack = await rollbackPublishedSiteVersion({
+      siteId,
+      slug,
+      vertical: Vertical.RESTAURANT,
+      targetSiteVersionId: ownerPublished.id,
+      actor,
+    });
+    expect(rolledBack.id).not.toBe(ownerPublished.id);
+    expect(rolledBack.theme).toEqual(ownerPublished.theme);
+    expect((await findPublishedSiteView(slug))?.draft.attributes.themeSelection)
+      .toEqual(ownerSelection);
+    expect(
+      localizeSiteDraft((await findPublishedSiteView(slug))!.draft, "fr")
+        .attributes.themeSelection,
+    ).toEqual(ownerSelection);
+    // Rollback moves only the public pointer; the owner's later private draft
+    // remains available for another edit or publish.
+    expect((await findSiteView(slug))?.draft.attributes.themeSelection).toEqual(
+      nextSelection,
+    );
+    expect(
+      await db.auditEvent.count({
+        where: {
+          siteId,
+          type: "site.rolled_back",
+          actor: actor.id,
+        },
+      }),
+    ).toBe(1);
   });
 });

--- a/src/lib/site-publication.ts
+++ b/src/lib/site-publication.ts
@@ -2,6 +2,7 @@ import "server-only";
 import { Prisma } from "@/generated/prisma/client";
 import { getDb } from "@/lib/db";
 import {
+  projectPublishedSiteVersion,
   projectSiteDraft,
   siteDraftRelations,
 } from "@/lib/sites";
@@ -25,6 +26,18 @@ export type PublishedSiteVersion = {
   id: string;
   version: number;
   publishedAt: Date;
+  theme: {
+    id: string;
+    version: string;
+  };
+};
+
+export type SitePublicationHistoryItem = {
+  id: string;
+  version: number;
+  publishedAt: Date;
+  changeSummary: string;
+  current: boolean;
   theme: {
     id: string;
     version: string;
@@ -162,6 +175,205 @@ export async function publishSiteDraft(
   }
 
   throw new Error("Site could not be published");
+}
+
+export async function getSitePublicationHistory(
+  siteId: string,
+): Promise<SitePublicationHistoryItem[]> {
+  if (!process.env.DATABASE_URL) return [];
+  const site = await getDb().site.findUnique({
+    where: { id: siteId },
+    select: {
+      publishedSiteVersionId: true,
+      siteVersions: {
+        where: { publishedAt: { not: null } },
+        orderBy: { version: "desc" },
+        take: 20,
+        select: {
+          id: true,
+          version: true,
+          vertical: true,
+          theme: true,
+          themeVersion: true,
+          palette: true,
+          content: true,
+          translations: true,
+          integrations: true,
+          publishedAt: true,
+          changeSummary: true,
+        },
+      },
+    },
+  });
+  if (!site) return [];
+
+  return site.siteVersions.flatMap((version) => {
+    try {
+      const projected = projectPublishedSiteVersion(version);
+      if (!projected || !version.publishedAt) return [];
+      return [
+        {
+          id: version.id,
+          version: version.version,
+          publishedAt: version.publishedAt,
+          changeSummary: version.changeSummary ?? "Published site",
+          current: version.id === site.publishedSiteVersionId,
+          theme: {
+            id: projected.theme.id,
+            version: projected.theme.version,
+          },
+        },
+      ];
+    } catch {
+      // An adopted legacy database can contain incomplete historical rows.
+      // They remain immutable, but must not make the owner's whole dashboard
+      // unavailable or become rollback candidates.
+      return [];
+    }
+  });
+}
+
+export async function rollbackPublishedSiteVersion(input: {
+  siteId: string;
+  slug: string;
+  vertical: VerticalId;
+  targetSiteVersionId: string;
+  actor: {
+    id: string;
+    email: string;
+  };
+  now?: Date;
+}): Promise<PublishedSiteVersion> {
+  if (!process.env.DATABASE_URL) {
+    throw new Error("Site publishing is temporarily unavailable");
+  }
+
+  const db = getDb();
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      return await db.$transaction(
+        async (tx) => {
+          const site = await tx.site.findFirst({
+            where: {
+              id: input.siteId,
+              slug: input.slug,
+              vertical: input.vertical,
+            },
+            select: {
+              status: true,
+              publishedSiteVersionId: true,
+              siteVersions: {
+                where: {
+                  id: input.targetSiteVersionId,
+                  publishedAt: { not: null },
+                },
+                take: 1,
+                select: {
+                  id: true,
+                  version: true,
+                  vertical: true,
+                  theme: true,
+                  themeVersion: true,
+                  palette: true,
+                  content: true,
+                  translations: true,
+                  integrations: true,
+                  publishedAt: true,
+                  changeSummary: true,
+                },
+              },
+            },
+          });
+          if (!site) throw new Error("Site not found");
+          if (site.status !== "CLAIMED" && site.status !== "LIVE") {
+            throw new SitePublicationStateError();
+          }
+          const target = site.siteVersions[0];
+          if (!target) throw new Error("Published site version not found");
+          const projected = projectPublishedSiteVersion(target);
+          if (!projected || target.vertical !== input.vertical) {
+            throw new Error("Published site version is invalid");
+          }
+
+          const latest = await tx.siteVersion.findFirst({
+            where: { siteId: input.siteId },
+            orderBy: { version: "desc" },
+            select: { version: true },
+          });
+          const publishedAt = input.now ?? new Date();
+          const version = await tx.siteVersion.create({
+            data: {
+              siteId: input.siteId,
+              version: (latest?.version ?? 0) + 1,
+              vertical: target.vertical,
+              theme: projected.theme.selection as Prisma.InputJsonValue,
+              themeVersion: projected.theme.version,
+              palette: target.palette as Prisma.InputJsonValue,
+              content: target.content as Prisma.InputJsonValue,
+              translations: target.translations as Prisma.InputJsonValue,
+              integrations: target.integrations as Prisma.InputJsonValue,
+              publishedAt,
+              publishedBy: input.actor.id,
+              changeSummary: `Rollback to v${target.version}: ${target.changeSummary ?? "Published site"}`.slice(
+                0,
+                280,
+              ),
+            },
+            select: { id: true, version: true },
+          });
+
+          const moved = await tx.site.updateMany({
+            where: {
+              id: input.siteId,
+              slug: input.slug,
+              vertical: input.vertical,
+            },
+            data: {
+              publishedSiteVersionId: version.id,
+              status: "LIVE",
+            },
+          });
+          if (moved.count !== 1) {
+            throw new Error("Site could not be rolled back");
+          }
+
+          await tx.auditEvent.create({
+            data: {
+              type: "site.rolled_back",
+              actor: input.actor.id,
+              siteId: input.siteId,
+              metadata: {
+                siteVersionId: version.id,
+                version: version.version,
+                targetSiteVersionId: target.id,
+                targetVersion: target.version,
+                previousSiteVersionId: site.publishedSiteVersionId,
+                actorEmail: input.actor.email,
+                themeId: projected.theme.id,
+                themeVersion: projected.theme.version,
+              },
+            },
+          });
+
+          return {
+            id: version.id,
+            version: version.version,
+            publishedAt,
+            theme: {
+              id: projected.theme.id,
+              version: projected.theme.version,
+            },
+          };
+        },
+        { isolationLevel: "Serializable" },
+      );
+    } catch (error) {
+      if (attempt < 2 && isRetryablePublishError(error)) continue;
+      throw error;
+    }
+  }
+
+  throw new Error("Site could not be rolled back");
 }
 
 function isRetryablePublishError(error: unknown): boolean {

--- a/src/lib/site-themes/restaurant/configuration.ts
+++ b/src/lib/site-themes/restaurant/configuration.ts
@@ -1,0 +1,31 @@
+import { Vertical } from "@/generated/prisma/enums";
+import type { SiteThemeView } from "@/lib/site-draft";
+import {
+  parseRestaurantThemeSelection,
+} from "@/lib/site-themes/restaurant/selection";
+import type { VerticalId } from "@/lib/verticals/types";
+
+export function restaurantRendererVersionId(rendererVersion: number): string {
+  return `restaurant-renderer-v${rendererVersion}`;
+}
+
+/**
+ * Resolves the registered restaurant renderer stored in the vertical
+ * attributes bag. Returning null is intentional: legacy restaurants must keep
+ * their established cuisine-era renderer until an owner or a new import opts
+ * them into the versioned registry.
+ */
+export function restaurantSiteTheme(
+  vertical: VerticalId,
+  attributes: Record<string, unknown>,
+): SiteThemeView | null {
+  if (vertical !== Vertical.RESTAURANT) return null;
+  const selection = parseRestaurantThemeSelection(attributes.themeSelection);
+  if (!selection) return null;
+
+  return {
+    id: selection.themeId,
+    version: restaurantRendererVersionId(selection.rendererVersion),
+    selection,
+  };
+}

--- a/src/lib/site-themes/restaurant/contracts.ts
+++ b/src/lib/site-themes/restaurant/contracts.ts
@@ -135,7 +135,7 @@ export const restaurantThemeSelectionSchema = z
     schemaVersion: z.literal(RESTAURANT_THEME_SCHEMA_VERSION),
     themeId: restaurantThemeIdSchema,
     rendererVersion: z.literal(RESTAURANT_THEME_RENDERER_VERSION),
-    source: z.enum(["ai", "deterministic"]),
+    source: z.enum(["ai", "deterministic", "owner"]),
     confidence: z.number().min(0).max(1),
     reasons: z.array(selectionReasonSchema).min(1).max(4),
     alternatives: z.array(restaurantThemeIdSchema).length(2),

--- a/src/lib/site-themes/restaurant/selection.ts
+++ b/src/lib/site-themes/restaurant/selection.ts
@@ -103,7 +103,7 @@ export function scoreRestaurantThemes(
 
 function resolvedSelection(
   input: RestaurantAiThemeOutput,
-  source: "ai" | "deterministic",
+  source: "ai" | "deterministic" | "owner",
 ): RestaurantThemeSelection {
   const manifest = getRestaurantThemeManifest(input.themeId);
   return restaurantThemeSelectionSchema.parse({
@@ -166,6 +166,52 @@ export function selectRestaurantTheme(
   return parsed.success
     ? resolvedSelection(parsed.data, "ai")
     : selectDeterministicRestaurantTheme(profile);
+}
+
+/**
+ * Converts an owner choice into the same closed, versioned contract used by
+ * automatic selection. Tokens always come from the registered theme manifest;
+ * the dashboard can choose a renderer, but it cannot smuggle arbitrary style
+ * values into the public site.
+ */
+export function selectOwnerRestaurantTheme(
+  profileInput: RestaurantDesignProfile | undefined,
+  themeId: RestaurantThemeId,
+): RestaurantThemeSelection {
+  const profile =
+    restaurantDesignProfileSchema.safeParse(profileInput).data ??
+    DEFAULT_RESTAURANT_DESIGN_PROFILE;
+  const automatic = selectDeterministicRestaurantTheme(profile);
+  const alternatives = [
+    automatic.themeId,
+    ...automatic.alternatives,
+  ].filter((candidate) => candidate !== themeId);
+  const [firstAlternative, secondAlternative] = alternatives;
+  if (!firstAlternative || !secondAlternative) {
+    throw new Error(
+      "Owner theme selection requires at least three registered themes",
+    );
+  }
+
+  return resolvedSelection(
+    {
+      themeId,
+      confidence: 1,
+      reasons: ["Selected explicitly by the restaurant owner"],
+      alternatives: [firstAlternative, secondAlternative],
+      tokens: {},
+    },
+    "owner",
+  );
+}
+
+export function restoreAutomaticRestaurantTheme(
+  profileInput: RestaurantDesignProfile | undefined,
+): RestaurantThemeSelection {
+  const profile =
+    restaurantDesignProfileSchema.safeParse(profileInput).data ??
+    DEFAULT_RESTAURANT_DESIGN_PROFILE;
+  return selectDeterministicRestaurantTheme(profile);
 }
 
 /**

--- a/src/lib/site-themes/restaurant/theme-registry.test.tsx
+++ b/src/lib/site-themes/restaurant/theme-registry.test.tsx
@@ -11,12 +11,15 @@ import {
 import { restaurantThemeFixtures } from "@/lib/site-themes/restaurant/fixtures";
 import {
   findRestaurantThemeManifest,
+  getRestaurantThemeManifest,
   listRestaurantThemeManifests,
 } from "@/lib/site-themes/restaurant/registry";
 import {
   normalizeGeneratedRestaurantThemeSelection,
   parseRestaurantThemeSelection,
+  restoreAutomaticRestaurantTheme,
   scoreRestaurantThemes,
+  selectOwnerRestaurantTheme,
   selectRestaurantTheme,
 } from "@/lib/site-themes/restaurant/selection";
 import { colorContrast } from "@/lib/site-themes/restaurant/tokens";
@@ -162,6 +165,34 @@ describe("bounded restaurant theme selection", () => {
     expect(unknown).toEqual(absent);
     expect(injected).toEqual(absent);
     expect(absent.source).toBe("deterministic");
+  });
+
+  it("lets an owner override automatic selection and restore the bounded match", () => {
+    const automatic = restoreAutomaticRestaurantTheme(takeaway);
+    const selected = selectOwnerRestaurantTheme(
+      takeaway,
+      "terroir-editorial",
+    );
+
+    expect(automatic).toMatchObject({
+      themeId: "counter-service",
+      source: "deterministic",
+      rendererVersion: 1,
+    });
+    expect(selected).toMatchObject({
+      themeId: "terroir-editorial",
+      source: "owner",
+      confidence: 1,
+      rendererVersion: 1,
+    });
+    expect(selected.alternatives).toEqual([
+      "counter-service",
+      "after-dark",
+    ]);
+    expect(selected.tokens).toEqual(
+      getRestaurantThemeManifest("terroir-editorial").safeDefaultTokens,
+    );
+    expect(restoreAutomaticRestaurantTheme(takeaway)).toEqual(automatic);
   });
 
   it("does not upgrade bare or version-incompatible model output", () => {

--- a/src/lib/sites.ts
+++ b/src/lib/sites.ts
@@ -8,6 +8,11 @@ import type {
   SiteThemeView,
 } from "@/lib/site-draft";
 import { LEGACY_THEME_VERSION } from "@/lib/site-draft";
+import {
+  restaurantRendererVersionId,
+  restaurantSiteTheme,
+} from "@/lib/site-themes/restaurant/configuration";
+import { parseRestaurantThemeSelection } from "@/lib/site-themes/restaurant/selection";
 import { sampleSiteDraft } from "@/lib/verticals/restaurant/schema";
 import {
   resolveVerticalConfig,
@@ -44,6 +49,17 @@ export type SiteView = {
   vertical: VerticalId;
   draft: SiteDraftView;
   theme: SiteThemeView;
+};
+
+export type PublishedSiteVersionRecord = {
+  vertical: VerticalId;
+  theme: Prisma.JsonValue;
+  themeVersion: string;
+  palette: Prisma.JsonValue;
+  content: Prisma.JsonValue;
+  translations: Prisma.JsonValue;
+  integrations: Prisma.JsonValue;
+  publishedAt: Date | null;
 };
 
 /**
@@ -108,7 +124,13 @@ export function projectSiteDraft(site: PersistedSiteDraftRecord): LoadedSite {
     vertical: site.vertical,
     config,
     draft,
-    theme: editableTheme(config, attributes, site.draftTheme, site.draftThemeVersion),
+    theme: editableTheme(
+      site.vertical,
+      config,
+      attributes,
+      site.draftTheme,
+      site.draftThemeVersion,
+    ),
   };
 }
 
@@ -155,8 +177,13 @@ export async function findPublishedSiteView(
     },
   });
   const version = site?.publishedSiteVersion;
-  if (!version?.publishedAt) return null;
+  return version ? projectPublishedSiteVersion(version) : null;
+}
 
+export function projectPublishedSiteVersion(
+  version: PublishedSiteVersionRecord,
+): SiteView | null {
+  if (!version.publishedAt) return null;
   const config = resolveVerticalConfig(version.vertical);
   const content = jsonRecord(version.content);
   const draft = config.draftSchema.parse({
@@ -165,7 +192,13 @@ export async function findPublishedSiteView(
     translations: version.translations,
     integrations: version.integrations,
   }) as SiteDraftView;
-  const theme = publishedTheme(config, version.theme, version.themeVersion);
+  const theme = publishedTheme(
+    version.vertical,
+    config,
+    version.theme,
+    version.themeVersion,
+    draft.attributes,
+  );
   if (!theme) return null;
 
   return { vertical: version.vertical, draft, theme };
@@ -188,6 +221,7 @@ export async function findSiteView(slug: string): Promise<SiteView | null> {
       vertical: Vertical.RESTAURANT,
       draft,
       theme: editableTheme(
+        Vertical.RESTAURANT,
         config,
         attributes,
         {},
@@ -219,16 +253,26 @@ export async function getSiteView(slug: string): Promise<SiteView> {
   return {
     vertical: Vertical.RESTAURANT,
     draft,
-    theme: editableTheme(config, attributes, {}, LEGACY_THEME_VERSION),
+    theme: editableTheme(
+      Vertical.RESTAURANT,
+      config,
+      attributes,
+      {},
+      LEGACY_THEME_VERSION,
+    ),
   };
 }
 
 function editableTheme(
+  vertical: VerticalId,
   config: ErasedVerticalConfig,
   attributes: Record<string, unknown>,
   value: Prisma.JsonValue,
   version: string,
 ): SiteThemeView {
+  const registeredTheme = restaurantSiteTheme(vertical, attributes);
+  if (registeredTheme) return registeredTheme;
+
   const selection = jsonRecord(value);
   const storedId = typeof selection.id === "string" ? selection.id : null;
   const resolvedId = config.templates.resolve(attributes).id;
@@ -244,10 +288,34 @@ function editableTheme(
 }
 
 function publishedTheme(
+  vertical: VerticalId,
   config: ErasedVerticalConfig,
   value: Prisma.JsonValue,
   version: string,
+  attributes: Record<string, unknown>,
 ): SiteThemeView | null {
+  if (vertical === Vertical.RESTAURANT) {
+    const storedSelection = parseRestaurantThemeSelection(value);
+    if (storedSelection) {
+      const expectedVersion = restaurantRendererVersionId(
+        storedSelection.rendererVersion,
+      );
+      if (version !== expectedVersion) return null;
+      return {
+        id: storedSelection.themeId,
+        version,
+        selection: storedSelection,
+      };
+    }
+
+    // PR #64 stored the structured selection inside the immutable content
+    // snapshot before the dedicated theme column was wired to the registry.
+    // Read those snapshots compatibly; the next owner Save/Publish promotes the
+    // same validated selection into the dedicated versioned theme fields.
+    const contentTheme = restaurantSiteTheme(vertical, attributes);
+    if (contentTheme) return contentTheme;
+  }
+
   const selection = jsonRecord(value);
   const id = typeof selection.id === "string" ? selection.id : null;
   if (!id || !(id in config.templates.definitions) || !version) return null;


### PR DESCRIPTION
## Summary

- add an authenticated Design workspace where restaurant owners can preview every compatible registered theme with their own content, select one, or restore deterministic automatic matching without publishing
- persist owner selection as bounded, versioned restaurant configuration and promote the exact renderer identity into draft and immutable published theme fields
- add published history and authorization-scoped rollback that creates a new immutable snapshot while leaving the private draft untouched
- preserve legacy rendering and PR #64 snapshots while upgrading structured selections on the next save/publish
- cover owner override, automatic reset, locale preservation, and save → reload → publish → rollback semantics

## Verification

- `bun test` — 204 pass, 12 database-gated skips, 0 fail
- `bunx next typegen`
- `bunx tsc --noEmit`
- `bun run lint` — 0 errors; one pre-existing generated workflow warning
- `git diff --check`
- production build reached Next.js optimized build generation but produced no further output for more than five minutes; it was terminated and PR CI is the broad build gate
- the real-Postgres workflow test is included behind the repository's existing `SITE_PUBLICATION_POSTGRES_TEST=1` gate; this shell has no `DATABASE_URL`

## Planning

`planning_degraded`: authenticated genfeedai Fable and Opus planning calls both returned 429, so implementation proceeded from the bounded issue acceptance criteria without fabricating approval.

Closes #19
