### PR TITLE
feat(domains): harden live customer routing

### DIFF
--- a/prisma/migrations/20260727072000_domain_routing_hardening/migration.sql
+++ b/prisma/migrations/20260727072000_domain_routing_hardening/migration.sql
@@ -1,0 +1,6 @@
+CREATE TYPE "DomainTlsStatus" AS ENUM ('PENDING', 'READY', 'ERROR');
+
+ALTER TABLE "Domain"
+ADD COLUMN "tlsStatus" "DomainTlsStatus" NOT NULL DEFAULT 'PENDING',
+ADD COLUMN "tlsCheckedAt" TIMESTAMP(3),
+ADD COLUMN "tlsFailureCode" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,12 @@ enum SiteStatus {
   PAUSED
 }
 
+enum DomainTlsStatus {
+  PENDING
+  READY
+  ERROR
+}
+
 enum BookingRequestStatus {
   NEW
   NOTIFIED
@@ -231,15 +237,18 @@ model SiteVersion {
 }
 
 model Domain {
-  id                String    @id @default(cuid())
-  hostname          String    @unique
-  verified          Boolean   @default(false)
-  verificationToken String    @unique
+  id                String          @id @default(cuid())
+  hostname          String          @unique
+  verified          Boolean         @default(false)
+  verificationToken String          @unique
   verifiedAt        DateTime?
+  tlsStatus         DomainTlsStatus @default(PENDING)
+  tlsCheckedAt      DateTime?
+  tlsFailureCode    String?
   siteId            String
-  site              Site      @relation(fields: [siteId], references: [id], onDelete: Cascade)
-  createdAt         DateTime  @default(now())
-  updatedAt         DateTime  @updatedAt
+  site              Site            @relation(fields: [siteId], references: [id], onDelete: Cascade)
+  createdAt         DateTime        @default(now())
+  updatedAt         DateTime        @updatedAt
 }
 
 model ClaimInvitation {

--- a/src/app/api/domains/route.ts
+++ b/src/app/api/domains/route.ts
@@ -1,5 +1,7 @@
 import { randomBytes } from "node:crypto";
 import { resolve4, resolveCname } from "node:dns/promises";
+import type { Prisma } from "@/generated/prisma/client";
+import type { DomainTlsStatus, SiteStatus } from "@/generated/prisma/enums";
 import { z } from "zod";
 import {
   accessFailureResponse,
@@ -11,7 +13,14 @@ import {
 } from "@/lib/billing-access";
 import { getCurrentSession } from "@/lib/current-session";
 import { getDb } from "@/lib/db";
-import { claimDomainForSite } from "@/lib/domain-claim";
+import { claimDomainSetForSite } from "@/lib/domain-claim";
+import {
+  planDomainHostnames,
+  siteStatusForDomainState,
+  type DomainHostnamePlan,
+} from "@/lib/domain-routing";
+import { checkDomainTls } from "@/lib/domain-tls";
+import { isFactoryHostname } from "@/lib/hostnames";
 
 const hostnameSchema = z
   .string()
@@ -30,6 +39,15 @@ const hostnameSchema = z
         "Enter a valid domain name",
       ),
   );
+const siteSlugSchema = z.string().min(2).max(80);
+
+type DomainRow = {
+  hostname: string;
+  verified: boolean;
+  tlsStatus: DomainTlsStatus;
+  tlsCheckedAt: Date | null;
+  tlsFailureCode: string | null;
+};
 
 function getDomainTarget() {
   const address = process.env.PUBLIC_APP_IP;
@@ -47,12 +65,15 @@ export async function POST(request: Request) {
       siteSlug?: string;
     };
     const hostname = hostnameSchema.parse(body.hostname);
+    if (isFactoryHostname(hostname)) {
+      return Response.json(
+        { error: "This hostname is reserved for Cornershopdev" },
+        { status: 409 },
+      );
+    }
+
     const session = await getCurrentSession();
-    const siteSlug = z
-      .string()
-      .min(2)
-      .max(80)
-      .parse(body.siteSlug ?? session?.siteSlug);
+    const siteSlug = siteSlugSchema.parse(body.siteSlug ?? session?.siteSlug);
     const access = await getSiteAccess(siteSlug);
     if (!access.ok) return accessFailureResponse(access);
     const billing = await getSiteBillingAccess(access.site.id);
@@ -60,30 +81,33 @@ export async function POST(request: Request) {
 
     const db = getDb();
     const target = getDomainTarget();
-    const verificationToken = randomBytes(24).toString("base64url");
-    const claimed = await claimDomainForSite({
-      runSerializable: (operation) =>
-        db.$transaction(
-          (transaction) =>
-            operation({
-              findOwner: async (candidateHostname) =>
-                (
-                  await transaction.domain.findUnique({
-                    where: { hostname: candidateHostname },
-                    select: { siteId: true },
-                  })
-                )?.siteId ?? null,
-              create: async (data) => {
-                await transaction.domain.create({ data });
-              },
-            }),
-          { isolationLevel: "Serializable" },
-        ),
-    }, {
-      hostname,
-      siteId: access.site.id,
-      verificationToken,
-    });
+    const plan = planDomainHostnames(hostname);
+    const claimed = await claimDomainSetForSite(
+      {
+        runSerializable: (operation) =>
+          db.$transaction(
+            (transaction) =>
+              operation({
+                findOwner: async (candidateHostname) =>
+                  (
+                    await transaction.domain.findUnique({
+                      where: { hostname: candidateHostname },
+                      select: { siteId: true },
+                    })
+                  )?.siteId ?? null,
+                create: async (data) => {
+                  await transaction.domain.create({ data });
+                },
+              }),
+            { isolationLevel: "Serializable" },
+          ),
+      },
+      plan.hostnames.map((candidateHostname) => ({
+        hostname: candidateHostname,
+        siteId: access.site.id,
+        verificationToken: randomBytes(24).toString("base64url"),
+      })),
+    );
     if (!claimed) {
       return Response.json(
         { error: "This domain is already connected to another site" },
@@ -91,87 +115,352 @@ export async function POST(request: Request) {
       );
     }
 
-    const isApex = hostname.split(".").length === 2;
-    return Response.json({
-      hostname,
-      attached: true,
-      verified: false,
-      records:
-        isApex
-          ? [{ type: "A", name: "@", value: target.address }]
-          : [
-              {
-                type: "CNAME",
-                name: hostname.split(".")[0],
-                value: target.cname,
-              },
-            ],
-    });
-  } catch (error) {
+    const [rows, site] = await Promise.all([
+      db.domain.findMany({
+        where: {
+          siteId: access.site.id,
+          hostname: { in: plan.hostnames },
+        },
+        select: domainRowSelect,
+      }),
+      db.site.findUnique({
+        where: { id: access.site.id },
+        select: { status: true },
+      }),
+    ]);
+    if (!site) throw new Error("Site not found");
     return Response.json(
-      {
-        error:
-          error instanceof Error ? error.message : "Domain could not be added",
-      },
-      { status: 400 },
+      domainSetup(plan, rows, target, site.status, access.site.slug, false),
     );
+  } catch (error) {
+    return domainFailure(error, "Domain could not be added");
   }
 }
 
 export async function GET(request: Request) {
   try {
     const searchParams = new URL(request.url).searchParams;
-    const hostname = hostnameSchema.parse(searchParams.get("hostname"));
-    const siteSlug = z
-      .string()
-      .min(2)
-      .max(80)
-      .parse(searchParams.get("siteSlug"));
+    const requestedHostname = searchParams.get("hostname");
+    const siteSlug = siteSlugSchema.parse(searchParams.get("siteSlug"));
     const access = await getSiteAccess(siteSlug);
     if (!access.ok) return accessFailureResponse(access);
 
-    const domain = await getDb().domain.findFirst({
-      where: {
-        hostname,
-        siteId: access.site.id,
-      },
-      select: { siteId: true },
-    });
-    if (!domain) {
-      return Response.json({ error: "Domain not found" }, { status: 404 });
-    }
-
-    const [aResult, cnameResult] = await Promise.allSettled([
-      resolve4(hostname),
-      resolveCname(hostname),
-    ]);
-    const addresses = aResult.status === "fulfilled" ? aResult.value : [];
-    const cnames = cnameResult.status === "fulfilled" ? cnameResult.value : [];
+    const db = getDb();
     const target = getDomainTarget();
-    const verified =
-      addresses.includes(target.address) ||
-      cnames.some(
-        (value) => value.replace(/\.$/, "").toLowerCase() === target.cname,
-      );
-
-    if (verified) {
-      await getDb().domain.updateMany({
-        where: {
-          hostname,
-          siteId: access.site.id,
-        },
-        data: { verified: true, verifiedAt: new Date() },
+    if (!requestedHostname) {
+      const [rows, site] = await Promise.all([
+        db.domain.findMany({
+          where: { siteId: access.site.id },
+          select: domainRowSelect,
+          orderBy: { createdAt: "asc" },
+        }),
+        db.site.findUnique({
+          where: { id: access.site.id },
+          select: { status: true },
+        }),
+      ]);
+      if (!site) throw new Error("Site not found");
+      return Response.json({
+        domains: domainSetups(rows, target, site.status, access.site.slug),
       });
     }
 
-    return Response.json({ hostname, verified, addresses, cnames });
-  } catch (error) {
-    return Response.json(
-      {
-        error:
-          error instanceof Error ? error.message : "DNS could not be checked",
+    const hostname = hostnameSchema.parse(requestedHostname);
+    const plan = planDomainHostnames(hostname);
+    const existing = await db.domain.findMany({
+      where: {
+        siteId: access.site.id,
+        hostname: { in: plan.hostnames },
       },
-      { status: 400 },
+      select: domainRowSelect,
+    });
+    if (!existing.length) {
+      return Response.json({ error: "Domain not found" }, { status: 404 });
+    }
+
+    const checkedAt = new Date();
+    const checked = await Promise.all(
+      existing.map(async (row) => {
+        const record = plan.records.find(
+          (candidate) => candidate.hostname === row.hostname,
+        );
+        if (!record) {
+          return {
+            ...row,
+            verifiedAt: row.verified ? checkedAt : null,
+          };
+        }
+        const verified = await recordResolves(record, target);
+        const tls = verified
+          ? await checkDomainTls(row.hostname, target.address)
+          : {
+              status: "PENDING" as const,
+              failureCode: null,
+              message: "Waiting for DNS before checking the secure connection.",
+            };
+        return {
+          ...row,
+          verified,
+          verifiedAt: verified ? checkedAt : null,
+          tlsStatus: tls.status,
+          tlsCheckedAt: verified ? checkedAt : null,
+          tlsFailureCode: tls.failureCode,
+        };
+      }),
+    );
+
+    const siteStatus = await db.$transaction(
+      async (transaction) => {
+        for (const row of checked) {
+          await transaction.domain.updateMany({
+            where: { hostname: row.hostname, siteId: access.site.id },
+            data: {
+              verified: row.verified,
+              verifiedAt: row.verifiedAt,
+              tlsStatus: row.tlsStatus,
+              tlsCheckedAt: row.tlsCheckedAt,
+              tlsFailureCode: row.tlsFailureCode,
+            },
+          });
+        }
+        return reconcileSiteStatus(transaction, access.site.id);
+      },
+      { isolationLevel: "Serializable" },
+    );
+
+    return Response.json(
+      domainSetup(plan, checked, target, siteStatus, access.site.slug, true),
+    );
+  } catch (error) {
+    return domainFailure(error, "DNS could not be checked");
+  }
+}
+
+export async function DELETE(request: Request) {
+  try {
+    const body = (await request.json()) as {
+      hostname?: string;
+      siteSlug?: string;
+    };
+    const hostname = hostnameSchema.parse(body.hostname);
+    const siteSlug = siteSlugSchema.parse(body.siteSlug);
+    const access = await getSiteAccess(siteSlug);
+    if (!access.ok) return accessFailureResponse(access);
+
+    const plan = planDomainHostnames(hostname);
+    const db = getDb();
+    const result = await db.$transaction(
+      async (transaction) => {
+        const rows = await transaction.domain.findMany({
+          where: {
+            siteId: access.site.id,
+            hostname: { in: plan.hostnames },
+          },
+          select: { id: true, hostname: true },
+        });
+        if (!rows.length) return null;
+
+        await transaction.domain.deleteMany({
+          where: {
+            siteId: access.site.id,
+            id: { in: rows.map((row) => row.id) },
+          },
+        });
+        const siteStatus = await reconcileSiteStatus(
+          transaction,
+          access.site.id,
+        );
+        await transaction.auditEvent.create({
+          data: {
+            type: "domain.removed",
+            actor: access.user.id,
+            siteId: access.site.id,
+            metadata: {
+              actorEmail: access.user.email,
+              canonicalHostname: plan.canonicalHostname,
+              hostnames: rows.map((row) => row.hostname),
+              resultingStatus: siteStatus,
+            },
+          },
+        });
+        return {
+          hostnames: rows.map((row) => row.hostname),
+          siteStatus,
+        };
+      },
+      { isolationLevel: "Serializable" },
+    );
+    if (!result) {
+      return Response.json({ error: "Domain not found" }, { status: 404 });
+    }
+
+    return Response.json({
+      removed: true,
+      hostnames: result.hostnames,
+      siteStatus: result.siteStatus,
+      previewPath: `/preview/${access.site.slug}`,
+    });
+  } catch (error) {
+    return domainFailure(error, "Domain could not be removed");
+  }
+}
+
+const domainRowSelect = {
+  hostname: true,
+  verified: true,
+  tlsStatus: true,
+  tlsCheckedAt: true,
+  tlsFailureCode: true,
+} as const;
+
+function domainSetups(
+  rows: DomainRow[],
+  target: ReturnType<typeof getDomainTarget>,
+  siteStatus: SiteStatus,
+  siteSlug: string,
+) {
+  const plans = new Map<string, DomainHostnamePlan>();
+  for (const row of rows) {
+    const plan = planDomainHostnames(row.hostname);
+    plans.set(plan.canonicalHostname, plan);
+  }
+  return [...plans.values()].map((plan) =>
+    domainSetup(plan, rows, target, siteStatus, siteSlug, false),
+  );
+}
+
+function domainSetup(
+  plan: DomainHostnamePlan,
+  rows: DomainRow[],
+  target: ReturnType<typeof getDomainTarget>,
+  siteStatus: SiteStatus,
+  siteSlug: string,
+  dnsChecked: boolean,
+) {
+  const plannedRows = rows.filter((row) => plan.hostnames.includes(row.hostname));
+  const verifiedRows = plannedRows.filter((row) => row.verified);
+  const tls = aggregateTls(verifiedRows);
+  return {
+    hostname: plan.canonicalHostname,
+    hostnames: plan.hostnames,
+    attached: plannedRows.length === plan.hostnames.length,
+    verified:
+      plannedRows.length === plan.hostnames.length &&
+      plannedRows.every((row) => row.verified),
+    dnsChecked,
+    records: plan.records.map((record) => ({
+      type: record.type,
+      name: record.name,
+      value: record.type === "A" ? target.address : target.cname,
+    })),
+    tls,
+    siteStatus,
+    previewPath: `/preview/${siteSlug}`,
+  };
+}
+
+function aggregateTls(rows: DomainRow[]) {
+  if (!rows.length) {
+    return {
+      status: "PENDING" as const,
+      checkedAt: null,
+      message: "Secure connection checks start after DNS is verified.",
+    };
+  }
+  const status: DomainTlsStatus = rows.some((row) => row.tlsStatus === "ERROR")
+    ? "ERROR"
+    : rows.every((row) => row.tlsStatus === "READY")
+      ? "READY"
+      : "PENDING";
+  return {
+    status,
+    checkedAt:
+      rows
+        .map((row) => row.tlsCheckedAt)
+        .filter((value): value is Date => Boolean(value))
+        .sort((left, right) => right.getTime() - left.getTime())[0] ?? null,
+    message:
+      status === "READY"
+        ? "Secure HTTPS is ready."
+        : status === "ERROR"
+          ? safeTlsFailureMessage(rows)
+          : "Certificate issuance is still in progress. Check again shortly.",
+  };
+}
+
+function safeTlsFailureMessage(rows: DomainRow[]) {
+  return rows.some((row) => row.tlsFailureCode === "INGRESS_UNREACHABLE")
+    ? "The production ingress is not reachable yet. Try again shortly."
+    : "The secure connection is not ready yet. Try again shortly.";
+}
+
+async function recordResolves(
+  record: DomainHostnamePlan["records"][number],
+  target: ReturnType<typeof getDomainTarget>,
+) {
+  if (record.type === "A") {
+    const result = await Promise.allSettled([resolve4(record.hostname)]);
+    return (
+      result[0].status === "fulfilled" &&
+      result[0].value.includes(target.address)
     );
   }
+  const result = await Promise.allSettled([resolveCname(record.hostname)]);
+  return (
+    result[0].status === "fulfilled" &&
+    result[0].value.some(
+      (value) => value.replace(/\.$/, "").toLowerCase() === target.cname,
+    )
+  );
+}
+
+async function reconcileSiteStatus(
+  transaction: Prisma.TransactionClient,
+  siteId: string,
+): Promise<SiteStatus> {
+  const [site, verifiedDomainCount] = await Promise.all([
+    transaction.site.findUnique({
+      where: { id: siteId },
+      select: {
+        status: true,
+        publishedSiteVersionId: true,
+        publishedSiteVersion: {
+          select: { id: true, siteId: true, publishedAt: true },
+        },
+      },
+    }),
+    transaction.domain.count({ where: { siteId, verified: true } }),
+  ]);
+  if (!site) throw new Error("Site not found");
+  const published = site.publishedSiteVersion;
+  const status = siteStatusForDomainState({
+    currentStatus: site.status,
+    hasVerifiedDomain: verifiedDomainCount > 0,
+    hasValidPublishedVersion:
+      Boolean(site.publishedSiteVersionId) &&
+      published?.id === site.publishedSiteVersionId &&
+      published.siteId === siteId &&
+      published.publishedAt instanceof Date,
+  });
+  if (status !== site.status) {
+    await transaction.site.update({
+      where: { id: siteId },
+      data: { status },
+    });
+  }
+  return status;
+}
+
+function domainFailure(error: unknown, fallback: string) {
+  const message =
+    error instanceof z.ZodError
+      ? error.issues[0]?.message ?? fallback
+      : error instanceof Error &&
+          error.message === "Customer domain routing is not configured"
+        ? "Customer domain routing is not configured"
+        : fallback;
+  return Response.json(
+    { error: message },
+    { status: 400, headers: { "Cache-Control": "no-store" } },
+  );
 }

--- a/src/app/dashboard/dashboard.tsx
+++ b/src/app/dashboard/dashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import {
   ArrowUpRight,
@@ -23,7 +23,9 @@ import {
   Save,
   Settings,
   Sparkles,
+  Trash2,
   TrendingUp,
+  TriangleAlert,
 } from "lucide-react";
 import { Brand } from "@/components/brand";
 import {
@@ -49,9 +51,17 @@ import {
 
 type DomainSetup = {
   hostname: string;
+  hostnames: string[];
   attached: boolean;
   verified: boolean;
   records: Array<{ type: string; name: string; value: string }>;
+  tls: {
+    status: "PENDING" | "READY" | "ERROR";
+    checkedAt: string | null;
+    message: string;
+  };
+  siteStatus: "PROSPECT" | "PREVIEW_READY" | "CLAIMED" | "LIVE" | "PAUSED";
+  previewPath: string;
 };
 
 /**
@@ -87,9 +97,38 @@ export function Dashboard({
   const [domain, setDomain] = useState("");
   const [domainSetup, setDomainSetup] = useState<DomainSetup | null>(null);
   const [domainError, setDomainError] = useState<string | null>(null);
+  const [domainNotice, setDomainNotice] = useState<string | null>(null);
   const [domainLoading, setDomainLoading] = useState(false);
   const [imageLoading, setImageLoading] = useState(false);
   const [portalLoading, setPortalLoading] = useState(false);
+
+  useEffect(() => {
+    if (demo) return;
+    let active = true;
+    void fetch(`/api/domains?siteSlug=${encodeURIComponent(draft.slug)}`, {
+      cache: "no-store",
+    })
+      .then(async (response) => {
+        const result = (await response.json()) as {
+          domains?: DomainSetup[];
+          error?: string;
+        };
+        if (!response.ok) throw new Error(result.error ?? "Could not load domain");
+        if (!active || !result.domains?.[0]) return;
+        setDomainSetup(result.domains[0]);
+        setDomain(result.domains[0].hostname);
+      })
+      .catch((caught) => {
+        if (active) {
+          setDomainError(
+            caught instanceof Error ? caught.message : "Could not load domain",
+          );
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, [demo, draft.slug]);
 
   async function save(): Promise<boolean> {
     setSaving(true);
@@ -171,6 +210,7 @@ export function Dashboard({
   async function connectDomain() {
     setDomainLoading(true);
     setDomainError(null);
+    setDomainNotice(null);
     try {
       const response = await fetch("/api/domains", {
         method: "POST",
@@ -185,9 +225,82 @@ export function Dashboard({
       };
       if (!response.ok) throw new Error(result.error ?? "Could not add domain");
       setDomainSetup(result);
+      setDomain(result.hostname);
     } catch (caught) {
       setDomainError(
         caught instanceof Error ? caught.message : "Could not add domain",
+      );
+    } finally {
+      setDomainLoading(false);
+    }
+  }
+
+  async function checkDomain() {
+    if (!domainSetup) return;
+    setDomainLoading(true);
+    setDomainError(null);
+    setDomainNotice(null);
+    try {
+      const response = await fetch(
+        `/api/domains?hostname=${encodeURIComponent(domainSetup.hostname)}&siteSlug=${encodeURIComponent(draft.slug)}`,
+        { cache: "no-store" },
+      );
+      const result = (await response.json()) as DomainSetup & {
+        error?: string;
+      };
+      if (!response.ok) {
+        throw new Error(result.error ?? "Could not check the domain");
+      }
+      setDomainSetup(result);
+    } catch (caught) {
+      setDomainError(
+        caught instanceof Error
+          ? caught.message
+          : "Could not check the domain",
+      );
+    } finally {
+      setDomainLoading(false);
+    }
+  }
+
+  async function removeDomain() {
+    if (
+      !domainSetup ||
+      !window.confirm(
+        `Remove ${domainSetup.hostname}? The public domain will stop routing here and the preview will remain available.`,
+      )
+    ) {
+      return;
+    }
+    setDomainLoading(true);
+    setDomainError(null);
+    setDomainNotice(null);
+    try {
+      const response = await fetch("/api/domains", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          hostname: domainSetup.hostname,
+          siteSlug: draft.slug,
+        }),
+      });
+      const result = (await response.json()) as {
+        removed?: boolean;
+        error?: string;
+      };
+      if (!response.ok || !result.removed) {
+        throw new Error(result.error ?? "Could not remove the domain");
+      }
+      setDomainSetup(null);
+      setDomain("");
+      setDomainNotice(
+        "Domain removed. The website is preview-only until another verified domain is connected.",
+      );
+    } catch (caught) {
+      setDomainError(
+        caught instanceof Error
+          ? caught.message
+          : "Could not remove the domain",
       );
     } finally {
       setDomainLoading(false);
@@ -772,8 +885,19 @@ export function Dashboard({
                       className="mt-2 h-11"
                     />
                     {domainError ? (
-                      <p className="mt-3 text-xs text-destructive">
+                      <p
+                        className="mt-3 text-xs text-destructive"
+                        role="alert"
+                      >
                         {domainError}
+                      </p>
+                    ) : null}
+                    {domainNotice ? (
+                      <p
+                        className="mt-3 text-xs text-muted-foreground"
+                        role="status"
+                      >
+                        {domainNotice}
                       </p>
                     ) : null}
                     <Button
@@ -831,31 +955,71 @@ export function Dashboard({
                             </Button>
                           </div>
                         ))}
+                        <div className="grid gap-2 rounded-xl border bg-muted/20 p-3 sm:grid-cols-2">
+                          <div>
+                            <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                              DNS
+                            </p>
+                            <p className="mt-1 flex items-center gap-2 text-xs font-medium">
+                              {domainSetup.verified ? (
+                                <CircleCheck className="size-4 text-emerald-500" />
+                              ) : (
+                                <RefreshCcw className="size-4 text-muted-foreground" />
+                              )}
+                              {domainSetup.verified
+                                ? "Verified"
+                                : "Waiting for records"}
+                            </p>
+                          </div>
+                          <div>
+                            <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                              HTTPS
+                            </p>
+                            <p className="mt-1 flex items-center gap-2 text-xs font-medium">
+                              {domainSetup.tls.status === "READY" ? (
+                                <CircleCheck className="size-4 text-emerald-500" />
+                              ) : domainSetup.tls.status === "ERROR" ? (
+                                <TriangleAlert className="size-4 text-amber-500" />
+                              ) : (
+                                <RefreshCcw className="size-4 text-muted-foreground" />
+                              )}
+                              {domainSetup.tls.status === "READY"
+                                ? "Secure connection ready"
+                                : domainSetup.tls.status === "ERROR"
+                                  ? "Needs attention"
+                                  : "Certificate pending"}
+                            </p>
+                          </div>
+                          <p className="text-xs leading-5 text-muted-foreground sm:col-span-2">
+                            {domainSetup.tls.message}
+                          </p>
+                        </div>
                         <Button
                           variant="outline"
                           className="w-full"
-                          onClick={async () => {
-                            const response = await fetch(
-                              `/api/domains?hostname=${encodeURIComponent(domainSetup.hostname)}&siteSlug=${encodeURIComponent(draft.slug)}`,
-                            );
-                            const result = (await response.json()) as {
-                              verified?: boolean;
-                            };
-                            setDomainSetup((current) =>
-                              current
-                                ? {
-                                    ...current,
-                                    verified: Boolean(result.verified),
-                                  }
-                                : current,
-                            );
-                          }}
+                          onClick={() => void checkDomain()}
+                          disabled={domainLoading}
                         >
-                          <RefreshCcw />
+                          <RefreshCcw
+                            className={domainLoading ? "animate-spin" : ""}
+                          />
                           {domainSetup.verified
-                            ? "Domain connected"
+                            ? "Check HTTPS again"
                             : "Check DNS again"}
                         </Button>
+                        <Button
+                          variant="ghost"
+                          className="w-full text-destructive hover:text-destructive"
+                          onClick={() => void removeDomain()}
+                          disabled={domainLoading}
+                        >
+                          <Trash2 />
+                          Remove domain
+                        </Button>
+                        <p className="text-xs leading-5 text-muted-foreground">
+                          Removing the domain immediately revokes public routing.
+                          Your private preview and published version are kept.
+                        </p>
                       </div>
                     ) : (
                       <ol className="space-y-5 text-sm">

--- a/src/app/preview/[slug]/[locale]/page.tsx
+++ b/src/app/preview/[slug]/[locale]/page.tsx
@@ -3,7 +3,7 @@ import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { SiteRenderer } from "@/components/site-renderer";
 import { getSiteLocales, localizeSiteDraft } from "@/lib/site-draft";
-import { isLiveSiteSurface } from "@/lib/site-surface";
+import { liveSiteVersionId } from "@/lib/site-surface";
 import {
   findPublishedSiteView,
   findSiteView,
@@ -17,11 +17,12 @@ export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
   const { slug, locale } = await params;
-  const liveSurface = isLiveSiteSurface(await headers(), slug);
-  const site = liveSurface
-    ? await findPublishedSiteView(slug)
+  const versionId = liveSiteVersionId(await headers(), slug);
+  const site = versionId
+    ? await findPublishedSiteView(slug, versionId)
     : await findSiteView(slug);
   if (!site) notFound();
+  const liveSurface = versionId !== null;
   const locales = getSiteLocales(site.draft);
   if (!locales.includes(locale)) notFound();
 
@@ -58,11 +59,12 @@ export async function generateMetadata({
 
 export default async function LocalizedPreviewPage({ params }: PageProps) {
   const { slug, locale } = await params;
-  const liveSurface = isLiveSiteSurface(await headers(), slug);
-  const site = liveSurface
-    ? await findPublishedSiteView(slug)
+  const versionId = liveSiteVersionId(await headers(), slug);
+  const site = versionId
+    ? await findPublishedSiteView(slug, versionId)
     : await findSiteView(slug);
   if (!site) notFound();
+  const liveSurface = versionId !== null;
   const locales = getSiteLocales(site.draft);
   if (!locales.includes(locale)) notFound();
 

--- a/src/app/preview/[slug]/page.tsx
+++ b/src/app/preview/[slug]/page.tsx
@@ -3,7 +3,7 @@ import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { SiteRenderer } from "@/components/site-renderer";
 import { getSiteLocales } from "@/lib/site-draft";
-import { isLiveSiteSurface } from "@/lib/site-surface";
+import { liveSiteVersionId } from "@/lib/site-surface";
 import {
   findPublishedSiteView,
   findSiteView,
@@ -17,11 +17,12 @@ export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
   const { slug } = await params;
-  const liveSurface = isLiveSiteSurface(await headers(), slug);
-  const site = liveSurface
-    ? await findPublishedSiteView(slug)
+  const versionId = liveSiteVersionId(await headers(), slug);
+  const site = versionId
+    ? await findPublishedSiteView(slug, versionId)
     : await findSiteView(slug);
   if (!site) notFound();
+  const liveSurface = versionId !== null;
   const locales = getSiteLocales(site.draft);
   return {
     title: liveSurface
@@ -50,11 +51,12 @@ export async function generateMetadata({
 
 export default async function PreviewPage({ params }: PageProps) {
   const { slug } = await params;
-  const liveSurface = isLiveSiteSurface(await headers(), slug);
-  const site = liveSurface
-    ? await findPublishedSiteView(slug)
+  const versionId = liveSiteVersionId(await headers(), slug);
+  const site = versionId
+    ? await findPublishedSiteView(slug, versionId)
     : await findSiteView(slug);
   if (!site) notFound();
+  const liveSurface = versionId !== null;
   return (
     <SiteRenderer
       draft={site.draft}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -50,14 +50,31 @@ export async function resolveAnalyticsSiteForHeaders(headers: Headers) {
         where: { hostname: verifiedHostname },
         select: {
           verified: true,
-          site: { select: { id: true, slug: true } },
+          site: {
+            select: {
+              id: true,
+              slug: true,
+              status: true,
+              publishedSiteVersionId: true,
+              publishedSiteVersion: {
+                select: { id: true, siteId: true, publishedAt: true },
+              },
+            },
+          },
         },
       });
       if (!domain) return null;
+      const published = domain.site.publishedSiteVersion;
       return {
         id: domain.site.id,
         slug: domain.site.slug,
-        verified: domain.verified,
+        verified:
+          domain.verified &&
+          domain.site.status === "LIVE" &&
+          Boolean(domain.site.publishedSiteVersionId) &&
+          published?.id === domain.site.publishedSiteVersionId &&
+          published.siteId === domain.site.id &&
+          published.publishedAt instanceof Date,
       };
     },
   });

--- a/src/lib/domain-claim.test.ts
+++ b/src/lib/domain-claim.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
   claimDomainForSite,
+  claimDomainSetForSite,
   type DomainClaimStore,
 } from "@/lib/domain-claim";
 
@@ -50,6 +51,51 @@ describe("domain ownership claim", () => {
     expect(state.owner).toBe("site_2");
     expect(transactions).toBe(2);
   });
+
+  it("claims an apex and www atomically", async () => {
+    const state = {
+      owners: new Map<string, string>(),
+      creates: [] as string[],
+    };
+    const claimed = await claimDomainSetForSite(setStore(state), [
+      {
+        hostname: "example.test",
+        siteId: "site_1",
+        verificationToken: "token_apex",
+      },
+      {
+        hostname: "www.example.test",
+        siteId: "site_1",
+        verificationToken: "token_www",
+      },
+    ]);
+
+    expect(claimed).toBe(true);
+    expect(state.creates).toEqual(["example.test", "www.example.test"]);
+  });
+
+  it("does not partially claim a pair whose companion is owned", async () => {
+    const state = {
+      owners: new Map([["www.example.test", "site_2"]]),
+      creates: [] as string[],
+    };
+    const claimed = await claimDomainSetForSite(setStore(state), [
+      {
+        hostname: "example.test",
+        siteId: "site_1",
+        verificationToken: "token_apex",
+      },
+      {
+        hostname: "www.example.test",
+        siteId: "site_1",
+        verificationToken: "token_www",
+      },
+    ]);
+
+    expect(claimed).toBe(false);
+    expect(state.creates).toEqual([]);
+    expect(state.owners.get("example.test")).toBeUndefined();
+  });
 });
 
 function store(
@@ -67,5 +113,21 @@ function store(
         },
       });
     },
+  };
+}
+
+function setStore(state: {
+  owners: Map<string, string>;
+  creates: string[];
+}): DomainClaimStore {
+  return {
+    runSerializable: async (operation) =>
+      operation({
+        findOwner: async (hostname) => state.owners.get(hostname) ?? null,
+        create: async ({ hostname, siteId }) => {
+          state.creates.push(hostname);
+          state.owners.set(hostname, siteId);
+        },
+      }),
   };
 }

--- a/src/lib/domain-claim.ts
+++ b/src/lib/domain-claim.ts
@@ -28,12 +28,41 @@ export async function claimDomainForSite(
     verificationToken: string;
   },
 ): Promise<boolean> {
+  return claimDomainSetForSite(store, [input]);
+}
+
+/**
+ * Claims an apex/www set atomically. Ownership of every hostname is checked
+ * before the first insert, so a companion already owned by another site cannot
+ * leave half of a canonical pair attached.
+ */
+export async function claimDomainSetForSite(
+  store: DomainClaimStore,
+  inputs: Array<{
+    hostname: string;
+    siteId: string;
+    verificationToken: string;
+  }>,
+): Promise<boolean> {
+  if (!inputs.length) return false;
+  const siteId = inputs[0].siteId;
+  if (inputs.some((input) => input.siteId !== siteId)) {
+    throw new Error("A domain set must belong to one site");
+  }
+
   for (let attempt = 0; attempt < 3; attempt += 1) {
     try {
       return await store.runSerializable(async (transaction) => {
-        const owner = await transaction.findOwner(input.hostname);
-        if (owner) return owner === input.siteId;
-        await transaction.create(input);
+        const owners = await Promise.all(
+          inputs.map(async (input) => ({
+            input,
+            owner: await transaction.findOwner(input.hostname),
+          })),
+        );
+        if (owners.some(({ owner }) => owner && owner !== siteId)) return false;
+        for (const { input, owner } of owners) {
+          if (!owner) await transaction.create(input);
+        }
         return true;
       });
     } catch (error) {

--- a/src/lib/domain-routing.test.ts
+++ b/src/lib/domain-routing.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "bun:test";
+import {
+  decideCustomerHostRoute,
+  planDomainHostnames,
+  siteStatusForDomainState,
+  type PublishedDomainRecord,
+} from "@/lib/domain-routing";
+
+describe("custom-domain hostname plans", () => {
+  it("claims an apex and www together with the apex canonical", () => {
+    expect(planDomainHostnames("www.example.com")).toEqual({
+      canonicalHostname: "example.com",
+      hostnames: ["example.com", "www.example.com"],
+      records: [
+        { hostname: "example.com", type: "A", name: "@" },
+        { hostname: "www.example.com", type: "CNAME", name: "www" },
+      ],
+    });
+    expect(planDomainHostnames("example.com")).toEqual(
+      planDomainHostnames("www.example.com"),
+    );
+  });
+
+  it("does not guess a registrable parent for deeper hostnames", () => {
+    expect(planDomainHostnames("book.example.co.uk")).toEqual({
+      canonicalHostname: "book.example.co.uk",
+      hostnames: ["book.example.co.uk"],
+      records: [
+        {
+          hostname: "book.example.co.uk",
+          type: "CNAME",
+          name: "book",
+        },
+      ],
+    });
+  });
+});
+
+describe("customer host isolation", () => {
+  it("serves only root, locales and the two public site endpoints", () => {
+    const records = livePair();
+    expect(
+      decideCustomerHostRoute({
+        hostname: "example.com",
+        pathname: "/",
+        records,
+      }),
+    ).toEqual({
+      kind: "page",
+      slug: "chez-lea",
+      versionId: "version_1",
+      locale: null,
+    });
+    expect(
+      decideCustomerHostRoute({
+        hostname: "example.com",
+        pathname: "/fr",
+        records,
+      }),
+    ).toEqual({
+      kind: "page",
+      slug: "chez-lea",
+      versionId: "version_1",
+      locale: "fr",
+    });
+    expect(
+      decideCustomerHostRoute({
+        hostname: "example.com",
+        pathname: "/api/analytics/events",
+        records,
+      }).kind,
+    ).toBe("public_api");
+    expect(
+      decideCustomerHostRoute({
+        hostname: "example.com",
+        pathname: "/api/sites/chez-lea/booking-requests",
+        records,
+      }).kind,
+    ).toBe("public_api");
+
+    for (const pathname of [
+      "/dashboard",
+      "/admin",
+      "/sign-in",
+      "/create",
+      "/preview/chez-lea",
+      "/api/domains",
+      "/api/sites/another/booking-requests",
+    ]) {
+      expect(
+        decideCustomerHostRoute({
+          hostname: "example.com",
+          pathname,
+          records,
+        }),
+      ).toEqual({ kind: "not_found" });
+    }
+  });
+
+  it("permanently canonicalizes a verified www alias", () => {
+    expect(
+      decideCustomerHostRoute({
+        hostname: "www.example.com",
+        pathname: "/fr",
+        records: livePair(),
+      }),
+    ).toEqual({
+      kind: "redirect",
+      canonicalHostname: "example.com",
+    });
+  });
+
+  it("rejects unknown, unverified, paused and invalid snapshots", () => {
+    const base = livePair()[0];
+    for (const record of [
+      { ...base, verified: false },
+      { ...base, site: { ...base.site, status: "PAUSED" as const } },
+      {
+        ...base,
+        site: {
+          ...base.site,
+          publishedSiteVersion: {
+            ...base.site.publishedSiteVersion!,
+            siteId: "site_other",
+          },
+        },
+      },
+      {
+        ...base,
+        site: {
+          ...base.site,
+          publishedSiteVersion: {
+            ...base.site.publishedSiteVersion!,
+            publishedAt: null,
+          },
+        },
+      },
+    ]) {
+      expect(
+        decideCustomerHostRoute({
+          hostname: "example.com",
+          pathname: "/",
+          records: [record],
+        }),
+      ).toEqual({ kind: "not_found" });
+    }
+  });
+});
+
+describe("site domain lifecycle", () => {
+  it("requires both a verified domain and a valid snapshot for LIVE", () => {
+    expect(
+      siteStatusForDomainState({
+        currentStatus: "CLAIMED",
+        hasVerifiedDomain: true,
+        hasValidPublishedVersion: true,
+      }),
+    ).toBe("LIVE");
+    expect(
+      siteStatusForDomainState({
+        currentStatus: "LIVE",
+        hasVerifiedDomain: false,
+        hasValidPublishedVersion: true,
+      }),
+    ).toBe("CLAIMED");
+    expect(
+      siteStatusForDomainState({
+        currentStatus: "LIVE",
+        hasVerifiedDomain: true,
+        hasValidPublishedVersion: false,
+      }),
+    ).toBe("CLAIMED");
+  });
+
+  it("never bypasses a pause or changes pre-claim states", () => {
+    expect(
+      siteStatusForDomainState({
+        currentStatus: "PAUSED",
+        hasVerifiedDomain: true,
+        hasValidPublishedVersion: true,
+      }),
+    ).toBe("PAUSED");
+    expect(
+      siteStatusForDomainState({
+        currentStatus: "PREVIEW_READY",
+        hasVerifiedDomain: true,
+        hasValidPublishedVersion: true,
+      }),
+    ).toBe("PREVIEW_READY");
+  });
+});
+
+function livePair(): PublishedDomainRecord[] {
+  const site = {
+    id: "site_1",
+    slug: "chez-lea",
+    status: "LIVE" as const,
+    publishedSiteVersionId: "version_1",
+    publishedSiteVersion: {
+      id: "version_1",
+      siteId: "site_1",
+      publishedAt: new Date("2026-07-27T00:00:00.000Z"),
+    },
+  };
+  return [
+    { hostname: "example.com", verified: true, site },
+    { hostname: "www.example.com", verified: true, site },
+  ];
+}

--- a/src/lib/domain-routing.ts
+++ b/src/lib/domain-routing.ts
@@ -1,0 +1,193 @@
+export type DomainHostnamePlan = {
+  canonicalHostname: string;
+  hostnames: string[];
+  records: Array<{
+    hostname: string;
+    type: "A" | "CNAME";
+    name: string;
+  }>;
+};
+
+export type PublishedDomainRecord = {
+  hostname: string;
+  verified: boolean;
+  site: {
+    id: string;
+    slug: string;
+    status: "PROSPECT" | "PREVIEW_READY" | "CLAIMED" | "LIVE" | "PAUSED";
+    publishedSiteVersionId: string | null;
+    publishedSiteVersion: {
+      id: string;
+      siteId: string;
+      publishedAt: Date | null;
+    } | null;
+  };
+};
+
+export type CustomerHostDecision =
+  | { kind: "not_found" }
+  | {
+      kind: "redirect";
+      canonicalHostname: string;
+    }
+  | {
+      kind: "page";
+      slug: string;
+      versionId: string;
+      locale: string | null;
+    }
+  | {
+      kind: "public_api";
+      slug: string;
+      versionId: string;
+    };
+
+/**
+ * Cornershop's explicit apex/www policy.
+ *
+ * A two-label hostname and its `www` form are one claim with the apex canonical.
+ * Deeper hostnames are exact CNAME claims: guessing registrable domains such as
+ * `co.uk` without a maintained public-suffix list would risk claiming a sibling.
+ */
+export function planDomainHostnames(hostname: string): DomainHostnamePlan {
+  const normalized = hostname.trim().toLowerCase().replace(/\.$/, "");
+  const withoutWww = normalized.startsWith("www.")
+    ? normalized.slice(4)
+    : normalized;
+  const isApexPair = withoutWww.split(".").length === 2;
+
+  if (isApexPair) {
+    return {
+      canonicalHostname: withoutWww,
+      hostnames: [withoutWww, `www.${withoutWww}`],
+      records: [
+        { hostname: withoutWww, type: "A", name: "@" },
+        {
+          hostname: `www.${withoutWww}`,
+          type: "CNAME",
+          name: "www",
+        },
+      ],
+    };
+  }
+
+  return {
+    canonicalHostname: normalized,
+    hostnames: [normalized],
+    records: [
+      {
+        hostname: normalized,
+        type: "CNAME",
+        name: normalized.split(".")[0] ?? normalized,
+      },
+    ],
+  };
+}
+
+/**
+ * Resolves the only surfaces a customer hostname may expose.
+ *
+ * All owner/operator routes and unrelated public APIs are denied here before
+ * Next's filesystem router can see them. The two public write endpoints remain
+ * available because the live renderer needs analytics and booking requests.
+ */
+export function decideCustomerHostRoute(input: {
+  hostname: string;
+  pathname: string;
+  records: PublishedDomainRecord[];
+}): CustomerHostDecision {
+  const exact = input.records.find(
+    (record) =>
+      record.hostname === input.hostname &&
+      record.verified &&
+      hasValidPublishedSite(record),
+  );
+  if (!exact) return { kind: "not_found" };
+
+  const plan = planDomainHostnames(input.hostname);
+  const canonical = input.records.find(
+    (record) =>
+      record.hostname === plan.canonicalHostname &&
+      record.site.id === exact.site.id &&
+      record.verified &&
+      hasValidPublishedSite(record),
+  );
+  const surface = customerSurface(input.pathname, exact.site.slug);
+  if (surface.kind === "blocked") return { kind: "not_found" };
+
+  if (
+    input.hostname !== plan.canonicalHostname &&
+    canonical &&
+    canonical.site.publishedSiteVersionId ===
+      exact.site.publishedSiteVersionId
+  ) {
+    return {
+      kind: "redirect",
+      canonicalHostname: plan.canonicalHostname,
+    };
+  }
+
+  const versionId = exact.site.publishedSiteVersionId;
+  if (!versionId) return { kind: "not_found" };
+  if (surface.kind === "public_api") {
+    return {
+      kind: "public_api",
+      slug: exact.site.slug,
+      versionId,
+    };
+  }
+  return {
+    kind: "page",
+    slug: exact.site.slug,
+    versionId,
+    locale: surface.locale,
+  };
+}
+
+export function siteStatusForDomainState(input: {
+  currentStatus: "PROSPECT" | "PREVIEW_READY" | "CLAIMED" | "LIVE" | "PAUSED";
+  hasVerifiedDomain: boolean;
+  hasValidPublishedVersion: boolean;
+}): "PROSPECT" | "PREVIEW_READY" | "CLAIMED" | "LIVE" | "PAUSED" {
+  if (input.currentStatus === "PAUSED") return "PAUSED";
+  if (
+    input.currentStatus !== "CLAIMED" &&
+    input.currentStatus !== "LIVE"
+  ) {
+    return input.currentStatus;
+  }
+  return input.hasVerifiedDomain && input.hasValidPublishedVersion
+    ? "LIVE"
+    : "CLAIMED";
+}
+
+function hasValidPublishedSite(record: PublishedDomainRecord): boolean {
+  const version = record.site.publishedSiteVersion;
+  return (
+    record.site.status === "LIVE" &&
+    Boolean(record.site.publishedSiteVersionId) &&
+    version?.id === record.site.publishedSiteVersionId &&
+    version.siteId === record.site.id &&
+    version.publishedAt instanceof Date
+  );
+}
+
+function customerSurface(
+  pathname: string,
+  slug: string,
+):
+  | { kind: "page"; locale: string | null }
+  | { kind: "public_api" }
+  | { kind: "blocked" } {
+  if (pathname === "/") return { kind: "page", locale: null };
+  const locale = pathname.match(/^\/([a-z]{2})\/?$/i)?.[1];
+  if (locale) return { kind: "page", locale: locale.toLowerCase() };
+  if (pathname === "/api/analytics/events") return { kind: "public_api" };
+  if (
+    pathname ===
+    `/api/sites/${encodeURIComponent(slug)}/booking-requests`
+  ) {
+    return { kind: "public_api" };
+  }
+  return { kind: "blocked" };
+}

--- a/src/lib/domain-tls.test.ts
+++ b/src/lib/domain-tls.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, mock } from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+const { checkDomainTls, tlsFailure } = await import("@/lib/domain-tls");
+
+describe("domain TLS readiness", () => {
+  it("reports a verified certificate as ready", async () => {
+    expect(
+      await checkDomainTls(
+        "example.com",
+        "192.0.2.1",
+        async () => undefined,
+      ),
+    ).toEqual({
+      status: "READY",
+      failureCode: null,
+      message: "Secure connection is ready",
+    });
+  });
+
+  it("maps certificate issuance and ingress failures to safe messages", () => {
+    expect(tlsFailure("ERR_TLS_CERT_ALTNAME_INVALID")).toMatchObject({
+      status: "PENDING",
+      failureCode: "CERTIFICATE_NOT_READY",
+    });
+    expect(tlsFailure("ECONNREFUSED")).toMatchObject({
+      status: "ERROR",
+      failureCode: "INGRESS_UNREACHABLE",
+    });
+    expect(tlsFailure("SOME_INTERNAL_LIBRARY_ERROR")).toEqual({
+      status: "ERROR",
+      failureCode: "TLS_CHECK_FAILED",
+      message:
+        "DNS is connected, but secure connection readiness could not be confirmed. Try the check again.",
+    });
+  });
+
+  it("never returns the underlying connection error", async () => {
+    const result = await checkDomainTls(
+      "example.com",
+      "192.0.2.1",
+      async () => {
+        throw Object.assign(new Error("secret internal topology"), {
+          code: "ECONNRESET",
+        });
+      },
+    );
+    expect(result.message).not.toContain("secret");
+    expect(result).toMatchObject({
+      status: "ERROR",
+      failureCode: "INGRESS_UNREACHABLE",
+    });
+  });
+});

--- a/src/lib/domain-tls.ts
+++ b/src/lib/domain-tls.ts
@@ -1,0 +1,105 @@
+import "server-only";
+import { connect } from "node:tls";
+
+export type DomainTlsCheck =
+  | {
+      status: "READY";
+      failureCode: null;
+      message: string;
+    }
+  | {
+      status: "PENDING" | "ERROR";
+      failureCode:
+        | "CERTIFICATE_NOT_READY"
+        | "INGRESS_UNREACHABLE"
+        | "TLS_CHECK_FAILED";
+      message: string;
+    };
+
+type TlsProbe = (hostname: string, address: string) => Promise<void>;
+
+/**
+ * Probes the production ingress IP with SNI set to the customer hostname. DNS
+ * has already been verified before this runs, so it never follows an arbitrary
+ * customer-controlled address and cannot become a general SSRF primitive.
+ */
+export async function checkDomainTls(
+  hostname: string,
+  address: string,
+  probe: TlsProbe = probeTls,
+): Promise<DomainTlsCheck> {
+  try {
+    await probe(hostname, address);
+    return {
+      status: "READY",
+      failureCode: null,
+      message: "Secure connection is ready",
+    };
+  } catch (error) {
+    return tlsFailure(
+      typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        typeof error.code === "string"
+        ? error.code
+        : null,
+    );
+  }
+}
+
+export function tlsFailure(code: string | null): DomainTlsCheck {
+  if (
+    code === "ERR_TLS_CERT_ALTNAME_INVALID" ||
+    code === "DEPTH_ZERO_SELF_SIGNED_CERT" ||
+    code === "UNABLE_TO_VERIFY_LEAF_SIGNATURE" ||
+    code === "CERT_HAS_EXPIRED"
+  ) {
+    return {
+      status: "PENDING",
+      failureCode: "CERTIFICATE_NOT_READY",
+      message:
+        "DNS is connected, but the secure certificate is still being issued. Check again in a few minutes.",
+    };
+  }
+  if (
+    code === "ETIMEDOUT" ||
+    code === "ECONNREFUSED" ||
+    code === "ECONNRESET" ||
+    code === "EHOSTUNREACH"
+  ) {
+    return {
+      status: "ERROR",
+      failureCode: "INGRESS_UNREACHABLE",
+      message:
+        "DNS is connected, but the secure site could not be reached. Check again after DNS propagation completes.",
+    };
+  }
+  return {
+    status: "ERROR",
+    failureCode: "TLS_CHECK_FAILED",
+    message:
+      "DNS is connected, but secure connection readiness could not be confirmed. Try the check again.",
+  };
+}
+
+async function probeTls(hostname: string, address: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const socket = connect(
+      {
+        host: address,
+        port: 443,
+        servername: hostname,
+        rejectUnauthorized: true,
+      },
+      () => {
+        socket.end();
+        resolve();
+      },
+    );
+    socket.setTimeout(4_000, () => {
+      socket.destroy();
+      reject(Object.assign(new Error("TLS probe timed out"), { code: "ETIMEDOUT" }));
+    });
+    socket.once("error", reject);
+  });
+}

--- a/src/lib/site-publication.postgres.test.ts
+++ b/src/lib/site-publication.postgres.test.ts
@@ -124,6 +124,15 @@ describe.skipIf(!enabled)("safe draft and publish PostgreSQL integration", () =>
         },
       },
     });
+    await db.domain.create({
+      data: {
+        hostname: `${randomUUID()}.example.test`,
+        siteId,
+        verificationToken: randomUUID(),
+        verified: true,
+        verifiedAt: new Date(),
+      },
+    });
   });
 
   afterAll(async () => {

--- a/src/lib/site-publication.ts
+++ b/src/lib/site-publication.ts
@@ -111,6 +111,9 @@ export async function publishSiteDraft(
             },
             select: { id: true, version: true },
           });
+          const verifiedDomainCount = await tx.domain.count({
+            where: { siteId: input.siteId, verified: true },
+          });
 
           const moved = await tx.site.updateMany({
             where: {
@@ -120,7 +123,9 @@ export async function publishSiteDraft(
             },
             data: {
               publishedSiteVersionId: version.id,
-              status: "LIVE",
+              // A snapshot can be published before DNS is connected, but it is
+              // only live after at least one verified hostname routes to it.
+              status: verifiedDomainCount > 0 ? "LIVE" : "CLAIMED",
             },
           });
           if (moved.count !== 1) {
@@ -139,6 +144,7 @@ export async function publishSiteDraft(
                 actorEmail: input.actor.email,
                 themeId: loaded.theme.id,
                 themeVersion: loaded.theme.version,
+                live: verifiedDomainCount > 0,
               },
             },
           });

--- a/src/lib/site-surface.test.ts
+++ b/src/lib/site-surface.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "bun:test";
 import {
   isLiveSiteSurface,
   LIVE_SITE_SLUG_HEADER,
+  LIVE_SITE_VERSION_HEADER,
+  liveSiteVersionId,
   localeHref,
 } from "@/lib/site-surface";
 
@@ -9,11 +11,19 @@ describe("live site surfaces", () => {
   it("requires the proxy-attested slug", () => {
     const headers = new Headers({
       [LIVE_SITE_SLUG_HEADER]: "chez-lea",
+      [LIVE_SITE_VERSION_HEADER]: "version_1",
     });
 
     expect(isLiveSiteSurface(headers, "chez-lea")).toBe(true);
     expect(isLiveSiteSurface(headers, "another-site")).toBe(false);
     expect(isLiveSiteSurface(new Headers(), "chez-lea")).toBe(false);
+    expect(liveSiteVersionId(headers, "chez-lea")).toBe("version_1");
+    expect(
+      isLiveSiteSurface(
+        new Headers({ [LIVE_SITE_SLUG_HEADER]: "chez-lea" }),
+        "chez-lea",
+      ),
+    ).toBe(false);
   });
 
   it("keeps live locale links on the customer hostname", () => {

--- a/src/lib/site-surface.ts
+++ b/src/lib/site-surface.ts
@@ -1,10 +1,20 @@
 export const LIVE_SITE_SLUG_HEADER = "x-cornershop-live-site-slug";
+export const LIVE_SITE_VERSION_HEADER = "x-cornershop-live-site-version";
+
+export function liveSiteVersionId(
+  headers: Pick<Headers, "get">,
+  siteSlug: string,
+): string | null {
+  if (headers.get(LIVE_SITE_SLUG_HEADER) !== siteSlug) return null;
+  const versionId = headers.get(LIVE_SITE_VERSION_HEADER)?.trim();
+  return versionId || null;
+}
 
 export function isLiveSiteSurface(
   headers: Pick<Headers, "get">,
   siteSlug: string,
 ): boolean {
-  return headers.get(LIVE_SITE_SLUG_HEADER) === siteSlug;
+  return liveSiteVersionId(headers, siteSlug) !== null;
 }
 
 export function localeHref(

--- a/src/lib/sites.ts
+++ b/src/lib/sites.ts
@@ -134,13 +134,21 @@ export async function findSiteDraft(slug: string): Promise<LoadedSite | null> {
  */
 export async function findPublishedSiteView(
   slug: string,
+  versionId?: string,
 ): Promise<SiteView | null> {
   if (!process.env.DATABASE_URL) return null;
 
-  const site = await getDb().site.findUnique({
-    where: { slug },
-    select: {
-      publishedSiteVersion: {
+  const version = versionId
+    ? await getDb().siteVersion.findFirst({
+        where: {
+          id: versionId,
+          publishedAt: { not: null },
+          site: {
+            slug,
+            status: "LIVE",
+            publishedSiteVersionId: versionId,
+          },
+        },
         select: {
           vertical: true,
           theme: true,
@@ -151,10 +159,26 @@ export async function findPublishedSiteView(
           integrations: true,
           publishedAt: true,
         },
-      },
-    },
-  });
-  const version = site?.publishedSiteVersion;
+      })
+    : (
+        await getDb().site.findUnique({
+          where: { slug },
+          select: {
+            publishedSiteVersion: {
+              select: {
+                vertical: true,
+                theme: true,
+                themeVersion: true,
+                palette: true,
+                content: true,
+                translations: true,
+                integrations: true,
+                publishedAt: true,
+              },
+            },
+          },
+        })
+      )?.publishedSiteVersion;
   if (!version?.publishedAt) return null;
 
   const config = resolveVerticalConfig(version.vertical);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,8 +1,15 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
+import {
+  decideCustomerHostRoute,
+  planDomainHostnames,
+} from "@/lib/domain-routing";
 import { platformHostnames, requestHostname } from "@/lib/hostnames";
-import { LIVE_SITE_SLUG_HEADER } from "@/lib/site-surface";
+import {
+  LIVE_SITE_SLUG_HEADER,
+  LIVE_SITE_VERSION_HEADER,
+} from "@/lib/site-surface";
 import {
   listEmbedFrameOrigins,
   resolveVerticalByHostname,
@@ -36,20 +43,16 @@ export async function proxy(request: NextRequest) {
   // Never trust a caller-supplied surface marker. Only the verified-domain
   // branch below may add it for the rewritten Server Component request.
   upstreamHeaders.delete(LIVE_SITE_SLUG_HEADER);
-
-  // A `/preview` URL is already the rendered site, whatever hostname asked for
-  // it, so it is passed through with the frame policy attached and never
-  // resolved against the domain table. Handling it before the hostname branch
-  // keeps custom-domain behaviour on these paths exactly as it was.
-  if (request.nextUrl.pathname.startsWith("/preview/")) {
-    return withEmbedFrameCsp(
-      NextResponse.next({ request: { headers: upstreamHeaders } }),
-    );
-  }
+  upstreamHeaders.delete(LIVE_SITE_VERSION_HEADER);
 
   const hostname = requestHostname(request.headers);
   if (!hostname || platformHostnames().has(hostname)) {
-    return NextResponse.next({ request: { headers: upstreamHeaders } });
+    const response = NextResponse.next({
+      request: { headers: upstreamHeaders },
+    });
+    return request.nextUrl.pathname.startsWith("/preview/")
+      ? withEmbedFrameCsp(response)
+      : response;
   }
 
   // A niche's own marketing domain — restofront.com today, a nails or barber
@@ -62,35 +65,66 @@ export async function proxy(request: NextRequest) {
     // The locale segment is dropped deliberately: a niche's marketing copy lives
     // in its config in one language, unlike a generated site, so `/fr` here
     // serves the same page rather than 404ing on a URL a visitor may well try.
-    return NextResponse.rewrite(
-      new URL(`/niche/${verticalSlug(niche)}`, request.url),
-      { request: { headers: upstreamHeaders } },
-    );
+    const locale = request.nextUrl.pathname.match(/^\/([a-z]{2})\/?$/i);
+    if (request.nextUrl.pathname === "/" || locale) {
+      return NextResponse.rewrite(
+        new URL(`/niche/${verticalSlug(niche)}`, request.url),
+        { request: { headers: upstreamHeaders } },
+      );
+    }
+    return NextResponse.next({ request: { headers: upstreamHeaders } });
   }
 
-  const domain = await getDb().domain.findFirst({
-    where: { hostname, verified: true },
+  const plan = planDomainHostnames(hostname);
+  const domains = await getDb().domain.findMany({
+    where: { hostname: { in: plan.hostnames } },
     select: {
+      hostname: true,
+      verified: true,
       site: {
         select: {
+          id: true,
           slug: true,
+          status: true,
           publishedSiteVersionId: true,
+          publishedSiteVersion: {
+            select: {
+              id: true,
+              siteId: true,
+              publishedAt: true,
+            },
+          },
         },
       },
     },
   });
-  if (!domain?.site.publishedSiteVersionId) {
-    return new NextResponse("Not found", { status: 404 });
+  const decision = decideCustomerHostRoute({
+    hostname,
+    pathname: request.nextUrl.pathname,
+    records: domains,
+  });
+  if (decision.kind === "not_found") {
+    return new NextResponse("Not found", {
+      status: 404,
+      headers: { "Cache-Control": "private, no-store" },
+    });
+  }
+  if (decision.kind === "redirect") {
+    const canonical = new URL(request.url);
+    canonical.protocol = "https:";
+    canonical.hostname = decision.canonicalHostname;
+    canonical.port = "";
+    return NextResponse.redirect(canonical, 308);
   }
 
-  const locale = request.nextUrl.pathname.match(/^\/([a-z]{2})\/?$/i)?.[1];
-  const destination = locale
-    ? `/preview/${domain.site.slug}/${locale.toLowerCase()}`
-    : `/preview/${domain.site.slug}`;
-  upstreamHeaders.set(LIVE_SITE_SLUG_HEADER, domain.site.slug);
-  // The rewrite target is a preview route, so the frame policy rides along here
-  // too — the visitor's URL never says `/preview`, but the page it gets is the
-  // one that may embed a booking widget.
+  upstreamHeaders.set(LIVE_SITE_SLUG_HEADER, decision.slug);
+  upstreamHeaders.set(LIVE_SITE_VERSION_HEADER, decision.versionId);
+  if (decision.kind === "public_api") {
+    return NextResponse.next({ request: { headers: upstreamHeaders } });
+  }
+  const destination = decision.locale
+    ? `/preview/${decision.slug}/${decision.locale}`
+    : `/preview/${decision.slug}`;
   return withEmbedFrameCsp(
     NextResponse.rewrite(new URL(destination, request.url), {
       request: { headers: upstreamHeaders },
@@ -99,5 +133,7 @@ export async function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/", "/:locale([a-zA-Z]{2})", "/preview/:path*"],
+  matcher: [
+    "/((?!_next/static|_next/image|_next/webpack-hmr|.*\\.(?:png|jpg|jpeg|gif|svg|webp|ico|css|js|map|woff|woff2)$).*)",
+  ],
 };


### PR DESCRIPTION
## Summary
- isolate every customer hostname from owner/operator surfaces and route only immutable published snapshots
- claim apex + www atomically, canonicalize www, and reconcile LIVE/CLAIMED status from verified DNS + a valid published version
- expose safe DNS/TLS readiness in the customer dashboard and add authorized audited domain removal

## Verification
- `bun test` — 215 pass, 11 database-gated skips, 0 fail
- `bunx next typegen && bunx tsc --noEmit` — pass
- focused ESLint on all changed TypeScript/TSX — pass
- `git diff --check` — pass
- `bun run build` reached optimized Turbopack compilation but did not complete locally after 90 seconds; PR CI owns the production build gate

Refs #15