### PR TITLE
feat(admin): complete operator lead workflow

### DIFF
--- a/src/app/admin/claim-invitation-form.tsx
+++ b/src/app/admin/claim-invitation-form.tsx
@@ -1,17 +1,26 @@
 "use client";
 
 import { useState } from "react";
-import { Check, LoaderCircle, Send } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { Check, LoaderCircle, RotateCw, Send, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import type { OperatorSiteRow } from "@/lib/operator-dashboard";
 
-export function ClaimInvitationForm({ siteSlug }: { siteSlug: string }) {
-  const [email, setEmail] = useState("");
+export function ClaimInvitationForm({
+  siteSlug,
+  invitation,
+}: {
+  siteSlug: string;
+  invitation: OperatorSiteRow["invitation"];
+}) {
+  const router = useRouter();
+  const [email, setEmail] = useState(invitation?.email ?? "");
   const [sending, setSending] = useState(false);
   const [sent, setSent] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  async function approve() {
+  async function send(action: "issue" | "resend") {
     setSending(true);
     setSent(false);
     setError(null);
@@ -19,7 +28,12 @@ export function ClaimInvitationForm({ siteSlug }: { siteSlug: string }) {
       const response = await fetch("/api/admin/claim-invitations", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ siteSlug, email }),
+        body: JSON.stringify({
+          siteSlug,
+          email,
+          action,
+          invitationId: invitation?.id,
+        }),
       });
       const result = (await response.json()) as {
         ok?: boolean;
@@ -29,6 +43,7 @@ export function ClaimInvitationForm({ siteSlug }: { siteSlug: string }) {
         throw new Error(result.error ?? "Invitation could not be sent.");
       }
       setSent(true);
+      router.refresh();
     } catch (caught) {
       setError(
         caught instanceof Error ? caught.message : "Invitation could not be sent.",
@@ -38,8 +53,58 @@ export function ClaimInvitationForm({ siteSlug }: { siteSlug: string }) {
     }
   }
 
+  async function revoke() {
+    if (!invitation) return;
+    setSending(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/admin/claim-invitations", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ siteSlug, invitationId: invitation.id }),
+      });
+      const result = (await response.json()) as {
+        ok?: boolean;
+        error?: string;
+      };
+      if (!response.ok || !result.ok) {
+        throw new Error(result.error ?? "Invitation could not be revoked.");
+      }
+      router.refresh();
+    } catch (caught) {
+      setError(
+        caught instanceof Error ? caught.message : "Invitation could not be revoked.",
+      );
+    } finally {
+      setSending(false);
+    }
+  }
+
+  const canRevoke =
+    invitation &&
+    ["ACTIVE", "VERIFIED", "CHECKOUT_STARTED"].includes(invitation.state);
+  const hasPreviousInvitation = Boolean(invitation);
+  const sameRecipient =
+    invitation?.email.trim().toLowerCase() === email.trim().toLowerCase();
+  const sendAction =
+    hasPreviousInvitation && sameRecipient ? ("resend" as const) : ("issue" as const);
+  const checkoutStarted = invitation?.state === "CHECKOUT_STARTED";
+  const sendLabel = sent
+    ? "Sent"
+    : sendAction === "resend"
+      ? "Resend"
+      : hasPreviousInvitation
+        ? "Replace"
+        : "Issue";
+
   return (
     <div className="min-w-56">
+      {invitation ? (
+        <p className="mb-2 text-[11px] text-muted-foreground">
+          Latest: {humanize(invitation.state)} · expires{" "}
+          {formatDate(invitation.expiresAt)}
+        </p>
+      ) : null}
       <div className="flex gap-2">
         <Input
           aria-label={`Approved owner email for ${siteSlug}`}
@@ -56,21 +121,39 @@ export function ClaimInvitationForm({ siteSlug }: { siteSlug: string }) {
           type="button"
           variant="outline"
           size="sm"
-          disabled={!email || sending}
-          onClick={() => void approve()}
+          disabled={!email || sending || checkoutStarted}
+          onClick={() => void send(sendAction)}
         >
           {sending ? (
             <LoaderCircle className="animate-spin" />
           ) : sent ? (
             <Check />
+          ) : sendAction === "resend" ? (
+            <RotateCw />
           ) : (
             <Send />
           )}
-          {sent ? "Sent" : "Approve"}
+          {sendLabel}
         </Button>
+        {canRevoke ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={sending}
+            onClick={() => void revoke()}
+          >
+            <X />
+            Revoke
+          </Button>
+        ) : null}
       </div>
       {error ? (
         <p className="mt-1 max-w-64 text-[11px] text-destructive">{error}</p>
+      ) : checkoutStarted ? (
+        <p className="mt-1 text-[11px] text-muted-foreground">
+          Revoke the checkout-bound invitation before replacing it.
+        </p>
       ) : (
         <p className="mt-1 text-[11px] text-muted-foreground">
           Sends a 48-hour one-time claim link.
@@ -78,4 +161,17 @@ export function ClaimInvitationForm({ siteSlug }: { siteSlug: string }) {
       )}
     </div>
   );
+}
+
+function humanize(value: string): string {
+  return value
+    .toLowerCase()
+    .replaceAll("_", " ")
+    .replace(/^\w/, (character) => character.toUpperCase());
+}
+
+function formatDate(value: Date): string {
+  return new Intl.DateTimeFormat("en", {
+    dateStyle: "medium",
+  }).format(new Date(value));
 }

--- a/src/app/admin/operator-lead-form.tsx
+++ b/src/app/admin/operator-lead-form.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { ArrowUpRight, LoaderCircle, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+export function OperatorLeadForm() {
+  const router = useRouter();
+  const [source, setSource] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<{
+    preview: string;
+    created: boolean;
+    reopened: boolean;
+  } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit() {
+    setSubmitting(true);
+    setResult(null);
+    setError(null);
+    try {
+      const response = await fetch("/api/admin/leads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ source, vertical: "RESTAURANT" }),
+      });
+      const payload = (await response.json()) as {
+        ok?: boolean;
+        created?: boolean;
+        reopened?: boolean;
+        urls?: { preview: string };
+        error?: string;
+      };
+      if (!response.ok || !payload.ok || !payload.urls) {
+        throw new Error(payload.error ?? "Lead could not be created.");
+      }
+      setResult({
+        preview: payload.urls.preview,
+        created: Boolean(payload.created),
+        reopened: Boolean(payload.reopened),
+      });
+      setSource("");
+      router.refresh();
+    } catch (caught) {
+      setError(
+        caught instanceof Error ? caught.message : "Lead could not be created.",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+      <div className="space-y-2">
+        <Label htmlFor="operator-lead-source">Business URL or name</Label>
+        <Input
+          id="operator-lead-source"
+          value={source}
+          onChange={(event) => setSource(event.target.value)}
+          placeholder="https://restaurant.example or Restaurant name"
+          maxLength={500}
+        />
+      </div>
+      <Button
+        type="button"
+        disabled={source.trim().length < 2 || submitting}
+        onClick={() => void submit()}
+      >
+        {submitting ? (
+          <LoaderCircle className="animate-spin" />
+        ) : (
+          <Plus />
+        )}
+        {submitting ? "Creating preview…" : "Create or reopen"}
+      </Button>
+      <div className="md:col-span-2" aria-live="polite">
+        {error ? (
+          <p className="text-xs text-destructive">{error}</p>
+        ) : result ? (
+          <p className="flex items-center gap-2 text-xs text-muted-foreground">
+            {result.created
+              ? "Lead created."
+              : result.reopened
+                ? "Existing lead reopened."
+                : "Lead ready."}
+            <a
+              href={result.preview}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 font-medium text-foreground underline-offset-4 hover:underline"
+            >
+              Review preview <ArrowUpRight className="size-3" />
+            </a>
+          </p>
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            URL imports inspect the public site; a business name creates a
+            deterministic private preview for manual enrichment.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/operator-review-panel.tsx
+++ b/src/app/admin/operator-review-panel.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Check, LoaderCircle, MessageSquarePlus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import type { OperatorSiteRow } from "@/lib/operator-dashboard";
+
+type OperatorReviewPanelProps = Pick<
+  OperatorSiteRow,
+  "slug" | "reviewedAt" | "notes" | "contentReview"
+>;
+
+export function OperatorReviewPanel({
+  slug,
+  reviewedAt,
+  notes,
+  contentReview,
+}: OperatorReviewPanelProps) {
+  const router = useRouter();
+  const [note, setNote] = useState("");
+  const [pendingAction, setPendingAction] = useState<
+    "add_note" | "complete_review" | null
+  >(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function mutate(action: "add_note" | "complete_review") {
+    setPendingAction(action);
+    setError(null);
+    try {
+      const response = await fetch(
+        `/api/admin/sites/${encodeURIComponent(slug)}/review`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ action, note: note.trim() || null }),
+        },
+      );
+      const payload = (await response.json()) as {
+        ok?: boolean;
+        error?: string;
+      };
+      if (!response.ok || !payload.ok) {
+        throw new Error(payload.error ?? "Review action failed.");
+      }
+      setNote("");
+      router.refresh();
+    } catch (caught) {
+      setError(
+        caught instanceof Error ? caught.message : "Review action failed.",
+      );
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  const heroLabel =
+    contentReview.heroImage === "provenance_recorded"
+      ? "image provenance recorded"
+      : contentReview.heroImage === "provenance_missing"
+        ? "image provenance missing"
+        : "hero image missing";
+
+  return (
+    <div className="min-w-72 space-y-2">
+      <p className="text-[11px] leading-5 text-muted-foreground">
+        {contentReview.missingFields.length > 0
+          ? `Missing: ${contentReview.missingFields.join(", ")}. `
+          : "Core fields present. "}
+        {heroLabel}. {contentReview.translationCount} translation
+        {contentReview.translationCount === 1 ? "" : "s"},{" "}
+        {contentReview.integrationCount} integration
+        {contentReview.integrationCount === 1 ? "" : "s"},{" "}
+        {contentReview.catalogItemCount} catalog item
+        {contentReview.catalogItemCount === 1 ? "" : "s"}.
+      </p>
+      {notes[0] ? (
+        <p className="rounded-md border bg-muted/30 px-2 py-1.5 text-[11px] leading-4">
+          {notes[0].note}
+        </p>
+      ) : null}
+      <Textarea
+        aria-label={`Operator note for ${slug}`}
+        value={note}
+        onChange={(event) => setNote(event.target.value)}
+        placeholder="Private operator note"
+        maxLength={2_000}
+        className="min-h-16 text-xs"
+      />
+      <div className="flex flex-wrap gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={!note.trim() || Boolean(pendingAction)}
+          onClick={() => void mutate("add_note")}
+        >
+          {pendingAction === "add_note" ? (
+            <LoaderCircle className="animate-spin" />
+          ) : (
+            <MessageSquarePlus />
+          )}
+          Save note
+        </Button>
+        <Button
+          type="button"
+          variant={reviewedAt ? "outline" : "default"}
+          size="sm"
+          disabled={Boolean(pendingAction)}
+          onClick={() => void mutate("complete_review")}
+        >
+          {pendingAction === "complete_review" ? (
+            <LoaderCircle className="animate-spin" />
+          ) : (
+            <Check />
+          )}
+          {reviewedAt ? "Review again" : "Mark reviewed"}
+        </Button>
+      </div>
+      {error ? (
+        <p className="text-[11px] text-destructive">{error}</p>
+      ) : reviewedAt ? (
+        <p className="text-[11px] text-muted-foreground">
+          Reviewed {formatDate(reviewedAt)}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function formatDate(value: Date): string {
+  return new Intl.DateTimeFormat("en", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -9,6 +9,8 @@ import {
   Users,
 } from "lucide-react";
 import { ClaimInvitationForm } from "@/app/admin/claim-invitation-form";
+import { OperatorLeadForm } from "@/app/admin/operator-lead-form";
+import { OperatorReviewPanel } from "@/app/admin/operator-review-panel";
 import { Brand } from "@/components/brand";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -107,6 +109,20 @@ export default async function AdminPage() {
           />
         </section>
 
+        <Card className="mt-6">
+          <CardHeader>
+            <CardTitle>Create or reopen a lead</CardTitle>
+            <p className="text-xs text-muted-foreground">
+              Authorized operator imports persist directly into the private
+              preview workflow. Existing unclaimed leads reopen without
+              replacing reviewed content.
+            </p>
+          </CardHeader>
+          <CardContent>
+            <OperatorLeadForm />
+          </CardContent>
+        </Card>
+
         <Card className="mt-6 overflow-hidden py-0">
           <CardHeader className="border-b py-5">
             <CardTitle>Live-site performance</CardTitle>
@@ -148,7 +164,7 @@ export default async function AdminPage() {
             <CardTitle>All sites</CardTitle>
           </CardHeader>
           <CardContent className="overflow-x-auto p-0">
-            <table className="w-full min-w-[1500px] text-left text-sm">
+            <table className="w-full min-w-[2200px] text-left text-sm">
               <thead className="border-b bg-muted/50 text-xs uppercase tracking-[0.12em] text-muted-foreground">
                 <tr>
                   <th scope="col" className="px-5 py-3 font-medium">Business</th>
@@ -160,6 +176,8 @@ export default async function AdminPage() {
                   <th scope="col" className="px-5 py-3 font-medium">Visits · 30d</th>
                   <th scope="col" className="px-5 py-3 font-medium">Lead conv. · 30d</th>
                   <th scope="col" className="px-5 py-3 font-medium">Created</th>
+                  <th scope="col" className="px-5 py-3 font-medium">Blocker rollup</th>
+                  <th scope="col" className="px-5 py-3 font-medium">Content review</th>
                   <th scope="col" className="px-5 py-3 font-medium">Concierge claim</th>
                   <th scope="col" className="px-5 py-3 text-right font-medium">Site</th>
                 </tr>
@@ -222,6 +240,9 @@ function SiteRow({ site }: { site: OperatorSiteRow }) {
           {site.vertical.toLowerCase()}
           {site.verifiedDomain ? ` · ${site.verifiedDomain}` : ""}
         </p>
+        <p className="mt-1 text-[11px] text-muted-foreground">
+          TLS: {humanize(site.tlsReadiness)}
+        </p>
       </td>
       <td className="px-5 py-4">
         <Badge variant="outline">{humanize(site.status)}</Badge>
@@ -276,8 +297,43 @@ function SiteRow({ site }: { site: OperatorSiteRow }) {
         {formatDate(site.createdAt)}
       </td>
       <td className="px-5 py-4">
+        <div className="grid min-w-64 gap-1.5">
+          {site.blockers.map((blocker) => (
+            <div
+              key={blocker.stage}
+              className="flex items-start justify-between gap-3"
+              title={blocker.detail}
+            >
+              <span className="text-xs">{blocker.label}</span>
+              <Badge
+                variant={
+                  blocker.status === "complete"
+                    ? "secondary"
+                    : blocker.status === "ready"
+                      ? "outline"
+                      : "destructive"
+                }
+              >
+                {blocker.status}
+              </Badge>
+            </div>
+          ))}
+        </div>
+      </td>
+      <td className="px-5 py-4">
+        <OperatorReviewPanel
+          slug={site.slug}
+          reviewedAt={site.reviewedAt}
+          notes={site.notes}
+          contentReview={site.contentReview}
+        />
+      </td>
+      <td className="px-5 py-4">
         {site.ownerCount === 0 ? (
-          <ClaimInvitationForm siteSlug={site.slug} />
+          <ClaimInvitationForm
+            siteSlug={site.slug}
+            invitation={site.invitation}
+          />
         ) : (
           <span className="text-muted-foreground">Owned</span>
         )}

--- a/src/app/api/admin/claim-invitations/route.ts
+++ b/src/app/api/admin/claim-invitations/route.ts
@@ -6,6 +6,8 @@ import {
   deliverClaimInvitation,
   issueClaimInvitation,
   recordClaimRejection,
+  resendClaimInvitation,
+  revokeClaimInvitation,
   revokeUndeliveredInvitation,
 } from "@/lib/claim-invitations";
 import { limitOperatorClaimInvitation } from "@/lib/rate-limit";
@@ -16,6 +18,8 @@ export const runtime = "nodejs";
 const requestSchema = z.object({
   siteSlug: z.string().trim().min(2).max(80),
   email: z.email().max(320),
+  action: z.enum(["issue", "resend"]).default("issue"),
+  invitationId: z.string().trim().min(1).max(100).optional(),
 });
 
 export async function POST(request: Request) {
@@ -45,12 +49,19 @@ export async function POST(request: Request) {
   try {
     const input = requestSchema.parse(await request.json());
     siteSlug = input.siteSlug;
-    const invitation = await issueClaimInvitation({
-      siteSlug,
-      email: input.email,
-      proofMethod: "OPERATOR_APPROVAL",
-      actor: `operator:${operator.id}`,
-    });
+    const invitation =
+      input.action === "resend"
+        ? await resendClaimInvitation({
+            siteSlug,
+            invitationId: z.string().parse(input.invitationId),
+            actor: `operator:${operator.id}`,
+          })
+        : await issueClaimInvitation({
+            siteSlug,
+            email: input.email,
+            proofMethod: "OPERATOR_APPROVAL",
+            actor: `operator:${operator.id}`,
+          });
     try {
       await deliverClaimInvitation(
         invitation,
@@ -91,6 +102,53 @@ export async function POST(request: Request) {
     });
     return NextResponse.json(
       { error: "The claim invitation could not be sent." },
+      { status: 503 },
+    );
+  }
+}
+
+const revokeRequestSchema = z.object({
+  siteSlug: z.string().trim().min(2).max(80),
+  invitationId: z.string().trim().min(1).max(100),
+});
+
+export async function DELETE(request: Request) {
+  if (!isSameOriginMutation(request, { requireOrigin: true })) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const operator = await getSuperadminAccess();
+  if (!operator) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  try {
+    const input = revokeRequestSchema.parse(await request.json());
+    const revoked = await revokeClaimInvitation({
+      ...input,
+      actor: `operator:${operator.id}`,
+    });
+    return NextResponse.json(
+      { ok: true, revoked },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: error.issues[0]?.message ?? "Check the invitation details." },
+        { status: 400 },
+      );
+    }
+    if (error instanceof ClaimFlowError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: error.status },
+      );
+    }
+    console.error("[operator-claim-revoke] failed", {
+      operatorId: operator.id,
+      error: error instanceof Error ? error.message : "unknown",
+    });
+    return NextResponse.json(
+      { error: "The claim invitation could not be revoked." },
       { status: 503 },
     );
   }

--- a/src/app/api/admin/leads/route.ts
+++ b/src/app/api/admin/leads/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { Vertical } from "@/generated/prisma/enums";
+import { getSuperadminAccess } from "@/lib/authorization";
+import {
+  createOrReopenOperatorLead,
+  OperatorLeadError,
+} from "@/lib/operator-leads";
+import { limitOperatorLeadMutation } from "@/lib/rate-limit";
+import { isSameOriginMutation } from "@/lib/request-origin";
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+const requestSchema = z.object({
+  source: z.string().trim().min(2).max(500),
+  vertical: z.enum(Vertical).default(Vertical.RESTAURANT),
+});
+
+export async function POST(request: Request) {
+  if (!isSameOriginMutation(request, { requireOrigin: true })) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const operator = await getSuperadminAccess();
+  if (!operator) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const rateLimit = await limitOperatorLeadMutation(request);
+  if (!rateLimit.success) {
+    return NextResponse.json(
+      {
+        error:
+          rateLimit.reason === "unavailable"
+            ? "Operator imports are temporarily unavailable."
+            : "Too many operator imports. Try again later.",
+      },
+      { status: rateLimit.reason === "unavailable" ? 503 : 429 },
+    );
+  }
+
+  try {
+    const input = requestSchema.parse(await request.json());
+    const lead = await createOrReopenOperatorLead({
+      ...input,
+      actor: `operator:${operator.id}`,
+    });
+    return NextResponse.json(
+      { ok: true, ...lead },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: error.issues[0]?.message ?? "Check the lead details." },
+        { status: 400 },
+      );
+    }
+    if (error instanceof OperatorLeadError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: error.status },
+      );
+    }
+    console.error("[operator-lead] failed", {
+      operatorId: operator.id,
+      error: error instanceof Error ? error.message : "unknown",
+    });
+    return NextResponse.json(
+      { error: "The operator lead could not be created." },
+      { status: 503 },
+    );
+  }
+}

--- a/src/app/api/admin/sites/[slug]/review/route.ts
+++ b/src/app/api/admin/sites/[slug]/review/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getSuperadminAccess } from "@/lib/authorization";
+import {
+  OperatorLeadError,
+  recordOperatorLeadAction,
+} from "@/lib/operator-leads";
+import { isSameOriginMutation } from "@/lib/request-origin";
+
+const requestSchema = z.object({
+  action: z.enum(["add_note", "complete_review"]),
+  note: z.string().trim().max(2_000).nullable().default(null),
+});
+
+export async function POST(
+  request: Request,
+  { params }: RouteContext<"/api/admin/sites/[slug]/review">,
+) {
+  if (!isSameOriginMutation(request, { requireOrigin: true })) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const operator = await getSuperadminAccess();
+  if (!operator) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  try {
+    const { slug } = await params;
+    const input = requestSchema.parse(await request.json());
+    const result = await recordOperatorLeadAction({
+      siteSlug: slug,
+      action: input.action,
+      note: input.note,
+      actor: `operator:${operator.id}`,
+    });
+    return NextResponse.json(
+      { ok: true, createdAt: result.createdAt.toISOString() },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: error.issues[0]?.message ?? "Check the review details." },
+        { status: 400 },
+      );
+    }
+    if (error instanceof OperatorLeadError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: error.status },
+      );
+    }
+    console.error("[operator-review] failed", {
+      operatorId: operator.id,
+      error: error instanceof Error ? error.message : "unknown",
+    });
+    return NextResponse.json(
+      { error: "The operator review could not be saved." },
+      { status: 503 },
+    );
+  }
+}

--- a/src/lib/claim-invitations.ts
+++ b/src/lib/claim-invitations.ts
@@ -118,6 +118,8 @@ export async function issueClaimInvitation(input: {
   email: string;
   proofMethod: ClaimProofMethodValue;
   actor: string;
+  auditType?: "claim.invitation.created" | "claim.invitation.resent";
+  replacesInvitationId?: string;
   now?: Date;
 }): Promise<IssuedClaimInvitation> {
   const email = normalizeAccountEmail(input.email);
@@ -213,10 +215,11 @@ export async function issueClaimInvitation(input: {
           });
           await tx.auditEvent.create({
             data: {
-              type: "claim.invitation.created",
+              type: input.auditType ?? "claim.invitation.created",
               actor: input.actor,
               metadata: {
                 invitationId: invitation.id,
+                replacesInvitationId: input.replacesInvitationId ?? null,
                 proofMethod: input.proofMethod,
                 expiresAt: expiresAt.toISOString(),
               },
@@ -245,6 +248,70 @@ export async function issueClaimInvitation(input: {
   if (!issued) throw new Error("Claim invitation could not be issued");
 
   return { ...issued, token, email, expiresAt };
+}
+
+export async function resendClaimInvitation(input: {
+  siteSlug: string;
+  invitationId: string;
+  actor: string;
+}): Promise<IssuedClaimInvitation> {
+  const invitation = await getDb().claimInvitation.findFirst({
+    where: {
+      id: input.invitationId,
+      site: { slug: input.siteSlug },
+      acceptedAt: null,
+    },
+    select: { id: true, email: true },
+  });
+  if (!invitation) throw invalidInvitation();
+
+  return issueClaimInvitation({
+    siteSlug: input.siteSlug,
+    email: invitation.email,
+    proofMethod: "OPERATOR_APPROVAL",
+    actor: input.actor,
+    auditType: "claim.invitation.resent",
+    replacesInvitationId: invitation.id,
+  });
+}
+
+export async function revokeClaimInvitation(input: {
+  siteSlug: string;
+  invitationId: string;
+  actor: string;
+  now?: Date;
+}): Promise<boolean> {
+  const now = input.now ?? new Date();
+  return getDb().$transaction(async (tx) => {
+    const invitation = await tx.claimInvitation.findFirst({
+      where: {
+        id: input.invitationId,
+        site: { slug: input.siteSlug },
+      },
+      select: { id: true, siteId: true, acceptedAt: true, revokedAt: true },
+    });
+    if (!invitation) throw invalidInvitation();
+    if (invitation.acceptedAt || invitation.revokedAt) return false;
+
+    const revoked = await tx.claimInvitation.updateMany({
+      where: {
+        id: invitation.id,
+        acceptedAt: null,
+        revokedAt: null,
+      },
+      data: { revokedAt: now },
+    });
+    if (revoked.count !== 1) return false;
+    await tx.auditEvent.create({
+      data: {
+        type: "claim.invitation.revoked",
+        actor: input.actor,
+        metadata: { invitationId: invitation.id },
+        siteId: invitation.siteId,
+      },
+    });
+    return true;
+  });
 }
 
 export type CheckoutClaimInvitation = {

--- a/src/lib/operator-dashboard.ts
+++ b/src/lib/operator-dashboard.ts
@@ -6,6 +6,13 @@ import type {
   Vertical,
 } from "@/generated/prisma/enums";
 import {
+  buildOperatorLeadRollup,
+  getOperatorInvitationState,
+  isOperatorReviewCurrent,
+  type OperatorInvitationState,
+  type OperatorLeadStageRollup,
+} from "@/lib/operator-lead-status";
+import {
   getPortfolioAnalytics,
   type AnalyticsSummaryDto,
   type SiteAnalyticsRowDto,
@@ -23,9 +30,37 @@ export type OperatorSiteRow = {
   subscriptionStatus: SubscriptionStatus | null;
   latestImportStatus: ImportStatus | null;
   latestImportAt: Date | null;
+  latestImportError: string | null;
   bookingRequestCount: number;
   pendingBookingRequestCount: number;
   verifiedDomain: string | null;
+  domainCount: number;
+  verifiedDomainCount: number;
+  tlsReadiness: "NOT_CONFIGURED" | "WAITING_FOR_DNS" | "AUTHORIZED";
+  invitation: {
+    id: string;
+    email: string;
+    state: OperatorInvitationState;
+    expiresAt: Date;
+    createdAt: Date;
+  } | null;
+  reviewedAt: Date | null;
+  reviewedBy: string | null;
+  notes: Array<{
+    id: string;
+    note: string;
+    actor: string | null;
+    createdAt: Date;
+  }>;
+  contentReview: {
+    missingFields: string[];
+    heroImage: "missing" | "provenance_missing" | "provenance_recorded";
+    translationCount: number;
+    integrationCount: number;
+    catalogItemCount: number;
+  };
+  isPublished: boolean;
+  blockers: OperatorLeadStageRollup[];
   analytics30d: SiteAnalyticsRowDto;
 };
 
@@ -76,27 +111,62 @@ export async function getOperatorDashboardData(): Promise<OperatorDashboardData>
         vertical: true,
         status: true,
         createdAt: true,
+        updatedAt: true,
+        description: true,
+        address: true,
+        phone: true,
+        sourceUrl: true,
+        heroImageUrl: true,
+        heroImageProvenance: true,
+        defaultLocale: true,
+        translations: true,
+        publishedSiteVersionId: true,
         organization: {
           select: {
             _count: { select: { memberships: true } },
-            subscriptions: {
-              orderBy: { createdAt: "desc" },
-              take: 1,
-              select: { status: true },
-            },
           },
         },
+        subscription: { select: { status: true } },
         importJobs: {
           orderBy: { createdAt: "desc" },
           take: 1,
-          select: { status: true, createdAt: true },
+          select: { status: true, createdAt: true, error: true },
         },
-        _count: { select: { bookingRequests: true } },
+        _count: { select: { bookingRequests: true, integrations: true } },
+        catalogSections: {
+          select: { _count: { select: { items: true } } },
+        },
         domains: {
-          where: { verified: true },
-          orderBy: { verifiedAt: "desc" },
+          orderBy: [{ verified: "desc" }, { verifiedAt: "desc" }],
+          select: { hostname: true, verified: true },
+        },
+        claimInvitations: {
+          orderBy: { createdAt: "desc" },
           take: 1,
-          select: { hostname: true },
+          select: {
+            id: true,
+            email: true,
+            expiresAt: true,
+            verifiedAt: true,
+            acceptedAt: true,
+            revokedAt: true,
+            checkoutSessionId: true,
+            createdAt: true,
+          },
+        },
+        auditEvents: {
+          where: {
+            type: { in: ["operator.note.created", "site.review.completed"] },
+          },
+          orderBy: { createdAt: "desc" },
+          take: 12,
+          select: {
+            id: true,
+            type: true,
+            actor: true,
+            metadata: true,
+            createdAt: true,
+          },
         },
       },
     }),
@@ -127,28 +197,133 @@ export async function getOperatorDashboardData(): Promise<OperatorDashboardData>
       pendingBookingRequests: pendingBookingRequestCount,
     },
     analytics: analytics.summary,
-    sites: sites.map((site) => ({
-      id: site.id,
-      slug: site.slug,
-      name: site.name,
-      vertical: site.vertical,
-      status: site.status,
-      createdAt: site.createdAt,
-      ownerCount: site.organization?._count.memberships ?? 0,
-      subscriptionStatus: site.organization?.subscriptions[0]?.status ?? null,
-      latestImportStatus: site.importJobs[0]?.status ?? null,
-      latestImportAt: site.importJobs[0]?.createdAt ?? null,
-      bookingRequestCount: site._count.bookingRequests,
-      pendingBookingRequestCount:
-        pendingBookingRequestCounts.get(site.id) ?? 0,
-      verifiedDomain: site.domains[0]?.hostname ?? null,
-      analytics30d: analytics.displayedSites30d.get(site.id) ?? {
-        visits: 0,
-        ctaVisitors: 0,
-        bookingLeads: 0,
-        ctaRate: 0,
-        leadRate: 0,
-      },
-    })),
+    sites: sites.map((site) => {
+      const ownerCount = site.organization?._count.memberships ?? 0;
+      const invitationRecord = site.claimInvitations[0] ?? null;
+      const invitationState = getOperatorInvitationState(invitationRecord);
+      const latestReviewEvent = site.auditEvents.find(
+        (event) => event.type === "site.review.completed",
+      );
+      const reviewEvent =
+        latestReviewEvent &&
+        isOperatorReviewCurrent(latestReviewEvent.createdAt, site.updatedAt)
+          ? latestReviewEvent
+          : undefined;
+      const notes = site.auditEvents.flatMap((event) => {
+        if (event.type !== "operator.note.created") return [];
+        const note = metadataString(event.metadata, "note");
+        return note
+          ? [
+              {
+                id: event.id,
+                note,
+                actor: event.actor,
+                createdAt: event.createdAt,
+              },
+            ]
+          : [];
+      });
+      const verifiedDomainCount = site.domains.filter(
+        (domain) => domain.verified,
+      ).length;
+      const contentReview = {
+        missingFields: [
+          !site.name.trim() ? "name" : null,
+          !site.description?.trim() ? "description" : null,
+          !site.address?.trim() ? "address" : null,
+          !site.phone?.trim() ? "phone" : null,
+          !site.sourceUrl?.trim() ? "source URL" : null,
+        ].filter((value): value is string => Boolean(value)),
+        heroImage: !site.heroImageUrl
+          ? ("missing" as const)
+          : site.heroImageProvenance
+            ? ("provenance_recorded" as const)
+            : ("provenance_missing" as const),
+        translationCount: jsonArrayLength(site.translations),
+        integrationCount: site._count.integrations,
+        catalogItemCount: site.catalogSections.reduce(
+          (sum, section) => sum + section._count.items,
+          0,
+        ),
+      };
+      const blockers = buildOperatorLeadRollup({
+        importStatus: site.importJobs[0]?.status ?? null,
+        reviewedAt: reviewEvent?.createdAt ?? null,
+        ownerCount,
+        invitationState,
+        subscriptionStatus: site.subscription?.status ?? null,
+        domainCount: site.domains.length,
+        verifiedDomainCount,
+        isPublished:
+          Boolean(site.publishedSiteVersionId) && site.status === "LIVE",
+      });
+
+      return {
+        id: site.id,
+        slug: site.slug,
+        name: site.name,
+        vertical: site.vertical,
+        status: site.status,
+        createdAt: site.createdAt,
+        ownerCount,
+        subscriptionStatus: site.subscription?.status ?? null,
+        latestImportStatus: site.importJobs[0]?.status ?? null,
+        latestImportAt: site.importJobs[0]?.createdAt ?? null,
+        latestImportError: site.importJobs[0]?.error ?? null,
+        bookingRequestCount: site._count.bookingRequests,
+        pendingBookingRequestCount:
+          pendingBookingRequestCounts.get(site.id) ?? 0,
+        verifiedDomain:
+          site.domains.find((domain) => domain.verified)?.hostname ?? null,
+        domainCount: site.domains.length,
+        verifiedDomainCount,
+        tlsReadiness:
+          verifiedDomainCount > 0
+            ? ("AUTHORIZED" as const)
+            : site.domains.length > 0
+              ? ("WAITING_FOR_DNS" as const)
+              : ("NOT_CONFIGURED" as const),
+        invitation: invitationRecord
+          ? {
+              id: invitationRecord.id,
+              email: invitationRecord.email,
+              state: invitationState,
+              expiresAt: invitationRecord.expiresAt,
+              createdAt: invitationRecord.createdAt,
+            }
+          : null,
+        reviewedAt: reviewEvent?.createdAt ?? null,
+        reviewedBy: reviewEvent?.actor ?? null,
+        notes,
+        contentReview,
+        isPublished:
+          Boolean(site.publishedSiteVersionId) && site.status === "LIVE",
+        blockers,
+        analytics30d: analytics.displayedSites30d.get(site.id) ?? {
+          visits: 0,
+          ctaVisitors: 0,
+          bookingLeads: 0,
+          ctaRate: 0,
+          leadRate: 0,
+        },
+      };
+    }),
   };
+}
+
+function metadataString(metadata: unknown, key: string): string | null {
+  if (
+    typeof metadata !== "object" ||
+    metadata === null ||
+    Array.isArray(metadata) ||
+    !(key in metadata)
+  ) {
+    return null;
+  }
+  const value = (metadata as Record<string, unknown>)[key];
+  return typeof value === "string" ? value : null;
+}
+
+function jsonArrayLength(value: unknown): number {
+  return Array.isArray(value) ? value.length : 0;
 }

--- a/src/lib/operator-lead-status.test.ts
+++ b/src/lib/operator-lead-status.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "bun:test";
+import {
+  buildOperatorLeadRollup,
+  getOperatorInvitationState,
+  isOperatorReviewCurrent,
+} from "@/lib/operator-lead-status";
+
+describe("operator invitation state", () => {
+  const future = new Date("2026-08-01T00:00:00.000Z");
+  const now = new Date("2026-07-27T00:00:00.000Z");
+
+  it("distinguishes active, checkout-bound and terminal invitations", () => {
+    expect(
+      getOperatorInvitationState(
+        {
+          expiresAt: future,
+          verifiedAt: null,
+          acceptedAt: null,
+          revokedAt: null,
+          checkoutSessionId: null,
+        },
+        now,
+      ),
+    ).toBe("ACTIVE");
+    expect(
+      getOperatorInvitationState(
+        {
+          expiresAt: future,
+          verifiedAt: now,
+          acceptedAt: null,
+          revokedAt: null,
+          checkoutSessionId: "cs_1",
+        },
+        now,
+      ),
+    ).toBe("CHECKOUT_STARTED");
+    expect(
+      getOperatorInvitationState(
+        {
+          expiresAt: future,
+          verifiedAt: now,
+          acceptedAt: now,
+          revokedAt: null,
+          checkoutSessionId: "cs_1",
+        },
+        now,
+      ),
+    ).toBe("ACCEPTED");
+  });
+
+  it("does not present an expired or revoked invitation as actionable", () => {
+    const expired = new Date("2026-07-26T00:00:00.000Z");
+    expect(
+      getOperatorInvitationState(
+        {
+          expiresAt: expired,
+          verifiedAt: null,
+          acceptedAt: null,
+          revokedAt: null,
+          checkoutSessionId: null,
+        },
+        now,
+      ),
+    ).toBe("EXPIRED");
+    expect(
+      getOperatorInvitationState(
+        {
+          expiresAt: future,
+          verifiedAt: null,
+          acceptedAt: null,
+          revokedAt: now,
+          checkoutSessionId: null,
+        },
+        now,
+      ),
+    ).toBe("REVOKED");
+  });
+});
+
+describe("operator blocker rollup", () => {
+  it("invalidates a review when the private draft changes later", () => {
+    expect(
+      isOperatorReviewCurrent(
+        new Date("2026-07-27T10:00:00.000Z"),
+        new Date("2026-07-27T09:00:00.000Z"),
+      ),
+    ).toBe(true);
+    expect(
+      isOperatorReviewCurrent(
+        new Date("2026-07-27T09:00:00.000Z"),
+        new Date("2026-07-27T10:00:00.000Z"),
+      ),
+    ).toBe(false);
+  });
+
+  it("shows the complete launch path without hiding domain readiness", () => {
+    const stages = buildOperatorLeadRollup({
+      importStatus: "READY",
+      reviewedAt: new Date("2026-07-27T00:00:00.000Z"),
+      ownerCount: 1,
+      invitationState: "ACCEPTED",
+      subscriptionStatus: "ACTIVE",
+      domainCount: 1,
+      verifiedDomainCount: 1,
+      isPublished: true,
+    });
+
+    expect(stages.map(({ stage }) => stage)).toEqual([
+      "import",
+      "content_review",
+      "claim",
+      "checkout",
+      "domain_tls",
+      "publish",
+    ]);
+    expect(stages.every(({ status }) => status === "complete")).toBe(true);
+  });
+
+  it("keeps a private preview blocked until review, claim and billing finish", () => {
+    const stages = buildOperatorLeadRollup({
+      importStatus: "READY",
+      reviewedAt: null,
+      ownerCount: 0,
+      invitationState: "ACTIVE",
+      subscriptionStatus: null,
+      domainCount: 0,
+      verifiedDomainCount: 0,
+      isPublished: false,
+    });
+
+    expect(stages.find(({ stage }) => stage === "claim")?.status).toBe("ready");
+    expect(stages.find(({ stage }) => stage === "content_review")?.status).toBe(
+      "blocked",
+    );
+    expect(stages.find(({ stage }) => stage === "checkout")?.status).toBe(
+      "blocked",
+    );
+    expect(stages.find(({ stage }) => stage === "publish")?.status).toBe(
+      "blocked",
+    );
+  });
+});

--- a/src/lib/operator-lead-status.ts
+++ b/src/lib/operator-lead-status.ts
@@ -1,0 +1,245 @@
+export type OperatorLeadStage =
+  | "import"
+  | "content_review"
+  | "claim"
+  | "checkout"
+  | "domain_tls"
+  | "publish";
+
+export type OperatorLeadStageStatus = "blocked" | "ready" | "complete";
+
+export type OperatorLeadStageRollup = {
+  stage: OperatorLeadStage;
+  status: OperatorLeadStageStatus;
+  label: string;
+  detail: string;
+};
+
+export type OperatorInvitationState =
+  | "NONE"
+  | "ACTIVE"
+  | "VERIFIED"
+  | "CHECKOUT_STARTED"
+  | "ACCEPTED"
+  | "REVOKED"
+  | "EXPIRED";
+
+type InvitationSnapshot = {
+  expiresAt: Date;
+  verifiedAt: Date | null;
+  acceptedAt: Date | null;
+  revokedAt: Date | null;
+  checkoutSessionId: string | null;
+};
+
+export type OperatorLeadRollupInput = {
+  importStatus:
+    | "QUEUED"
+    | "CRAWLING"
+    | "EXTRACTING"
+    | "GENERATING"
+    | "READY"
+    | "FAILED"
+    | null;
+  reviewedAt: Date | null;
+  ownerCount: number;
+  invitationState: OperatorInvitationState;
+  subscriptionStatus:
+    | "INCOMPLETE"
+    | "ACTIVE"
+    | "PAST_DUE"
+    | "CANCELED"
+    | null;
+  domainCount: number;
+  verifiedDomainCount: number;
+  isPublished: boolean;
+};
+
+export function getOperatorInvitationState(
+  invitation: InvitationSnapshot | null,
+  now = new Date(),
+): OperatorInvitationState {
+  if (!invitation) return "NONE";
+  if (invitation.acceptedAt) return "ACCEPTED";
+  if (invitation.revokedAt) return "REVOKED";
+  if (invitation.expiresAt <= now) return "EXPIRED";
+  if (invitation.checkoutSessionId) return "CHECKOUT_STARTED";
+  if (invitation.verifiedAt) return "VERIFIED";
+  return "ACTIVE";
+}
+
+export function isOperatorReviewCurrent(
+  reviewedAt: Date | null,
+  contentUpdatedAt: Date,
+): boolean {
+  return Boolean(reviewedAt && reviewedAt >= contentUpdatedAt);
+}
+
+export function buildOperatorLeadRollup(
+  input: OperatorLeadRollupInput,
+): OperatorLeadStageRollup[] {
+  const importStage: OperatorLeadStageRollup =
+    input.importStatus === "READY"
+      ? {
+          stage: "import",
+          status: "complete",
+          label: "Import ready",
+          detail: "The latest persisted import completed successfully.",
+        }
+      : {
+          stage: "import",
+          status: "blocked",
+          label:
+            input.importStatus === "FAILED"
+              ? "Import failed"
+              : input.importStatus
+                ? "Import in progress"
+                : "Import missing",
+          detail: input.importStatus
+            ? `Latest import state: ${input.importStatus.toLowerCase()}.`
+            : "Create or reopen this lead before review.",
+        };
+
+  const contentReviewStage: OperatorLeadStageRollup = input.reviewedAt
+    ? {
+        stage: "content_review",
+        status: "complete",
+        label: "Content reviewed",
+        detail: "An operator accepted the current private preview.",
+      }
+    : {
+        stage: "content_review",
+        status: "blocked",
+        label: "Content review pending",
+        detail:
+          "Review content completeness, image provenance, translations, and integrations.",
+      };
+
+  const claimStage = claimRollup(input);
+  const checkoutStage = checkoutRollup(input);
+  const domainStage: OperatorLeadStageRollup =
+    input.verifiedDomainCount > 0
+      ? {
+          stage: "domain_tls",
+          status: "complete",
+          label: "TLS authorized",
+          detail:
+            "A verified customer domain is authorized for certificate issuance.",
+        }
+      : input.domainCount > 0
+        ? {
+            stage: "domain_tls",
+            status: "blocked",
+            label: "DNS verification pending",
+            detail:
+              "A customer domain is attached but is not yet authorized for TLS.",
+          }
+        : {
+            stage: "domain_tls",
+            status: "blocked",
+            label: "Custom domain missing",
+            detail:
+              "The platform preview works, but no customer domain is configured.",
+          };
+
+  const publishDependenciesReady =
+    Boolean(input.reviewedAt) &&
+    input.ownerCount > 0 &&
+    input.subscriptionStatus === "ACTIVE";
+  const publishStage: OperatorLeadStageRollup = input.isPublished
+    ? {
+        stage: "publish",
+        status: "complete",
+        label: "Published",
+        detail: "A version is live from the immutable publication snapshot.",
+      }
+    : publishDependenciesReady
+      ? {
+          stage: "publish",
+          status: "ready",
+          label: "Ready to publish",
+          detail: "The owner can publish the reviewed draft.",
+        }
+      : {
+          stage: "publish",
+          status: "blocked",
+          label: "Publish blocked",
+          detail:
+            "Content review, ownership, and an active subscription are required.",
+        };
+
+  return [
+    importStage,
+    contentReviewStage,
+    claimStage,
+    checkoutStage,
+    domainStage,
+    publishStage,
+  ];
+}
+
+function claimRollup(
+  input: OperatorLeadRollupInput,
+): OperatorLeadStageRollup {
+  if (input.ownerCount > 0 || input.invitationState === "ACCEPTED") {
+    return {
+      stage: "claim",
+      status: "complete",
+      label: "Claim complete",
+      detail: "The site is connected to an owner organization.",
+    };
+  }
+  if (
+    input.invitationState === "ACTIVE" ||
+    input.invitationState === "VERIFIED" ||
+    input.invitationState === "CHECKOUT_STARTED"
+  ) {
+    return {
+      stage: "claim",
+      status: "ready",
+      label:
+        input.invitationState === "CHECKOUT_STARTED"
+          ? "Checkout started"
+          : input.invitationState === "VERIFIED"
+            ? "Invitation verified"
+            : "Invitation active",
+      detail: "The owner has a current authorized path to claim this preview.",
+    };
+  }
+  return {
+    stage: "claim",
+    status: "blocked",
+    label: "Claim invitation needed",
+    detail: "Issue or resend an authorized owner invitation.",
+  };
+}
+
+function checkoutRollup(
+  input: OperatorLeadRollupInput,
+): OperatorLeadStageRollup {
+  if (input.subscriptionStatus === "ACTIVE") {
+    return {
+      stage: "checkout",
+      status: "complete",
+      label: "Subscription active",
+      detail: "Stripe access is active for this site.",
+    };
+  }
+  if (input.invitationState === "CHECKOUT_STARTED") {
+    return {
+      stage: "checkout",
+      status: "ready",
+      label: "Checkout in progress",
+      detail: "The current invitation is bound to a Stripe Checkout session.",
+    };
+  }
+  return {
+    stage: "checkout",
+    status: "blocked",
+    label: input.subscriptionStatus
+      ? `Subscription ${input.subscriptionStatus.toLowerCase()}`
+      : "Subscription missing",
+    detail:
+      "The claim Checkout flow must produce an active site subscription.",
+  };
+}

--- a/src/lib/operator-leads.ts
+++ b/src/lib/operator-leads.ts
@@ -1,0 +1,164 @@
+import "server-only";
+import { Vertical } from "@/generated/prisma/enums";
+import { getDb } from "@/lib/db";
+import {
+  buildImportUrls,
+  importFailureMessage,
+  normalizeImportSource,
+} from "@/lib/import-identity";
+import {
+  createImportJob,
+  persistSiteImport,
+  recordImportFailure,
+  type PersistableSiteDraft,
+} from "@/lib/site-persistence";
+import {
+  crawlSiteSource,
+  generateDraftForVertical,
+} from "@/lib/site-pipeline";
+import type { VerticalId } from "@/lib/verticals/types";
+
+const mutableLeadStatuses = new Set(["PROSPECT", "PREVIEW_READY"]);
+
+export class OperatorLeadError extends Error {
+  constructor(
+    message: string,
+    public readonly status: 400 | 404 | 409 | 503 = 400,
+  ) {
+    super(message);
+    this.name = "OperatorLeadError";
+  }
+}
+
+export async function createOrReopenOperatorLead(input: {
+  source: string;
+  vertical: VerticalId;
+  actor: string;
+}): Promise<{
+  siteSlug: string;
+  importJobId: string | null;
+  created: boolean;
+  reopened: boolean;
+  urls: { preview: string; claim: string };
+}> {
+  const sourceKey = normalizeImportSource(input.source);
+  const db = getDb();
+  const existing = await db.site.findUnique({
+    where: { sourceKey },
+    select: { id: true, slug: true, status: true },
+  });
+
+  if (existing) {
+    if (!mutableLeadStatuses.has(existing.status)) {
+      throw new OperatorLeadError(
+        "This business is already claimed and cannot be reopened as a prospect.",
+        409,
+      );
+    }
+    await db.$transaction(async (tx) => {
+      const reopened = await tx.site.updateMany({
+        where: {
+          id: existing.id,
+          status: { in: ["PROSPECT", "PREVIEW_READY"] },
+        },
+        data: { status: "PREVIEW_READY" },
+      });
+      if (reopened.count !== 1) {
+        throw new OperatorLeadError(
+          "This lead changed while it was being reopened.",
+          409,
+        );
+      }
+      await tx.auditEvent.create({
+        data: {
+          type: "site.lead.reopened",
+          actor: input.actor,
+          metadata: {
+            sourceKey,
+            previousStatus: existing.status,
+          },
+          siteId: existing.id,
+        },
+      });
+    });
+    return {
+      siteSlug: existing.slug,
+      importJobId: null,
+      created: false,
+      reopened: true,
+      urls: buildImportUrls(existing.slug),
+    };
+  }
+
+  let importJobId: string | null = null;
+  try {
+    const importJob = await createImportJob(input.source, input.vertical);
+    importJobId = importJob.id;
+    const extracted = await crawlSiteSource(input.source, input.vertical);
+    const draft = await generateDraftForVertical(extracted, input.vertical);
+    const persisted = await persistSiteImport<PersistableSiteDraft>({
+      draft,
+      vertical: input.vertical,
+      source: input.source,
+      importJobId,
+      actor: input.actor,
+    });
+    return {
+      siteSlug: persisted.draft.slug,
+      importJobId,
+      created: persisted.created,
+      reopened: !persisted.created,
+      urls: persisted.urls,
+    };
+  } catch (error) {
+    if (importJobId) {
+      try {
+        await recordImportFailure(importJobId, error);
+      } catch (recordError) {
+        console.error("[operator-lead] failed to record import failure", {
+          importJobId,
+          error:
+            recordError instanceof Error ? recordError.message : "unknown",
+        });
+      }
+    }
+    if (error instanceof OperatorLeadError) throw error;
+    throw new OperatorLeadError(importFailureMessage(error), 400);
+  }
+}
+
+export async function recordOperatorLeadAction(input: {
+  siteSlug: string;
+  action: "add_note" | "complete_review";
+  note: string | null;
+  actor: string;
+}): Promise<{ createdAt: Date }> {
+  const note = input.note?.trim() || null;
+  if (input.action === "add_note" && !note) {
+    throw new OperatorLeadError("Write a note before saving.", 400);
+  }
+  const db = getDb();
+  return db.$transaction(async (tx) => {
+    const site = await tx.site.findUnique({
+      where: { slug: input.siteSlug },
+      select: { id: true },
+    });
+    if (!site) throw new OperatorLeadError("Lead not found.", 404);
+    const createdAt = new Date();
+    await tx.auditEvent.create({
+      data: {
+        type:
+          input.action === "add_note"
+            ? "operator.note.created"
+            : "site.review.completed",
+        actor: input.actor,
+        metadata: note ? { note } : {},
+        siteId: site.id,
+        createdAt,
+      },
+    });
+    return { createdAt };
+  });
+}
+
+export const DEFAULT_OPERATOR_VERTICAL = Vertical.RESTAURANT;

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -159,3 +159,13 @@ export function limitOperatorClaimInvitation(
     windowMs,
   });
 }
+
+export function limitOperatorLeadMutation(
+  request: Request,
+): Promise<RateLimitResult> {
+  return limitByIp(request, {
+    namespace: "operator-lead",
+    limit: 30,
+    windowMs,
+  });
+}

--- a/src/lib/site-persistence.ts
+++ b/src/lib/site-persistence.ts
@@ -190,6 +190,7 @@ export async function persistSiteImport<TDraft extends PersistableSiteDraft>(inp
   vertical: VerticalId;
   source: string;
   importJobId: string;
+  actor?: string;
 }): Promise<PersistedSiteImport<TDraft>> {
   const db = requireImportDatabase();
   const config = resolveVerticalConfig(input.vertical);
@@ -291,7 +292,7 @@ export async function persistSiteImport<TDraft extends PersistableSiteDraft>(inp
           await tx.auditEvent.create({
             data: {
               type: existing ? "site.import.updated" : "site.import.created",
-              actor: "system:import",
+              actor: input.actor ?? "system:import",
               metadata: {
                 importJobId: input.importJobId,
                 vertical: input.vertical,


### PR DESCRIPTION
## Summary
- add superadmin-authorized business URL/name create-or-reopen into the persisted private-preview workflow
- persist private operator notes and content-review decisions as append-only audit events, invalidating review when the draft changes
- show one rollup for import, content review, claim, checkout/subscription, domain/TLS readiness, and publication
- expose authorized claim invitation issue, resend, and revoke actions on the existing hashed, expiring invitation lifecycle

## Verification
- bun test: 208 passed, 11 expected PostgreSQL integration skips
- bunx next typegen: passed
- bunx tsc --noEmit: passed
- bun run lint: 0 errors; one pre-existing generated workflow warning
- git diff --check: passed
- local next build was terminated after hanging without output; PR CI owns the broad build gate
- exact-head genfeedai Opus review attempted at b30b2d25158cddc9f157f1cd543a4fcec83f3cf6, but Anthropic returned HTTP 429 with zero usage; no verdict was fabricated

## Issue #17
This implements the remaining code-level acceptance criteria for #17. The issue stays open until the complete operator path is exercised in production and evidence is attached; this PR does not deploy.