### PR TITLE
feat(auth): harden sessions and workspace access

### DIFF
--- a/docs/runbooks/auth-session-production.md
+++ b/docs/runbooks/auth-session-production.md
@@ -1,0 +1,29 @@
+# Auth session production verification
+
+The migration is additive: it creates `AuthMagicLink`, `AuthSession`, and
+`AuthEvent` plus their enum types, indexes, and foreign keys. Existing signed
+cookies become invalid after release and owners must request a new link.
+
+## Release gate
+
+1. Apply all Prisma migrations before routing traffic to the new application.
+2. Confirm `DATABASE_URL`, `REDIS_URL`, `RESEND_API_KEY`,
+   `NEXT_PUBLIC_APP_URL`, and the dual-gated `SUPERADMIN_EMAILS` are configured.
+3. Request one owner link and one operator link from the production hostname.
+4. In `/admin/auth`, confirm each attempt shows `sent` or a safe failure code.
+5. Use the owner link once. Confirm a second use redirects to
+   `/sign-in?error=invalid-link`.
+6. For a multi-site account, confirm sign-in opens `/workspace/select`, then
+   selection rotates the cookie and opens only that tenant.
+7. Sign out and confirm the old cookie no longer resolves.
+8. Remove a test membership and confirm its still-unexpired site session is
+   denied immediately.
+
+Record timestamps and screenshots in the release evidence. Do not mark email
+receipt or link use as verified unless the real owner performed those actions.
+
+## Failed delivery
+
+Only `FAILED` or stale `PENDING` attempts are retryable. A retry revokes the old
+link, creates a new 20-minute credential, and is capped at two replacements.
+The console masks account emails and never exposes provider response bodies.

