### PR TITLE
feat: ship multilingual restaurant menu CRUD

### DIFF
--- a/src/app/api/sites/[slug]/publish/route.ts
+++ b/src/app/api/sites/[slug]/publish/route.ts
@@ -6,6 +6,7 @@ import {
 import {
   publishSiteDraft,
   SitePublicationStateError,
+  SitePublicationTranslationError,
 } from "@/lib/site-publication";
 
 const publishRequestSchema = z.object({
@@ -51,6 +52,9 @@ export async function POST(
       );
     }
     if (error instanceof SitePublicationStateError) {
+      return Response.json({ error: error.message }, { status: 409 });
+    }
+    if (error instanceof SitePublicationTranslationError) {
       return Response.json({ error: error.message }, { status: 409 });
     }
 

--- a/src/app/api/sites/[slug]/translations/[locale]/regenerate/route.ts
+++ b/src/app/api/sites/[slug]/translations/[locale]/regenerate/route.ts
@@ -1,0 +1,65 @@
+import {
+  accessFailureResponse,
+  getSiteAccess,
+} from "@/lib/authorization";
+import { regenerateRestaurantTranslation } from "@/lib/ai/site-generation";
+import { fromRestaurantDraft, localeSchema } from "@/lib/restaurant";
+import { getRestaurantDraft } from "@/lib/restaurants";
+import { updateSiteDraft } from "@/lib/site-persistence";
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+export async function POST(
+  _request: Request,
+  {
+    params,
+  }: RouteContext<"/api/sites/[slug]/translations/[locale]/regenerate">,
+) {
+  const { slug, locale: rawLocale } = await params;
+  const access = await getSiteAccess(slug);
+  if (!access.ok) return accessFailureResponse(access);
+  const locale = localeSchema.safeParse(rawLocale);
+  if (!locale.success) {
+    return Response.json({ error: "Unsupported locale" }, { status: 400 });
+  }
+
+  try {
+    const draft = await getRestaurantDraft(access.site.slug);
+    if (
+      !draft.translations.some(
+        (translation) => translation.locale === locale.data,
+      )
+    ) {
+      return Response.json({ error: "Translation not found" }, { status: 404 });
+    }
+    const regenerated = await regenerateRestaurantTranslation(
+      draft,
+      locale.data,
+    );
+    await updateSiteDraft(
+      access.site.slug,
+      fromRestaurantDraft(regenerated),
+      access.site.vertical,
+    );
+    return Response.json({ ok: true, draft: regenerated });
+  } catch (error) {
+    const unavailable =
+      error instanceof Error &&
+      error.message === "Translation regeneration is not configured";
+    console.error("[menu-translation] regeneration failed", {
+      slug,
+      locale: locale.data,
+      actorId: access.user.id,
+      error: error instanceof Error ? error.message : "unknown",
+    });
+    return Response.json(
+      {
+        error: unavailable
+          ? "Translation regeneration is temporarily unavailable"
+          : "Translation could not be regenerated",
+      },
+      { status: unavailable ? 503 : 500 },
+    );
+  }
+}

--- a/src/app/api/sites/[slug]/translations/[locale]/regenerate/route.ts
+++ b/src/app/api/sites/[slug]/translations/[locale]/regenerate/route.ts
@@ -1,24 +1,38 @@
-import {
-  accessFailureResponse,
-  getSiteAccess,
-} from "@/lib/authorization";
+import { accessFailureResponse, getSiteAccess } from "@/lib/authorization";
 import { regenerateRestaurantTranslation } from "@/lib/ai/site-generation";
 import { fromRestaurantDraft, localeSchema } from "@/lib/restaurant";
 import { getRestaurantDraft } from "@/lib/restaurants";
+import { limitTranslationRegeneration } from "@/lib/rate-limit";
+import { isSameOriginMutation } from "@/lib/request-origin";
 import { updateSiteDraft } from "@/lib/site-persistence";
 
 export const runtime = "nodejs";
 export const maxDuration = 60;
 
 export async function POST(
-  _request: Request,
+  request: Request,
   {
     params,
   }: RouteContext<"/api/sites/[slug]/translations/[locale]/regenerate">,
 ) {
+  if (!isSameOriginMutation(request, { requireOrigin: true })) {
+    return Response.json({ error: "Invalid request origin" }, { status: 403 });
+  }
   const { slug, locale: rawLocale } = await params;
   const access = await getSiteAccess(slug);
   if (!access.ok) return accessFailureResponse(access);
+  const rateLimit = await limitTranslationRegeneration(request);
+  if (!rateLimit.success) {
+    return Response.json(
+      {
+        error:
+          rateLimit.reason === "unavailable"
+            ? "Translation regeneration is temporarily unavailable"
+            : "Too many translation requests. Try again later.",
+      },
+      { status: rateLimit.reason === "unavailable" ? 503 : 429 },
+    );
+  }
   const locale = localeSchema.safeParse(rawLocale);
   if (!locale.success) {
     return Response.json({ error: "Unsupported locale" }, { status: 400 });

--- a/src/app/dashboard/dashboard.tsx
+++ b/src/app/dashboard/dashboard.tsx
@@ -30,6 +30,7 @@ import {
   ClientAnalyticsPanel,
   ClientBookingRequestInbox,
 } from "@/components/client-workspace";
+import { RestaurantMenuEditor } from "@/components/restaurant-menu-editor";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -43,9 +44,17 @@ import type { AnalyticsSummaryDto } from "@/lib/analytics-contract";
 import type { BookingRequestInboxDto } from "@/lib/booking-request-inbox";
 import type { BillingAccess } from "@/lib/billing-access";
 import {
-  formatPrice,
+  restaurantDraftSchema,
   type RestaurantDraft,
 } from "@/lib/restaurant";
+import {
+  applyRestaurantMenuMutation,
+  hasUnreviewedRestaurantTranslations,
+  markRestaurantTranslationReviewed,
+  updateRestaurantTranslation,
+  validateRestaurantMenuDraft,
+  type RestaurantMenuMutation,
+} from "@/lib/restaurant-menu-editor";
 
 type DomainSetup = {
   hostname: string;
@@ -90,11 +99,27 @@ export function Dashboard({
   const [domainLoading, setDomainLoading] = useState(false);
   const [imageLoading, setImageLoading] = useState(false);
   const [portalLoading, setPortalLoading] = useState(false);
+  const [menuDirty, setMenuDirty] = useState(false);
+  const [menuSaveError, setMenuSaveError] = useState<string | null>(null);
+  const [menuValidationIssues, setMenuValidationIssues] = useState<
+    ReturnType<typeof validateRestaurantMenuDraft>
+  >([]);
+  const [menuUndoStack, setMenuUndoStack] = useState<RestaurantDraft[]>([]);
+  const [regeneratingLocale, setRegeneratingLocale] = useState<string | null>(
+    null,
+  );
 
   async function save(): Promise<boolean> {
+    const validationIssues = validateRestaurantMenuDraft(draft);
+    setMenuValidationIssues(validationIssues);
+    if (validationIssues.length > 0) {
+      setMenuSaveError("The menu contains invalid or incomplete fields");
+      return false;
+    }
     setSaving(true);
     setSaved(false);
     setPublishError(null);
+    setMenuSaveError(null);
     try {
       if (!demo) {
         const response = await fetch(`/api/sites/${draft.slug}`, {
@@ -102,15 +127,22 @@ export function Dashboard({
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(draft),
         });
-        if (!response.ok) throw new Error("Save failed");
+        const result = (await response.json()) as {
+          error?: string;
+        };
+        if (!response.ok) {
+          throw new Error(result.error ?? "Save failed");
+        }
       }
       setSaved(true);
+      setMenuDirty(false);
+      setMenuValidationIssues([]);
       setPublishedVersion(null);
       return true;
     } catch (caught) {
-      setPublishError(
-        caught instanceof Error ? caught.message : "Save failed",
-      );
+      const message = caught instanceof Error ? caught.message : "Save failed";
+      setPublishError(message);
+      setMenuSaveError(message);
       return false;
     } finally {
       setSaving(false);
@@ -118,6 +150,12 @@ export function Dashboard({
   }
 
   async function publish() {
+    if (hasUnreviewedRestaurantTranslations(draft)) {
+      setPublishError(
+        "Review every stale or regenerated translation before publishing",
+      );
+      return;
+    }
     const changeSummary = window
       .prompt(
         "Summarize what will change on the public site:",
@@ -143,6 +181,7 @@ export function Dashboard({
       if (!(await save())) return;
       if (demo) {
         setPublishedVersion(1);
+        setMenuUndoStack([]);
         return;
       }
 
@@ -159,6 +198,7 @@ export function Dashboard({
         throw new Error(result.error ?? "Publish failed");
       }
       setPublishedVersion(result.published.version);
+      setMenuUndoStack([]);
     } catch (caught) {
       setPublishError(
         caught instanceof Error ? caught.message : "Publish failed",
@@ -166,6 +206,108 @@ export function Dashboard({
     } finally {
       setPublishing(false);
     }
+  }
+
+  function mutateMenu(
+    mutation: RestaurantMenuMutation,
+    destructive = false,
+  ) {
+    try {
+      if (destructive) {
+        setMenuUndoStack((current) => [
+          ...current,
+          structuredClone(draft),
+        ]);
+      }
+      const next = applyRestaurantMenuMutation(draft, mutation);
+      setDraft(next);
+      setMenuDirty(true);
+      setSaved(false);
+      setMenuSaveError(null);
+      setMenuValidationIssues(validateRestaurantMenuDraft(next));
+    } catch (error) {
+      setMenuSaveError(
+        error instanceof Error ? error.message : "Menu change failed",
+      );
+    }
+  }
+
+  function changeTranslation(
+    locale: string,
+    updater: Parameters<typeof updateRestaurantTranslation>[2],
+  ) {
+    const next = updateRestaurantTranslation(draft, locale, updater);
+    setDraft(next);
+    setMenuDirty(true);
+    setSaved(false);
+    setMenuSaveError(null);
+    setMenuValidationIssues(validateRestaurantMenuDraft(next));
+  }
+
+  function reviewTranslation(locale: string) {
+    try {
+      const next = markRestaurantTranslationReviewed(draft, locale);
+      setDraft(next);
+      setMenuDirty(true);
+      setSaved(false);
+      setMenuSaveError(null);
+      setMenuValidationIssues([]);
+    } catch {
+      setMenuSaveError(
+        "Fix the translated menu fields before marking this locale reviewed",
+      );
+    }
+  }
+
+  async function regenerateTranslation(locale: string) {
+    if (menuDirty) {
+      setMenuSaveError(
+        "Save canonical changes before regenerating a translation",
+      );
+      return;
+    }
+    setRegeneratingLocale(locale);
+    setMenuSaveError(null);
+    try {
+      const response = await fetch(
+        `/api/sites/${draft.slug}/translations/${locale}/regenerate`,
+        { method: "POST" },
+      );
+      const result = (await response.json()) as {
+        error?: string;
+        draft?: unknown;
+      };
+      if (!response.ok || !result.draft) {
+        throw new Error(result.error ?? "Translation regeneration failed");
+      }
+      const regenerated = restaurantDraftSchema.parse(result.draft);
+      setDraft((current) => ({
+        ...current,
+        translations: regenerated.translations,
+      }));
+      setSaved(true);
+      setMenuDirty(false);
+      setMenuValidationIssues([]);
+    } catch (error) {
+      setMenuSaveError(
+        error instanceof Error
+          ? error.message
+          : "Translation regeneration failed",
+      );
+    } finally {
+      setRegeneratingLocale(null);
+    }
+  }
+
+  function undoMenuDeletion() {
+    const previous = menuUndoStack.at(-1);
+    if (!previous) return;
+    setDraft(previous);
+    setMenuUndoStack((current) => current.slice(0, -1));
+    setMenuDirty(true);
+    setSaved(false);
+    setMenuSaveError(null);
+    setMenuValidationIssues([]);
   }
 
   async function connectDomain() {
@@ -518,91 +660,23 @@ export function Dashboard({
             </TabsContent>
 
             <TabsContent value="menu" className="mt-0">
-              <PageHeading
-                eyebrow="Menu editor"
-                title="The menu, structured."
-                copy="Edit what guests see. Prices and dietary labels stay machine-readable."
-                action={
-                  <Button size="sm">
-                    <Plus /> Add item
-                  </Button>
+              <RestaurantMenuEditor
+                draft={draft}
+                dirty={menuDirty}
+                saving={saving}
+                saveError={menuSaveError}
+                validationIssues={menuValidationIssues}
+                canUndo={menuUndoStack.length > 0}
+                regeneratingLocale={regeneratingLocale}
+                onMutation={mutateMenu}
+                onTranslationChange={changeTranslation}
+                onReviewTranslation={reviewTranslation}
+                onRegenerateTranslation={(locale) =>
+                  void regenerateTranslation(locale)
                 }
+                onUndo={undoMenuDeletion}
+                onSave={() => void save()}
               />
-              <div className="mt-8 space-y-5">
-                {draft.menuSections.map((section, sectionIndex) => (
-                  <Card key={section.name}>
-                    <CardHeader className="flex-row items-center justify-between">
-                      <div>
-                        <CardTitle>{section.name}</CardTitle>
-                        <p className="mt-1 text-xs text-muted-foreground">
-                          {section.description}
-                        </p>
-                      </div>
-                      <Button variant="ghost" size="icon-sm">
-                        <MoreHorizontal />
-                      </Button>
-                    </CardHeader>
-                    <CardContent className="divide-y">
-                      {section.items.map((item, itemIndex) => (
-                        <div
-                          key={`${sectionIndex}-${itemIndex}`}
-                          className="grid gap-4 py-5 md:grid-cols-[1fr_1.5fr_110px_auto]"
-                        >
-                          <Input
-                            value={item.name}
-                            onChange={(event) =>
-                              setDraft((current) => {
-                                const menuSections = structuredClone(
-                                  current.menuSections,
-                                );
-                                menuSections[sectionIndex].items[
-                                  itemIndex
-                                ].name = event.target.value;
-                                return { ...current, menuSections };
-                              })
-                            }
-                          />
-                          <Input
-                            value={item.description}
-                            onChange={(event) =>
-                              setDraft((current) => {
-                                const menuSections = structuredClone(
-                                  current.menuSections,
-                                );
-                                menuSections[sectionIndex].items[
-                                  itemIndex
-                                ].description = event.target.value;
-                                return { ...current, menuSections };
-                              })
-                            }
-                          />
-                          <Input
-                            type="number"
-                            value={item.price ?? ""}
-                            onChange={(event) =>
-                              setDraft((current) => {
-                                const menuSections = structuredClone(
-                                  current.menuSections,
-                                );
-                                menuSections[sectionIndex].items[
-                                  itemIndex
-                                ].price = event.target.value
-                                  ? Number(event.target.value)
-                                  : null;
-                                return { ...current, menuSections };
-                              })
-                            }
-                            aria-label={`Price for ${item.name}`}
-                          />
-                          <span className="self-center font-mono text-xs text-muted-foreground">
-                            {formatPrice(item.price, item.currency)}
-                          </span>
-                        </div>
-                      ))}
-                    </CardContent>
-                  </Card>
-                ))}
-              </div>
             </TabsContent>
 
             <TabsContent value="imagery" className="mt-0">

--- a/src/components/restaurant-menu-editor.tsx
+++ b/src/components/restaurant-menu-editor.tsx
@@ -1,0 +1,592 @@
+"use client";
+
+import { useState } from "react";
+import {
+  AlertTriangle,
+  ArrowDown,
+  ArrowUp,
+  Check,
+  Languages,
+  LoaderCircle,
+  Plus,
+  RotateCcw,
+  Save,
+  Trash2,
+  Undo2,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import type { RestaurantDraft } from "@/lib/restaurant";
+import {
+  SUPPORTED_MENU_CURRENCIES,
+  type MenuValidationIssue,
+  type RestaurantMenuMutation,
+} from "@/lib/restaurant-menu-editor";
+
+export function RestaurantMenuEditor({
+  draft,
+  dirty,
+  saving,
+  saveError,
+  validationIssues,
+  canUndo,
+  regeneratingLocale,
+  onMutation,
+  onTranslationChange,
+  onReviewTranslation,
+  onRegenerateTranslation,
+  onUndo,
+  onSave,
+}: {
+  draft: RestaurantDraft;
+  dirty: boolean;
+  saving: boolean;
+  saveError: string | null;
+  validationIssues: MenuValidationIssue[];
+  canUndo: boolean;
+  regeneratingLocale: string | null;
+  onMutation: (mutation: RestaurantMenuMutation, destructive?: boolean) => void;
+  onTranslationChange: (
+    locale: string,
+    updater: (
+      translation: RestaurantDraft["translations"][number],
+    ) => void,
+  ) => void;
+  onReviewTranslation: (locale: string) => void;
+  onRegenerateTranslation: (locale: string) => void;
+  onUndo: () => void;
+  onSave: () => void;
+}) {
+  const [activeLocale, setActiveLocale] = useState(draft.defaultLocale);
+  const translation = draft.translations.find(
+    (candidate) => candidate.locale === activeLocale,
+  );
+  const canonical = activeLocale === draft.defaultLocale;
+
+  return (
+    <div>
+      <div className="flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-primary">
+            Menu editor
+          </p>
+          <h1 className="font-display mt-2 text-5xl leading-none tracking-[-0.045em]">
+            The menu, structured.
+          </h1>
+          <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+            Maintain the canonical menu, then regenerate and review each
+            translated draft before publishing.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onUndo}
+            disabled={!canUndo}
+          >
+            <Undo2 /> Undo deletion
+          </Button>
+          {canonical ? (
+            <Button
+              size="sm"
+              onClick={() => onMutation({ type: "add-section" })}
+            >
+              <Plus /> Add section
+            </Button>
+          ) : null}
+          <Button size="sm" onClick={onSave} disabled={saving || !dirty}>
+            {saving ? <LoaderCircle className="animate-spin" /> : <Save />}
+            {dirty ? "Save menu" : "Saved"}
+          </Button>
+        </div>
+      </div>
+
+      <Card className="mt-8">
+        <CardContent className="flex flex-col gap-4 pt-6 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-wrap gap-2" aria-label="Menu locale">
+            <Button
+              size="sm"
+              variant={canonical ? "default" : "outline"}
+              onClick={() => setActiveLocale(draft.defaultLocale)}
+            >
+              {draft.defaultLocale.toUpperCase()} · canonical
+            </Button>
+            {draft.translations.map((candidate) => (
+              <Button
+                key={candidate.locale}
+                size="sm"
+                variant={
+                  activeLocale === candidate.locale ? "default" : "outline"
+                }
+                onClick={() => setActiveLocale(candidate.locale)}
+              >
+                {candidate.locale.toUpperCase()}
+                {candidate.status !== "current" ? (
+                  <span className="size-2 rounded-full bg-amber-400" />
+                ) : null}
+              </Button>
+            ))}
+          </div>
+          {dirty ? (
+            <Badge variant="outline">Unsaved changes</Badge>
+          ) : (
+            <Badge className="bg-emerald-600 text-white">Saved</Badge>
+          )}
+        </CardContent>
+      </Card>
+
+      {saveError ? (
+        <div className="mt-4 flex items-center justify-between gap-4 rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-900">
+          <span className="flex items-center gap-2">
+            <AlertTriangle className="size-4" />
+            {saveError}
+          </span>
+          <Button variant="outline" size="sm" onClick={onSave}>
+            Retry
+          </Button>
+        </div>
+      ) : null}
+      {validationIssues.length > 0 ? (
+        <div className="mt-4 rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-950">
+          <p className="font-semibold">Fix these fields before saving:</p>
+          <ul className="mt-2 list-disc space-y-1 pl-5">
+            {validationIssues.slice(0, 8).map((issue) => (
+              <li key={`${issue.path}-${issue.message}`}>
+                {issue.path}: {issue.message}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {!canonical && translation ? (
+        <Card className="mt-5 border-amber-200">
+          <CardContent className="flex flex-col gap-4 pt-6 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <div className="flex items-center gap-2">
+                <Languages className="size-4" />
+                <p className="font-semibold">
+                  {translation.locale.toUpperCase()} translation
+                </p>
+                <Badge
+                  variant={
+                    translation.status === "current"
+                      ? "secondary"
+                      : "outline"
+                  }
+                >
+                  {translation.status}
+                </Badge>
+              </div>
+              <p className="mt-2 max-w-2xl text-xs leading-5 text-muted-foreground">
+                Canonical changes mark this copy stale. Regeneration can change
+                text only; structure, prices, currency, availability and images
+                remain canonical.
+              </p>
+            </div>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  onRegenerateTranslation(translation.locale)
+                }
+                disabled={dirty || regeneratingLocale !== null}
+              >
+                {regeneratingLocale === translation.locale ? (
+                  <LoaderCircle className="animate-spin" />
+                ) : (
+                  <RotateCcw />
+                )}
+                Regenerate
+              </Button>
+              <Button
+                size="sm"
+                onClick={() => onReviewTranslation(translation.locale)}
+                disabled={translation.status === "current"}
+              >
+                <Check /> Mark reviewed
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      ) : null}
+
+      <div className="mt-5 space-y-5">
+        {(canonical ? draft.menuSections : translation?.menuSections ?? []).map(
+          (section, sectionIndex) => (
+            <Card key={`${activeLocale}-${sectionIndex}`}>
+              <CardHeader className="gap-4">
+                <div className="grid flex-1 gap-3 md:grid-cols-[1fr_1.5fr]">
+                  <div>
+                    <Label htmlFor={`section-${activeLocale}-${sectionIndex}`}>
+                      Section name
+                    </Label>
+                    <Input
+                      id={`section-${activeLocale}-${sectionIndex}`}
+                      className="mt-2"
+                      value={section.name}
+                      onChange={(event) =>
+                        canonical
+                          ? onMutation({
+                              type: "update-section",
+                              sectionIndex,
+                              name: event.target.value,
+                            })
+                          : onTranslationChange(activeLocale, (current) => {
+                              current.menuSections[sectionIndex].name =
+                                event.target.value;
+                            })
+                      }
+                    />
+                  </div>
+                  <div>
+                    <Label
+                      htmlFor={`section-description-${activeLocale}-${sectionIndex}`}
+                    >
+                      Section description
+                    </Label>
+                    <Input
+                      id={`section-description-${activeLocale}-${sectionIndex}`}
+                      className="mt-2"
+                      value={section.description}
+                      onChange={(event) =>
+                        canonical
+                          ? onMutation({
+                              type: "update-section",
+                              sectionIndex,
+                              description: event.target.value,
+                            })
+                          : onTranslationChange(activeLocale, (current) => {
+                              current.menuSections[
+                                sectionIndex
+                              ].description = event.target.value;
+                            })
+                      }
+                    />
+                  </div>
+                </div>
+                {canonical ? (
+                  <div className="flex flex-wrap gap-2">
+                    <Button
+                      variant="outline"
+                      size="icon-sm"
+                      aria-label={`Move ${section.name} up`}
+                      disabled={sectionIndex === 0}
+                      onClick={() =>
+                        onMutation({
+                          type: "move-section",
+                          sectionIndex,
+                          direction: -1,
+                        })
+                      }
+                    >
+                      <ArrowUp />
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="icon-sm"
+                      aria-label={`Move ${section.name} down`}
+                      disabled={sectionIndex === draft.menuSections.length - 1}
+                      onClick={() =>
+                        onMutation({
+                          type: "move-section",
+                          sectionIndex,
+                          direction: 1,
+                        })
+                      }
+                    >
+                      <ArrowDown />
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() =>
+                        onMutation({ type: "add-item", sectionIndex })
+                      }
+                    >
+                      <Plus /> Add item
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={draft.menuSections.length === 1}
+                      onClick={() =>
+                        onMutation(
+                          { type: "delete-section", sectionIndex },
+                          true,
+                        )
+                      }
+                    >
+                      <Trash2 /> Delete section
+                    </Button>
+                  </div>
+                ) : null}
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {section.items.map((item, itemIndex) => {
+                  const canonicalItem =
+                    draft.menuSections[sectionIndex].items[itemIndex];
+                  return (
+                    <div
+                      key={`${activeLocale}-${sectionIndex}-${itemIndex}`}
+                      className="rounded-xl border bg-muted/20 p-4"
+                    >
+                      <div className="grid gap-4 lg:grid-cols-2">
+                        <Field label="Item name">
+                          <Input
+                            value={item.name}
+                            onChange={(event) =>
+                              canonical
+                                ? onMutation({
+                                    type: "update-item",
+                                    sectionIndex,
+                                    itemIndex,
+                                    changes: { name: event.target.value },
+                                  })
+                                : onTranslationChange(
+                                    activeLocale,
+                                    (current) => {
+                                      current.menuSections[
+                                        sectionIndex
+                                      ].items[itemIndex].name =
+                                        event.target.value;
+                                    },
+                                  )
+                            }
+                          />
+                        </Field>
+                        <Field label="Description">
+                          <Textarea
+                            value={item.description}
+                            onChange={(event) =>
+                              canonical
+                                ? onMutation({
+                                    type: "update-item",
+                                    sectionIndex,
+                                    itemIndex,
+                                    changes: {
+                                      description: event.target.value,
+                                    },
+                                  })
+                                : onTranslationChange(
+                                    activeLocale,
+                                    (current) => {
+                                      current.menuSections[
+                                        sectionIndex
+                                      ].items[itemIndex].description =
+                                        event.target.value;
+                                    },
+                                  )
+                            }
+                          />
+                        </Field>
+                      </div>
+                      {canonical ? (
+                        <>
+                          <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                            <Field label="Price">
+                              <Input
+                                type="number"
+                                min="0"
+                                step="0.01"
+                                value={canonicalItem.price ?? ""}
+                                onChange={(event) =>
+                                  onMutation({
+                                    type: "update-item",
+                                    sectionIndex,
+                                    itemIndex,
+                                    changes: {
+                                      price:
+                                        event.target.value === ""
+                                          ? null
+                                          : Number(event.target.value),
+                                    },
+                                  })
+                                }
+                              />
+                            </Field>
+                            <Field label="Currency">
+                              <select
+                                className="border-input bg-background h-9 w-full rounded-md border px-3 text-sm"
+                                value={canonicalItem.currency}
+                                onChange={(event) =>
+                                  onMutation({
+                                    type: "update-item",
+                                    sectionIndex,
+                                    itemIndex,
+                                    changes: {
+                                      currency: event.target
+                                        .value as typeof canonicalItem.currency,
+                                    },
+                                  })
+                                }
+                              >
+                                {SUPPORTED_MENU_CURRENCIES.map((currency) => (
+                                  <option key={currency}>{currency}</option>
+                                ))}
+                              </select>
+                            </Field>
+                            <Field label="Dietary labels">
+                              <Input
+                                value={canonicalItem.dietaryLabels.join(", ")}
+                                placeholder="vegan, gluten-free"
+                                onChange={(event) =>
+                                  onMutation({
+                                    type: "update-item",
+                                    sectionIndex,
+                                    itemIndex,
+                                    changes: {
+                                      dietaryLabels: event.target.value
+                                        .split(",")
+                                        .map((label) => label.trim())
+                                        .filter(Boolean)
+                                        .slice(0, 6),
+                                    },
+                                  })
+                                }
+                              />
+                            </Field>
+                            <div className="flex items-end">
+                              <div className="flex h-9 w-full items-center justify-between rounded-md border bg-background px-3">
+                                <Label
+                                  htmlFor={`available-${sectionIndex}-${itemIndex}`}
+                                >
+                                  Available
+                                </Label>
+                                <Switch
+                                  id={`available-${sectionIndex}-${itemIndex}`}
+                                  checked={canonicalItem.available}
+                                  onCheckedChange={(available) =>
+                                    onMutation({
+                                      type: "update-item",
+                                      sectionIndex,
+                                      itemIndex,
+                                      changes: { available },
+                                    })
+                                  }
+                                />
+                              </div>
+                            </div>
+                          </div>
+                          <div className="mt-4 grid gap-4 lg:grid-cols-[1fr_auto]">
+                            <Field label="Approved image URL">
+                              <Input
+                                value={canonicalItem.imageUrl ?? ""}
+                                placeholder="https://… or /approved/image.webp"
+                                onChange={(event) =>
+                                  onMutation({
+                                    type: "update-item",
+                                    sectionIndex,
+                                    itemIndex,
+                                    changes: {
+                                      imageUrl: event.target.value || null,
+                                      imageProvenance: event.target.value
+                                        ? "owner"
+                                        : null,
+                                    },
+                                  })
+                                }
+                              />
+                            </Field>
+                            <div className="flex items-end gap-2">
+                              <Button
+                                variant="outline"
+                                size="icon-sm"
+                                aria-label={`Move ${canonicalItem.name} up`}
+                                disabled={itemIndex === 0}
+                                onClick={() =>
+                                  onMutation({
+                                    type: "move-item",
+                                    sectionIndex,
+                                    itemIndex,
+                                    direction: -1,
+                                  })
+                                }
+                              >
+                                <ArrowUp />
+                              </Button>
+                              <Button
+                                variant="outline"
+                                size="icon-sm"
+                                aria-label={`Move ${canonicalItem.name} down`}
+                                disabled={
+                                  itemIndex ===
+                                  draft.menuSections[sectionIndex].items
+                                    .length -
+                                    1
+                                }
+                                onClick={() =>
+                                  onMutation({
+                                    type: "move-item",
+                                    sectionIndex,
+                                    itemIndex,
+                                    direction: 1,
+                                  })
+                                }
+                              >
+                                <ArrowDown />
+                              </Button>
+                              <Button
+                                variant="outline"
+                                size="icon-sm"
+                                aria-label={`Delete ${canonicalItem.name}`}
+                                onClick={() =>
+                                  onMutation(
+                                    {
+                                      type: "delete-item",
+                                      sectionIndex,
+                                      itemIndex,
+                                    },
+                                    true,
+                                  )
+                                }
+                              >
+                                <Trash2 />
+                              </Button>
+                            </div>
+                          </div>
+                        </>
+                      ) : (
+                        <p className="mt-3 text-xs text-muted-foreground">
+                          {canonicalItem.price === null
+                            ? "No price"
+                            : `${canonicalItem.price} ${canonicalItem.currency}`}
+                          {" · "}
+                          {canonicalItem.available
+                            ? "available"
+                            : "unavailable"}
+                        </p>
+                      )}
+                    </div>
+                  );
+                })}
+              </CardContent>
+            </Card>
+          ),
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="grid gap-2">
+      <Label>{label}</Label>
+      {children}
+    </div>
+  );
+}

--- a/src/components/restaurant-themes/after-dark.tsx
+++ b/src/components/restaurant-themes/after-dark.tsx
@@ -172,7 +172,7 @@ export function AfterDarkTheme({
                   </p>
                 </div>
                 <div className="divide-y divide-current/15">
-                  {section.items.map((item) => (
+                  {section.items.filter((item) => item.available).map((item) => (
                     <div
                       key={item.name}
                       className="grid grid-cols-[1fr_auto] gap-5 py-5"

--- a/src/components/restaurant-themes/counter-service.tsx
+++ b/src/components/restaurant-themes/counter-service.tsx
@@ -158,7 +158,7 @@ export function CounterServiceTheme({
                   </p>
                 </div>
                 <div className="grid gap-4 md:grid-cols-2">
-                  {section.items.map((item) => (
+                  {section.items.filter((item) => item.available).map((item) => (
                     <article
                       key={item.name}
                       className="grid min-h-44 grid-cols-[1fr_auto] gap-5 rounded-[1.4rem] border-2 border-current bg-[var(--theme-surface)] p-5"

--- a/src/components/restaurant-themes/terroir-editorial.tsx
+++ b/src/components/restaurant-themes/terroir-editorial.tsx
@@ -135,7 +135,7 @@ export function TerroirEditorialTheme({
                   </p>
                 </div>
                 <div className="divide-y divide-current/12">
-                  {section.items.map((item) => (
+                  {section.items.filter((item) => item.available).map((item) => (
                     <div
                       key={item.name}
                       className="grid gap-4 py-6 sm:grid-cols-[1fr_auto]"

--- a/src/components/site-renderer.tsx
+++ b/src/components/site-renderer.tsx
@@ -106,7 +106,7 @@ export function SiteRenderer({
     .flatMap((section) => section.items)
     .filter(
       (item): item is typeof item & { imageUrl: string } =>
-        Boolean(item.imageUrl),
+        item.available && Boolean(item.imageUrl),
     )
     .slice(0, 4);
   const immersiveHero = template.heroLayout === "immersive";
@@ -432,7 +432,7 @@ export function SiteRenderer({
                 ) : null}
               </div>
               <div className="space-y-6">
-                {section.items.map((item) => (
+                {section.items.filter((item) => item.available).map((item) => (
                   <div
                     key={item.name}
                     className="grid grid-cols-[minmax(0,1fr)_auto] gap-4 sm:gap-5"

--- a/src/lib/ai/site-generation.ts
+++ b/src/lib/ai/site-generation.ts
@@ -2,6 +2,9 @@ import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { generateText, Output } from "ai";
 import type { ExtractedSite } from "@/lib/importer";
 import { slugify } from "@/lib/restaurant";
+import type { RestaurantDraft } from "@/lib/restaurant";
+import { applyRegeneratedRestaurantTranslation } from "@/lib/restaurant-menu-editor";
+import { restaurantTranslationCandidateSchema } from "@/lib/verticals/restaurant/schema";
 import type {
   VerticalConfig,
   VerticalTemplateDefinition,
@@ -107,6 +110,52 @@ function getTextModel() {
       usage: { include: true },
     },
   );
+}
+
+export async function regenerateRestaurantTranslation(
+  draft: RestaurantDraft,
+  locale: string,
+): Promise<RestaurantDraft> {
+  if (!aiIsConfigured()) {
+    throw new Error("Translation regeneration is not configured");
+  }
+  const source = {
+    locale: draft.defaultLocale,
+    cuisine: draft.cuisine,
+    eyebrow: draft.eyebrow,
+    description: draft.description,
+    menuSections: draft.menuSections.map((section) => ({
+      name: section.name,
+      description: section.description,
+      items: section.items.map((item) => ({
+        name: item.name,
+        description: item.description,
+        dietaryLabels: item.dietaryLabels,
+      })),
+    })),
+    integrationLabels: draft.integrations.map(
+      (integration) => integration.label,
+    ),
+  };
+  const { output } = await generateText({
+    model: getTextModel(),
+    output: Output.object({
+      schema: restaurantTranslationCandidateSchema,
+      name: "restaurant_menu_translation",
+      description:
+        "A text-only restaurant translation with exactly the source structure.",
+    }),
+    maxRetries: 2,
+    timeout: { totalMs: 45_000, stepMs: 35_000 },
+    prompt: `Translate this restaurant copy from ${draft.defaultLocale} to ${locale}.
+Return exactly the same number and order of menu sections, items, dietary-label arrays and integration labels.
+Translate text only. Never add, remove, merge, split or reorder a section or item. Never invent facts.
+Prices, currencies, availability and images are deliberately absent from the output contract and must remain untouched.
+
+Canonical source:
+${JSON.stringify(source)}`,
+  });
+  return applyRegeneratedRestaurantTranslation(draft, locale, output);
 }
 
 /**

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -140,12 +140,20 @@ export function limitClaimInvitationRequest(
   });
 }
 
-export function limitClaimCheckout(
-  request: Request,
-): Promise<RateLimitResult> {
+export function limitClaimCheckout(request: Request): Promise<RateLimitResult> {
   return limitByIp(request, {
     namespace: "claim-checkout",
     limit: 10,
+    windowMs,
+  });
+}
+
+export function limitTranslationRegeneration(
+  request: Request,
+): Promise<RateLimitResult> {
+  return limitByIp(request, {
+    namespace: "translation-regeneration",
+    limit: 12,
     windowMs,
   });
 }

--- a/src/lib/restaurant-menu-editor.test.ts
+++ b/src/lib/restaurant-menu-editor.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "bun:test";
+import {
+  fromRestaurantDraft,
+  restaurantDraftSchema,
+  sampleRestaurant,
+} from "@/lib/restaurant";
+import {
+  applyRegeneratedRestaurantTranslation,
+  applyRestaurantMenuMutation,
+  hasUnreviewedRestaurantTranslations,
+  markRestaurantTranslationReviewed,
+  updateRestaurantTranslation,
+  validateRestaurantMenuDraft,
+} from "@/lib/restaurant-menu-editor";
+
+function multilingualDraft() {
+  return restaurantDraftSchema.parse({
+    ...sampleRestaurant,
+    defaultLocale: "fr",
+    translations: [
+      {
+        locale: "en",
+        status: "current",
+        cuisine: sampleRestaurant.cuisine,
+        eyebrow: sampleRestaurant.eyebrow,
+        description: sampleRestaurant.description,
+        menuSections: sampleRestaurant.menuSections.map((section) => ({
+          name: section.name,
+          description: section.description,
+          items: section.items.map((item) => ({
+            name: item.name,
+            description: item.description,
+            dietaryLabels: item.dietaryLabels,
+          })),
+        })),
+        integrationLabels: sampleRestaurant.integrations.map(
+          (integration) => integration.label,
+        ),
+      },
+    ],
+  });
+}
+
+describe("restaurant menu CRUD", () => {
+  it("keeps translated structure aligned while adding, deleting and reordering", () => {
+    let draft = multilingualDraft();
+    draft = applyRestaurantMenuMutation(draft, { type: "add-section" });
+    draft = applyRestaurantMenuMutation(draft, {
+      type: "add-item",
+      sectionIndex: 2,
+    });
+    draft = applyRestaurantMenuMutation(draft, {
+      type: "move-section",
+      sectionIndex: 2,
+      direction: -1,
+    });
+    draft = applyRestaurantMenuMutation(draft, {
+      type: "delete-item",
+      sectionIndex: 0,
+      itemIndex: 0,
+    });
+
+    expect(restaurantDraftSchema.parse(draft)).toEqual(draft);
+    expect(draft.translations[0].status).toBe("stale");
+    expect(
+      draft.translations[0].menuSections.map((section) => section.items.length),
+    ).toEqual(draft.menuSections.map((section) => section.items.length));
+  });
+
+  it("blocks empty names, negative prices and unsupported currencies clearly", () => {
+    let draft = multilingualDraft();
+    draft = applyRestaurantMenuMutation(draft, {
+      type: "update-item",
+      sectionIndex: 0,
+      itemIndex: 0,
+      changes: {
+        name: "",
+        price: -1,
+        currency: "ZZZ" as "EUR",
+      },
+    });
+    const issues = validateRestaurantMenuDraft(draft);
+
+    expect(issues.some((issue) => issue.path.endsWith(".name"))).toBe(true);
+    expect(issues.some((issue) => issue.path.endsWith(".price"))).toBe(true);
+    expect(issues.some((issue) => issue.path.endsWith(".currency"))).toBe(true);
+  });
+
+  it("regenerates text only and preserves canonical facts", () => {
+    const draft = applyRestaurantMenuMutation(multilingualDraft(), {
+      type: "update-item",
+      sectionIndex: 0,
+      itemIndex: 0,
+      changes: {
+        price: 12.5,
+        currency: "GBP",
+        available: false,
+        imageUrl: "/approved/focaccia.webp",
+        imageProvenance: "owner",
+      },
+    });
+    const candidate = {
+      cuisine: "Italian",
+      eyebrow: "Seasonal neighbourhood kitchen",
+      description:
+        "An English draft prepared for owner review before it can be published.",
+      menuSections: draft.menuSections.map((section) => ({
+        name: `English ${section.name}`,
+        description: section.description,
+        items: section.items.map((item) => ({
+          name: `English ${item.name}`,
+          description: item.description,
+          dietaryLabels: item.dietaryLabels,
+        })),
+      })),
+      integrationLabels: draft.integrations.map(
+        (integration) => integration.label,
+      ),
+    };
+    const regenerated = applyRegeneratedRestaurantTranslation(
+      draft,
+      "en",
+      candidate,
+    );
+
+    expect(regenerated.translations[0].status).toBe("draft");
+    expect(regenerated.menuSections).toEqual(draft.menuSections);
+    expect(fromRestaurantDraft(regenerated).catalogSections[0].items[0])
+      .toMatchObject({
+        price: 12.5,
+        currency: "GBP",
+        available: false,
+        imageUrl: "/approved/focaccia.webp",
+      });
+    expect(
+      () =>
+        applyRegeneratedRestaurantTranslation(draft, "en", {
+          ...candidate,
+          menuSections: candidate.menuSections.slice(1),
+        }),
+    ).toThrow();
+  });
+
+  it("requires edited or regenerated translations to be reviewed", () => {
+    const edited = updateRestaurantTranslation(
+      multilingualDraft(),
+      "en",
+      (translation) => {
+        translation.menuSections[0].name = "Starters";
+      },
+    );
+    expect(hasUnreviewedRestaurantTranslations(edited)).toBe(true);
+    const reviewed = markRestaurantTranslationReviewed(edited, "en");
+    expect(hasUnreviewedRestaurantTranslations(reviewed)).toBe(false);
+  });
+});

--- a/src/lib/restaurant-menu-editor.ts
+++ b/src/lib/restaurant-menu-editor.ts
@@ -1,0 +1,267 @@
+import type {
+  RestaurantDraft,
+  RestaurantTranslation,
+} from "@/lib/verticals/restaurant/schema";
+import {
+  restaurantDraftSchema,
+  restaurantTranslationCandidateSchema,
+} from "@/lib/verticals/restaurant/schema";
+import { supportedCurrencySchema } from "@/lib/verticals/schema";
+
+export const SUPPORTED_MENU_CURRENCIES = supportedCurrencySchema.options;
+
+export type RestaurantMenuMutation =
+  | { type: "add-section" }
+  | { type: "update-section"; sectionIndex: number; name?: string; description?: string }
+  | { type: "delete-section"; sectionIndex: number }
+  | { type: "move-section"; sectionIndex: number; direction: -1 | 1 }
+  | { type: "add-item"; sectionIndex: number }
+  | {
+      type: "update-item";
+      sectionIndex: number;
+      itemIndex: number;
+      changes: Partial<RestaurantDraft["menuSections"][number]["items"][number]>;
+    }
+  | { type: "delete-item"; sectionIndex: number; itemIndex: number }
+  | {
+      type: "move-item";
+      sectionIndex: number;
+      itemIndex: number;
+      direction: -1 | 1;
+    };
+
+export type MenuValidationIssue = {
+  path: string;
+  message: string;
+};
+
+export function applyRestaurantMenuMutation(
+  input: RestaurantDraft,
+  mutation: RestaurantMenuMutation,
+): RestaurantDraft {
+  const draft = structuredClone(input);
+  const translations = draft.translations;
+
+  switch (mutation.type) {
+    case "add-section": {
+      draft.menuSections.push({
+        name: "New section",
+        description: "",
+        items: [],
+      });
+      for (const translation of translations) {
+        translation.menuSections.push({
+          name: "New section",
+          description: "",
+          items: [],
+        });
+      }
+      break;
+    }
+    case "update-section": {
+      const section = requireSection(draft, mutation.sectionIndex);
+      if (mutation.name !== undefined) section.name = mutation.name;
+      if (mutation.description !== undefined) {
+        section.description = mutation.description;
+      }
+      break;
+    }
+    case "delete-section": {
+      if (draft.menuSections.length === 1) {
+        throw new Error("A menu must keep at least one section");
+      }
+      requireSection(draft, mutation.sectionIndex);
+      draft.menuSections.splice(mutation.sectionIndex, 1);
+      for (const translation of translations) {
+        translation.menuSections.splice(mutation.sectionIndex, 1);
+      }
+      break;
+    }
+    case "move-section": {
+      const targetIndex = mutation.sectionIndex + mutation.direction;
+      requireSection(draft, mutation.sectionIndex);
+      requireSection(draft, targetIndex);
+      move(draft.menuSections, mutation.sectionIndex, targetIndex);
+      for (const translation of translations) {
+        move(translation.menuSections, mutation.sectionIndex, targetIndex);
+      }
+      break;
+    }
+    case "add-item": {
+      const section = requireSection(draft, mutation.sectionIndex);
+      const item = {
+        name: "New item",
+        description: "",
+        price: null,
+        currency: "EUR" as const,
+        available: true,
+        dietaryLabels: [],
+        imageUrl: null,
+      };
+      section.items.push(item);
+      for (const translation of translations) {
+        translation.menuSections[mutation.sectionIndex].items.push({
+          name: item.name,
+          description: item.description,
+          dietaryLabels: [],
+        });
+      }
+      break;
+    }
+    case "update-item": {
+      const item = requireItem(
+        draft,
+        mutation.sectionIndex,
+        mutation.itemIndex,
+      );
+      Object.assign(item, mutation.changes);
+      break;
+    }
+    case "delete-item": {
+      const section = requireSection(draft, mutation.sectionIndex);
+      requireItem(draft, mutation.sectionIndex, mutation.itemIndex);
+      section.items.splice(mutation.itemIndex, 1);
+      for (const translation of translations) {
+        translation.menuSections[mutation.sectionIndex].items.splice(
+          mutation.itemIndex,
+          1,
+        );
+      }
+      break;
+    }
+    case "move-item": {
+      const section = requireSection(draft, mutation.sectionIndex);
+      const targetIndex = mutation.itemIndex + mutation.direction;
+      requireItem(draft, mutation.sectionIndex, mutation.itemIndex);
+      requireItem(draft, mutation.sectionIndex, targetIndex);
+      move(section.items, mutation.itemIndex, targetIndex);
+      for (const translation of translations) {
+        move(
+          translation.menuSections[mutation.sectionIndex].items,
+          mutation.itemIndex,
+          targetIndex,
+        );
+      }
+      break;
+    }
+  }
+
+  return markRestaurantTranslationsStale(draft);
+}
+
+export function updateRestaurantTranslation(
+  input: RestaurantDraft,
+  locale: string,
+  updater: (translation: RestaurantTranslation) => void,
+): RestaurantDraft {
+  const draft = structuredClone(input);
+  const translation = draft.translations.find(
+    (candidate) => candidate.locale === locale,
+  );
+  if (!translation) throw new Error("Translation not found");
+  updater(translation);
+  translation.status = "draft";
+  return draft;
+}
+
+export function markRestaurantTranslationReviewed(
+  input: RestaurantDraft,
+  locale: string,
+): RestaurantDraft {
+  const draft = structuredClone(input);
+  const translation = draft.translations.find(
+    (candidate) => candidate.locale === locale,
+  );
+  if (!translation) throw new Error("Translation not found");
+  const parsed = restaurantDraftSchema.parse(draft);
+  const parsedTranslation = parsed.translations.find(
+    (candidate) => candidate.locale === locale,
+  );
+  if (!parsedTranslation) throw new Error("Translation not found");
+  parsedTranslation.status = "current";
+  return parsed;
+}
+
+export function applyRegeneratedRestaurantTranslation(
+  input: RestaurantDraft,
+  locale: string,
+  candidate: unknown,
+): RestaurantDraft {
+  const generated = restaurantTranslationCandidateSchema.parse(candidate);
+  const draft = structuredClone(input);
+  const translationIndex = draft.translations.findIndex(
+    (translation) => translation.locale === locale,
+  );
+  if (translationIndex < 0) throw new Error("Translation not found");
+  draft.translations[translationIndex] = {
+    ...generated,
+    locale,
+    status: "draft",
+  };
+  // The whole draft parse is the structural firewall: generated text cannot
+  // add/remove/reorder items or sections because parity must still match the
+  // canonical menu. Prices and availability do not exist in the candidate
+  // schema, so regeneration cannot mutate those facts at all.
+  return restaurantDraftSchema.parse(draft);
+}
+
+export function markRestaurantTranslationsStale(
+  draft: RestaurantDraft,
+): RestaurantDraft {
+  return {
+    ...draft,
+    translations: draft.translations.map((translation) => ({
+      ...translation,
+      status: "stale" as const,
+    })),
+  };
+}
+
+export function hasUnreviewedRestaurantTranslations(
+  draft: {
+    translations: Array<{ status: "current" | "stale" | "draft" }>;
+  },
+): boolean {
+  return draft.translations.some(
+    (translation) => translation.status !== "current",
+  );
+}
+
+export function validateRestaurantMenuDraft(
+  draft: RestaurantDraft,
+): MenuValidationIssue[] {
+  const parsed = restaurantDraftSchema.safeParse(draft);
+  if (parsed.success) return [];
+  return parsed.error.issues
+    .filter(
+      (issue) =>
+        issue.path[0] === "menuSections" ||
+        issue.path[0] === "translations",
+    )
+    .map((issue) => ({
+      path: issue.path.join("."),
+      message: issue.message,
+    }));
+}
+
+function requireSection(draft: RestaurantDraft, sectionIndex: number) {
+  const section = draft.menuSections[sectionIndex];
+  if (!section) throw new Error("Menu section not found");
+  return section;
+}
+
+function requireItem(
+  draft: RestaurantDraft,
+  sectionIndex: number,
+  itemIndex: number,
+) {
+  const item = requireSection(draft, sectionIndex).items[itemIndex];
+  if (!item) throw new Error("Menu item not found");
+  return item;
+}
+
+function move<T>(items: T[], from: number, to: number): void {
+  const [item] = items.splice(from, 1);
+  if (item === undefined) throw new Error("Menu entry not found");
+  items.splice(to, 0, item);
+}

--- a/src/lib/site-draft.ts
+++ b/src/lib/site-draft.ts
@@ -35,6 +35,7 @@ export type SiteCatalogItemView = {
   description: string;
   price: number | null;
   currency: string;
+  available: boolean;
   imageUrl: string | null;
   attributes: Record<string, unknown>;
 };

--- a/src/lib/site-persistence.ts
+++ b/src/lib/site-persistence.ts
@@ -50,6 +50,7 @@ export type PersistableSiteDraft = {
       description: string;
       price: number | null;
       currency: string;
+      available: boolean;
       attributes: Record<string, unknown>;
       imageUrl: string | null;
       originalImageUrl?: string | null;
@@ -629,6 +630,7 @@ function catalogSectionCreateData(
         description: item.description,
         price: item.price,
         currency: item.currency,
+        available: item.available,
         attributes: config.itemAttributesSchema.parse(
           item.attributes,
         ) as Prisma.InputJsonValue,

--- a/src/lib/site-publication.postgres.test.ts
+++ b/src/lib/site-publication.postgres.test.ts
@@ -293,6 +293,121 @@ describe.skipIf(!enabled)("safe draft and publish PostgreSQL integration", () =>
     });
   });
 
+  test("persists menu order, availability, currency and approved imagery", async () => {
+    const firstSection = sampleSiteDraft.catalogSections[0];
+    const secondSection = sampleSiteDraft.catalogSections[1];
+    const editedDraft = {
+      ...sampleSiteDraft,
+      slug,
+      catalogSections: [
+        {
+          ...secondSection,
+          items: [...secondSection.items].reverse(),
+        },
+        {
+          ...firstSection,
+          items: firstSection.items.map((item, index) =>
+            index === 0
+              ? {
+                  ...item,
+                  price: 8.5,
+                  currency: "GBP" as const,
+                  available: false,
+                  imageUrl: "/approved/menu-item.webp",
+                  originalImageUrl: "/approved/menu-item.webp",
+                  imageProvenance: "owner" as const,
+                }
+              : item,
+          ),
+        },
+      ],
+    };
+
+    await updateSiteDraft(slug, editedDraft, Vertical.RESTAURANT);
+    const reloaded = await findSiteView(slug);
+    expect(
+      reloaded?.draft.catalogSections.map((section) => section.name),
+    ).toEqual([
+      secondSection.name,
+      firstSection.name,
+    ]);
+    expect(reloaded?.draft.catalogSections[0].items.map((item) => item.name))
+      .toEqual([...secondSection.items].reverse().map((item) => item.name));
+    expect(reloaded?.draft.catalogSections[1].items[0]).toMatchObject({
+      price: 8.5,
+      currency: "GBP",
+      available: false,
+      imageUrl: "/approved/menu-item.webp",
+    });
+  });
+
+  test("refuses to publish stale translated copy without moving the live pointer", async () => {
+    const current = await findSiteView(slug);
+    if (!current) throw new Error("Expected the persisted restaurant draft");
+    const staleDraft = {
+      ...current.draft,
+      autoEnhanceImages: sampleSiteDraft.autoEnhanceImages,
+      translations: [
+        {
+          locale: "fr" as const,
+          status: "stale" as const,
+          attributes: {
+            cuisine: current.draft.attributes.cuisine,
+          },
+          eyebrow: current.draft.eyebrow,
+          description: current.draft.description,
+          catalogSections: current.draft.catalogSections.map((section) => ({
+            name: section.name,
+            description: section.description,
+            items: section.items.map((item) => ({
+              name: item.name,
+              description: item.description,
+              attributes: {
+                dietaryLabels: item.attributes.dietaryLabels,
+              },
+            })),
+          })),
+          integrationLabels: current.draft.integrations.map(
+            (integration) => integration.label,
+          ),
+        },
+      ],
+    };
+    await updateSiteDraft(slug, staleDraft, Vertical.RESTAURANT);
+    const before = await db.site.findUniqueOrThrow({
+      where: { id: siteId },
+      select: {
+        publishedSiteVersionId: true,
+        _count: { select: { siteVersions: true, auditEvents: true } },
+      },
+    });
+
+    await expect(
+      publishSiteDraft({
+        siteId,
+        slug,
+        vertical: Vertical.RESTAURANT,
+        actor,
+        changeSummary: "Stale translation must not publish",
+      }),
+    ).rejects.toThrow("Review every stale translation before publishing");
+
+    expect(
+      await db.site.findUniqueOrThrow({
+        where: { id: siteId },
+        select: {
+          publishedSiteVersionId: true,
+          _count: { select: { siteVersions: true, auditEvents: true } },
+        },
+      }),
+    ).toEqual(before);
+    await updateSiteDraft(
+      slug,
+      { ...staleDraft, translations: [] },
+      Vertical.RESTAURANT,
+    );
+  });
+
   test("leaves the live pointer untouched when persisted draft validation fails", async () => {
     const before = await db.site.findUniqueOrThrow({
       where: { id: siteId },

--- a/src/lib/site-publication.ts
+++ b/src/lib/site-publication.ts
@@ -1,6 +1,8 @@
 import "server-only";
 import { Prisma } from "@/generated/prisma/client";
+import { Vertical } from "@/generated/prisma/enums";
 import { getDb } from "@/lib/db";
+import { hasUnreviewedRestaurantTranslations } from "@/lib/restaurant-menu-editor";
 import {
   projectSiteDraft,
   siteDraftRelations,
@@ -35,6 +37,13 @@ export class SitePublicationStateError extends Error {
   constructor() {
     super("Only claimed or live sites can be published");
     this.name = "SitePublicationStateError";
+  }
+}
+
+export class SitePublicationTranslationError extends Error {
+  constructor() {
+    super("Review every stale translation before publishing");
+    this.name = "SitePublicationTranslationError";
   }
 }
 
@@ -81,6 +90,18 @@ export async function publishSiteDraft(
           // here before any write means validation failure cannot create a
           // version, move the pointer, change status, or write an audit row.
           const loaded = projectSiteDraft(site);
+          if (
+            loaded.vertical === Vertical.RESTAURANT &&
+            hasUnreviewedRestaurantTranslations(
+              loaded.draft as {
+                translations: Array<{
+                  status: "current" | "stale" | "draft";
+                }>;
+              },
+            )
+          ) {
+            throw new SitePublicationTranslationError();
+          }
           const draft = loaded.draft as Prisma.InputJsonValue;
           const latest = await tx.siteVersion.findFirst({
             where: { siteId: input.siteId },

--- a/src/lib/site-themes/restaurant/fixtures.ts
+++ b/src/lib/site-themes/restaurant/fixtures.ts
@@ -1,3 +1,4 @@
+import type { z } from "zod";
 import {
   restaurantDesignProfileSchema,
   type RestaurantDesignProfile,
@@ -15,7 +16,7 @@ export type RestaurantThemeFixture = RestaurantSiteDraft & {
 
 function fixture(
   draft: Omit<
-    RestaurantSiteDraft,
+    z.input<typeof restaurantSiteDraftSchema>,
     "attributes" | "autoEnhanceImages"
   > & {
     cuisine: string;

--- a/src/lib/site-themes/restaurant/theme-registry.test.tsx
+++ b/src/lib/site-themes/restaurant/theme-registry.test.tsx
@@ -262,6 +262,7 @@ describe("restaurant theme compatibility", () => {
       translations: [
         {
           locale: "fr",
+          status: "current" as const,
           cuisine: "Méditerranéenne de saison",
           eyebrow: "Le champ, le feu et la saison maltaise",
           description:
@@ -364,5 +365,28 @@ describe("restaurant theme renderers", () => {
     expect(html).not.toContain("Drinks from 18:00");
     expect(html).not.toContain("late kitchen");
     expect(html).toContain("Tonight’s programme");
+  });
+
+  it("does not render unavailable menu items", () => {
+    const fixture = restaurantThemeFixtures["counter-service"];
+    const unavailableName = fixture.catalogSections[0].items[0].name;
+    const selection = restaurantThemeSelectionSchema.parse(
+      fixture.attributes.themeSelection,
+    );
+    const draft = {
+      ...fixture,
+      catalogSections: fixture.catalogSections.map((section, sectionIndex) => ({
+        ...section,
+        items: section.items.map((item, itemIndex) => ({
+          ...item,
+          available: sectionIndex === 0 && itemIndex === 0 ? false : true,
+        })),
+      })),
+    };
+    const html = renderToStaticMarkup(
+      <RestaurantThemeRenderer draft={draft} selection={selection} />,
+    );
+
+    expect(html).not.toContain(unavailableName);
   });
 });

--- a/src/lib/sites.ts
+++ b/src/lib/sites.ts
@@ -89,6 +89,7 @@ export function projectSiteDraft(site: PersistedSiteDraftRecord): LoadedSite {
         description: item.description ?? "",
         price: item.price === null ? null : Number(item.price),
         currency: item.currency,
+        available: item.available,
         attributes: config.itemAttributesSchema.parse(item.attributes),
         imageUrl: item.imageUrl,
         originalImageUrl: item.originalImageUrl,

--- a/src/lib/verticals/restaurant/schema.ts
+++ b/src/lib/verticals/restaurant/schema.ts
@@ -50,7 +50,14 @@ export const menuSectionSchema = catalogSectionSchema.extend({
   items: z.array(menuItemSchema).max(40),
 });
 
+export const restaurantTranslationStatusSchema = z.enum([
+  "current",
+  "stale",
+  "draft",
+]);
+
 const restaurantSiteTranslationSchema = baseSiteTranslationSchema.extend({
+  status: restaurantTranslationStatusSchema.default("current"),
   attributes: restaurantAttributesSchema.pick({ cuisine: true }),
   catalogSections: z.array(
     translatedCatalogSectionSchema.extend({
@@ -65,6 +72,7 @@ const restaurantSiteTranslationSchema = baseSiteTranslationSchema.extend({
 
 export const restaurantTranslationSchema = z.object({
   locale: localeSchema,
+  status: restaurantTranslationStatusSchema.default("current"),
   cuisine: z.string().max(80),
   eyebrow: z.string().max(100),
   description: z.string().min(20).max(500),
@@ -83,6 +91,12 @@ export const restaurantTranslationSchema = z.object({
   ),
   integrationLabels: z.array(z.string().min(1).max(60)).max(12),
 });
+
+export const restaurantTranslationCandidateSchema =
+  restaurantTranslationSchema.omit({
+    locale: true,
+    status: true,
+  });
 
 export const restaurantSiteDraftSchema = z
   .object({
@@ -113,7 +127,7 @@ export const restaurantDraftSchema = z
   .object({
     ...baseSiteDraftCoreShape,
     ...restaurantAttributesSchema.shape,
-  translations: z.array(restaurantTranslationSchema).max(8).default([]),
+    translations: z.array(restaurantTranslationSchema).max(8).default([]),
     menuSections: z.array(menuSectionSchema).min(1).max(12),
   })
   .superRefine((draft, context) => {
@@ -139,6 +153,9 @@ export type RestaurantItemAttributes = z.infer<
   typeof restaurantItemAttributesSchema
 >;
 export type RestaurantDraft = z.infer<typeof restaurantDraftSchema>;
+export type RestaurantTranslation = z.infer<
+  typeof restaurantTranslationSchema
+>;
 export type RestaurantSiteDraft = z.infer<typeof restaurantSiteDraftSchema>;
 export type RestaurantLocale = z.infer<typeof localeSchema>;
 
@@ -268,6 +285,7 @@ export function toRestaurantDraft(
     defaultLocale: draft.defaultLocale,
     translations: draft.translations.map((translation) => ({
       locale: translation.locale,
+      status: translation.status,
       cuisine: translation.attributes.cuisine,
       eyebrow: translation.eyebrow,
       description: translation.description,
@@ -290,6 +308,7 @@ export function toRestaurantDraft(
         description: item.description,
         price: item.price,
         currency: item.currency,
+        available: item.available,
         dietaryLabels: item.attributes.dietaryLabels,
         imageUrl: item.imageUrl,
         originalImageUrl: item.originalImageUrl,
@@ -325,6 +344,7 @@ export function fromRestaurantDraft(
     defaultLocale: draft.defaultLocale,
     translations: draft.translations.map((translation) => ({
       locale: translation.locale,
+      status: translation.status,
       attributes: {
         cuisine: translation.cuisine,
       },
@@ -351,6 +371,7 @@ export function fromRestaurantDraft(
         description: item.description,
         price: item.price,
         currency: item.currency,
+        available: item.available,
         attributes: {
           dietaryLabels: item.dietaryLabels,
         },

--- a/src/lib/verticals/schema.ts
+++ b/src/lib/verticals/schema.ts
@@ -30,11 +30,27 @@ export const siteImageUrlSchema = z.union([
   z.string().regex(/^\/[a-zA-Z0-9/_\-.]+$/),
 ]);
 
+export const supportedCurrencySchema = z.enum([
+  "EUR",
+  "USD",
+  "GBP",
+  "CHF",
+  "CAD",
+  "AUD",
+  "NZD",
+  "JPY",
+  "SEK",
+  "NOK",
+  "DKK",
+  "PLN",
+]);
+
 export const catalogItemSchema = z.object({
   name: z.string().min(1).max(120),
   description: z.string().max(320).default(""),
   price: z.number().nonnegative().nullable().default(null),
-  currency: z.string().length(3).default("EUR"),
+  currency: supportedCurrencySchema.default("EUR"),
+  available: z.boolean().default(true),
   imageUrl: siteImageUrlSchema.nullable().default(null),
   originalImageUrl: siteImageUrlSchema.nullable().optional(),
   imageProvenance: imageProvenanceSchema.nullable().optional(),


### PR DESCRIPTION
Closes #9

## What changed
- replaces the placeholder menu tab with full section/item CRUD, ordering, availability, dietary, currency, approved-image and recoverable deletion controls
- adds explicit canonical/locale states, stale and draft review workflow, text-only AI regeneration, and a server-side stale-translation publish gate
- persists availability and translation status through the existing PostgreSQL draft/publish path and hides unavailable items from public renderers
- adds unit coverage plus PostgreSQL-gated persistence and publish-safety coverage

## Verification
- `bun test` — 208 passed, 13 PostgreSQL-gated skipped
- `bunx tsc --noEmit`
- `bun run lint` — 0 errors; one pre-existing generated-route warning
- `git diff --check`

## Planning
- `planning_degraded`: genfeedai Fable and Opus planning calls were unavailable with HTTP 429; implementation proceeded from the issue acceptance contract as instructed.