### PR TITLE
feat(marketing): give Cornershopdev a dark technical identity

### DIFF
--- a/docs/brand/cornershopdev/DESIGN.md
+++ b/docs/brand/cornershopdev/DESIGN.md
@@ -1,39 +1,40 @@
 ---
-version: "alpha"
+version: "beta"
 name: Cornershopdev
-description: Friendly factory identity built from a folded storefront tile and a clear C.
+description: Dark technical factory identity built around a folded storefront tile and a clear C.
 colors:
-  primary: "#0D4A39"
-  on-primary: "#F7F1E7"
-  accent: "#F15A3D"
-  background: "#F7F1E7"
-  foreground: "#1F2622"
-  muted: "#646863"
-  border: "#D7D2C8"
-  on-dark: "#FFFFFF"
+  primary: "#F7F7F4"
+  on-primary: "#050505"
+  accent: "#FF775F"
+  signal: "#74D7A4"
+  background: "#050505"
+  surface: "#090909"
+  foreground: "#F7F7F4"
+  muted: "#929292"
+  border: "#262626"
 typography:
   display:
-    fontFamily: Instrument Serif
-    fontSize: 64px
-    fontWeight: 400
-    lineHeight: 0.94
-    letterSpacing: -0.04em
+    fontFamily: Geist
+    fontSize: 72px
+    fontWeight: 600
+    lineHeight: 0.88
+    letterSpacing: -0.065em
   body-md:
     fontFamily: Geist
     fontSize: 16px
     fontWeight: 400
     lineHeight: 1.7
-  label-caps:
-    fontFamily: Geist
-    fontSize: 12px
-    fontWeight: 600
-    lineHeight: 1
-    letterSpacing: 0.16em
+  data-label:
+    fontFamily: Geist Mono
+    fontSize: 11px
+    fontWeight: 500
+    lineHeight: 1.4
+    letterSpacing: 0.12em
 rounded:
-  sm: 8px
-  md: 14px
-  lg: 24px
-  xl: 32px
+  sm: 6px
+  md: 8px
+  lg: 12px
+  xl: 16px
 spacing:
   xs: 4px
   sm: 8px
@@ -43,8 +44,8 @@ spacing:
   2xl: 48px
 components:
   brand-mark:
-    backgroundColor: "{colors.primary}"
-    textColor: "{colors.on-primary}"
+    backgroundColor: "#0D4A39"
+    textColor: "#F7F1E7"
     rounded: "{rounded.lg}"
     size: 36px
   button-primary:
@@ -55,17 +56,20 @@ components:
     height: 44px
   accent-detail:
     backgroundColor: "{colors.accent}"
-    textColor: "{colors.foreground}"
+    textColor: "{colors.on-primary}"
+  status-live:
+    backgroundColor: "{colors.signal}"
+    textColor: "{colors.on-primary}"
   surface-default:
     backgroundColor: "{colors.background}"
+    textColor: "{colors.foreground}"
+  surface-panel:
+    backgroundColor: "{colors.surface}"
     textColor: "{colors.foreground}"
   body-copy-muted:
     backgroundColor: "{colors.background}"
     textColor: "{colors.muted}"
     typography: "{typography.body-md}"
-  surface-dark:
-    backgroundColor: "{colors.primary}"
-    textColor: "{colors.on-dark}"
   divider:
     backgroundColor: "{colors.border}"
     textColor: "{colors.foreground}"
@@ -73,61 +77,109 @@ components:
 
 ## Overview
 
-Cornershopdev is the factory behind many focused storefront products. Its mark
-combines a folded page, a small shop awning and a direct C. The result should
-feel useful, modular and human—not like infrastructure software or a generic
-shopping app.
+Cornershopdev is the technical factory behind focused storefront products. Its
+public site should look like the system it describes: precise, modular,
+inspectable and fast. Near-black surfaces, crisp sans typography, restrained
+data labels, and architecture motifs separate the factory from the warmer,
+industry-specific brands it powers.
+
+The identity is inspired by the clarity of modern developer tooling, not by any
+single product composition. It must remain original and should never reproduce a
+third party's copy, assets, component geometry or distinctive page structure.
 
 ## Colors
 
-- **Factory green (`#0D4A39`):** the structural tile, primary controls and dark
-  brand surfaces.
-- **Coral (`#F15A3D`):** the three awning tabs and small, deliberate accents.
-- **Warm cream (`#F7F1E7`):** the C, page background and breathing room.
-- **Foreground (`#1F2622`):** near-black green for text.
-- **Muted (`#646863`):** supporting copy with AA contrast on cream.
+- **Factory black (`#050505`):** the default Cornershopdev marketing surface.
+- **Panel black (`#090909`):** subtle separation for system panels and cards.
+- **Foreground (`#F7F7F4`):** warm-white primary type and primary controls.
+- **Muted (`#929292`):** supporting copy with WCAG AA contrast on factory black.
+- **Border (`#262626`):** quiet dividers and technical grid lines.
+- **Coral (`#FF775F`):** brand accent for commands, labels and directional cues.
+- **Signal green (`#74D7A4`):** operational status only: live, ready or healthy.
 
-The three logo colors are exact flat sRGB values. Do not sample softened colors
-from the generated concept board.
+The existing logo keeps its exact factory green (`#0D4A39`), coral
+(`#F15A3D`) and cream (`#F7F1E7`). The brighter page accents are interface
+tokens chosen for contrast on black; they do not modify the raster mark.
 
 ## Typography
 
-Instrument Serif carries large factory statements. Geist handles navigation,
-body copy, controls and technical explanations. Geist Mono is reserved for
-commands, schemas and implementation details.
+Geist carries display headlines, navigation, body copy, and controls. Large
+headlines are compact, sans-serif, and tightly tracked. Instrument Serif belongs
+to hospitality and other editorial niche identities; do not use it on the
+Cornershopdev factory homepage.
+
+Geist Mono labels commands, paths, statuses, registry counts, versions and
+pipeline stages. It should clarify real system structure, not decorate every
+sentence.
 
 ## Layout
 
-Use generous cream space and a 32px grid. The factory explains a system, so
-layouts should make hierarchy and relationships obvious without looking like an
-enterprise architecture diagram.
+Use strong horizontal boundaries, a 48px technical grid for major factory
+surfaces, and asymmetric editorial-to-system compositions. Sections should make
+the relationship between source, vertical schema, theme and published site
+immediately legible.
+
+The mobile layout must preserve the hierarchy at 390px without horizontal
+overflow. System diagrams may stack, but their labels and directional flow must
+remain understandable.
 
 ## Elevation & Depth
 