--- a/prisma/migrations/20260727071000_auth_session_hardening/migration.sql
+++ b/prisma/migrations/20260727071000_auth_session_hardening/migration.sql
@@ -1,0 +1,99 @@
+BEGIN;
+
+CREATE TYPE "AuthLinkDestination" AS ENUM ('ADMIN', 'WORKSPACE');
+CREATE TYPE "AuthDeliveryStatus" AS ENUM ('PENDING', 'SENT', 'FAILED');
+CREATE TYPE "AuthSessionPurpose" AS ENUM ('ADMIN', 'WORKSPACE_SELECTION', 'SITE');
+
+CREATE TABLE "AuthMagicLink" (
+    "id" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "destination" "AuthLinkDestination" NOT NULL,
+    "brandVertical" "Vertical",
+    "deliveryStatus" "AuthDeliveryStatus" NOT NULL DEFAULT 'PENDING',
+    "deliveryAttempts" INTEGER NOT NULL DEFAULT 0,
+    "retryCount" INTEGER NOT NULL DEFAULT 0,
+    "providerMessageId" TEXT,
+    "failureCode" TEXT,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "deliveredAt" TIMESTAMP(3),
+    "lastAttemptAt" TIMESTAMP(3),
+    "consumedAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AuthMagicLink_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "AuthSession" (
+    "id" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "purpose" "AuthSessionPurpose" NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "revokedAt" TIMESTAMP(3),
+    "userId" TEXT NOT NULL,
+    "organizationId" TEXT,
+    "siteId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AuthSession_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "AuthEvent" (
+    "id" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "actor" TEXT,
+    "subjectUserId" TEXT,
+    "magicLinkId" TEXT,
+    "sessionId" TEXT,
+    "siteId" TEXT,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AuthEvent_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "AuthMagicLink_tokenHash_key"
+ON "AuthMagicLink"("tokenHash");
+CREATE INDEX "AuthMagicLink_userId_createdAt_idx"
+ON "AuthMagicLink"("userId", "createdAt");
+CREATE INDEX "AuthMagicLink_deliveryStatus_createdAt_idx"
+ON "AuthMagicLink"("deliveryStatus", "createdAt");
+
+CREATE UNIQUE INDEX "AuthSession_tokenHash_key"
+ON "AuthSession"("tokenHash");
+CREATE INDEX "AuthSession_userId_expiresAt_idx"
+ON "AuthSession"("userId", "expiresAt");
+CREATE INDEX "AuthSession_siteId_expiresAt_idx"
+ON "AuthSession"("siteId", "expiresAt");
+
+CREATE INDEX "AuthEvent_subjectUserId_createdAt_idx"
+ON "AuthEvent"("subjectUserId", "createdAt");
+CREATE INDEX "AuthEvent_magicLinkId_createdAt_idx"
+ON "AuthEvent"("magicLinkId", "createdAt");
+CREATE INDEX "AuthEvent_sessionId_createdAt_idx"
+ON "AuthEvent"("sessionId", "createdAt");
+
+ALTER TABLE "AuthMagicLink"
+ADD CONSTRAINT "AuthMagicLink_userId_fkey"
+FOREIGN KEY ("userId") REFERENCES "User"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "AuthSession"
+ADD CONSTRAINT "AuthSession_userId_fkey"
+FOREIGN KEY ("userId") REFERENCES "User"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "AuthSession"
+ADD CONSTRAINT "AuthSession_organizationId_fkey"
+FOREIGN KEY ("organizationId") REFERENCES "Organization"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "AuthSession"
+ADD CONSTRAINT "AuthSession_siteId_fkey"
+FOREIGN KEY ("siteId") REFERENCES "Site"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -73,6 +73,23 @@ enum ClaimProofMethod {
   OPERATOR_APPROVAL
 }
 
+enum AuthLinkDestination {
+  ADMIN
+  WORKSPACE
+}
+
+enum AuthDeliveryStatus {
+  PENDING
+  SENT
+  FAILED
+}
+
+enum AuthSessionPurpose {
+  ADMIN
+  WORKSPACE_SELECTION
+  SITE
+}
+
 model User {
   id           String       @id @default(cuid())
   email        String       @unique
@@ -81,6 +98,8 @@ model User {
   createdAt    DateTime     @default(now())
   updatedAt    DateTime     @updatedAt
   memberships  Membership[]
+  authMagicLinks AuthMagicLink[]
+  authSessions   AuthSession[]
 }
 
 model Organization {
@@ -91,6 +110,7 @@ model Organization {
   memberships   Membership[]
   sites         Site[]
   subscriptions Subscription[]
+  authSessions   AuthSession[]
 }
 
 model Membership {
@@ -144,6 +164,66 @@ model Site {
   auditEvents            AuditEvent[]
   bookingRequests        BookingRequest[]
   analyticsEvents        AnalyticsEvent[]
+  authSessions           AuthSession[]
+}
+
+model AuthMagicLink {
+  id                String             @id @default(cuid())
+  tokenHash         String             @unique
+  destination       AuthLinkDestination
+  brandVertical     Vertical?
+  deliveryStatus    AuthDeliveryStatus @default(PENDING)
+  deliveryAttempts  Int                @default(0)
+  retryCount        Int                @default(0)
+  providerMessageId String?
+  failureCode       String?
+  expiresAt         DateTime
+  deliveredAt       DateTime?
+  lastAttemptAt     DateTime?
+  consumedAt        DateTime?
+  revokedAt         DateTime?
+  userId            String
+  user              User               @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt         DateTime           @default(now())
+  updatedAt         DateTime           @updatedAt
+
+  @@index([userId, createdAt])
+  @@index([deliveryStatus, createdAt])
+}
+
+model AuthSession {
+  id             String             @id @default(cuid())
+  tokenHash      String             @unique
+  purpose        AuthSessionPurpose
+  expiresAt      DateTime
+  revokedAt      DateTime?
+  userId         String
+  user           User               @relation(fields: [userId], references: [id], onDelete: Cascade)
+  organizationId String?
+  organization   Organization?      @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  siteId         String?
+  site           Site?              @relation(fields: [siteId], references: [id], onDelete: Cascade)
+  createdAt      DateTime           @default(now())
+  updatedAt      DateTime           @updatedAt
+
+  @@index([userId, expiresAt])
+  @@index([siteId, expiresAt])
+}
+
+model AuthEvent {
+  id            String   @id @default(cuid())
+  type          String
+  actor         String?
+  subjectUserId String?
+  magicLinkId   String?
+  sessionId     String?
+  siteId        String?
+  metadata      Json?
+  createdAt     DateTime @default(now())
+
+  @@index([subjectUserId, createdAt])
+  @@index([magicLinkId, createdAt])
+  @@index([sessionId, createdAt])
 }
 
 model CatalogSection {

--- a/src/app/admin/auth/page.tsx
+++ b/src/app/admin/auth/page.tsx
@@ -1,0 +1,87 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { RetryDeliveryButton } from "@/app/admin/auth/retry-delivery-button";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { getRecentAuthDeliveries } from "@/lib/auth-operations";
+import { getSuperadminAccess } from "@/lib/authorization";
+import { getCurrentSession } from "@/lib/current-session";
+
+export const dynamic = "force-dynamic";
+export const metadata: Metadata = {
+  title: "Authentication delivery",
+  robots: { index: false, follow: false },
+};
+
+export default async function AuthOperationsPage() {
+  if (!(await getCurrentSession())) redirect("/sign-in");
+  if (!(await getSuperadminAccess())) notFound();
+  const rows = await getRecentAuthDeliveries();
+
+  return (
+    <main className="min-h-screen bg-[#f3f1eb] px-4 py-10">
+      <section className="mx-auto max-w-6xl">
+        <div className="flex items-end justify-between gap-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary">
+              Operator console
+            </p>
+            <h1 className="font-display mt-2 text-5xl tracking-[-0.04em]">
+              Sign-in delivery.
+            </h1>
+            <p className="mt-3 text-sm text-muted-foreground">
+              Masked account identifiers, safe provider outcomes, and bounded replacement links.
+            </p>
+          </div>
+          <Button render={<Link href="/admin" />} variant="outline">Back</Button>
+        </div>
+        <Card className="mt-8 overflow-hidden py-0">
+          <CardHeader className="border-b py-5">
+            <CardTitle>Latest 100 attempts</CardTitle>
+          </CardHeader>
+          <CardContent className="overflow-x-auto p-0">
+            <table className="w-full min-w-[840px] text-left text-sm">
+              <thead className="border-b bg-muted/50 text-xs uppercase tracking-[0.12em] text-muted-foreground">
+                <tr>
+                  <th className="px-5 py-3">Account</th>
+                  <th className="px-5 py-3">Destination</th>
+                  <th className="px-5 py-3">Delivery</th>
+                  <th className="px-5 py-3">Failure</th>
+                  <th className="px-5 py-3">Created</th>
+                  <th className="px-5 py-3 text-right">Action</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {rows.map((row) => (
+                  <tr key={row.id}>
+                    <td className="px-5 py-4 font-mono text-xs">{row.account}</td>
+                    <td className="px-5 py-4">{row.destination.toLowerCase()}</td>
+                    <td className="px-5 py-4">
+                      <Badge variant={row.status === "FAILED" ? "destructive" : "outline"}>
+                        {row.status.toLowerCase()}
+                      </Badge>
+                    </td>
+                    <td className="px-5 py-4 text-muted-foreground">
+                      {row.failureCode ?? "—"}
+                    </td>
+                    <td className="px-5 py-4">{row.createdAt.toLocaleString()}</td>
+                    <td className="px-5 py-4 text-right">
+                      {row.retryable ? <RetryDeliveryButton id={row.id} /> : "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {rows.length === 0 ? (
+              <p className="px-5 py-12 text-center text-muted-foreground">
+                No sign-in attempts yet.
+              </p>
+            ) : null}
+          </CardContent>
+        </Card>
+      </section>
+    </main>
+  );
+}

--- a/src/app/admin/auth/retry-delivery-button.tsx
+++ b/src/app/admin/auth/retry-delivery-button.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState } from "react";
+import { RefreshCcw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export function RetryDeliveryButton({ id }: { id: string }) {
+  const [pending, setPending] = useState(false);
+
+  async function retry() {
+    if (!window.confirm("Send one replacement sign-in link?")) return;
+    setPending(true);
+    try {
+      const response = await fetch("/api/admin/auth-deliveries/retry", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id }),
+      });
+      if (!response.ok) throw new Error("Retry failed");
+      window.location.reload();
+    } catch {
+      setPending(false);
+    }
+  }
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      disabled={pending}
+      onClick={retry}
+    >
+      <RefreshCcw className={pending ? "animate-spin" : ""} />
+      Retry
+    </Button>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import { ClaimInvitationForm } from "@/app/admin/claim-invitation-form";
 import { Brand } from "@/components/brand";
+import { AccountActions } from "@/components/account-actions";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -53,6 +54,10 @@ export default async function AdminPage() {
               Client dashboard
             </Button>
           ) : null}
+          <AccountActions canSwitch />
+          <Button render={<Link href="/admin/auth" />} variant="outline" size="sm">
+            Sign-in delivery
+          </Button>
         </div>
       </header>
 

--- a/src/app/api/admin/auth-deliveries/retry/route.ts
+++ b/src/app/api/admin/auth-deliveries/retry/route.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import { getSuperadminAccess } from "@/lib/authorization";
+import { retryMagicLink } from "@/lib/magic-links";
+import { limitOperatorAuthRetry } from "@/lib/rate-limit";
+import { isSameOriginMutation } from "@/lib/request-origin";
+
+const schema = z.object({ id: z.string().min(1).max(128) });
+
+export async function POST(request: Request) {
+  if (!isSameOriginMutation(request, { requireOrigin: true })) {
+    return Response.json({ error: "Invalid request origin" }, { status: 403 });
+  }
+  const operator = await getSuperadminAccess();
+  if (!operator) return Response.json({ error: "Not found" }, { status: 404 });
+  const rateLimit = await limitOperatorAuthRetry(request);
+  if (!rateLimit.success) {
+    return Response.json({ error: "Retry limit reached" }, { status: 429 });
+  }
+  const parsed = schema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return Response.json({ error: "Invalid delivery" }, { status: 400 });
+  }
+  try {
+    await retryMagicLink(parsed.data.id, operator.id);
+    return Response.json({ ok: true });
+  } catch {
+    return Response.json({ error: "Delivery cannot be retried" }, { status: 409 });
+  }
+}

--- a/src/app/api/auth/checkout/route.ts
+++ b/src/app/api/auth/checkout/route.ts
@@ -2,12 +2,13 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { z } from "zod";
 import { normalizeAccountEmail } from "@/lib/account-email";
+import { createSiteSession } from "@/lib/auth-sessions";
 import {
   CHECKOUT_RETURN_COOKIE,
   verifyHashedToken,
 } from "@/lib/claim-security";
 import { getDb } from "@/lib/db";
-import { createSessionToken, SESSION_COOKIE } from "@/lib/session";
+import { SESSION_COOKIE, sessionCookieOptions } from "@/lib/session";
 
 const querySchema = z.object({
   sessionId: z.string().startsWith("cs_").max(256),
@@ -109,19 +110,17 @@ export async function GET(request: Request) {
     },
   });
   cookieStore.delete(CHECKOUT_RETURN_COOKIE);
+  const existingToken = cookieStore.get(SESSION_COOKIE)?.value;
+  const created = await createSiteSession({
+    userId: membership.userId,
+    siteId: invitation.site.id,
+    actor: "checkout-return",
+    previousToken: existingToken,
+  });
   cookieStore.set(
     SESSION_COOKIE,
-    createSessionToken({
-      userId: membership.userId,
-      siteSlug: invitation.site.slug,
-    }),
-    {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
-      sameSite: "lax",
-      maxAge: 30 * 24 * 60 * 60,
-      path: "/",
-    },
+    created.token,
+    sessionCookieOptions(created.session.expiresAt),
   );
 
   if (poll) {

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,20 @@
+import { cookies } from "next/headers";
+import { revokeCurrentSession } from "@/lib/auth-sessions";
+import { isSameOriginMutation } from "@/lib/request-origin";
+import { SESSION_COOKIE } from "@/lib/session";
+
+export async function POST(request: Request) {
+  if (!isSameOriginMutation(request, { requireOrigin: true })) {
+    return Response.json({ error: "Invalid request origin" }, { status: 403 });
+  }
+  const cookieStore = await cookies();
+  const token = cookieStore.get(SESSION_COOKIE)?.value;
+  if (token && process.env.DATABASE_URL) {
+    await revokeCurrentSession(token);
+  }
+  cookieStore.delete(SESSION_COOKIE);
+  return Response.json(
+    { ok: true, url: "/sign-in" },
+    { headers: { "Cache-Control": "no-store" } },
+  );
+}

--- a/src/app/api/auth/magic-link/route.ts
+++ b/src/app/api/auth/magic-link/route.ts
@@ -1,103 +1,39 @@
 import { z } from "zod";
 import { normalizeAccountEmail } from "@/lib/account-email";
-import { getDb } from "@/lib/db";
-import { buildMagicLinkEmail } from "@/lib/magic-link-email";
-import { getResend } from "@/lib/resend";
-import { createSessionToken } from "@/lib/session";
-import { isConfiguredSuperadminEmail } from "@/lib/superadmin-config";
+import { requestMagicLink } from "@/lib/magic-links";
+import { limitMagicLinkRequest } from "@/lib/rate-limit";
+import { isSameOriginMutation } from "@/lib/request-origin";
 
-const schema = z.object({
-  email: z.string(),
-});
+const schema = z.object({ email: z.string().email().max(320) });
 
 export async function POST(request: Request) {
-  try {
-    const input = schema.parse(await request.json());
-    const email = normalizeAccountEmail(input.email);
-    if (!process.env.DATABASE_URL) {
-      throw new Error("Account database is not configured");
-    }
-
-    const user = await getDb().user.findUnique({
-      where: { email },
-      select: {
-        id: true,
-        email: true,
-        platformRole: true,
-        memberships: {
-          select: {
-            organization: {
-              select: {
-                sites: {
-                  orderBy: { createdAt: "asc" },
-                  take: 1,
-                  select: {
-                    slug: true,
-                    name: true,
-                    vertical: true,
-                  },
-                },
-              },
-            },
-          },
-          take: 1,
-        },
-      },
-    });
-
-    // Keep account existence private.
-    if (!user) return Response.json({ ok: true });
-    const site = user.memberships[0]?.organization.sites[0];
-    const isSuperadmin =
-      user.platformRole === "SUPERADMIN" &&
-      isConfiguredSuperadminEmail(user.email);
-    if (!site && !isSuperadmin) return Response.json({ ok: true });
-
-    const token = createSessionToken({
-      userId: user.id,
-      siteSlug: site?.slug,
-      expiresAt: Date.now() + 20 * 60 * 1000,
-    });
-    const configuredAppUrl = process.env.NEXT_PUBLIC_APP_URL;
-    if (!configuredAppUrl) {
-      throw new Error("NEXT_PUBLIC_APP_URL is not configured");
-    }
-    const appUrl = new URL(configuredAppUrl).origin;
-    const destination = isSuperadmin ? "admin" : "dashboard";
-    const verifyUrl = `${appUrl}/api/auth/verify?token=${encodeURIComponent(token)}&destination=${destination}`;
-    // Customer links use the niche identity they already trust. Operator links
-    // use the factory consistently, including for admins who also own a site.
-    const emailMessage = buildMagicLinkEmail({
-      verifyUrl,
-      isSuperadmin,
-      site: site ?? null,
-    });
-    const { error } = await getResend().emails.send(
-      {
-        from: emailMessage.from,
-        to: email,
-        replyTo: emailMessage.replyTo,
-        subject: emailMessage.subject,
-        html: emailMessage.html,
-      },
-      {
-        headers: {
-          "Idempotency-Key": `magic-link-${user.id}-${Math.floor(Date.now() / 300_000)}`,
-        },
-      },
-    );
-    if (error) throw new Error(error.message);
-
-    return Response.json({ ok: true });
-  } catch (error) {
+  if (!isSameOriginMutation(request)) {
+    return Response.json({ error: "Invalid request origin" }, { status: 403 });
+  }
+  const rateLimit = await limitMagicLinkRequest(request);
+  if (!rateLimit.success) {
     return Response.json(
-      {
-        error:
-          error instanceof Error
-            ? error.message
-            : "Sign-in link could not be sent",
-      },
-      { status: 400 },
+      { error: "Please wait before requesting another link." },
+      { status: 429, headers: { "Retry-After": "60" } },
     );
   }
+  if (!process.env.DATABASE_URL) {
+    return Response.json(
+      { error: "Accounts are temporarily unavailable." },
+      { status: 503 },
+    );
+  }
+
+  const parsed = schema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return Response.json({ error: "Enter a valid email address." }, { status: 400 });
+  }
+
+  // Delivery failures and unknown accounts deliberately share the same response.
+  // Durable outcomes are visible only in the operator console.
+  await requestMagicLink(normalizeAccountEmail(parsed.data.email)).catch(() => undefined);
+  return Response.json(
+    { ok: true },
+    { headers: { "Cache-Control": "no-store" } },
+  );
 }

--- a/src/app/api/auth/verify/route.ts
+++ b/src/app/api/auth/verify/route.ts
@@ -1,27 +1,81 @@
-import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import { consumeMagicLink } from "@/lib/magic-links";
-import { SESSION_COOKIE, sessionCookieOptions } from "@/lib/session";
+import { isSameOriginMutation } from "@/lib/request-origin";
+import {
+  PENDING_MAGIC_LINK_COOKIE,
+  pendingMagicLinkCookieOptions,
+  SESSION_COOKIE,
+  sessionCookieOptions,
+} from "@/lib/session";
 
-export async function GET(request: Request) {
+function signInError(request: Request) {
+  return NextResponse.redirect(
+    new URL("/sign-in?error=invalid-link", request.url),
+    303,
+  );
+}
+
+/**
+ * Stages the credential without consuming it. Email security scanners routinely
+ * follow GET links; requiring a deliberate same-origin POST prevents those
+ * scanners from burning a one-time link before its owner opens the message.
+ */
+export async function GET(request: NextRequest) {
   const token = new URL(request.url).searchParams.get("token");
   if (!token || !process.env.DATABASE_URL) {
-    redirect("/sign-in?error=invalid-link");
+    return signInError(request);
+  }
+
+  const response = NextResponse.redirect(
+    new URL("/sign-in/verify", request.url),
+    303,
+  );
+  response.cookies.set(
+    PENDING_MAGIC_LINK_COOKIE,
+    token,
+    pendingMagicLinkCookieOptions(),
+  );
+  response.headers.set("Cache-Control", "private, no-store");
+  response.headers.set("Referrer-Policy", "no-referrer");
+  return response;
+}
+
+export async function POST(request: NextRequest) {
+  if (!isSameOriginMutation(request, { requireOrigin: true })) {
+    return NextResponse.json(
+      { error: "Invalid request origin" },
+      { status: 403 },
+    );
+  }
+  const token = request.cookies.get(PENDING_MAGIC_LINK_COOKIE)?.value;
+  if (!token || !process.env.DATABASE_URL) {
+    return signInError(request);
   }
 
   const created = await consumeMagicLink(token).catch(() => null);
-  if (!created) redirect("/sign-in?error=invalid-link");
+  if (!created) {
+    const response = signInError(request);
+    response.cookies.delete(PENDING_MAGIC_LINK_COOKIE);
+    return response;
+  }
 
-  (await cookies()).set(
-    SESSION_COOKIE,
-    created.token,
-    sessionCookieOptions(created.session.expiresAt),
-  );
-  redirect(
+  const destination =
     created.session.purpose === "ADMIN"
       ? "/admin"
       : created.session.purpose === "WORKSPACE_SELECTION"
         ? "/workspace/select"
-        : "/dashboard",
+        : "/dashboard";
+  const response = NextResponse.redirect(
+    new URL(destination, request.url),
+    303,
   );
+  response.cookies.delete(PENDING_MAGIC_LINK_COOKIE);
+  response.cookies.set(
+    SESSION_COOKIE,
+    created.token,
+    sessionCookieOptions(created.session.expiresAt),
+  );
+  response.headers.set("Cache-Control", "private, no-store");
+  return response;
 }

--- a/src/app/api/auth/verify/route.ts
+++ b/src/app/api/auth/verify/route.ts
@@ -1,31 +1,27 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
-import {
-  createSessionToken,
-  SESSION_COOKIE,
-  verifySessionToken,
-} from "@/lib/session";
+import { consumeMagicLink } from "@/lib/magic-links";
+import { SESSION_COOKIE, sessionCookieOptions } from "@/lib/session";
 
 export async function GET(request: Request) {
-  const searchParams = new URL(request.url).searchParams;
-  const token = searchParams.get("token");
-  const session = token ? verifySessionToken(token) : null;
-  if (!token || !session) redirect("/sign-in?error=invalid-link");
+  const token = new URL(request.url).searchParams.get("token");
+  if (!token || !process.env.DATABASE_URL) {
+    redirect("/sign-in?error=invalid-link");
+  }
 
-  const cookieStore = await cookies();
-  cookieStore.set(
+  const created = await consumeMagicLink(token).catch(() => null);
+  if (!created) redirect("/sign-in?error=invalid-link");
+
+  (await cookies()).set(
     SESSION_COOKIE,
-    createSessionToken({
-      userId: session.userId,
-      siteSlug: session.siteSlug,
-    }),
-    {
-    httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
-    sameSite: "lax",
-    maxAge: 30 * 24 * 60 * 60,
-    path: "/",
-    },
+    created.token,
+    sessionCookieOptions(created.session.expiresAt),
   );
-  redirect(searchParams.get("destination") === "admin" ? "/admin" : "/dashboard");
+  redirect(
+    created.session.purpose === "ADMIN"
+      ? "/admin"
+      : created.session.purpose === "WORKSPACE_SELECTION"
+        ? "/workspace/select"
+        : "/dashboard",
+  );
 }

--- a/src/app/api/auth/workspace/route.ts
+++ b/src/app/api/auth/workspace/route.ts
@@ -1,0 +1,38 @@
+import { cookies } from "next/headers";
+import { z } from "zod";
+import { rotateSessionToWorkspace } from "@/lib/auth-sessions";
+import { isSameOriginMutation } from "@/lib/request-origin";
+import { SESSION_COOKIE, sessionCookieOptions } from "@/lib/session";
+
+const schema = z.object({ siteId: z.string().min(1).max(128) });
+
+export async function POST(request: Request) {
+  if (!isSameOriginMutation(request, { requireOrigin: true })) {
+    return Response.json({ error: "Invalid request origin" }, { status: 403 });
+  }
+  const parsed = schema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return Response.json({ error: "Invalid workspace" }, { status: 400 });
+  }
+  const cookieStore = await cookies();
+  const currentToken = cookieStore.get(SESSION_COOKIE)?.value;
+  if (!currentToken) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const created = await rotateSessionToWorkspace({
+    currentToken,
+    siteId: parsed.data.siteId,
+  }).catch(() => null);
+  if (!created) {
+    return Response.json({ error: "Workspace access is unavailable" }, { status: 403 });
+  }
+  cookieStore.set(
+    SESSION_COOKIE,
+    created.token,
+    sessionCookieOptions(created.session.expiresAt),
+  );
+  return Response.json(
+    { ok: true, url: "/dashboard" },
+    { headers: { "Cache-Control": "no-store" } },
+  );
+}

--- a/src/app/dashboard/dashboard.tsx
+++ b/src/app/dashboard/dashboard.tsx
@@ -26,6 +26,7 @@ import {
   TrendingUp,
 } from "lucide-react";
 import { Brand } from "@/components/brand";
+import { AccountActions } from "@/components/account-actions";
 import {
   ClientAnalyticsPanel,
   ClientBookingRequestInbox,
@@ -68,6 +69,7 @@ export function Dashboard({
   analyticsSummary,
   bookingInbox,
   billingAccess,
+  canSwitchWorkspace,
 }: {
   initialDraft: RestaurantDraft;
   email: string;
@@ -77,6 +79,7 @@ export function Dashboard({
   analyticsSummary: AnalyticsSummaryDto;
   bookingInbox: BookingRequestInboxDto;
   billingAccess: BillingAccess | null;
+  canSwitchWorkspace: boolean;
 }) {
   const [draft, setDraft] = useState(initialDraft);
   const [saving, setSaving] = useState(false);
@@ -330,6 +333,9 @@ export function Dashboard({
               ? `Published v${publishedVersion}`
               : "Publish"}
           </Button>
+          {!demo ? (
+            <AccountActions canSwitch={canSwitchWorkspace} />
+          ) : null}
         </div>
       </header>
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -10,6 +10,7 @@ import { getCurrentSession } from "@/lib/current-session";
 import { getRestaurantDraft } from "@/lib/restaurants";
 import { sampleRestaurant } from "@/lib/restaurant";
 import { resolveRequestBrand } from "@/lib/verticals/request-site";
+import { listAccountWorkspaces } from "@/lib/workspaces";
 
 export const metadata: Metadata = {
   title: "Dashboard",
@@ -24,18 +25,21 @@ export default async function DashboardPage({
   const query = await searchParams;
   const session = await getCurrentSession();
   if (!session && query.demo !== "1") redirect("/sign-in");
-  if (session && !session.siteSlug) redirect("/admin");
+  if (session?.purpose === "WORKSPACE_SELECTION") redirect("/workspace/select");
+  if (session?.purpose === "ADMIN") redirect("/admin");
+  if (session && session.purpose !== "SITE") redirect("/sign-in");
 
   const access =
     session?.siteSlug ? await getSiteAccess(session.siteSlug) : null;
   if (session && (!access || !access.ok)) redirect("/sign-in");
 
-  const [draft, analyticsSummary, bookingInbox, billingAccess] = access?.ok
+  const [draft, analyticsSummary, bookingInbox, billingAccess, workspaces] = access?.ok
     ? await Promise.all([
         getRestaurantDraft(access.site.slug),
         getSiteAnalyticsSummary(access.site.id),
         getBookingRequestInbox(access.site.id),
         getSiteBillingAccess(access.site.id),
+        listAccountWorkspaces(access.session.userId),
       ])
     : [
         sampleRestaurant,
@@ -47,6 +51,7 @@ export default async function DashboardPage({
           truncated: false,
         },
         null,
+        [],
       ];
 
   return (
@@ -59,6 +64,7 @@ export default async function DashboardPage({
       analyticsSummary={analyticsSummary}
       bookingInbox={bookingInbox}
       billingAccess={billingAccess}
+      canSwitchWorkspace={workspaces.length > 1}
     />
   );
 }

--- a/src/app/sign-in/verify/page.tsx
+++ b/src/app/sign-in/verify/page.tsx
@@ -1,0 +1,52 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft, ArrowRight, ShieldCheck } from "lucide-react";
+import { Brand } from "@/components/brand";
+import { Button } from "@/components/ui/button";
+import { resolveRequestBrand } from "@/lib/verticals/request-site";
+
+export const metadata: Metadata = {
+  title: "Confirm sign in",
+  robots: { index: false, follow: false },
+  referrer: "no-referrer",
+};
+
+export default async function VerifySignInPage() {
+  const brand = await resolveRequestBrand();
+
+  return (
+    <main className="min-h-screen">
+      <header className="flex h-16 items-center gap-4 border-b px-5">
+        <Button
+          render={<Link href="/sign-in" />}
+          variant="ghost"
+          size="icon-sm"
+        >
+          <ArrowLeft />
+        </Button>
+        <Brand {...brand} />
+      </header>
+      <div className="grid min-h-[calc(100vh-4rem)] place-items-center px-5 py-16">
+        <section className="w-full max-w-md rounded-3xl border bg-card p-7 shadow-xl">
+          <span className="grid size-10 place-items-center rounded-full bg-primary/10 text-primary">
+            <ShieldCheck className="size-5" />
+          </span>
+          <h1 className="font-display mt-5 text-5xl leading-none tracking-[-0.045em]">
+            Confirm it&apos;s you.
+          </h1>
+          <p className="mt-4 text-sm leading-6 text-muted-foreground">
+            Your secure link is ready. Continue to open your workspace. This
+            confirmation keeps automated email scanners from using the link
+            before you do.
+          </p>
+          <form action="/api/auth/verify" method="post" className="mt-7">
+            <Button type="submit" className="h-11 w-full">
+              Continue securely
+              <ArrowRight />
+            </Button>
+          </form>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/workspace/select/page.tsx
+++ b/src/app/workspace/select/page.tsx
@@ -1,0 +1,40 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { WorkspaceChooser } from "@/app/workspace/select/workspace-chooser";
+import { AccountActions } from "@/components/account-actions";
+import { getCurrentSession } from "@/lib/current-session";
+import { listAccountWorkspaces } from "@/lib/workspaces";
+
+export const metadata: Metadata = {
+  title: "Choose workspace",
+  robots: { index: false, follow: false },
+};
+
+export default async function WorkspaceSelectPage() {
+  const session = await getCurrentSession();
+  if (!session) redirect("/sign-in");
+  const workspaces = await listAccountWorkspaces(session.userId);
+  if (workspaces.length === 0) redirect("/sign-in");
+
+  return (
+    <main className="min-h-screen bg-muted/30 px-4 py-16">
+      <section className="mx-auto max-w-2xl">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary">
+              Account workspace
+            </p>
+            <h1 className="font-display mt-3 text-5xl tracking-[-0.045em]">
+              Choose where to work.
+            </h1>
+            <p className="mt-4 text-sm text-muted-foreground">
+              Your session will be freshly bound to the workspace you select.
+            </p>
+          </div>
+          <AccountActions canSwitch={false} />
+        </div>
+        <WorkspaceChooser workspaces={workspaces} />
+      </section>
+    </main>
+  );
+}

--- a/src/app/workspace/select/workspace-chooser.tsx
+++ b/src/app/workspace/select/workspace-chooser.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import { ArrowRight, LoaderCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import type { AccountWorkspace } from "@/lib/workspaces";
+
+export function WorkspaceChooser({
+  workspaces,
+}: {
+  workspaces: AccountWorkspace[];
+}) {
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function choose(siteId: string) {
+    setPendingId(siteId);
+    setError(null);
+    try {
+      const response = await fetch("/api/auth/workspace", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ siteId }),
+      });
+      if (!response.ok) throw new Error("Workspace access is unavailable.");
+      window.location.assign("/dashboard");
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Could not switch workspace.");
+      setPendingId(null);
+    }
+  }
+
+  return (
+    <div className="mt-8 grid gap-3">
+      {workspaces.map((workspace) => (
+        <Card key={workspace.id}>
+          <CardContent className="flex items-center justify-between gap-4 pt-1">
+            <div>
+              <p className="font-medium">{workspace.name}</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {workspace.vertical.toLowerCase()} · {workspace.slug}
+              </p>
+            </div>
+            <Button
+              onClick={() => choose(workspace.id)}
+              disabled={pendingId !== null}
+              aria-label={`Open ${workspace.name}`}
+            >
+              {pendingId === workspace.id ? (
+                <LoaderCircle className="animate-spin" />
+              ) : (
+                <ArrowRight />
+              )}
+              Open
+            </Button>
+          </CardContent>
+        </Card>
+      ))}
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+    </div>
+  );
+}

--- a/src/components/account-actions.tsx
+++ b/src/components/account-actions.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { LogOut } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export function AccountActions({ canSwitch }: { canSwitch: boolean }) {
+  const [pending, setPending] = useState(false);
+
+  async function logout() {
+    setPending(true);
+    try {
+      const response = await fetch("/api/auth/logout", { method: "POST" });
+      if (response.ok) window.location.assign("/sign-in");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      {canSwitch ? (
+        <Button render={<Link href="/workspace/select" />} variant="outline" size="sm">
+          Switch workspace
+        </Button>
+      ) : null}
+      <Button
+        variant="ghost"
+        size="sm"
+        disabled={pending}
+        onClick={logout}
+        aria-label="Sign out"
+      >
+        <LogOut />
+        Sign out
+      </Button>
+    </div>
+  );
+}

--- a/src/lib/auth-operations.ts
+++ b/src/lib/auth-operations.ts
@@ -1,0 +1,46 @@
+import "server-only";
+import { getDb } from "@/lib/db";
+import { canRetryMagicLink, maskAccountEmail } from "@/lib/session";
+
+export type AuthDeliveryRow = {
+  id: string;
+  account: string;
+  destination: "ADMIN" | "WORKSPACE";
+  status: "PENDING" | "SENT" | "FAILED";
+  failureCode: string | null;
+  retryCount: number;
+  retryable: boolean;
+  createdAt: Date;
+  lastAttemptAt: Date | null;
+};
+
+export async function getRecentAuthDeliveries(): Promise<AuthDeliveryRow[]> {
+  const rows = await getDb().authMagicLink.findMany({
+    orderBy: { createdAt: "desc" },
+    take: 100,
+    select: {
+      id: true,
+      destination: true,
+      deliveryStatus: true,
+      failureCode: true,
+      retryCount: true,
+      expiresAt: true,
+      consumedAt: true,
+      revokedAt: true,
+      createdAt: true,
+      lastAttemptAt: true,
+      user: { select: { email: true } },
+    },
+  });
+  return rows.map((row) => ({
+    id: row.id,
+    account: maskAccountEmail(row.user.email),
+    destination: row.destination,
+    status: row.deliveryStatus,
+    failureCode: row.failureCode,
+    retryCount: row.retryCount,
+    retryable: canRetryMagicLink(row),
+    createdAt: row.createdAt,
+    lastAttemptAt: row.lastAttemptAt,
+  }));
+}

--- a/src/lib/auth-sessions.ts
+++ b/src/lib/auth-sessions.ts
@@ -1,0 +1,322 @@
+import "server-only";
+import type { Prisma } from "@/generated/prisma/client";
+import type { AuthSessionPurpose } from "@/generated/prisma/enums";
+import { getDb } from "@/lib/db";
+import {
+  createOpaqueAuthToken,
+  hashAuthToken,
+  SESSION_TTL_MS,
+} from "@/lib/session";
+
+export type CurrentSession = {
+  id: string;
+  userId: string;
+  purpose: AuthSessionPurpose;
+  organizationId: string | null;
+  siteId: string | null;
+  siteSlug: string | null;
+  expiresAt: Date;
+};
+
+export type CreatedSession = {
+  token: string;
+  session: CurrentSession;
+};
+
+type CreateSessionInput = {
+  userId: string;
+  purpose: AuthSessionPurpose;
+  organizationId?: string | null;
+  site?: { id: string; slug: string } | null;
+  actor: string;
+  eventType?: "auth.session.created" | "auth.session.rotated";
+  previousSessionId?: string;
+  now?: Date;
+};
+
+export async function createSessionInTransaction(
+  tx: Prisma.TransactionClient,
+  input: CreateSessionInput,
+): Promise<CreatedSession> {
+  const now = input.now ?? new Date();
+  const expiresAt = new Date(now.getTime() + SESSION_TTL_MS);
+  const credential = createOpaqueAuthToken();
+  const organizationId = input.organizationId ?? null;
+  const site = input.site ?? null;
+  assertSessionBinding(input.purpose, organizationId, site);
+
+  const row = await tx.authSession.create({
+    data: {
+      tokenHash: credential.tokenHash,
+      purpose: input.purpose,
+      expiresAt,
+      userId: input.userId,
+      organizationId,
+      siteId: site?.id ?? null,
+    },
+    select: { id: true },
+  });
+  await tx.authEvent.create({
+    data: {
+      type: input.eventType ?? "auth.session.created",
+      actor: input.actor,
+      subjectUserId: input.userId,
+      sessionId: row.id,
+      siteId: site?.id ?? null,
+      metadata: {
+        purpose: input.purpose,
+        previousSessionId: input.previousSessionId ?? null,
+        expiresAt: expiresAt.toISOString(),
+      },
+    },
+  });
+  return {
+    token: credential.token,
+    session: {
+      id: row.id,
+      userId: input.userId,
+      purpose: input.purpose,
+      organizationId,
+      siteId: site?.id ?? null,
+      siteSlug: site?.slug ?? null,
+      expiresAt,
+    },
+  };
+}
+
+export async function resolveSessionToken(
+  token: string,
+  now = new Date(),
+): Promise<CurrentSession | null> {
+  if (!process.env.DATABASE_URL) return null;
+  const row = await getDb().authSession.findUnique({
+    where: { tokenHash: hashAuthToken(token) },
+    select: {
+      id: true,
+      userId: true,
+      purpose: true,
+      organizationId: true,
+      siteId: true,
+      expiresAt: true,
+      revokedAt: true,
+      site: { select: { slug: true, organizationId: true } },
+    },
+  });
+  if (!row || row.revokedAt || row.expiresAt <= now) return null;
+  if (
+    row.purpose === "SITE" &&
+    (!row.siteId ||
+      !row.organizationId ||
+      !row.site ||
+      row.site.organizationId !== row.organizationId)
+  ) {
+    return null;
+  }
+  if (
+    row.purpose !== "SITE" &&
+    (row.siteId || row.organizationId || row.site)
+  ) {
+    return null;
+  }
+
+  return {
+    id: row.id,
+    userId: row.userId,
+    purpose: row.purpose,
+    organizationId: row.organizationId,
+    siteId: row.siteId,
+    siteSlug: row.site?.slug ?? null,
+    expiresAt: row.expiresAt,
+  };
+}
+
+export async function createSiteSession(input: {
+  userId: string;
+  siteId: string;
+  actor: string;
+  previousToken?: string | null;
+}): Promise<CreatedSession> {
+  const now = new Date();
+  return getDb().$transaction(
+    async (tx) => {
+      const site = await tx.site.findFirst({
+        where: {
+          id: input.siteId,
+          organization: {
+            memberships: { some: { userId: input.userId } },
+          },
+        },
+        select: { id: true, slug: true, organizationId: true },
+      });
+      if (!site?.organizationId) {
+        throw new AuthSessionError("Workspace access is no longer available.");
+      }
+      const previous = input.previousToken
+        ? await revokeSessionInTransaction(tx, {
+            tokenHash: hashAuthToken(input.previousToken),
+            userId: input.userId,
+            actor: input.actor,
+            now,
+            audit: false,
+          })
+        : null;
+      return createSessionInTransaction(tx, {
+        userId: input.userId,
+        purpose: "SITE",
+        organizationId: site.organizationId,
+        site: { id: site.id, slug: site.slug },
+        actor: input.actor,
+        eventType: previous ? "auth.session.rotated" : "auth.session.created",
+        previousSessionId: previous?.id,
+        now,
+      });
+    },
+    { isolationLevel: "Serializable" },
+  );
+}
+
+export async function rotateSessionToWorkspace(input: {
+  currentToken: string;
+  siteId: string;
+}): Promise<CreatedSession> {
+  const now = new Date();
+  return getDb().$transaction(
+    async (tx) => {
+      const current = await tx.authSession.findUnique({
+        where: { tokenHash: hashAuthToken(input.currentToken) },
+        select: {
+          id: true,
+          userId: true,
+          expiresAt: true,
+          revokedAt: true,
+        },
+      });
+      if (!current || current.revokedAt || current.expiresAt <= now) {
+        throw new AuthSessionError("Your session has expired.");
+      }
+      const site = await tx.site.findFirst({
+        where: {
+          id: input.siteId,
+          organization: {
+            memberships: { some: { userId: current.userId } },
+          },
+        },
+        select: { id: true, slug: true, organizationId: true },
+      });
+      if (!site?.organizationId) {
+        throw new AuthSessionError("Workspace access is no longer available.");
+      }
+      const revoked = await tx.authSession.updateMany({
+        where: {
+          id: current.id,
+          revokedAt: null,
+          expiresAt: { gt: now },
+        },
+        data: { revokedAt: now },
+      });
+      if (revoked.count !== 1) {
+        throw new AuthSessionError("Your session changed. Sign in again.");
+      }
+      return createSessionInTransaction(tx, {
+        userId: current.userId,
+        purpose: "SITE",
+        organizationId: site.organizationId,
+        site: { id: site.id, slug: site.slug },
+        actor: `user:${current.userId}`,
+        eventType: "auth.session.rotated",
+        previousSessionId: current.id,
+        now,
+      });
+    },
+    { isolationLevel: "Serializable" },
+  );
+}
+
+export async function revokeCurrentSession(
+  token: string,
+): Promise<boolean> {
+  const now = new Date();
+  return getDb().$transaction(async (tx) => {
+    const revoked = await revokeSessionInTransaction(tx, {
+      tokenHash: hashAuthToken(token),
+      actor: "user:self",
+      now,
+      audit: true,
+    });
+    return Boolean(revoked);
+  });
+}
+
+async function revokeSessionInTransaction(
+  tx: Prisma.TransactionClient,
+  input: {
+    tokenHash: string;
+    userId?: string;
+    actor: string;
+    now: Date;
+    audit: boolean;
+  },
+): Promise<{ id: string; userId: string; siteId: string | null } | null> {
+  const session = await tx.authSession.findUnique({
+    where: { tokenHash: input.tokenHash },
+    select: {
+      id: true,
+      userId: true,
+      siteId: true,
+      revokedAt: true,
+      expiresAt: true,
+    },
+  });
+  if (
+    !session ||
+    session.revokedAt ||
+    session.expiresAt <= input.now ||
+    (input.userId && session.userId !== input.userId)
+  ) {
+    return null;
+  }
+  const revoked = await tx.authSession.updateMany({
+    where: {
+      id: session.id,
+      revokedAt: null,
+      expiresAt: { gt: input.now },
+    },
+    data: { revokedAt: input.now },
+  });
+  if (revoked.count !== 1) return null;
+  if (input.audit) {
+    await tx.authEvent.create({
+      data: {
+        type: "auth.session.revoked",
+        actor: input.actor,
+        subjectUserId: session.userId,
+        sessionId: session.id,
+        siteId: session.siteId,
+      },
+    });
+  }
+  return session;
+}
+
+function assertSessionBinding(
+  purpose: AuthSessionPurpose,
+  organizationId: string | null,
+  site: { id: string; slug: string } | null,
+): void {
+  if (purpose === "SITE") {
+    if (!organizationId || !site) {
+      throw new Error("A site session requires organization and site binding.");
+    }
+    return;
+  }
+  if (organizationId || site) {
+    throw new Error("An unbound session cannot carry tenant identifiers.");
+  }
+}
+
+export class AuthSessionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AuthSessionError";
+  }
+}

--- a/src/lib/authorization-policy.ts
+++ b/src/lib/authorization-policy.ts
@@ -7,7 +7,10 @@ export type AccessFailure = {
 };
 
 export type SessionIdentity = {
+  id: string;
   userId: string;
+  purpose: "ADMIN" | "WORKSPACE_SELECTION" | "SITE";
+  organizationId: string | null;
   siteSlug: string | null;
 };
 
@@ -61,7 +64,11 @@ export function createAuthorizationPolicy(adapter: AuthorizationAdapter) {
       if (!session) {
         return { ok: false, status: 401, message: "Unauthorized" };
       }
-      if (!session.siteSlug || session.siteSlug !== siteSlug) {
+      if (
+        session.purpose !== "SITE" ||
+        !session.siteSlug ||
+        session.siteSlug !== siteSlug
+      ) {
         return { ok: false, status: 403, message: "Forbidden" };
       }
       if (!adapter.isDatabaseConfigured()) {
@@ -77,6 +84,9 @@ export function createAuthorizationPolicy(adapter: AuthorizationAdapter) {
         session.userId,
       );
       if (!record) {
+        return { ok: false, status: 403, message: "Forbidden" };
+      }
+      if (record.organizationId !== session.organizationId) {
         return { ok: false, status: 403, message: "Forbidden" };
       }
 

--- a/src/lib/authorization.test.ts
+++ b/src/lib/authorization.test.ts
@@ -77,6 +77,44 @@ describe("site authorization", () => {
     expect(queried).toBe(false);
   });
 
+  it("rejects an unbound workspace-selection session", async () => {
+    const policy = createAuthorizationPolicy(
+      adapter({
+        session: {
+          id: "session_1",
+          userId: "user_1",
+          purpose: "WORKSPACE_SELECTION",
+          organizationId: null,
+          siteSlug: null,
+        },
+      }),
+    );
+
+    expect(await policy.getSiteAccess("chez-lea")).toMatchObject({
+      ok: false,
+      status: 403,
+    });
+  });
+
+  it("rejects a stale organization binding after membership lookup", async () => {
+    const policy = createAuthorizationPolicy(
+      adapter({
+        session: {
+          id: "session_1",
+          userId: "user_1",
+          purpose: "SITE",
+          organizationId: "org_stale",
+          siteSlug: "chez-lea",
+        },
+      }),
+    );
+
+    expect(await policy.getSiteAccess("chez-lea")).toMatchObject({
+      ok: false,
+      status: 403,
+    });
+  });
+
   it("revokes access when current membership is absent", async () => {
     const policy = createAuthorizationPolicy(adapter({ site: null }));
 
@@ -151,7 +189,13 @@ describe("superadmin authorization", () => {
 
 function adapter(
   overrides: {
-    session?: { userId: string; siteSlug: string | null } | null;
+    session?: {
+      id: string;
+      userId: string;
+      purpose: "ADMIN" | "WORKSPACE_SELECTION" | "SITE";
+      organizationId: string | null;
+      siteSlug: string | null;
+    } | null;
     site?: SiteAccessRecord | null;
     user?: Awaited<ReturnType<AuthorizationAdapter["findUser"]>>;
     allowedSuperadminEmail?: string | null;
@@ -163,7 +207,13 @@ function adapter(
     getSession: async () =>
       "session" in overrides
         ? (overrides.session ?? null)
-        : { userId: "user_1", siteSlug: "chez-lea" },
+        : {
+            id: "session_1",
+            userId: "user_1",
+            purpose: "SITE",
+            organizationId: "org_1",
+            siteSlug: "chez-lea",
+          },
     findSiteForMember: async () => {
       overrides.onFindSite?.();
       return "site" in overrides ? (overrides.site ?? null) : siteRecord;

--- a/src/lib/authorization.ts
+++ b/src/lib/authorization.ts
@@ -59,7 +59,7 @@ const authorization = createAuthorizationPolicy({
 });
 
 /**
- * Revalidates the signed session against current organization membership.
+ * Revalidates the database-backed session against current organization membership.
  * Removing a user from an organization therefore revokes access immediately,
  * even if their browser still holds an unexpired cookie.
  */

--- a/src/lib/current-session.ts
+++ b/src/lib/current-session.ts
@@ -1,12 +1,12 @@
 import "server-only";
 import { cookies } from "next/headers";
 import {
-  SESSION_COOKIE,
-  verifySessionToken,
-  type SessionPayload,
-} from "@/lib/session";
+  resolveSessionToken,
+  type CurrentSession,
+} from "@/lib/auth-sessions";
+import { SESSION_COOKIE } from "@/lib/session";
 
-export async function getCurrentSession(): Promise<SessionPayload | null> {
+export async function getCurrentSession(): Promise<CurrentSession | null> {
   const token = (await cookies()).get(SESSION_COOKIE)?.value;
-  return token ? verifySessionToken(token) : null;
+  return token ? resolveSessionToken(token) : null;
 }

--- a/src/lib/magic-link-email.test.ts
+++ b/src/lib/magic-link-email.test.ts
@@ -25,4 +25,16 @@ describe("magic-link email identity", () => {
     expect(email.from).toContain("Restofrontapp");
     expect(email.html).toContain("Chez Lea dashboard");
   });
+
+  it("does not silently select the first of multiple workspaces", () => {
+    const email = buildMagicLinkEmail({
+      verifyUrl: "https://cornershop.dev/api/auth/verify?token=opaque",
+      isSuperadmin: false,
+      site: { name: "Chez Lea", vertical: "RESTAURANT" },
+      workspaceCount: 2,
+    });
+
+    expect(email.html).toContain("workspace chooser");
+    expect(email.html).toContain("Choose workspace");
+  });
 });

--- a/src/lib/magic-link-email.ts
+++ b/src/lib/magic-link-email.ts
@@ -24,6 +24,7 @@ export function buildMagicLinkEmail(input: {
   verifyUrl: string;
   isSuperadmin: boolean;
   site: MagicLinkSite | null;
+  workspaceCount?: number;
 }): MagicLinkEmail {
   if (!input.isSuperadmin && !input.site) {
     throw new Error("A customer site is required for a customer sign-in link");
@@ -33,11 +34,18 @@ export function buildMagicLinkEmail(input: {
     ? FACTORY_BRAND
     : resolveVerticalConfig(input.site!.vertical).marketing.brand;
   const vertical = input.isSuperadmin ? null : input.site!.vertical;
+  const multipleWorkspaces = (input.workspaceCount ?? 0) > 1;
   const accountName = input.isSuperadmin
     ? "operator console"
+    : multipleWorkspaces
+      ? "workspace chooser"
     : `${input.site!.name} dashboard`;
   const escapedAccountName = escapeHtml(accountName);
-  const actionLabel = input.isSuperadmin ? "Open console" : "Open dashboard";
+  const actionLabel = input.isSuperadmin
+    ? "Open console"
+    : multipleWorkspaces
+      ? "Choose workspace"
+      : "Open dashboard";
   const subject = input.isSuperadmin
     ? `Open the ${FACTORY_BRAND.name} operator console`
     : `Open ${input.site!.name} in ${brand.name}`;

--- a/src/lib/magic-links.ts
+++ b/src/lib/magic-links.ts
@@ -1,0 +1,381 @@
+import "server-only";
+import type { Prisma } from "@/generated/prisma/client";
+import { createSessionInTransaction, type CreatedSession } from "@/lib/auth-sessions";
+import { getDb } from "@/lib/db";
+import { buildMagicLinkEmail } from "@/lib/magic-link-email";
+import { getResend } from "@/lib/resend";
+import {
+  canRetryMagicLink,
+  createOpaqueAuthToken,
+  hashAuthToken,
+  MAGIC_LINK_MAX_RETRIES,
+  MAGIC_LINK_TTL_MS,
+} from "@/lib/session";
+import { isConfiguredSuperadminEmail } from "@/lib/superadmin-config";
+import type { VerticalId } from "@/lib/verticals/types";
+
+type Workspace = {
+  id: string;
+  slug: string;
+  name: string;
+  vertical: VerticalId;
+  organizationId: string;
+};
+
+export async function requestMagicLink(email: string): Promise<void> {
+  const user = await getDb().user.findUnique({
+    where: { email },
+    select: {
+      id: true,
+      email: true,
+      platformRole: true,
+      memberships: {
+        select: {
+          organization: {
+            select: {
+              sites: {
+                orderBy: { createdAt: "asc" },
+                select: {
+                  id: true,
+                  slug: true,
+                  name: true,
+                  vertical: true,
+                  organizationId: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+  if (!user) return;
+
+  const workspaces = normalizeWorkspaces(
+    user.memberships.flatMap((row) => row.organization.sites),
+  );
+  const isSuperadmin =
+    user.platformRole === "SUPERADMIN" &&
+    isConfiguredSuperadminEmail(user.email);
+  if (!isSuperadmin && workspaces.length === 0) return;
+
+  await createAndDeliverMagicLink({
+    userId: user.id,
+    email: user.email,
+    isSuperadmin,
+    workspaces,
+    retryCount: 0,
+  });
+}
+
+export async function retryMagicLink(
+  magicLinkId: string,
+  actorUserId: string,
+): Promise<void> {
+  const source = await getDb().authMagicLink.findUnique({
+    where: { id: magicLinkId },
+    select: {
+      id: true,
+      destination: true,
+      retryCount: true,
+      createdAt: true,
+      deliveryStatus: true,
+      expiresAt: true,
+      consumedAt: true,
+      revokedAt: true,
+      lastAttemptAt: true,
+      user: {
+        select: {
+          id: true,
+          email: true,
+          platformRole: true,
+          memberships: {
+            select: {
+              organization: {
+                select: {
+                  sites: {
+                    orderBy: { createdAt: "asc" },
+                    select: {
+                      id: true,
+                      slug: true,
+                      name: true,
+                      vertical: true,
+                      organizationId: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+  if (!source || !canRetryMagicLink(source)) {
+    throw new Error("This delivery cannot be retried.");
+  }
+  const workspaces = normalizeWorkspaces(
+    source.user.memberships.flatMap((row) => row.organization.sites),
+  );
+  const isSuperadmin =
+    source.destination === "ADMIN" &&
+    source.user.platformRole === "SUPERADMIN" &&
+    isConfiguredSuperadminEmail(source.user.email);
+  if (!isSuperadmin && workspaces.length === 0) {
+    throw new Error("This account no longer has a workspace.");
+  }
+
+  await createAndDeliverMagicLink({
+    userId: source.user.id,
+    email: source.user.email,
+    isSuperadmin,
+    workspaces,
+    retryCount: source.retryCount + 1,
+    replacesId: source.id,
+    actor: `operator:${actorUserId}`,
+  });
+}
+
+async function createAndDeliverMagicLink(input: {
+  userId: string;
+  email: string;
+  isSuperadmin: boolean;
+  workspaces: Workspace[];
+  retryCount: number;
+  replacesId?: string;
+  actor?: string;
+}): Promise<void> {
+  const configuredAppUrl = process.env.NEXT_PUBLIC_APP_URL;
+  if (!configuredAppUrl) throw new Error("NEXT_PUBLIC_APP_URL is not configured");
+  const credential = createOpaqueAuthToken();
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + MAGIC_LINK_TTL_MS);
+  const destination = input.isSuperadmin ? "ADMIN" : "WORKSPACE";
+  const primarySite = input.workspaces[0] ?? null;
+
+  const link = await getDb().$transaction(
+    async (tx) => {
+      if (input.replacesId) {
+        const revoked = await tx.authMagicLink.updateMany({
+          where: {
+            id: input.replacesId,
+            consumedAt: null,
+            revokedAt: null,
+            retryCount: { lt: MAGIC_LINK_MAX_RETRIES },
+          },
+          data: { revokedAt: now },
+        });
+        if (revoked.count !== 1) {
+          throw new Error("This delivery was already retried.");
+        }
+      } else {
+        await tx.authMagicLink.updateMany({
+          where: {
+            userId: input.userId,
+            destination,
+            consumedAt: null,
+            revokedAt: null,
+          },
+          data: { revokedAt: now },
+        });
+      }
+      const created = await tx.authMagicLink.create({
+        data: {
+          tokenHash: credential.tokenHash,
+          destination,
+          brandVertical: input.isSuperadmin ? null : primarySite?.vertical,
+          expiresAt,
+          userId: input.userId,
+          retryCount: input.retryCount,
+        },
+        select: { id: true },
+      });
+      await tx.authEvent.create({
+        data: {
+          type: input.replacesId
+            ? "auth.magic_link.retried"
+            : "auth.magic_link.requested",
+          actor: input.actor ?? "user:self",
+          subjectUserId: input.userId,
+          magicLinkId: created.id,
+          metadata: {
+            destination,
+            replacesId: input.replacesId ?? null,
+            retryCount: input.retryCount,
+          },
+        },
+      });
+      return created;
+    },
+    { isolationLevel: "Serializable" },
+  );
+
+  const verifyUrl = new URL("/api/auth/verify", configuredAppUrl);
+  verifyUrl.searchParams.set("token", credential.token);
+  const emailMessage = buildMagicLinkEmail({
+    verifyUrl: verifyUrl.toString(),
+    isSuperadmin: input.isSuperadmin,
+    site: primarySite,
+    workspaceCount: input.workspaces.length,
+  });
+
+  try {
+    const { data, error } = await getResend().emails.send(
+      {
+        from: emailMessage.from,
+        to: input.email,
+        replyTo: emailMessage.replyTo,
+        subject: emailMessage.subject,
+        html: emailMessage.html,
+      },
+      { headers: { "Idempotency-Key": `magic-link-${link.id}` } },
+    );
+    if (error) throw new Error(error.message);
+    await recordDelivery(link.id, "SENT", data?.id ?? null, null);
+  } catch (error) {
+    await recordDelivery(link.id, "FAILED", null, deliveryFailureCode(error));
+  }
+}
+
+async function recordDelivery(
+  id: string,
+  status: "SENT" | "FAILED",
+  providerMessageId: string | null,
+  failureCode: string | null,
+): Promise<void> {
+  const now = new Date();
+  await getDb().$transaction(async (tx) => {
+    const updated = await tx.authMagicLink.updateMany({
+      where: { id, deliveryStatus: "PENDING" },
+      data: {
+        deliveryStatus: status,
+        deliveryAttempts: { increment: 1 },
+        providerMessageId,
+        failureCode,
+        lastAttemptAt: now,
+        deliveredAt: status === "SENT" ? now : null,
+      },
+    });
+    if (updated.count === 1) {
+      await tx.authEvent.create({
+        data: {
+          type:
+            status === "SENT"
+              ? "auth.magic_link.delivered"
+              : "auth.magic_link.delivery_failed",
+          magicLinkId: id,
+          metadata: { failureCode },
+        },
+      });
+    }
+  });
+}
+
+export async function consumeMagicLink(token: string): Promise<CreatedSession> {
+  const now = new Date();
+  return getDb().$transaction(
+    async (tx) => {
+      const link = await tx.authMagicLink.findUnique({
+        where: { tokenHash: hashAuthToken(token) },
+        select: {
+          id: true,
+          destination: true,
+          userId: true,
+          expiresAt: true,
+          consumedAt: true,
+          revokedAt: true,
+          user: { select: { email: true, platformRole: true } },
+        },
+      });
+      if (
+        !link ||
+        link.consumedAt ||
+        link.revokedAt ||
+        link.expiresAt <= now
+      ) {
+        throw new Error("Invalid or expired sign-in link.");
+      }
+
+      const workspaces = await listWorkspacesInTransaction(tx, link.userId);
+      const operator =
+        link.destination === "ADMIN" &&
+        link.user.platformRole === "SUPERADMIN" &&
+        isConfiguredSuperadminEmail(link.user.email);
+      if (!operator && workspaces.length === 0) {
+        throw new Error("Workspace access is no longer available.");
+      }
+      const consumed = await tx.authMagicLink.updateMany({
+        where: { id: link.id, consumedAt: null, revokedAt: null, expiresAt: { gt: now } },
+        data: { consumedAt: now },
+      });
+      if (consumed.count !== 1) {
+        throw new Error("This sign-in link was already used.");
+      }
+
+      const singleSite = !operator && workspaces.length === 1 ? workspaces[0] : null;
+      const session = await createSessionInTransaction(tx, {
+        userId: link.userId,
+        purpose: operator
+          ? "ADMIN"
+          : singleSite
+            ? "SITE"
+            : "WORKSPACE_SELECTION",
+        organizationId: singleSite?.organizationId,
+        site: singleSite ? { id: singleSite.id, slug: singleSite.slug } : null,
+        actor: "magic-link",
+        now,
+      });
+      await tx.authEvent.create({
+        data: {
+          type: "auth.magic_link.consumed",
+          actor: "user:self",
+          subjectUserId: link.userId,
+          magicLinkId: link.id,
+          sessionId: session.session.id,
+        },
+      });
+      return session;
+    },
+    { isolationLevel: "Serializable" },
+  );
+}
+
+async function listWorkspacesInTransaction(
+  tx: Prisma.TransactionClient,
+  userId: string,
+): Promise<Workspace[]> {
+  const rows = await tx.site.findMany({
+    where: { organization: { memberships: { some: { userId } } } },
+    orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+    select: {
+      id: true,
+      slug: true,
+      name: true,
+      vertical: true,
+      organizationId: true,
+    },
+  });
+  return normalizeWorkspaces(rows);
+}
+
+function normalizeWorkspaces(
+  rows: Array<{
+    id: string;
+    slug: string;
+    name: string;
+    vertical: VerticalId;
+    organizationId: string | null;
+  }>,
+): Workspace[] {
+  return rows.flatMap((row) =>
+    row.organizationId ? [{ ...row, organizationId: row.organizationId }] : [],
+  );
+}
+
+function deliveryFailureCode(error: unknown): string {
+  const message = error instanceof Error ? error.message.toLowerCase() : "";
+  if (message.includes("rate") || message.includes("429")) return "provider_rate_limited";
+  if (message.includes("domain") || message.includes("sender")) return "sender_rejected";
+  if (message.includes("recipient") || message.includes("email")) return "recipient_rejected";
+  return "provider_error";
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -159,3 +159,23 @@ export function limitOperatorClaimInvitation(
     windowMs,
   });
 }
+
+export function limitMagicLinkRequest(
+  request: Request,
+): Promise<RateLimitResult> {
+  return limitByIp(request, {
+    namespace: "magic-link",
+    limit: 5,
+    windowMs: 15 * 60_000,
+  });
+}
+
+export function limitOperatorAuthRetry(
+  request: Request,
+): Promise<RateLimitResult> {
+  return limitByIp(request, {
+    namespace: "operator-auth-retry",
+    limit: 20,
+    windowMs,
+  });
+}

--- a/src/lib/session.test.ts
+++ b/src/lib/session.test.ts
@@ -1,55 +1,97 @@
-import { afterEach, describe, expect, it } from "bun:test";
-import { createSessionToken, verifySessionToken } from "@/lib/session";
+import { describe, expect, it } from "bun:test";
+import {
+  canRetryMagicLink,
+  createOpaqueAuthToken,
+  hashAuthToken,
+  MAGIC_LINK_MAX_RETRIES,
+  maskAccountEmail,
+} from "@/lib/session";
 
-const originalSecret = process.env.CLAIM_TOKEN_SECRET;
+describe("opaque authentication tokens", () => {
+  it("stores only a deterministic one-way digest", () => {
+    const issued = createOpaqueAuthToken();
 
-afterEach(() => {
-  if (originalSecret === undefined) {
-    delete process.env.CLAIM_TOKEN_SECRET;
-  } else {
-    process.env.CLAIM_TOKEN_SECRET = originalSecret;
-  }
+    expect(issued.token).toHaveLength(43);
+    expect(issued.tokenHash).toHaveLength(64);
+    expect(issued.tokenHash).toBe(hashAuthToken(issued.token));
+    expect(issued.tokenHash).not.toContain(issued.token);
+    expect(createOpaqueAuthToken().tokenHash).not.toBe(issued.tokenHash);
+  });
 });
 
-describe("signed sessions", () => {
-  it("round-trips the minimum account identity", () => {
-    process.env.CLAIM_TOKEN_SECRET =
-      "test-session-secret-with-at-least-thirty-two-characters";
-    const token = createSessionToken({
-      userId: "user_123",
-      siteSlug: "chez-lea",
-      expiresAt: Date.now() + 60_000,
-    });
+describe("magic-link retries", () => {
+  const now = new Date("2026-07-27T12:00:00.000Z");
+  const stale = new Date("2026-07-27T11:50:00.000Z");
 
-    expect(verifySessionToken(token)).toMatchObject({
-      userId: "user_123",
-      siteSlug: "chez-lea",
-    });
+  it("retries failed and stale pending deliveries only", () => {
+    expect(
+      canRetryMagicLink(
+        {
+          deliveryStatus: "FAILED",
+          retryCount: 0,
+          consumedAt: null,
+          revokedAt: null,
+          createdAt: now,
+          lastAttemptAt: now,
+        },
+        now,
+      ),
+    ).toBe(true);
+    expect(
+      canRetryMagicLink(
+        {
+          deliveryStatus: "PENDING",
+          retryCount: 0,
+          consumedAt: null,
+          revokedAt: null,
+          createdAt: stale,
+          lastAttemptAt: stale,
+        },
+        now,
+      ),
+    ).toBe(true);
+    expect(
+      canRetryMagicLink(
+        {
+          deliveryStatus: "SENT",
+          retryCount: 0,
+          consumedAt: null,
+          revokedAt: null,
+          createdAt: stale,
+          lastAttemptAt: stale,
+        },
+        now,
+      ),
+    ).toBe(false);
   });
 
-  it("supports a platform operator with no client site", () => {
-    process.env.CLAIM_TOKEN_SECRET =
-      "test-session-secret-with-at-least-thirty-two-characters";
-    const token = createSessionToken({
-      userId: "user_admin",
-      expiresAt: Date.now() + 60_000,
-    });
-
-    expect(verifySessionToken(token)).toMatchObject({
-      userId: "user_admin",
-      siteSlug: null,
-    });
+  it("stops terminal and exhausted retry chains", () => {
+    const base = {
+      deliveryStatus: "FAILED" as const,
+      retryCount: 0,
+      consumedAt: null,
+      revokedAt: null,
+      createdAt: stale,
+      lastAttemptAt: stale,
+    };
+    expect(
+      canRetryMagicLink({ ...base, consumedAt: now }, now),
+    ).toBe(false);
+    expect(
+      canRetryMagicLink({ ...base, revokedAt: now }, now),
+    ).toBe(false);
+    expect(
+      canRetryMagicLink(
+        { ...base, retryCount: MAGIC_LINK_MAX_RETRIES },
+        now,
+      ),
+    ).toBe(false);
   });
+});
 
-  it("rejects a modified token", () => {
-    process.env.CLAIM_TOKEN_SECRET =
-      "test-session-secret-with-at-least-thirty-two-characters";
-    const token = createSessionToken({
-      userId: "user_123",
-      siteSlug: "chez-lea",
-      expiresAt: Date.now() + 60_000,
-    });
-
-    expect(verifySessionToken(`${token}tampered`)).toBeNull();
+describe("operator-safe account display", () => {
+  it("masks the local part without hiding the delivery domain", () => {
+    expect(maskAccountEmail("owner@example.com")).toBe("o****@example.com");
+    expect(maskAccountEmail("a@example.com")).toBe("a**@example.com");
   });
 });

--- a/src/lib/session.test.ts
+++ b/src/lib/session.test.ts
@@ -4,7 +4,9 @@ import {
   createOpaqueAuthToken,
   hashAuthToken,
   MAGIC_LINK_MAX_RETRIES,
+  MAGIC_LINK_TTL_MS,
   maskAccountEmail,
+  pendingMagicLinkCookieOptions,
 } from "@/lib/session";
 
 describe("opaque authentication tokens", () => {
@@ -74,18 +76,22 @@ describe("magic-link retries", () => {
       createdAt: stale,
       lastAttemptAt: stale,
     };
+    expect(canRetryMagicLink({ ...base, consumedAt: now }, now)).toBe(false);
+    expect(canRetryMagicLink({ ...base, revokedAt: now }, now)).toBe(false);
     expect(
-      canRetryMagicLink({ ...base, consumedAt: now }, now),
+      canRetryMagicLink({ ...base, retryCount: MAGIC_LINK_MAX_RETRIES }, now),
     ).toBe(false);
-    expect(
-      canRetryMagicLink({ ...base, revokedAt: now }, now),
-    ).toBe(false);
-    expect(
-      canRetryMagicLink(
-        { ...base, retryCount: MAGIC_LINK_MAX_RETRIES },
-        now,
-      ),
-    ).toBe(false);
+  });
+});
+
+describe("magic-link scanner protection", () => {
+  it("stages the pending credential in a short-lived strict HttpOnly cookie", () => {
+    expect(pendingMagicLinkCookieOptions()).toMatchObject({
+      httpOnly: true,
+      sameSite: "strict",
+      maxAge: MAGIC_LINK_TTL_MS / 1_000,
+      path: "/",
+    });
   });
 });
 

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,56 +1,69 @@
-import { createHmac, timingSafeEqual } from "node:crypto";
-import { z } from "zod";
-import { getClaimTokenSecret } from "@/lib/claim-security";
+import { createHash, randomBytes } from "node:crypto";
 
 export const SESSION_COOKIE = "cornershopdev_session";
+export const SESSION_TTL_MS = 30 * 24 * 60 * 60_000;
+export const MAGIC_LINK_TTL_MS = 20 * 60_000;
+export const MAGIC_LINK_MAX_RETRIES = 2;
+export const MAGIC_LINK_PENDING_RETRY_AFTER_MS = 5 * 60_000;
 
-const sessionPayloadSchema = z.object({
-  userId: z.string().min(1).max(128),
-  siteSlug: z.string().min(2).max(80).nullable(),
-  expiresAt: z.number().int().positive(),
-});
+export type OpaqueAuthToken = {
+  token: string;
+  tokenHash: string;
+};
 
-export type SessionPayload = z.infer<typeof sessionPayloadSchema>;
-
-function signature(value: string): string {
-  return createHmac("sha256", getClaimTokenSecret())
-    .update(value)
-    .digest("base64url");
+export function createOpaqueAuthToken(): OpaqueAuthToken {
+  const token = randomBytes(32).toString("base64url");
+  return { token, tokenHash: hashAuthToken(token) };
 }
 
-export function createSessionToken(
-  input: Omit<SessionPayload, "expiresAt" | "siteSlug"> & {
-    siteSlug?: string | null;
-    expiresAt?: number;
-  },
-): string {
-  const payload = sessionPayloadSchema.parse({
-    ...input,
-    siteSlug: input.siteSlug ?? null,
-    expiresAt: input.expiresAt ?? Date.now() + 30 * 24 * 60 * 60 * 1000,
-  });
-  const encoded = Buffer.from(JSON.stringify(payload)).toString("base64url");
-  return `${encoded}.${signature(encoded)}`;
+export function hashAuthToken(token: string): string {
+  return createHash("sha256").update(token, "utf8").digest("hex");
 }
 
-export function verifySessionToken(token: string): SessionPayload | null {
-  try {
-    const [encoded, suppliedSignature] = token.split(".");
-    if (!encoded || !suppliedSignature) return null;
-    const expected = signature(encoded);
-    const suppliedBuffer = Buffer.from(suppliedSignature);
-    const expectedBuffer = Buffer.from(expected);
-    if (
-      suppliedBuffer.length !== expectedBuffer.length ||
-      !timingSafeEqual(suppliedBuffer, expectedBuffer)
-    ) {
-      return null;
-    }
-    const payload = sessionPayloadSchema.parse(
-      JSON.parse(Buffer.from(encoded, "base64url").toString("utf8")),
-    );
-    return payload.expiresAt > Date.now() ? payload : null;
-  } catch {
-    return null;
+export function sessionCookieOptions(expiresAt: Date) {
+  return {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax" as const,
+    expires: expiresAt,
+    path: "/",
+    priority: "high" as const,
+  };
+}
+
+export function maskAccountEmail(email: string): string {
+  const separator = email.lastIndexOf("@");
+  if (separator <= 0) return "hidden";
+  const local = email.slice(0, separator);
+  const domain = email.slice(separator + 1);
+  return `${local.slice(0, 1)}${"*".repeat(Math.min(6, Math.max(2, local.length - 1)))}@${domain}`;
+}
+
+export type MagicLinkRetrySnapshot = {
+  deliveryStatus: "PENDING" | "SENT" | "FAILED";
+  retryCount: number;
+  consumedAt: Date | null;
+  revokedAt: Date | null;
+  createdAt: Date;
+  lastAttemptAt: Date | null;
+};
+
+export function canRetryMagicLink(
+  link: MagicLinkRetrySnapshot,
+  now = new Date(),
+): boolean {
+  if (
+    link.consumedAt ||
+    link.revokedAt ||
+    link.deliveryStatus === "SENT" ||
+    link.retryCount >= MAGIC_LINK_MAX_RETRIES
+  ) {
+    return false;
   }
+  if (link.deliveryStatus === "FAILED") return true;
+  const lastActivityAt = link.lastAttemptAt ?? link.createdAt;
+  return (
+    now.getTime() - lastActivityAt.getTime() >=
+    MAGIC_LINK_PENDING_RETRY_AFTER_MS
+  );
 }

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,6 +1,7 @@
 import { createHash, randomBytes } from "node:crypto";
 
 export const SESSION_COOKIE = "cornershopdev_session";
+export const PENDING_MAGIC_LINK_COOKIE = "cornershopdev_pending_magic_link";
 export const SESSION_TTL_MS = 30 * 24 * 60 * 60_000;
 export const MAGIC_LINK_TTL_MS = 20 * 60_000;
 export const MAGIC_LINK_MAX_RETRIES = 2;
@@ -26,6 +27,17 @@ export function sessionCookieOptions(expiresAt: Date) {
     secure: process.env.NODE_ENV === "production",
     sameSite: "lax" as const,
     expires: expiresAt,
+    path: "/",
+    priority: "high" as const,
+  };
+}
+
+export function pendingMagicLinkCookieOptions() {
+  return {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "strict" as const,
+    maxAge: MAGIC_LINK_TTL_MS / 1_000,
     path: "/",
     priority: "high" as const,
   };

--- a/src/lib/workspaces.ts
+++ b/src/lib/workspaces.ts
@@ -1,0 +1,17 @@
+import "server-only";
+import { getDb } from "@/lib/db";
+
+export type AccountWorkspace = {
+  id: string;
+  slug: string;
+  name: string;
+  vertical: "RESTAURANT" | "BEAUTY";
+};
+
+export function listAccountWorkspaces(userId: string): Promise<AccountWorkspace[]> {
+  return getDb().site.findMany({
+    where: { organization: { memberships: { some: { userId } } } },
+    orderBy: [{ name: "asc" }, { id: "asc" }],
+    select: { id: true, slug: true, name: true, vertical: true },
+  });
+}


### PR DESCRIPTION
Closes code-shippable scope of #16; production owner receive/use evidence remains an external release gate.

## What changed
- replace reusable signed cookies/links with hashed, opaque, one-time 20-minute magic links and revocable database-backed sessions
- add logout, explicit multi-workspace chooser, CAS session rotation, and fresh organization/site binding
- persist delivery outcomes with safe failure codes, masked operator visibility, and at most two replacement-link retries
- preserve dual-gated superadmin authorization, current membership revalidation, niche email identity, same-origin mutation checks, and endpoint-specific rate limits
- add additive Prisma migration and production verification/recovery runbook

## Verification
- `bunx prisma validate` PASS
- `bunx next typegen` PASS
- `bunx tsc --noEmit` PASS
- `bun test` PASS (205 passed, 11 expected DB-gated skips), then 18 focused tests PASS after two additional authorization cases
- `bun run lint` PASS with zero errors and one pre-existing generated warning
- `git diff --check` PASS
- full `bun run build` reached Turbopack compilation but did not finish within the bounded local window; terminated and delegated to PR CI

## Merge gate
Exact-head GenfeedAI Opus review for `28c6ae5` returned HTTP 429 with zero usage and no verdict. This is not approval. Leave unmerged until required CI is green and a fresh exact-head Opus verdict is PASS.