-Use borders and tonal contrast before shadows. The logo is always flat: no
-lighting, gradients, bevels, grain or mockup texture.
+Prefer borders, black-on-black tonal separation and restrained grid lines.
+Technical panels may use one broad dark shadow to separate them from the page.
+Ambient coral or green light may appear at very low opacity behind a hero
+diagram; it must never reduce text contrast or resemble glossy product chrome.
+
+## Motion
+
+Motion communicates state. A cursor blink or slow system scan is acceptable;
+continuous decorative movement is not. Every animation must stop under
+`prefers-reduced-motion`.
 
 ## Shapes
 
-The mark uses one clipped page tile, exactly three awning tabs and one C. Keep
-the 45-degree lower-right fold and equal transparent canvas padding. Do not add
-windows, doors, carts, bags, gears or extra modular blocks.
+Factory interface cards use tighter corners than the niche storefronts. Data
+panels and architecture modules are usually rectangular. Pills are reserved for
+compact status lines.
+
+The mark itself still uses one clipped page tile, exactly three awning tabs and
+one C. Keep the 45-degree lower-right fold and equal transparent canvas padding.
+Do not add windows, doors, carts, bags, gears or extra modular blocks.
 
 ## Components
 
-- **Brand mark:** `public/brand/cornershopdev/logo-square.png` is the 1024 ×
-  1024 transparent RGBA master.
+- **Brand mark:** `public/brand/cornershopdev/logo-square.png` is the 1024 × 1024
+  transparent RGBA master.
 - **Header mark:** use the 512px derivative; render it at 36px.
 - **Browser chrome:** use the dedicated 32px favicon and 180px Apple touch icon.
-- **Primary button:** factory green with cream text.
-- **Accent:** coral is supporting color, never the dominant page fill.
+- **Primary button:** warm-white background, factory-black text, 44px height.
+- **System panel:** black tonal surface, one-pixel border, mono data labels.
+- **Status:** signal green means a real operational state, never a generic accent.
+- **Grid:** one-pixel low-opacity lines at 48px; denser 24px lines may support a
+  bounded module section.
+
+## Scope
+
+This dark technical system belongs to `cornershop.dev` marketing surfaces only.
+It must not globally retheme:
+
+- Restofrontapp or any other niche marketing site.
+- Restaurant theme previews or generated customer websites.
+- Customer workspaces, claim screens, operator tools or authentication screens.
+- Brand marks and browser assets owned by a niche.
+
+Opt-in variants on shared components must preserve their existing default
+appearance.
 
 ## Do's and Don'ts
 
+- Do make the factory/niche distinction obvious at first glance.
+- Do expose real registry, theme-library and pipeline concepts.
+- Do keep primary and supporting copy at WCAG AA contrast on black.
+- Do route visitors clearly to live niche products, themes and source.
 - Do preserve the folded lower-right corner and three-tab awning.
-- Do keep the C readable at 16px.
-- Do use the exact factory green, coral and cream values.
 - Do keep every raster export square with a transparent exterior.
-- Don't add gradients, texture, highlights, shadows or an enclosing app tile.
-- Don't turn the mark into a generic shopping bag or SaaS cube.
-- Don't use the Cornershopdev identity on a niche storefront.
+- Don't use the warm paper grid, editorial serif scale or hospitality palette.
+- Don't fake command output, customer counts, uptime or deployment activity.
+- Don't copy third-party code, wording, assets or recognizable compositions.
+- Don't use the Cornershopdev identity on a niche storefront or generated site.

--- a/src/app/factory-home.module.css
+++ b/src/app/factory-home.module.css
@@ -1,0 +1,110 @@
+.factoryShell {
+  --factory-bg: #050505;
+  --factory-line: rgb(255 255 255 / 0.07);
+  background: var(--factory-bg);
+  color: #f7f7f4;
+  color-scheme: dark;
+  isolation: isolate;
+}
+
+.factoryShell ::selection {
+  background: #ff775f;
+  color: #050505;
+}
+
+.factoryGrid {
+  position: relative;
+  background-color: #050505;
+  background-image:
+    linear-gradient(to right, var(--factory-line) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--factory-line) 1px, transparent 1px);
+  background-position: center;
+  background-size: 48px 48px;
+}
+
+.factoryGrid::before {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  background:
+    radial-gradient(circle at 18% 18%, rgb(241 90 61 / 0.11), transparent 28rem),
+    radial-gradient(circle at 78% 42%, rgb(13 74 57 / 0.2), transparent 30rem);
+  content: "";
+  pointer-events: none;
+}
+
+.moduleGrid {
+  background-color: #060606;
+  background-image:
+    linear-gradient(to right, rgb(255 255 255 / 0.035) 1px, transparent 1px),
+    linear-gradient(to bottom, rgb(255 255 255 / 0.035) 1px, transparent 1px);
+  background-size: 24px 24px;
+}
+
+.systemPanel {
+  box-shadow:
+    0 0 0 1px rgb(255 255 255 / 0.02),
+    0 28px 80px rgb(0 0 0 / 0.54);
+}
+
+.systemPanel::after {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to bottom,
+    transparent 0%,
+    rgb(116 215 164 / 0.025) 48%,
+    transparent 52%
+  );
+  background-size: 100% 160px;
+  content: "";
+  pointer-events: none;
+  animation: scan 9s linear infinite;
+}
+
+.statusDot {
+  display: inline-block;
+  width: 0.375rem;
+  height: 0.375rem;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: #74d7a4;
+  box-shadow: 0 0 0 3px rgb(116 215 164 / 0.1);
+}
+
+.cursor {
+  display: inline-block;
+  width: 0.4rem;
+  height: 0.9rem;
+  background: #ff775f;
+  animation: blink 1.1s steps(1, end) infinite;
+}
+
+@keyframes scan {
+  from {
+    background-position: 0 -160px;
+  }
+
+  to {
+    background-position: 0 320px;
+  }
+}
+
+@keyframes blink {
+  0%,
+  52% {
+    opacity: 1;
+  }
+
+  53%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .systemPanel::after,
+  .cursor {
+    animation: none;
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,338 +4,447 @@ import Link from "next/link";
 import {
   ArrowRight,
   ArrowUpRight,
+  Blocks,
   Check,
+  Code2,
   Database,
   GitBranch,
   Globe2,
-  Layers,
-  ScanSearch,
+  Layers3,
+  ScanLine,
   Sparkles,
-  Store,
+  Terminal,
+  Workflow,
 } from "lucide-react";
 import { SiteHeader } from "@/components/site-header";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { FACTORY_BRAND } from "@/lib/brand";
+import { listRestaurantThemeManifests } from "@/lib/site-themes/restaurant/registry";
 import {
-  listMarketingVerticals,
+  listVerticalIds,
   resolveVerticalConfig,
   verticalSlug,
 } from "@/lib/verticals/registry";
-
-/**
- * cornershop.dev — the factory itself, not a niche. It sells two things at once:
- * a finished website to a small business, and the machine that makes them to a
- * builder. The niche list is read from the vertical registry, so shipping a nails
- * or barber domain adds a card here with no edit to this file.
- *
- * Deliberately has no import form. A lead has to be attached to a niche, and on
- * this page nobody has chosen one yet — so the only route into the studio from
- * here goes through a niche first.
- */
+import styles from "./factory-home.module.css";
 
 const REPO_URL = "https://github.com/VincentShipsIt/cornershopdev";
 
 export const metadata: Metadata = {
-  title: "Cornershopdev — the website factory for small business",
+  title: "Cornershopdev — one factory for every local business",
   description:
-    "One engine, one database, one deploy — and a storefront brand for every trade. Cornershopdev turns a small business's existing web presence into a finished site it can claim.",
+    "An open-source website factory that scans an existing business, structures what it finds, and publishes a focused storefront for its trade.",
 };
 
-const steps = [
+const pipeline = [
   {
     number: "01",
-    title: "A niche gets a domain",
-    copy: "restofront.com for restaurants. A nails domain, a barber domain next. Each one is a config entry in the vertical registry and a DNS record — never a new codebase.",
+    command: "scan(source)",
+    title: "Recover the business",
+    copy: "Read the existing site, menu or service list, imagery, hours, contact details, and the tools customers already use.",
   },
   {
     number: "02",
-    title: "The factory builds the site",
-    copy: "One import pipeline recovers the catalogue, contact details, imagery and existing booking tools, then renders them through that niche's own templates and vocabulary.",
+    command: "structure(vertical)",
+    title: "Apply the niche schema",
+    copy: "Restaurant data becomes a menu. Salon data becomes services and durations. The shared engine never flattens every trade into generic blocks.",
   },
   {
     number: "03",
-    title: "The owner claims it",
-    copy: "Every lead arrives tagged with the niche it came from, into the same database and the same billing. Different storefronts, one operation behind them.",
+    command: "render(theme)",
+    title: "Match a registered system",
+    copy: "AI selects from bounded layouts and tokens built for the business model. It does not improvise fragile production CSS.",
+  },
+  {
+    number: "04",
+    command: "publish(domain)",
+    title: "Claim, connect, keep current",
+    copy: "The owner reviews a private preview, chooses a plan, connects the domain, and keeps the website maintained from one workspace.",
   },
 ];
 
 const platform = [
   {
-    icon: Layers,
-    title: "A vertical is a config, not a fork",
-    copy: "Schema, providers, prompt, templates and marketing copy live in one directory per niche. Register it and the router, the CSP allow-list and this homepage pick it up.",
+    icon: Layers3,
+    label: "Vertical registry",
+    title: "A trade is configuration, not a fork.",
+    copy: "Schema, providers, prompts, templates, vocabulary, and positioning live together. Register a vertical once and the factory knows how to sell and build it.",
   },
   {
     icon: Database,
-    title: "One database behind every domain",
-    copy: "Leads, sites, domains and subscriptions are shared. A niche is a column, so a second trade costs a config entry rather than a second deployment to keep alive.",
+    label: "Shared operations",
+    title: "One data model behind every brand.",
+    copy: "Sites, leads, claims, subscriptions, analytics, and domains share the same operational layer without leaking the factory brand into customer-facing sites.",
   },
   {
-    icon: ScanSearch,
-    title: "Import over onboarding",
-    copy: "The pipeline starts from what a business already published instead of an empty form. The first thing the owner sees is a finished site, not a setup wizard.",
+    icon: Workflow,
+    label: "Durable pipeline",
+    title: "Import first. Ask questions second.",
+    copy: "A business sees a populated preview instead of an empty wizard. Missing details become a small review task, not a multi-hour setup project.",
   },
   {
     icon: GitBranch,
-    title: "Open source, self-hostable",
-    copy: "Next.js, Postgres and durable workflows. Clone it, register your own trade, point a domain at it and run the factory yourself.",
+    label: "Open source",
+    title: "Inspect it, extend it, run it.",
+    copy: "Next.js, Postgres, durable workflows, and a typed registry. The product is usable as a service and legible as infrastructure.",
   },
 ];
 
 export default function Home() {
-  const niches = listMarketingVerticals().map((id) => {
+  const niches = listVerticalIds().map((id) => {
     const { marketing } = resolveVerticalConfig(id);
-    return { slug: verticalSlug(id), marketing };
+    return {
+      id,
+      slug: verticalSlug(id),
+      marketing,
+      status: marketing.domain ? "live" : "in build",
+    } as const;
   });
+  const liveNiches = niches.filter(({ marketing }) => marketing.domain);
+  const themes = listRestaurantThemeManifests();
+  const primaryNiche = liveNiches[0] ?? niches[0];
 
   return (
-    <>
+    <div className={`${styles.factoryShell} min-h-screen`}>
       <SiteHeader
         brand={FACTORY_BRAND}
+        inverse
         links={[
-          { href: "#niches", label: "Niches" },
-          { href: "#how-it-works", label: "How it works" },
-          { href: "#platform", label: "The factory" },
+          { href: "#products", label: "Products" },
+          { href: "#system", label: "System" },
+          { href: "/themes/restaurant", label: "Themes" },
+          { href: REPO_URL, label: "GitHub" },
         ]}
-        createHref="#niches"
-        ctaLabel="Pick a niche"
+        createHref={
+          primaryNiche
+            ? `/niche/${primaryNiche.slug}`
+            : "/create?vertical=restaurant"
+        }
+        ctaLabel="Build a site"
       />
+
       <main>
-        <section className="paper-grid overflow-hidden border-b">
-          <div className="mx-auto flex max-w-4xl flex-col items-center px-5 pb-20 pt-20 text-center lg:px-8 lg:pb-28 lg:pt-24">
-            <Badge
-              variant="secondary"
-              className="mb-6 rounded-full border border-primary/15 bg-primary/8 px-3 py-1 text-primary"
-            >
-              <Sparkles className="size-3" />
-              An open source website factory
-            </Badge>
-            <h1 className="font-display text-balance text-[clamp(4.2rem,8vw,7.6rem)] leading-[0.83] tracking-[-0.055em]">
-              One factory. Every corner shop.
-            </h1>
-            <p className="mt-7 max-w-xl text-balance text-lg leading-8 text-muted-foreground">
-              Restaurants today, more trades when they are ready — each gets its
-              own brand and domain. Behind all of them: one engine, one database,
-              one deploy.
-            </p>
-            <div className="mt-9 flex flex-col gap-3 sm:flex-row">
-              <Button
-                render={<Link href="#niches" />}
-                nativeButton={false}
-                size="lg"
-                className="h-11 rounded-xl"
-              >
-                Find your trade
-                <ArrowRight className="size-4" />
-              </Button>
-              <Button
-                render={
-                  <a href={REPO_URL} target="_blank" rel="noreferrer noopener" />
-                }
-                nativeButton={false}
-                size="lg"
-                variant="outline"
-                className="h-11 rounded-xl"
-              >
-                Read the source
-                <ArrowUpRight className="size-3.5" />
-              </Button>
+        <section className={`${styles.factoryGrid} overflow-hidden border-b border-white/10`}>
+          <div className="mx-auto grid min-h-[calc(100svh-4rem)] max-w-7xl lg:grid-cols-[1.08fr_0.92fr]">
+            <div className="flex flex-col justify-center border-white/10 px-5 py-20 lg:border-r lg:px-8 lg:py-28">
+              <div className="mb-8 inline-flex w-fit items-center gap-2 rounded-full border border-white/12 bg-white/[0.035] px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.12em] text-white/66">
+                <span className={styles.statusDot} />
+                Website factory · system online
+              </div>
+              <h1 className="max-w-4xl text-balance text-[clamp(3.65rem,7.5vw,7.25rem)] font-semibold leading-[0.88] tracking-[-0.065em] text-white">
+                The system behind your next local website.
+              </h1>
+              <p className="mt-7 max-w-2xl text-balance text-base leading-7 text-white/58 md:text-lg md:leading-8">
+                Scan an existing business. Recover what matters. Publish a
+                focused website built for its trade—not another blank template
+                wearing different colours.
+              </p>
+
+              <div className="mt-9 flex flex-col gap-3 sm:flex-row">
+                {primaryNiche?.marketing.domain ? (
+                  <a
+                    href={`https://${primaryNiche.marketing.domain}`}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    className="inline-flex h-11 items-center justify-center gap-2 rounded-lg bg-white px-5 text-sm font-semibold text-black transition-colors hover:bg-white/82 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+                  >
+                    Explore {primaryNiche.marketing.brand.name}
+                    <ArrowUpRight className="size-4" />
+                  </a>
+                ) : null}
+                <a
+                  href={REPO_URL}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="inline-flex h-11 items-center justify-center gap-2 rounded-lg border border-white/16 bg-white/[0.035] px-5 text-sm font-medium text-white transition-colors hover:border-white/28 hover:bg-white/[0.07] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+                >
+                  <Code2 className="size-4 text-[#ff775f]" />
+                  View source
+                </a>
+              </div>
+
+              <div className="mt-8 flex flex-wrap gap-x-6 gap-y-2 font-mono text-[11px] uppercase tracking-[0.08em] text-white/58">
+                <span className="flex items-center gap-2">
+                  <Check className="size-3.5 text-[#74d7a4]" />
+                  Preview before payment
+                </span>
+                <span className="flex items-center gap-2">
+                  <Check className="size-3.5 text-[#74d7a4]" />
+                  Existing tools stay
+                </span>
+                <span className="flex items-center gap-2">
+                  <Check className="size-3.5 text-[#74d7a4]" />
+                  Self-hostable
+                </span>
+              </div>
             </div>
-            <div className="mt-6 flex flex-wrap justify-center gap-x-5 gap-y-2 text-xs text-muted-foreground">
-              <span className="flex items-center gap-1.5">
-                <Check className="size-3.5 text-primary" /> Import, don&apos;t
-                onboard
-              </span>
-              <span className="flex items-center gap-1.5">
-                <Check className="size-3.5 text-primary" /> A new trade is a
-                config entry
-              </span>
-              <span className="flex items-center gap-1.5">
-                <Check className="size-3.5 text-primary" /> Self-host the whole
-                thing
-              </span>
+
+            <div className="relative flex items-center px-5 py-14 lg:px-10 lg:py-20">
+              <div className={`${styles.systemPanel} relative w-full overflow-hidden rounded-2xl border border-white/12 bg-[#090909]`}>
+                <div className="flex h-11 items-center justify-between border-b border-white/10 px-4">
+                  <div className="flex items-center gap-2">
+                    <span className="size-2 rounded-full bg-[#ff775f]" />
+                    <span className="size-2 rounded-full bg-white/22" />
+                    <span className="size-2 rounded-full bg-white/12" />
+                  </div>
+                  <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-white/55">
+                    factory/run
+                  </span>
+                </div>
+
+                <div className="p-5 sm:p-6">
+                  <div className="flex items-center gap-2 font-mono text-xs">
+                    <Terminal className="size-3.5 text-[#ff775f]" />
+                    <span className="text-white/55">$</span>
+                    <span className="text-white/76">cornershop build</span>
+                    <span className={styles.cursor} />
+                  </div>
+
+                  <div className="mt-7 space-y-3 font-mono text-[11px] leading-5 sm:text-xs">
+                    <DataRow label="source" value="restaurant.example" />
+                    <DataRow label="vertical" value="restaurant" signal />
+                    <DataRow label="content" value="menu · hours · bookings" />
+                    <DataRow
+                      label="theme"
+                      value={themes[0]?.id ?? "registered-system"}
+                      signal
+                    />
+                  </div>
+
+                  <div className="my-7 h-px bg-white/10" />
+
+                  <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2 sm:gap-3">
+                    <SystemNode icon={ScanLine} label="scan" detail="source" />
+                    <ArrowRight className="size-3.5 text-white/50" />
+                    <SystemNode icon={Blocks} label="shape" detail="schema" />
+                    <div className="col-span-3 mx-auto h-5 w-px bg-white/12" />
+                    <SystemNode icon={Sparkles} label="match" detail="theme" />
+                    <ArrowRight className="size-3.5 text-white/50" />
+                    <SystemNode icon={Globe2} label="ship" detail="domain" />
+                  </div>
+
+                  <div className="mt-7 flex items-center justify-between border-t border-white/10 pt-4 font-mono text-[10px] uppercase tracking-[0.1em]">
+                    <span className="text-white/52">private preview</span>
+                    <span className="flex items-center gap-2 text-[#74d7a4]">
+                      <span className={styles.statusDot} />
+                      ready to claim
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="border-t border-white/10 bg-black/30">
+            <div className="mx-auto grid max-w-7xl divide-y divide-white/10 sm:grid-cols-3 sm:divide-x sm:divide-y-0">
+              <Metric value={liveNiches.length} label="live niche product" />
+              <Metric value={themes.length} label="restaurant theme systems" />
+              <Metric value={niches.length} label="verticals in the registry" />
             </div>
           </div>
         </section>
 
-        <section
-          id="niches"
-          className="mx-auto max-w-7xl px-5 py-24 lg:px-8 lg:py-32"
-        >
-          <div className="flex flex-col gap-6 border-b pb-10 md:flex-row md:items-end md:justify-between">
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary">
-                The storefronts
-              </p>
-              <h2 className="font-display mt-4 max-w-lg text-6xl leading-[0.92] tracking-[-0.045em]">
-                Each trade sells under its own name.
-              </h2>
-            </div>
-            <p className="max-w-sm text-sm leading-6 text-muted-foreground">
-              A restaurant should be sold a restaurant product, not a generic
-              website builder. Cornershopdev stays behind the curtain.
-            </p>
-          </div>
+        <section id="products" className="border-b border-white/10">
+          <div className="mx-auto max-w-7xl px-5 py-24 lg:px-8 lg:py-32">
+            <SectionIntro
+              eyebrow="Products, not presets"
+              title="One engine. Brands that speak the trade."
+              copy="Cornershopdev stays behind the curtain. Each niche gets the language, workflows, themes, and domain its customers already understand."
+            />
 
-          <div className="mt-10 grid gap-5 md:grid-cols-2">
-            {niches.map(({ slug, marketing }) => (
-              <article
-                key={slug}
-                className="flex flex-col rounded-3xl border bg-card p-7"
-              >
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-3">
-                    {marketing.brand.mark ? (
-                      <Image
-                        src={marketing.brand.mark.src}
-                        alt=""
-                        width={36}
-                        height={36}
-                        className="size-9 shrink-0 rounded-xl"
-                      />
-                    ) : (
-                      <span className="grid size-9 place-items-center rounded-full border border-primary/25 bg-primary text-[11px] font-bold tracking-[-0.08em] text-primary-foreground">
-                        {marketing.brand.initials}
-                      </span>
-                    )}
-                    <div>
-                      <p className="font-semibold">{marketing.brand.name}</p>
-                      <p className="font-mono text-[11px] text-muted-foreground">
-                        {marketing.domain ?? "domain not live yet"}
-                      </p>
+            <div className="mt-12 grid gap-4 lg:grid-cols-2">
+              {niches.map(({ slug, marketing, status }) => (
+                <article
+                  key={slug}
+                  className="group flex min-h-[360px] flex-col border border-white/10 bg-white/[0.025] p-6 transition-colors hover:border-white/20 hover:bg-white/[0.04] sm:p-8"
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="flex items-center gap-3">
+                      {marketing.brand.mark ? (
+                        <Image
+                          src={marketing.brand.mark.src}
+                          alt=""
+                          width={40}
+                          height={40}
+                          className="size-10 rounded-xl"
+                        />
+                      ) : (
+                        <span className="grid size-10 place-items-center rounded-xl border border-white/12 bg-white/6 font-mono text-[11px] font-semibold text-white">
+                          {marketing.brand.initials}
+                        </span>
+                      )}
+                      <div>
+                        <h3 className="font-semibold tracking-[-0.02em] text-white">
+                          {marketing.brand.name}
+                        </h3>
+                        <p className="mt-1 font-mono text-[10px] text-white/55">
+                          {marketing.domain ?? `/niche/${slug}`}
+                        </p>
+                      </div>
                     </div>
+                    <span className="inline-flex items-center gap-2 border border-white/10 px-2.5 py-1 font-mono text-[9px] uppercase tracking-[0.12em] text-white/55">
+                      <span
+                        className={
+                          status === "live"
+                            ? styles.statusDot
+                            : "size-1.5 rounded-full bg-white/28"
+                        }
+                      />
+                      {status}
+                    </span>
                   </div>
-                  <Badge
-                    variant="secondary"
-                    className={
-                      marketing.domain
-                        ? "border border-primary/15 bg-primary/8 text-primary"
-                        : ""
-                    }
-                  >
-                    {marketing.domain ? "Live" : "In build"}
-                  </Badge>
-                </div>
 
-                <p className="mt-6 text-sm font-medium">
-                  For {marketing.audience}
-                </p>
-                <p className="mt-2 max-w-md text-sm leading-6 text-muted-foreground">
-                  {marketing.tagline}
-                </p>
+                  <p className="mt-12 font-mono text-[10px] uppercase tracking-[0.14em] text-[#ff775f]">
+                    Built for {marketing.audience}
+                  </p>
+                  <p className="mt-3 max-w-lg text-2xl font-medium leading-tight tracking-[-0.035em] text-white sm:text-3xl">
+                    {marketing.tagline}
+                  </p>
 
-                <Button
-                  // Launched niches link to their own domain: that is where the
-                  // storefront actually lives and the URL a visitor should keep.
-                  // Unlaunched ones link to the internal route, which renders the
-                  // very same page from the same config.
-                  render={
-                    marketing.domain ? (
+                  <div className="mt-auto flex flex-wrap items-center gap-4 pt-10 text-sm">
+                    {marketing.domain ? (
                       <a
                         href={`https://${marketing.domain}`}
                         target="_blank"
                         rel="noreferrer noopener"
-                      />
+                        className="inline-flex items-center gap-2 font-medium text-white transition-colors hover:text-white/72"
+                      >
+                        Visit product
+                        <ArrowUpRight className="size-3.5" />
+                      </a>
                     ) : (
-                      <Link href={`/niche/${slug}`} />
-                    )
-                  }
-                  nativeButton={false}
-                  variant="outline"
-                  className="mt-8 w-full"
-                >
-                  Visit {marketing.brand.name}
-                  {marketing.domain ? (
-                    <ArrowUpRight className="size-3.5" />
-                  ) : (
-                    <ArrowRight className="size-4" />
-                  )}
-                </Button>
-              </article>
-            ))}
-
-            <article className="flex flex-col justify-center rounded-3xl border border-dashed bg-transparent p-7">
-              <Store className="size-5 text-primary" />
-              <p className="mt-5 font-semibold">Your trade next</p>
-              <p className="mt-2 max-w-md text-sm leading-6 text-muted-foreground">
-                Dog groomers, dentists, driving schools. A vertical is one
-                directory — catalogue schema, booking providers, prompt,
-                templates and the copy for its own homepage.
-              </p>
-              <Link
-                href={REPO_URL}
-                target="_blank"
-                rel="noreferrer noopener"
-                className="mt-6 flex items-center gap-1.5 text-sm font-medium text-primary"
-              >
-                See how a vertical is registered
-                <ArrowUpRight className="size-3.5" />
-              </Link>
-            </article>
-          </div>
-        </section>
-
-        <section
-          id="how-it-works"
-          className="mx-auto max-w-7xl px-5 pb-24 lg:px-8 lg:pb-32"
-        >
-          <div className="grid gap-12 lg:grid-cols-[0.8fr_1.2fr]">
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary">
-                Many fronts. One back.
-              </p>
-              <h2 className="font-display mt-4 max-w-md text-6xl leading-[0.92] tracking-[-0.045em]">
-                How a niche ships.
-              </h2>
-            </div>
-            <div className="divide-y border-y">
-              {steps.map((step) => (
-                <div
-                  key={step.number}
-                  className="grid gap-3 py-7 sm:grid-cols-[64px_1fr_1.4fr] sm:items-start"
-                >
-                  <span className="font-mono text-xs text-primary">
-                    {step.number}
-                  </span>
-                  <h3 className="font-medium">{step.title}</h3>
-                  <p className="text-sm leading-6 text-muted-foreground">
-                    {step.copy}
-                  </p>
-                </div>
+                      <Link
+                        href={`/niche/${slug}`}
+                        className="inline-flex items-center gap-2 font-medium text-white transition-colors hover:text-white/72"
+                      >
+                        Preview the vertical
+                        <ArrowRight className="size-3.5" />
+                      </Link>
+                    )}
+                    {marketing.themeGallery ? (
+                      <Link
+                        href={marketing.themeGallery.href}
+                        className="inline-flex items-center gap-2 text-white/55 transition-colors hover:text-white"
+                      >
+                        {marketing.themeGallery.label}
+                        <ArrowRight className="size-3.5" />
+                      </Link>
+                    ) : null}
+                  </div>
+                </article>
               ))}
             </div>
           </div>
         </section>
 
-        <section id="platform" className="bg-[#1d241f] text-white">
-          <div className="mx-auto max-w-7xl px-5 py-24 lg:px-8 lg:py-32">
-            <div className="flex flex-col gap-8 border-b border-white/15 pb-12 md:flex-row md:items-end md:justify-between">
-              <div>
-                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[#dc8d6d]">
-                  What you actually get
-                </p>
-                <h2 className="font-display mt-4 max-w-3xl text-6xl leading-[0.9] tracking-[-0.045em] md:text-7xl">
-                  Built to add the next trade cheaply.
-                </h2>
-              </div>
-              <p className="max-w-sm text-sm leading-6 text-white/58">
-                The expensive part of a website factory is the second vertical.
-                Cornershopdev is shaped around making that one cheap.
+        <section className={`${styles.moduleGrid} border-b border-white/10`}>
+          <div className="mx-auto grid max-w-7xl gap-12 px-5 py-24 lg:grid-cols-[0.8fr_1.2fr] lg:px-8 lg:py-32">
+            <div>
+              <p className="font-mono text-[11px] uppercase tracking-[0.14em] text-[#ff775f]">
+                Restaurant theme library
               </p>
+              <h2 className="mt-5 max-w-lg text-balance text-4xl font-semibold leading-[0.98] tracking-[-0.055em] text-white md:text-6xl">
+                Familiar commerce patterns. Hospitality-specific decisions.
+              </h2>
+              <p className="mt-6 max-w-lg text-base leading-7 text-white/52">
+                The library borrows interaction conventions diners already know
+                from ordering and booking products, then adapts them to an
+                independent restaurant’s own brand. AI matches the system; it
+                does not invent one on every scan.
+              </p>
+              <Link
+                href="/themes/restaurant"
+                className="mt-8 inline-flex items-center gap-2 text-sm font-semibold text-white"
+              >
+                Inspect the theme library
+                <ArrowRight className="size-4" />
+              </Link>
             </div>
 
-            <div className="grid md:grid-cols-2">
-              {platform.map((item, index) => (
+            <div className="border border-white/10 bg-[#080808]">
+              <div className="flex items-center justify-between border-b border-white/10 px-5 py-4 font-mono text-[10px] uppercase tracking-[0.12em] text-white/55">
+                <span>packages/themes/restaurant</span>
+                <span>{themes.length} registered</span>
+              </div>
+              <div className="divide-y divide-white/10">
+                {themes.map((theme, index) => (
+                  <Link
+                    key={theme.id}
+                    href={`/themes/restaurant/${theme.id}`}
+                    className="group grid gap-3 px-5 py-5 transition-colors hover:bg-white/[0.035] sm:grid-cols-[52px_1fr_auto] sm:items-center"
+                  >
+                    <span className="font-mono text-xs text-white/52">
+                      0{index + 1}
+                    </span>
+                    <span>
+                      <span className="block text-sm font-medium text-white">
+                        {theme.name}
+                      </span>
+                      <span className="mt-1 block text-xs leading-5 text-white/55">
+                        {theme.bestFor.slice(0, 2).join(" · ")}
+                      </span>
+                    </span>
+                    <ArrowUpRight className="size-4 text-white/52 transition-colors group-hover:text-[#ff775f]" />
+                  </Link>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section id="system" className="border-b border-white/10">
+          <div className="mx-auto max-w-7xl px-5 py-24 lg:px-8 lg:py-32">
+            <SectionIntro
+              eyebrow="From source to storefront"
+              title="A pipeline built around the finished thing."
+              copy="The factory begins with evidence from the business, not a blank canvas. Every stage narrows ambiguity before the owner is asked to review anything."
+            />
+
+            <div className="mt-12 divide-y divide-white/10 border-y border-white/10">
+              {pipeline.map((step) => (
+                <article
+                  key={step.number}
+                  className="grid gap-4 py-7 sm:grid-cols-[64px_0.7fr_1fr_1.2fr] sm:items-start lg:py-9"
+                >
+                  <span className="font-mono text-[11px] text-white/52">
+                    {step.number}
+                  </span>
+                  <code className="font-mono text-xs text-[#ff775f]">
+                    {step.command}
+                  </code>
+                  <h3 className="font-medium tracking-[-0.02em] text-white">
+                    {step.title}
+                  </h3>
+                  <p className="max-w-xl text-sm leading-6 text-white/58">
+                    {step.copy}
+                  </p>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="border-b border-white/10 bg-[#080808]">
+          <div className="mx-auto max-w-7xl px-5 py-24 lg:px-8 lg:py-32">
+            <SectionIntro
+              eyebrow="The shared core"
+              title="Small-business software without the generic shell."
+              copy="Each customer sees a product for their trade. The expensive operational machinery stays shared, typed, and inspectable."
+            />
+            <div className="mt-12 grid border-l border-t border-white/10 md:grid-cols-2">
+              {platform.map((item) => (
                 <article
                   key={item.title}
-                  className={`min-h-64 border-white/15 p-7 md:p-10 ${
-                    index % 2 === 0 ? "md:border-r" : ""
-                  } ${index < 2 ? "border-b" : ""}`}
+                  className="min-h-72 border-b border-r border-white/10 p-7 sm:p-9"
                 >
-                  <item.icon className="size-5 text-[#dc8d6d]" />
-                  <h3 className="mt-12 text-xl font-medium">{item.title}</h3>
-                  <p className="mt-3 max-w-md text-sm leading-6 text-white/55">
+                  <div className="flex items-center justify-between">
+                    <item.icon className="size-5 text-[#ff775f]" />
+                    <span className="font-mono text-[9px] uppercase tracking-[0.14em] text-white/52">
+                      {item.label}
+                    </span>
+                  </div>
+                  <h3 className="mt-14 max-w-md text-xl font-medium tracking-[-0.03em] text-white">
+                    {item.title}
+                  </h3>
+                  <p className="mt-3 max-w-md text-sm leading-6 text-white/58">
                     {item.copy}
                   </p>
                 </article>
@@ -344,43 +453,138 @@ export default function Home() {
           </div>
         </section>
 
-        <section className="paper-grid border-t">
-          <div className="mx-auto flex max-w-5xl flex-col items-center px-5 py-24 text-center lg:py-32">
-            <Globe2 className="size-6 text-primary" />
-            <h2 className="font-display text-balance mt-6 text-6xl leading-[0.9] tracking-[-0.05em] md:text-7xl">
-              Start with the trade, not the tool.
-            </h2>
-            <p className="mt-6 max-w-xl text-muted-foreground">
-              Pick the storefront that sells to your business. The factory
-              behind it is the same either way.
+        <section className={`${styles.factoryGrid} overflow-hidden`}>
+          <div className="mx-auto flex max-w-5xl flex-col items-center px-5 py-24 text-center lg:py-36">
+            <span className="grid size-11 place-items-center rounded-xl border border-white/12 bg-white/[0.035]">
+              <Globe2 className="size-5 text-[#ff775f]" />
+            </span>
+            <p className="mt-8 font-mono text-[11px] uppercase tracking-[0.14em] text-white/55">
+              Pick the vertical. See the result.
             </p>
-            <Button
-              render={<Link href="#niches" />}
-              nativeButton={false}
-              size="lg"
-              className="mt-9 h-11 rounded-xl"
-            >
-              See the niches
-              <ArrowRight className="size-4" />
-            </Button>
+            <h2 className="mt-5 max-w-4xl text-balance text-5xl font-semibold leading-[0.92] tracking-[-0.06em] text-white md:text-7xl">
+              Start with the business, not the builder.
+            </h2>
+            <p className="mt-7 max-w-2xl text-balance text-base leading-7 text-white/52">
+              Explore the live restaurant product, inspect the registered theme
+              systems, or open the source and build the next trade.
+            </p>
+            <div className="mt-9 flex flex-col gap-3 sm:flex-row">
+              {primaryNiche?.marketing.domain ? (
+                <a
+                  href={`https://${primaryNiche.marketing.domain}`}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="inline-flex h-11 items-center justify-center gap-2 rounded-lg bg-white px-5 text-sm font-semibold text-black transition-colors hover:bg-white/82"
+                >
+                  Visit {primaryNiche.marketing.brand.name}
+                  <ArrowUpRight className="size-4" />
+                </a>
+              ) : null}
+              <Link
+                href="/themes/restaurant"
+                className="inline-flex h-11 items-center justify-center gap-2 rounded-lg border border-white/16 bg-white/[0.035] px-5 text-sm font-medium text-white transition-colors hover:bg-white/[0.07]"
+              >
+                Browse restaurant themes
+                <ArrowRight className="size-4" />
+              </Link>
+            </div>
           </div>
         </section>
       </main>
 
-      <footer className="border-t bg-[#1d241f] text-white">
-        <div className="mx-auto flex max-w-7xl flex-col gap-8 px-5 py-10 text-sm text-white/55 sm:flex-row sm:items-center sm:justify-between lg:px-8">
+      <footer className="border-t border-white/10 bg-black">
+        <div className="mx-auto grid max-w-7xl gap-8 px-5 py-10 text-sm sm:grid-cols-[1fr_auto_auto] sm:items-center lg:px-8">
           <span className="font-semibold text-white">Cornershopdev</span>
-          <span>One factory. Every corner shop.</span>
+          <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-white/52">
+            One factory · every corner shop
+          </span>
           <a
             href={REPO_URL}
             target="_blank"
             rel="noreferrer noopener"
-            className="flex items-center gap-1.5 text-white"
+            className="inline-flex items-center gap-1.5 text-white/66 transition-colors hover:text-white"
           >
-            GitHub <ArrowUpRight className="size-3.5" />
+            GitHub
+            <ArrowUpRight className="size-3.5" />
           </a>
         </div>
       </footer>
-    </>
+    </div>
+  );
+}
+
+function DataRow({
+  label,
+  value,
+  signal = false,
+}: {
+  label: string;
+  value: string;
+  signal?: boolean;
+}) {
+  return (
+    <div className="grid grid-cols-[72px_1fr] gap-3">
+      <span className="text-white/55">{label}</span>
+      <span className={signal ? "text-[#74d7a4]" : "text-white/66"}>
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function SystemNode({
+  icon: Icon,
+  label,
+  detail,
+}: {
+  icon: typeof ScanLine;
+  label: string;
+  detail: string;
+}) {
+  return (
+    <div className="border border-white/10 bg-white/[0.025] px-3 py-4 text-center">
+      <Icon className="mx-auto size-4 text-white/66" />
+      <p className="mt-2 font-mono text-[10px] uppercase tracking-[0.12em] text-white/62">
+        {label}
+      </p>
+      <p className="mt-1 font-mono text-[9px] text-white/52">{detail}</p>
+    </div>
+  );
+}
+
+function Metric({ value, label }: { value: number; label: string }) {
+  return (
+    <div className="flex items-baseline gap-3 px-5 py-5 lg:px-8">
+      <span className="font-mono text-lg text-white">{String(value).padStart(2, "0")}</span>
+      <span className="font-mono text-[9px] uppercase tracking-[0.12em] text-white/52">
+        {label}
+      </span>
+    </div>
+  );
+}
+
+function SectionIntro({
+  eyebrow,
+  title,
+  copy,
+}: {
+  eyebrow: string;
+  title: string;
+  copy: string;
+}) {
+  return (
+    <div className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr] lg:items-end">
+      <div>
+        <p className="font-mono text-[11px] uppercase tracking-[0.14em] text-[#ff775f]">
+          {eyebrow}
+        </p>
+        <h2 className="mt-5 max-w-3xl text-balance text-4xl font-semibold leading-[0.98] tracking-[-0.055em] text-white md:text-6xl">
+          {title}
+        </h2>
+      </div>
+      <p className="max-w-xl text-sm leading-7 text-white/58 lg:justify-self-end">
+        {copy}
+      </p>
+    </div>
   );
 }

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -11,6 +11,7 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
 
 export type SiteHeaderLink = { href: string; label: string };
 
@@ -31,22 +32,39 @@ export function SiteHeader({
   links = defaultLinks,
   createHref = "/create",
   ctaLabel = "Build a preview",
+  inverse = false,
 }: {
   brand: BrandIdentity & { href?: string };
   links?: SiteHeaderLink[];
   createHref?: string;
   ctaLabel?: string;
+  inverse?: boolean;
 }) {
   return (
-    <header className="sticky top-0 z-50 border-b border-border/70 bg-background/88 backdrop-blur-xl">
+    <header
+      className={cn(
+        "sticky top-0 z-50 border-b backdrop-blur-xl",
+        inverse
+          ? "border-white/10 bg-[#050505]/88 text-white"
+          : "border-border/70 bg-background/88",
+      )}
+    >
       <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-5 lg:px-8">
-        <Brand {...brand} />
-        <nav className="hidden items-center gap-7 text-sm text-muted-foreground md:flex">
+        <Brand {...brand} inverse={inverse} />
+        <nav
+          className={cn(
+            "hidden items-center gap-7 text-sm md:flex",
+            inverse ? "text-white/58" : "text-muted-foreground",
+          )}
+        >
           {links.map((link) => (
             <Link
               key={link.href}
               href={link.href}
-              className="transition-colors hover:text-foreground"
+              className={cn(
+                "transition-colors",
+                inverse ? "hover:text-white" : "hover:text-foreground",
+              )}
             >
               {link.label}
             </Link>
@@ -58,6 +76,11 @@ export function SiteHeader({
             nativeButton={false}
             variant="ghost"
             size="sm"
+            className={
+              inverse
+                ? "text-white/65 hover:bg-white/8 hover:text-white"
+                : undefined
+            }
           >
             Sign in
           </Button>
@@ -65,6 +88,11 @@ export function SiteHeader({
             render={<Link href={createHref} />}
             nativeButton={false}
             size="sm"
+            className={
+              inverse
+                ? "border-white bg-white text-black hover:bg-white/82"
+                : undefined
+            }
           >
             {ctaLabel}
             <ArrowUpRight className="size-3.5" />
@@ -72,15 +100,27 @@ export function SiteHeader({
         </div>
         <Sheet>
           <SheetTrigger
-            className="grid size-9 place-items-center rounded-full border md:hidden"
+            className={cn(
+              "grid size-9 place-items-center rounded-full border md:hidden",
+              inverse ? "border-white/18 text-white" : "",
+            )}
             aria-label="Open navigation"
           >
             <Menu className="size-4" />
           </SheetTrigger>
-          <SheetContent className="p-6">
+          <SheetContent
+            className={cn(
+              "p-6",
+              inverse
+                ? "border-white/10 bg-[#080808] text-white [&_[data-slot=sheet-close]]:text-white"
+                : "",
+            )}
+          >
             <SheetHeader>
-              <SheetTitle className="text-left">
-                <Brand {...brand} />
+              <SheetTitle
+                className={cn("text-left", inverse ? "text-white" : "")}
+              >
+                <Brand {...brand} inverse={inverse} />
               </SheetTitle>
             </SheetHeader>
             <nav className="mt-10 flex flex-col gap-5 text-lg">
@@ -98,7 +138,12 @@ export function SiteHeader({
               <Button
                 render={<Link href={createHref} />}
                 nativeButton={false}
-                className="mt-4"
+                className={cn(
+                  "mt-4",
+                  inverse
+                    ? "border-white bg-white text-black hover:bg-white/82"
+                    : "",
+                )}
               >
                 {ctaLabel}
               </Button>

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -128,11 +128,15 @@ export function SiteHeader({
                 <SheetClose
                   key={link.href}
                   render={<Link href={link.href} />}
+                  nativeButton={false}
                 >
                   {link.label}
                 </SheetClose>
               ))}
-              <SheetClose render={<Link href="/dashboard" />}>
+              <SheetClose
+                render={<Link href="/dashboard" />}
+                nativeButton={false}
+              >
                 Sign in
               </SheetClose>
               <Button


### PR DESCRIPTION
## Summary

- replace the warm editorial Cornershop homepage with a scoped dark technical factory identity
- render live and upcoming niche products from the vertical registry, plus restaurant systems from the real theme registry
- add clear routes to Restofrontapp, restaurant themes, Salonfront, source, and the customer workspace
- add an opt-in inverse shared header variant without changing Restofront, generated sites, themes, or authenticated surfaces
- update the Cornershop brand contract with the dark palette, sans/mono typography, motion, contrast, and scope rules

## Verification

- `bunx eslint src/app/page.tsx src/components/site-header.tsx`
- `bun run design:lint` — zero errors and zero warnings
- headless Brave at 1440 × 1100 and 390 × 844
  - meaningful content rendered
  - no Next.js error overlay
  - zero horizontal overflow
  - mobile navigation control present
  - Axe WCAG 2 A/AA: zero violations
- production compilation and TypeScript completed under `next build --webpack`; local page-data collection then stopped on the workflow webhook runtime without deployment configuration, so PR CI remains the broad build gate
