### PR TITLE
feat: finish the owner integration editor

### DIFF
--- a/prisma/migrations/20260727080000_version_owner_draft_saves/migration.sql
+++ b/prisma/migrations/20260727080000_version_owner_draft_saves/migration.sql
@@ -1,0 +1,5 @@
+-- Every owner save advances a monotonic private-draft revision. Published
+-- versions remain immutable SiteVersion rows; this revision makes pre-publish
+-- edits independently auditable without pretending they are live releases.
+ALTER TABLE "Site"
+ADD COLUMN "draftRevision" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -127,6 +127,7 @@ model Site {
   draftPalette           Json              @default("{}")
   vertical               Vertical          @default(RESTAURANT)
   attributes             Json              @default("{}")
+  draftRevision          Int               @default(0)
   status                 SiteStatus        @default(PROSPECT)
   publishedSiteVersionId String?           @unique
   publishedSiteVersion   SiteVersion?      @relation("PublishedSiteVersion", fields: [publishedSiteVersionId], references: [id], onDelete: SetNull)

--- a/src/app/api/sites/[slug]/route.ts
+++ b/src/app/api/sites/[slug]/route.ts
@@ -4,12 +4,16 @@ import {
   getSiteAccess,
 } from "@/lib/authorization";
 import { fromRestaurantDraft, restaurantDraftSchema } from "@/lib/restaurant";
+import { isSameOriginMutation } from "@/lib/request-origin";
 import { updateSiteDraft } from "@/lib/site-persistence";
 
 export async function PUT(
   request: Request,
   { params }: RouteContext<"/api/sites/[slug]">,
 ) {
+  if (!isSameOriginMutation(request, { requireOrigin: true })) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
   const { slug } = await params;
   const access = await getSiteAccess(slug);
   if (!access.ok) return accessFailureResponse(access);
@@ -18,12 +22,17 @@ export async function PUT(
     const draft = restaurantDraftSchema.parse(await request.json());
     // Same column and relation mapping as the import path, so an owner edit can
     // never write a shape the read path refuses to parse.
-    await updateSiteDraft(
+    const saved = await updateSiteDraft(
       slug,
       fromRestaurantDraft(draft),
       Vertical.RESTAURANT,
+      { actor: access.user },
     );
-    return Response.json({ ok: true, persisted: true });
+    return Response.json({
+      ok: true,
+      persisted: true,
+      revision: saved.revision,
+    });
   } catch (error) {
     return Response.json(
       {

--- a/src/app/api/sites/[slug]/translations/[locale]/regenerate/route.ts
+++ b/src/app/api/sites/[slug]/translations/[locale]/regenerate/route.ts
@@ -1,9 +1,9 @@
 import { accessFailureResponse, getSiteAccess } from "@/lib/authorization";
 import { regenerateRestaurantTranslation } from "@/lib/ai/site-generation";
 import { fromRestaurantDraft, localeSchema } from "@/lib/restaurant";
+import { isSameOriginMutation } from "@/lib/request-origin";
 import { getRestaurantDraft } from "@/lib/restaurants";
 import { limitTranslationRegeneration } from "@/lib/rate-limit";
-import { isSameOriginMutation } from "@/lib/request-origin";
 import { updateSiteDraft } from "@/lib/site-persistence";
 
 export const runtime = "nodejs";
@@ -55,6 +55,10 @@ export async function POST(
       access.site.slug,
       fromRestaurantDraft(regenerated),
       access.site.vertical,
+      {
+        actor: access.user,
+        auditType: "site.translation.regenerated",
+      },
     );
     return Response.json({ ok: true, draft: regenerated });
   } catch (error) {

--- a/src/app/dashboard/dashboard.tsx
+++ b/src/app/dashboard/dashboard.tsx
@@ -17,7 +17,6 @@ import {
   LoaderCircle,
   Mail,
   MoreHorizontal,
-  Plus,
   RefreshCcw,
   Rocket,
   Save,
@@ -30,6 +29,7 @@ import {
   ClientAnalyticsPanel,
   ClientBookingRequestInbox,
 } from "@/components/client-workspace";
+import { RestaurantIntegrationEditor } from "@/components/restaurant-integration-editor";
 import { RestaurantMenuEditor } from "@/components/restaurant-menu-editor";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -47,6 +47,11 @@ import {
   restaurantDraftSchema,
   type RestaurantDraft,
 } from "@/lib/restaurant";
+import {
+  applyRestaurantIntegrationMutation,
+  validateRestaurantIntegrations,
+  type RestaurantIntegrationMutation,
+} from "@/lib/restaurant-integration-editor";
 import {
   applyRestaurantMenuMutation,
   hasUnreviewedRestaurantTranslations,
@@ -90,6 +95,7 @@ export function Dashboard({
   const [draft, setDraft] = useState(initialDraft);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
+  const [savedRevision, setSavedRevision] = useState<number | null>(null);
   const [publishing, setPublishing] = useState(false);
   const [publishedVersion, setPublishedVersion] = useState<number | null>(null);
   const [publishError, setPublishError] = useState<string | null>(null);
@@ -105,21 +111,42 @@ export function Dashboard({
     ReturnType<typeof validateRestaurantMenuDraft>
   >([]);
   const [menuUndoStack, setMenuUndoStack] = useState<RestaurantDraft[]>([]);
+  const [integrationDirty, setIntegrationDirty] = useState(false);
+  const [integrationSaveError, setIntegrationSaveError] = useState<
+    string | null
+  >(null);
+  const [integrationValidationIssues, setIntegrationValidationIssues] =
+    useState<ReturnType<typeof validateRestaurantIntegrations>>([]);
+  const [integrationUndoStack, setIntegrationUndoStack] = useState<
+    RestaurantDraft[]
+  >([]);
   const [regeneratingLocale, setRegeneratingLocale] = useState<string | null>(
     null,
   );
 
   async function save(): Promise<boolean> {
     const validationIssues = validateRestaurantMenuDraft(draft);
+    const integrationIssues = validateRestaurantIntegrations(draft);
     setMenuValidationIssues(validationIssues);
-    if (validationIssues.length > 0) {
-      setMenuSaveError("The menu contains invalid or incomplete fields");
+    setIntegrationValidationIssues(integrationIssues);
+    if (validationIssues.length > 0 || integrationIssues.length > 0) {
+      setMenuSaveError(
+        validationIssues.length > 0
+          ? "The menu contains invalid or incomplete fields"
+          : "Fix the integration labels before saving this draft",
+      );
+      setIntegrationSaveError(
+        integrationIssues.length > 0
+          ? "One or more external links are invalid or incomplete"
+          : "Fix the invalid menu fields before saving these links",
+      );
       return false;
     }
     setSaving(true);
     setSaved(false);
     setPublishError(null);
     setMenuSaveError(null);
+    setIntegrationSaveError(null);
     try {
       if (!demo) {
         const response = await fetch(`/api/sites/${draft.slug}`, {
@@ -129,20 +156,25 @@ export function Dashboard({
         });
         const result = (await response.json()) as {
           error?: string;
+          revision?: number;
         };
         if (!response.ok) {
           throw new Error(result.error ?? "Save failed");
         }
+        setSavedRevision(result.revision ?? null);
       }
       setSaved(true);
       setMenuDirty(false);
+      setIntegrationDirty(false);
       setMenuValidationIssues([]);
+      setIntegrationValidationIssues([]);
       setPublishedVersion(null);
       return true;
     } catch (caught) {
       const message = caught instanceof Error ? caught.message : "Save failed";
       setPublishError(message);
       setMenuSaveError(message);
+      setIntegrationSaveError(message);
       return false;
     } finally {
       setSaving(false);
@@ -182,6 +214,7 @@ export function Dashboard({
       if (demo) {
         setPublishedVersion(1);
         setMenuUndoStack([]);
+        setIntegrationUndoStack([]);
         return;
       }
 
@@ -199,6 +232,7 @@ export function Dashboard({
       }
       setPublishedVersion(result.published.version);
       setMenuUndoStack([]);
+      setIntegrationUndoStack([]);
     } catch (caught) {
       setPublishError(
         caught instanceof Error ? caught.message : "Publish failed",
@@ -260,9 +294,9 @@ export function Dashboard({
   }
 
   async function regenerateTranslation(locale: string) {
-    if (menuDirty) {
+    if (menuDirty || integrationDirty) {
       setMenuSaveError(
-        "Save canonical changes before regenerating a translation",
+        "Save canonical menu and integration changes before regenerating a translation",
       );
       return;
     }
@@ -287,7 +321,9 @@ export function Dashboard({
       }));
       setSaved(true);
       setMenuDirty(false);
+      setIntegrationDirty(false);
       setMenuValidationIssues([]);
+      setIntegrationValidationIssues([]);
     } catch (error) {
       setMenuSaveError(
         error instanceof Error
@@ -308,6 +344,81 @@ export function Dashboard({
     setSaved(false);
     setMenuSaveError(null);
     setMenuValidationIssues([]);
+  }
+
+  function mutateIntegration(
+    mutation: RestaurantIntegrationMutation,
+    destructive = false,
+  ) {
+    try {
+      if (destructive) {
+        setIntegrationUndoStack((current) => [
+          ...current,
+          structuredClone(draft),
+        ]);
+      }
+      const next = applyRestaurantIntegrationMutation(draft, mutation);
+      setDraft(next);
+      setIntegrationDirty(true);
+      setSaved(false);
+      setIntegrationSaveError(null);
+      setIntegrationValidationIssues(
+        validateRestaurantIntegrations(next),
+      );
+    } catch (error) {
+      setIntegrationSaveError(
+        error instanceof Error
+          ? error.message
+          : "Integration change failed",
+      );
+    }
+  }
+
+  function changeIntegrationTranslationLabel(
+    locale: string,
+    integrationIndex: number,
+    label: string,
+  ) {
+    const next = updateRestaurantTranslation(
+      draft,
+      locale,
+      (translation) => {
+        translation.integrationLabels[integrationIndex] = label;
+      },
+    );
+    setDraft(next);
+    setIntegrationDirty(true);
+    setSaved(false);
+    setIntegrationSaveError(null);
+    setIntegrationValidationIssues(
+      validateRestaurantIntegrations(next),
+    );
+  }
+
+  function reviewIntegrationTranslation(locale: string) {
+    try {
+      const next = markRestaurantTranslationReviewed(draft, locale);
+      setDraft(next);
+      setIntegrationDirty(true);
+      setSaved(false);
+      setIntegrationSaveError(null);
+      setIntegrationValidationIssues([]);
+    } catch {
+      setIntegrationSaveError(
+        "Fix every translated label before marking this locale reviewed",
+      );
+    }
+  }
+
+  function undoIntegrationRemoval() {
+    const previous = integrationUndoStack.at(-1);
+    if (!previous) return;
+    setDraft(previous);
+    setIntegrationUndoStack((current) => current.slice(0, -1));
+    setIntegrationDirty(true);
+    setSaved(false);
+    setIntegrationSaveError(null);
+    setIntegrationValidationIssues([]);
   }
 
   async function connectDomain() {
@@ -782,47 +893,22 @@ export function Dashboard({
             </TabsContent>
 
             <TabsContent value="integrations" className="mt-0">
-              <PageHeading
-                eyebrow="Existing systems"
-                title="Keep what already works."
-                copy="Cornershopdev sends guests to the restaurant's current booking, ordering and delivery providers."
+              <RestaurantIntegrationEditor
+                draft={draft}
+                dirty={integrationDirty}
+                saving={saving}
+                saveError={integrationSaveError}
+                validationIssues={integrationValidationIssues}
+                savedRevision={savedRevision}
+                canUndo={integrationUndoStack.length > 0}
+                onMutation={mutateIntegration}
+                onTranslationLabelChange={
+                  changeIntegrationTranslationLabel
+                }
+                onReviewTranslation={reviewIntegrationTranslation}
+                onUndo={undoIntegrationRemoval}
+                onSave={() => void save()}
               />
-              <div className="mt-8 grid gap-4">
-                {draft.integrations.map((integration) => (
-                  <Card key={integration.url}>
-                    <CardContent className="flex items-center gap-4 pt-6">
-                      <span className="grid size-10 place-items-center rounded-xl bg-muted">
-                        <Link2 className="size-4" />
-                      </span>
-                      <div className="min-w-0 flex-1">
-                        <div className="flex items-center gap-2">
-                          <p className="font-medium">{integration.label}</p>
-                          <Badge variant="secondary" className="text-[10px]">
-                            {integration.type}
-                          </Badge>
-                        </div>
-                        <p className="truncate text-xs text-muted-foreground">
-                          {integration.provider ?? "External provider"} ·{" "}
-                          {integration.url}
-                        </p>
-                      </div>
-                      <Switch defaultChecked />
-                      <Button
-                        render={
-                          <Link href={integration.url} target="_blank" />
-                        }
-                        variant="ghost"
-                        size="icon-sm"
-                      >
-                        <ExternalLink />
-                      </Button>
-                    </CardContent>
-                  </Card>
-                ))}
-                <Button variant="outline" className="h-14 border-dashed">
-                  <Plus /> Add another link
-                </Button>
-              </div>
             </TabsContent>
 
             <TabsContent value="domain" className="mt-0">

--- a/src/components/restaurant-integration-editor.tsx
+++ b/src/components/restaurant-integration-editor.tsx
@@ -1,0 +1,487 @@
+"use client";
+
+import { useState } from "react";
+import {
+  AlertTriangle,
+  ArrowDown,
+  ArrowUp,
+  Check,
+  ExternalLink,
+  Link2,
+  LoaderCircle,
+  Plus,
+  Save,
+  Trash2,
+  Undo2,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import type { RestaurantDraft } from "@/lib/restaurant";
+import {
+  integrationPlacement,
+  RESTAURANT_INTEGRATION_TYPES,
+  type RestaurantIntegrationMutation,
+} from "@/lib/restaurant-integration-editor";
+import type { MenuValidationIssue } from "@/lib/restaurant-menu-editor";
+import { restaurantIntegrationSchema } from "@/lib/verticals/restaurant/schema";
+
+export function RestaurantIntegrationEditor({
+  draft,
+  dirty,
+  saving,
+  saveError,
+  validationIssues,
+  savedRevision,
+  canUndo,
+  onMutation,
+  onTranslationLabelChange,
+  onReviewTranslation,
+  onUndo,
+  onSave,
+}: {
+  draft: RestaurantDraft;
+  dirty: boolean;
+  saving: boolean;
+  saveError: string | null;
+  validationIssues: MenuValidationIssue[];
+  savedRevision: number | null;
+  canUndo: boolean;
+  onMutation: (
+    mutation: RestaurantIntegrationMutation,
+    destructive?: boolean,
+  ) => void;
+  onTranslationLabelChange: (
+    locale: string,
+    integrationIndex: number,
+    label: string,
+  ) => void;
+  onReviewTranslation: (locale: string) => void;
+  onUndo: () => void;
+  onSave: () => void;
+}) {
+  const [activeLocale, setActiveLocale] = useState(draft.defaultLocale);
+  const translation = draft.translations.find(
+    (candidate) => candidate.locale === activeLocale,
+  );
+  const canonical = activeLocale === draft.defaultLocale;
+
+  return (
+    <div>
+      <div className="flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-primary">
+            Existing systems
+          </p>
+          <h1 className="font-display mt-2 text-5xl leading-none tracking-[-0.045em]">
+            Keep what already works.
+          </h1>
+          <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+            Maintain safe link-outs to booking, ordering and delivery. Nothing
+            here migrates customer or reservation data.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={!canUndo}
+            onClick={onUndo}
+          >
+            <Undo2 /> Undo removal
+          </Button>
+          <Button size="sm" disabled={saving || !dirty} onClick={onSave}>
+            {saving ? <LoaderCircle className="animate-spin" /> : <Save />}
+            {dirty ? "Save links" : "Saved"}
+          </Button>
+        </div>
+      </div>
+
+      <Card className="mt-8">
+        <CardContent className="flex flex-col gap-4 pt-6 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-wrap gap-2" aria-label="Integration locale">
+            <Button
+              size="sm"
+              variant={canonical ? "default" : "outline"}
+              onClick={() => setActiveLocale(draft.defaultLocale)}
+            >
+              {draft.defaultLocale.toUpperCase()} · canonical
+            </Button>
+            {draft.translations.map((candidate) => (
+              <Button
+                key={candidate.locale}
+                size="sm"
+                variant={
+                  candidate.locale === activeLocale ? "default" : "outline"
+                }
+                onClick={() => setActiveLocale(candidate.locale)}
+              >
+                {candidate.locale.toUpperCase()}
+                {candidate.status !== "current" ? (
+                  <span className="size-2 rounded-full bg-amber-400" />
+                ) : null}
+              </Button>
+            ))}
+          </div>
+          <Badge variant={dirty ? "outline" : "secondary"}>
+            {dirty
+              ? "Unsaved changes"
+              : savedRevision
+                ? `Draft revision ${savedRevision}`
+                : "Draft saved"}
+          </Badge>
+        </CardContent>
+      </Card>
+
+      {saveError ? (
+        <div className="mt-4 flex items-center justify-between gap-4 rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-900">
+          <span className="flex items-center gap-2">
+            <AlertTriangle className="size-4" /> {saveError}
+          </span>
+          <Button variant="outline" size="sm" onClick={onSave}>
+            Retry
+          </Button>
+        </div>
+      ) : null}
+
+      {validationIssues.length > 0 ? (
+        <div className="mt-4 rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-950">
+          <p className="font-semibold">Fix these links before saving:</p>
+          <ul className="mt-2 list-disc space-y-1 pl-5">
+            {validationIssues.slice(0, 8).map((issue) => (
+              <li key={`${issue.path}-${issue.message}`}>
+                {issue.path}: {issue.message}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {!canonical && translation ? (
+        <Card className="mt-5 border-amber-200">
+          <CardContent className="flex flex-col gap-4 pt-6 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="font-semibold">
+                {translation.locale.toUpperCase()} customer labels
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Link type, destination, provider and availability stay
+                canonical. Only customer-facing labels are localized.
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <Badge variant="outline">{translation.status}</Badge>
+              <Button
+                size="sm"
+                disabled={translation.status === "current"}
+                onClick={() => onReviewTranslation(translation.locale)}
+              >
+                <Check /> Mark reviewed
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      ) : null}
+
+      <div className="mt-5 grid gap-5 xl:grid-cols-[minmax(0,1fr)_280px]">
+        <div className="space-y-4">
+          {draft.integrations.map((integration, integrationIndex) => (
+            <Card
+              key={`${activeLocale}-${integrationIndex}`}
+              className={!integration.enabled ? "opacity-70" : undefined}
+            >
+              <CardHeader className="flex-row items-start justify-between gap-4">
+                <div className="flex items-center gap-3">
+                  <span className="grid size-10 place-items-center rounded-xl bg-muted">
+                    <Link2 className="size-4" />
+                  </span>
+                  <div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="font-medium">
+                        {canonical
+                          ? integration.label
+                          : translation?.integrationLabels[
+                              integrationIndex
+                            ] ?? integration.label}
+                      </p>
+                      <Badge variant="secondary">
+                        {integration.type}
+                      </Badge>
+                      {!integration.enabled ? (
+                        <Badge variant="outline">Hidden publicly</Badge>
+                      ) : null}
+                    </div>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {integrationPlacement(integration.type).label}
+                    </p>
+                  </div>
+                </div>
+                {canonical ? (
+                  <Switch
+                    aria-label={`Show ${integration.label} publicly`}
+                    checked={integration.enabled}
+                    onCheckedChange={(enabled) =>
+                      onMutation({
+                        type: "update",
+                        integrationIndex,
+                        changes: { enabled },
+                      })
+                    }
+                  />
+                ) : null}
+              </CardHeader>
+              <CardContent>
+                {canonical ? (
+                  <>
+                    <div className="grid gap-4 md:grid-cols-2">
+                      <Field
+                        label="Link type"
+                        htmlFor={`integration-type-${integrationIndex}`}
+                      >
+                        <select
+                          id={`integration-type-${integrationIndex}`}
+                          className="border-input bg-background h-9 w-full rounded-md border px-3 text-sm"
+                          value={integration.type}
+                          onChange={(event) =>
+                            onMutation({
+                              type: "update",
+                              integrationIndex,
+                              changes: {
+                                type: event.target
+                                  .value as typeof integration.type,
+                              },
+                            })
+                          }
+                        >
+                          {RESTAURANT_INTEGRATION_TYPES.map((type) => (
+                            <option key={type}>{type}</option>
+                          ))}
+                        </select>
+                      </Field>
+                      <Field
+                        label="Customer-facing label"
+                        htmlFor={`integration-label-${integrationIndex}`}
+                      >
+                        <Input
+                          id={`integration-label-${integrationIndex}`}
+                          value={integration.label}
+                          onChange={(event) =>
+                            onMutation({
+                              type: "update",
+                              integrationIndex,
+                              changes: { label: event.target.value },
+                            })
+                          }
+                        />
+                      </Field>
+                    </div>
+                    <div className="mt-4 grid gap-4 md:grid-cols-[1fr_180px]">
+                      <Field
+                        label="HTTPS destination"
+                        htmlFor={`integration-url-${integrationIndex}`}
+                      >
+                        <Input
+                          id={`integration-url-${integrationIndex}`}
+                          type="url"
+                          inputMode="url"
+                          value={integration.url}
+                          placeholder="https://provider.example/venue"
+                          onChange={(event) =>
+                            onMutation({
+                              type: "update",
+                              integrationIndex,
+                              changes: { url: event.target.value },
+                            })
+                          }
+                        />
+                      </Field>
+                      <Field label="Provider identity">
+                        <div className="flex h-9 items-center rounded-md border bg-muted/40 px-3 text-sm">
+                          {integration.provider ?? "Independent link"}
+                        </div>
+                      </Field>
+                    </div>
+                    <div className="mt-4 flex flex-wrap items-center gap-2">
+                      <Button
+                        variant="outline"
+                        size="icon-sm"
+                        aria-label={`Move ${integration.label} up`}
+                        disabled={integrationIndex === 0}
+                        onClick={() =>
+                          onMutation({
+                            type: "move",
+                            integrationIndex,
+                            direction: -1,
+                          })
+                        }
+                      >
+                        <ArrowUp />
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="icon-sm"
+                        aria-label={`Move ${integration.label} down`}
+                        disabled={
+                          integrationIndex ===
+                          draft.integrations.length - 1
+                        }
+                        onClick={() =>
+                          onMutation({
+                            type: "move",
+                            integrationIndex,
+                            direction: 1,
+                          })
+                        }
+                      >
+                        <ArrowDown />
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() =>
+                          onMutation(
+                            { type: "remove", integrationIndex },
+                            true,
+                          )
+                        }
+                      >
+                        <Trash2 /> Remove
+                      </Button>
+                      {restaurantIntegrationSchema.safeParse(integration)
+                        .success ? (
+                        <Button
+                          render={
+                            <a
+                              href={integration.url}
+                              target="_blank"
+                              rel="noreferrer"
+                            />
+                          }
+                          variant="ghost"
+                          size="sm"
+                        >
+                          Test link <ExternalLink />
+                        </Button>
+                      ) : null}
+                    </div>
+                  </>
+                ) : (
+                  <Field
+                    label="Localized customer-facing label"
+                    htmlFor={`translated-integration-${integrationIndex}`}
+                  >
+                    <Input
+                      id={`translated-integration-${integrationIndex}`}
+                      value={
+                        translation?.integrationLabels[integrationIndex] ??
+                        integration.label
+                      }
+                      onChange={(event) =>
+                        onTranslationLabelChange(
+                          activeLocale,
+                          integrationIndex,
+                          event.target.value,
+                        )
+                      }
+                    />
+                  </Field>
+                )}
+              </CardContent>
+            </Card>
+          ))}
+
+          {canonical ? (
+            <div className="grid gap-2 sm:grid-cols-4">
+              {RESTAURANT_INTEGRATION_TYPES.map((type) => (
+                <Button
+                  key={type}
+                  variant="outline"
+                  className="h-12 border-dashed"
+                  disabled={draft.integrations.length >= 12}
+                  onClick={() =>
+                    onMutation({ type: "add", integrationType: type })
+                  }
+                >
+                  <Plus /> Add {type}
+                </Button>
+              ))}
+            </div>
+          ) : null}
+        </div>
+
+        <Card className="h-fit xl:sticky xl:top-6">
+          <CardHeader>
+            <p className="font-semibold">Placement preview</p>
+            <p className="text-xs leading-5 text-muted-foreground">
+              Enabled links occupy these public-site regions. Exact styling
+              follows the selected restaurant theme.
+            </p>
+          </CardHeader>
+          <CardContent>
+            <div className="overflow-hidden rounded-xl border bg-muted/20">
+              {(["header", "content", "footer"] as const).map((region) => {
+                const links = draft.integrations.filter(
+                  (integration) =>
+                    integration.enabled &&
+                    integrationPlacement(integration.type).regions.includes(
+                      region,
+                    ),
+                );
+                return (
+                  <div
+                    key={region}
+                    className="border-b p-4 last:border-b-0"
+                  >
+                    <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                      {region}
+                    </p>
+                    <div className="mt-2 flex flex-wrap gap-1.5">
+                      {links.length ? (
+                        links.map((integration, index) => (
+                          <Badge
+                            key={`${integration.type}-${index}`}
+                            variant="secondary"
+                          >
+                            {integration.label}
+                          </Badge>
+                        ))
+                      ) : (
+                        <span className="text-xs text-muted-foreground">
+                          No external action
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+            <p className="mt-3 text-xs leading-5 text-muted-foreground">
+              Social links must use an approved provider. Operational links may
+              point to the restaurant’s independent HTTPS system.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  htmlFor,
+  children,
+}: {
+  label: string;
+  htmlFor?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor={htmlFor}>{label}</Label>
+      {children}
+    </div>
+  );
+}

--- a/src/components/restaurant-themes/after-dark.tsx
+++ b/src/components/restaurant-themes/after-dark.tsx
@@ -24,10 +24,12 @@ export function AfterDarkTheme({
   analyticsEnabled = false,
 }: RestaurantThemeRendererProps) {
   const booking = draft.integrations.find(
-    (integration) => integration.type === "booking",
+    (integration) =>
+      integration.enabled && integration.type === "booking",
   );
   const eventLink = draft.integrations.find(
-    (integration) => integration.type === "social",
+    (integration) =>
+      integration.enabled && integration.type === "social",
   );
   const tokens = selection.tokens;
 

--- a/src/components/restaurant-themes/counter-service.tsx
+++ b/src/components/restaurant-themes/counter-service.tsx
@@ -22,8 +22,10 @@ export function CounterServiceTheme({
   embedded = false,
   analyticsEnabled = false,
 }: RestaurantThemeRendererProps) {
-  const ordering = draft.integrations.find((integration) =>
-    ["ordering", "delivery"].includes(integration.type),
+  const ordering = draft.integrations.find(
+    (integration) =>
+      integration.enabled &&
+      ["ordering", "delivery"].includes(integration.type),
   );
   const tokens = selection.tokens;
 

--- a/src/components/restaurant-themes/terroir-editorial.tsx
+++ b/src/components/restaurant-themes/terroir-editorial.tsx
@@ -23,10 +23,12 @@ export function TerroirEditorialTheme({
   analyticsEnabled = false,
 }: RestaurantThemeRendererProps) {
   const booking = draft.integrations.find(
-    (integration) => integration.type === "booking",
+    (integration) =>
+      integration.enabled && integration.type === "booking",
   );
   const supportingLinks = draft.integrations.filter(
-    (integration) => integration !== booking,
+    (integration) =>
+      integration.enabled && integration !== booking,
   );
   const tokens = selection.tokens;
 

--- a/src/components/site-renderer.tsx
+++ b/src/components/site-renderer.tsx
@@ -81,10 +81,13 @@ export function SiteRenderer({
   }
 
   const booking = draft.integrations.find(
-    (integration) => integration.type === "booking",
+    (integration) =>
+      integration.enabled && integration.type === "booking",
   );
-  const ordering = draft.integrations.find((integration) =>
-    ["ordering", "delivery"].includes(integration.type),
+  const ordering = draft.integrations.find(
+    (integration) =>
+      integration.enabled &&
+      ["ordering", "delivery"].includes(integration.type),
   );
   const resolvedTemplate = config.templates.resolve(draft.attributes);
   const template = theme

--- a/src/lib/booking-embed.test.ts
+++ b/src/lib/booking-embed.test.ts
@@ -23,6 +23,7 @@ function bookingIntegration(
     label: "Reserve a table",
     provider: "OpenTable",
     url: "https://www.opentable.com/r/le-petit-meunier?rid=123456",
+    enabled: true,
     venueId: null,
     ...overrides,
   };
@@ -138,19 +139,16 @@ describe("booking embed — degrades to a link-out", () => {
   });
 
   /**
-   * The inverse of the above, and the reason `buildSrc` is a literal template
-   * rather than anything derived from the input URL. A hostile URL *can* satisfy
-   * the loose `/opentable/i` provider pattern by containing the word; what it
-   * cannot do is move the frame off the origin the descriptor declared.
+   * Provider matching is hostname-anchored. A hostile URL cannot select an
+   * embed merely by placing a trusted provider name in its path.
    */
-  it("keeps the frame on the declared origin even when the URL only looks like the provider", () => {
+  it("does not frame a hostname whose path only looks like the provider", () => {
     const embed = resolveBookingEmbed(
       Vertical.RESTAURANT,
       bookingIntegration({ url: "https://evil.example.com/opentable?rid=7" }),
     );
 
-    expect(new URL(embed!.src).origin).toBe("https://www.opentable.com");
-    expect(embed!.src).not.toContain("evil.example.com");
+    expect(embed).toBeNull();
   });
 
   /**

--- a/src/lib/booking-embed.ts
+++ b/src/lib/booking-embed.ts
@@ -31,11 +31,20 @@ export function resolveBookingEmbed(
   vertical: VerticalId,
   integration: SiteIntegrationView,
 ): ResolvedBookingEmbed | null {
-  if (integration.type !== "booking") return null;
+  if (!integration.enabled || integration.type !== "booking") return null;
 
   const config = resolveVerticalConfig(vertical);
+  let hostname: string;
+  try {
+    hostname = new URL(integration.url).hostname;
+  } catch {
+    return null;
+  }
   const provider = config.providers.find(
-    (candidate) => candidate.embed && candidate.pattern.test(integration.url),
+    (candidate) =>
+      candidate.embed &&
+      (candidate.hostnamePattern?.test(hostname) ??
+        candidate.pattern.test(hostname)),
   );
   const embed = provider?.embed;
   if (!provider || !embed) return null;

--- a/src/lib/integration-save-authorization.test.ts
+++ b/src/lib/integration-save-authorization.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "bun:test";
+import {
+  createAuthorizationPolicy,
+  type AuthorizationAdapter,
+} from "@/lib/authorization-policy";
+import { isSameOriginMutation } from "@/lib/request-origin";
+
+describe("owner integration save boundary", () => {
+  it("rejects a slug outside the signed-in owner's site before any tenant read", async () => {
+    let queried = false;
+    const policy = createAuthorizationPolicy(
+      adapter({
+        onFindSite: () => {
+          queried = true;
+        },
+      }),
+    );
+
+    expect(await policy.getSiteAccess("another-restaurant")).toMatchObject({
+      ok: false,
+      status: 403,
+    });
+    expect(queried).toBe(false);
+  });
+
+  it("revalidates current membership for the exact site on every save", async () => {
+    const policy = createAuthorizationPolicy(adapter({ member: false }));
+
+    expect(await policy.getSiteAccess("osteria-luna")).toMatchObject({
+      ok: false,
+      status: 403,
+    });
+  });
+
+  it("requires a same-origin browser mutation for cookie-authorized saves", () => {
+    const crossSite = new Request(
+      "https://cornershop.dev/api/sites/osteria-luna",
+      {
+        method: "PUT",
+        headers: {
+          origin: "https://attacker.example",
+          "sec-fetch-site": "cross-site",
+        },
+      },
+    );
+    const sameSite = new Request(
+      "https://cornershop.dev/api/sites/osteria-luna",
+      {
+        method: "PUT",
+        headers: { origin: "https://cornershop.dev" },
+      },
+    );
+
+    expect(isSameOriginMutation(crossSite, { requireOrigin: true })).toBe(
+      false,
+    );
+    expect(isSameOriginMutation(sameSite, { requireOrigin: true })).toBe(true);
+  });
+});
+
+function adapter({
+  member = true,
+  onFindSite,
+}: {
+  member?: boolean;
+  onFindSite?: () => void;
+} = {}): AuthorizationAdapter {
+  return {
+    isDatabaseConfigured: () => true,
+    getSession: async () => ({
+      userId: "owner_1",
+      siteSlug: "osteria-luna",
+    }),
+    findSiteForMember: async () => {
+      onFindSite?.();
+      return member
+        ? {
+            id: "site_1",
+            slug: "osteria-luna",
+            vertical: "RESTAURANT",
+            organizationId: "org_1",
+            user: { id: "owner_1", email: "owner@example.com" },
+          }
+        : null;
+    },
+    findUser: async () => ({
+      id: "owner_1",
+      email: "owner@example.com",
+      platformRole: "USER",
+    }),
+    isSuperadminEmail: () => false,
+  };
+}

--- a/src/lib/restaurant-integration-editor.test.ts
+++ b/src/lib/restaurant-integration-editor.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "bun:test";
+import {
+  restaurantDraftSchema,
+  sampleRestaurant,
+} from "@/lib/restaurant";
+import {
+  applyRestaurantIntegrationMutation,
+  integrationPlacement,
+  validateRestaurantIntegrations,
+} from "@/lib/restaurant-integration-editor";
+
+function multilingualDraft() {
+  return restaurantDraftSchema.parse({
+    ...sampleRestaurant,
+    defaultLocale: "fr",
+    translations: [
+      {
+        locale: "en",
+        status: "current",
+        cuisine: sampleRestaurant.cuisine,
+        eyebrow: sampleRestaurant.eyebrow,
+        description: sampleRestaurant.description,
+        menuSections: sampleRestaurant.menuSections.map((section) => ({
+          name: section.name,
+          description: section.description,
+          items: section.items.map((item) => ({
+            name: item.name,
+            description: item.description,
+            dietaryLabels: item.dietaryLabels,
+          })),
+        })),
+        integrationLabels: sampleRestaurant.integrations.map(
+          (integration) => integration.label,
+        ),
+      },
+    ],
+  });
+}
+
+describe("restaurant integration editor", () => {
+  it("keeps localized labels aligned through add, reorder and removal", () => {
+    let draft = multilingualDraft();
+    draft = applyRestaurantIntegrationMutation(draft, {
+      type: "add",
+      integrationType: "delivery",
+    });
+    draft = applyRestaurantIntegrationMutation(draft, {
+      type: "update",
+      integrationIndex: 2,
+      changes: {
+        label: "Deliver dinner",
+        url: "https://deliveroo.com/menu/valletta/osteria-luna",
+      },
+    });
+    draft = applyRestaurantIntegrationMutation(draft, {
+      type: "move",
+      integrationIndex: 2,
+      direction: -1,
+    });
+    draft = applyRestaurantIntegrationMutation(draft, {
+      type: "remove",
+      integrationIndex: 0,
+    });
+
+    expect(restaurantDraftSchema.parse(draft)).toEqual(draft);
+    expect(draft.translations[0].status).toBe("stale");
+    expect(draft.translations[0].integrationLabels).toHaveLength(
+      draft.integrations.length,
+    );
+    expect(draft.integrations[0]).toMatchObject({
+      provider: "Deliveroo",
+      type: "delivery",
+    });
+  });
+
+  it("keeps disabled links recoverable without making translations stale", () => {
+    const draft = multilingualDraft();
+    const disabled = applyRestaurantIntegrationMutation(draft, {
+      type: "update",
+      integrationIndex: 0,
+      changes: { enabled: false },
+    });
+
+    expect(disabled.integrations[0].enabled).toBe(false);
+    expect(disabled.translations[0].status).toBe("current");
+    expect(disabled.integrations[0]).toMatchObject({
+      type: draft.integrations[0].type,
+      label: draft.integrations[0].label,
+      provider: draft.integrations[0].provider,
+      url: draft.integrations[0].url,
+    });
+  });
+
+  it("rejects unsafe URLs, provider impersonation and unapproved social links", () => {
+    const unsafeUrls = [
+      "http://instagram.com/osteria",
+      "https://user:secret@instagram.com/osteria",
+      "https://localhost/restaurant",
+      "https://127.0.0.1/restaurant",
+      "https://instagram.com:8443/osteria",
+    ];
+    for (const url of unsafeUrls) {
+      const draft = {
+        ...sampleRestaurant,
+        integrations: [
+          {
+            type: "social" as const,
+            label: "Follow us",
+            provider: "Instagram",
+            url,
+            enabled: true,
+            venueId: null,
+          },
+        ],
+      };
+      expect(validateRestaurantIntegrations(draft).length).toBeGreaterThan(0);
+    }
+
+    const impersonated = {
+      ...sampleRestaurant,
+      integrations: [
+        {
+          type: "booking" as const,
+          label: "Book",
+          provider: "OpenTable",
+          url: "https://restaurant.example/reservations",
+          enabled: true,
+          venueId: null,
+        },
+      ],
+    };
+    const unapprovedSocial = {
+      ...sampleRestaurant,
+      integrations: [
+        {
+          type: "social" as const,
+          label: "Follow",
+          provider: null,
+          url: "https://social.example/osteria",
+          enabled: true,
+          venueId: null,
+        },
+      ],
+    };
+    const deceptiveSocial = {
+      ...sampleRestaurant,
+      integrations: [
+        {
+          type: "social" as const,
+          label: "Follow",
+          provider: "Instagram",
+          url: "https://instagram.com.attacker.example/osteria",
+          enabled: true,
+          venueId: null,
+        },
+      ],
+    };
+    expect(validateRestaurantIntegrations(impersonated)).not.toEqual([]);
+    expect(validateRestaurantIntegrations(unapprovedSocial)).not.toEqual([]);
+    expect(validateRestaurantIntegrations(deceptiveSocial)).not.toEqual([]);
+  });
+
+  it("normalizes provider identity from the hostname and previews placement", () => {
+    const parsed = restaurantDraftSchema.parse({
+      ...sampleRestaurant,
+      integrations: [
+        {
+          type: "booking",
+          label: "Reserve",
+          provider: null,
+          url: "https://www.opentable.com/r/osteria-luna",
+          enabled: true,
+        },
+      ],
+    });
+
+    expect(parsed.integrations[0].provider).toBe("OpenTable");
+    expect(integrationPlacement("booking").regions).toEqual([
+      "header",
+      "content",
+    ]);
+    expect(integrationPlacement("social").regions).toEqual(["footer"]);
+  });
+});

--- a/src/lib/restaurant-integration-editor.ts
+++ b/src/lib/restaurant-integration-editor.ts
@@ -1,0 +1,200 @@
+import {
+  markRestaurantTranslationsStale,
+  type MenuValidationIssue,
+} from "@/lib/restaurant-menu-editor";
+import type { RestaurantDraft } from "@/lib/restaurant";
+import { restaurantDraftSchema } from "@/lib/restaurant";
+import { findRestaurantProviderByUrl } from "@/lib/verticals/restaurant/providers";
+
+type RestaurantIntegration = RestaurantDraft["integrations"][number];
+
+export const RESTAURANT_INTEGRATION_TYPES = [
+  "booking",
+  "ordering",
+  "delivery",
+  "social",
+] as const;
+
+export type RestaurantIntegrationMutation =
+  | { type: "add"; integrationType: RestaurantIntegration["type"] }
+  | {
+      type: "update";
+      integrationIndex: number;
+      changes: Partial<RestaurantIntegration>;
+    }
+  | { type: "remove"; integrationIndex: number }
+  | {
+      type: "move";
+      integrationIndex: number;
+      direction: -1 | 1;
+    };
+
+export function applyRestaurantIntegrationMutation(
+  input: RestaurantDraft,
+  mutation: RestaurantIntegrationMutation,
+): RestaurantDraft {
+  const draft = structuredClone(input);
+  let translationTextChanged = false;
+
+  switch (mutation.type) {
+    case "add": {
+      const label = defaultIntegrationLabel(mutation.integrationType);
+      draft.integrations.push({
+        type: mutation.integrationType,
+        label,
+        provider: null,
+        url: "",
+        enabled: true,
+        venueId: null,
+      });
+      for (const translation of draft.translations) {
+        translation.integrationLabels.push(label);
+      }
+      translationTextChanged = true;
+      break;
+    }
+    case "update": {
+      const integration = requireIntegration(
+        draft.integrations,
+        mutation.integrationIndex,
+      );
+      const previousUrl = integration.url;
+      const previousProvider = integration.provider;
+      Object.assign(integration, mutation.changes);
+      if (
+        mutation.changes.url !== undefined ||
+        mutation.changes.type !== undefined
+      ) {
+        const matchedProvider = findRestaurantProviderByUrl(integration.url);
+        integration.provider = matchedProvider
+          ? matchedProvider.name
+          : mutation.changes.url !== undefined &&
+              !sameHostname(previousUrl, integration.url)
+            ? null
+            : previousProvider;
+        integration.venueId =
+          integration.type === "booking" &&
+          integration.provider === previousProvider
+            ? integration.venueId
+            : null;
+      }
+      translationTextChanged = mutation.changes.label !== undefined;
+      break;
+    }
+    case "remove": {
+      requireIntegration(draft.integrations, mutation.integrationIndex);
+      draft.integrations.splice(mutation.integrationIndex, 1);
+      for (const translation of draft.translations) {
+        translation.integrationLabels.splice(mutation.integrationIndex, 1);
+      }
+      translationTextChanged = true;
+      break;
+    }
+    case "move": {
+      const targetIndex =
+        mutation.integrationIndex + mutation.direction;
+      requireIntegration(draft.integrations, mutation.integrationIndex);
+      requireIntegration(draft.integrations, targetIndex);
+      move(draft.integrations, mutation.integrationIndex, targetIndex);
+      for (const translation of draft.translations) {
+        move(
+          translation.integrationLabels,
+          mutation.integrationIndex,
+          targetIndex,
+        );
+      }
+      translationTextChanged = true;
+      break;
+    }
+  }
+
+  return translationTextChanged
+    ? markRestaurantTranslationsStale(draft)
+    : draft;
+}
+
+export function validateRestaurantIntegrations(
+  draft: RestaurantDraft,
+): MenuValidationIssue[] {
+  const parsed = restaurantDraftSchema.safeParse(draft);
+  if (parsed.success) return [];
+  return parsed.error.issues
+    .filter(
+      (issue) =>
+        issue.path[0] === "integrations" ||
+        (issue.path[0] === "translations" &&
+          issue.path.includes("integrationLabels")),
+    )
+    .map((issue) => ({
+      path: issue.path.join("."),
+      message: issue.message,
+    }));
+}
+
+export function integrationPlacement(
+  type: RestaurantIntegration["type"],
+): {
+  label: string;
+  regions: Array<"header" | "content" | "footer">;
+} {
+  switch (type) {
+    case "booking":
+      return {
+        label: "Primary reservation action and booking section",
+        regions: ["header", "content"],
+      };
+    case "ordering":
+      return {
+        label: "Order action near the menu and site header",
+        regions: ["header", "content"],
+      };
+    case "delivery":
+      return {
+        label: "Delivery action near the menu and site header",
+        regions: ["header", "content"],
+      };
+    case "social":
+      return {
+        label: "Supporting link; exact position follows the selected theme",
+        regions: ["footer"],
+      };
+  }
+}
+
+function defaultIntegrationLabel(
+  type: RestaurantIntegration["type"],
+): string {
+  switch (type) {
+    case "booking":
+      return "Book a table";
+    case "ordering":
+      return "Order online";
+    case "delivery":
+      return "Get delivery";
+    case "social":
+      return "Follow us";
+  }
+}
+
+function requireIntegration(
+  integrations: RestaurantIntegration[],
+  index: number,
+): RestaurantIntegration {
+  const integration = integrations[index];
+  if (!integration) throw new Error("Integration not found");
+  return integration;
+}
+
+function move<T>(items: T[], from: number, to: number): void {
+  const [item] = items.splice(from, 1);
+  if (item === undefined) throw new Error("Integration not found");
+  items.splice(to, 0, item);
+}
+
+function sameHostname(left: string, right: string): boolean {
+  try {
+    return new URL(left).hostname === new URL(right).hostname;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/restaurant-menu-editor.ts
+++ b/src/lib/restaurant-menu-editor.ts
@@ -236,7 +236,8 @@ export function validateRestaurantMenuDraft(
     .filter(
       (issue) =>
         issue.path[0] === "menuSections" ||
-        issue.path[0] === "translations",
+        (issue.path[0] === "translations" &&
+          issue.path.includes("menuSections")),
     )
     .map((issue) => ({
       path: issue.path.join("."),

--- a/src/lib/site-draft.ts
+++ b/src/lib/site-draft.ts
@@ -51,6 +51,7 @@ export type SiteIntegrationView = {
   label: string;
   provider: string | null;
   url: string;
+  enabled: boolean;
   /**
    * The owner's id inside the provider (an OpenTable `rid`, a Fresha venue).
    * Only meaningful for providers that publish an embeddable widget, and only

--- a/src/lib/site-persistence.ts
+++ b/src/lib/site-persistence.ts
@@ -62,6 +62,7 @@ export type PersistableSiteDraft = {
     label: string;
     provider: string | null;
     url: string;
+    enabled: boolean;
     venueId?: string | null;
   }>;
 };
@@ -71,6 +72,18 @@ export type PersistedSiteImport<TDraft extends PersistableSiteDraft> = {
   importJobId: string;
   urls: ImportUrls;
   created: boolean;
+};
+
+export type OwnerDraftSaveOptions = {
+  actor?: {
+    id: string;
+    email: string;
+  };
+  auditType?: "site.draft.saved" | "site.translation.regenerated";
+};
+
+export type OwnerDraftSaveResult = {
+  revision: number;
 };
 
 export class ImportDatabaseUnavailableError extends Error {
@@ -507,31 +520,53 @@ export async function updateSiteDraft(
   slug: string,
   draft: PersistableSiteDraft,
   vertical: VerticalId,
-): Promise<void> {
+  options: OwnerDraftSaveOptions = {},
+): Promise<OwnerDraftSaveResult> {
   const config = resolveVerticalConfig(vertical);
   const parsed = config.draftSchema.parse(draft) as PersistableSiteDraft;
   const db = requireImportDatabase();
 
   for (let attempt = 0; attempt < 3; attempt += 1) {
     try {
-      await db.$transaction(
+      return await db.$transaction(
         async (tx) => {
-          await tx.site.update({
+          const updated = await tx.site.update({
             where: { slug, vertical },
             data: {
               ...editableSiteScalarData(parsed, vertical),
               ...siteRelationReplaceData(parsed, vertical),
+              draftRevision: { increment: 1 },
             },
+            select: { id: true, draftRevision: true },
           });
+          if (options.actor) {
+            await tx.auditEvent.create({
+              data: {
+                type: options.auditType ?? "site.draft.saved",
+                actor: options.actor.id,
+                siteId: updated.id,
+                metadata: {
+                  revision: updated.draftRevision,
+                  actorEmail: options.actor.email,
+                  integrationCount: parsed.integrations.length,
+                  enabledIntegrationCount: parsed.integrations.filter(
+                    (integration) => integration.enabled,
+                  ).length,
+                },
+              },
+            });
+          }
+          return { revision: updated.draftRevision };
         },
         { isolationLevel: "Serializable" },
       );
-      return;
     } catch (error) {
       if (attempt < 2 && isRetryablePrismaError(error)) continue;
       throw error;
     }
   }
+
+  throw new Error("The site draft could not be saved");
 }
 
 function requireImportDatabase() {
@@ -610,6 +645,7 @@ function integrationCreateData(draft: PersistableSiteDraft) {
     label: integration.label,
     provider: integration.provider,
     url: integration.url,
+    enabled: integration.enabled,
     venueId: integration.venueId ?? null,
     position,
   }));

--- a/src/lib/site-publication.postgres.test.ts
+++ b/src/lib/site-publication.postgres.test.ts
@@ -341,6 +341,82 @@ describe.skipIf(!enabled)("safe draft and publish PostgreSQL integration", () =>
     });
   });
 
+  test("versions and audits authorized integration saves without publishing", async () => {
+    const before = await db.site.findUniqueOrThrow({
+      where: { id: siteId },
+      select: {
+        draftRevision: true,
+        publishedSiteVersionId: true,
+        _count: { select: { siteVersions: true } },
+      },
+    });
+    const first = sampleSiteDraft.integrations[0];
+    const second = sampleSiteDraft.integrations[1];
+    const editedDraft = {
+      ...sampleSiteDraft,
+      slug,
+      integrations: [
+        { ...second, enabled: false },
+        {
+          ...first,
+          label: "Reserve securely",
+          enabled: true,
+        },
+      ],
+    };
+
+    const saved = await updateSiteDraft(
+      slug,
+      editedDraft,
+      Vertical.RESTAURANT,
+      { actor },
+    );
+    const [reloaded, after, audit] = await Promise.all([
+      findSiteView(slug),
+      db.site.findUniqueOrThrow({
+        where: { id: siteId },
+        select: {
+          draftRevision: true,
+          publishedSiteVersionId: true,
+          _count: { select: { siteVersions: true } },
+        },
+      }),
+      db.auditEvent.findFirst({
+        where: {
+          siteId,
+          type: "site.draft.saved",
+          actor: actor.id,
+        },
+        orderBy: { createdAt: "desc" },
+        select: { metadata: true },
+      }),
+    ]);
+
+    expect(saved.revision).toBe(before.draftRevision + 1);
+    expect(after).toEqual({
+      draftRevision: saved.revision,
+      publishedSiteVersionId: before.publishedSiteVersionId,
+      _count: before._count,
+    });
+    expect(reloaded?.draft.integrations).toEqual([
+      expect.objectContaining({
+        label: second.label,
+        enabled: false,
+      }),
+      expect.objectContaining({
+        label: "Reserve securely",
+        provider: first.provider,
+        enabled: true,
+      }),
+    ]);
+    expect(audit?.metadata).toMatchObject({
+      revision: saved.revision,
+      actorEmail: actor.email,
+      integrationCount: 2,
+      enabledIntegrationCount: 1,
+    });
+  });
+
   test("refuses to publish stale translated copy without moving the live pointer", async () => {
     const current = await findSiteView(slug);
     if (!current) throw new Error("Expected the persisted restaurant draft");

--- a/src/lib/site-themes/restaurant/theme-registry.test.tsx
+++ b/src/lib/site-themes/restaurant/theme-registry.test.tsx
@@ -389,4 +389,25 @@ describe("restaurant theme renderers", () => {
 
     expect(html).not.toContain(unavailableName);
   });
+
+  it("keeps disabled integrations out of public theme output", () => {
+    const fixture = restaurantThemeFixtures["counter-service"];
+    const hiddenLabel = fixture.integrations[0].label;
+    const selection = restaurantThemeSelectionSchema.parse(
+      fixture.attributes.themeSelection,
+    );
+    const draft = {
+      ...fixture,
+      integrations: fixture.integrations.map((integration, index) => ({
+        ...integration,
+        enabled: index !== 0,
+      })),
+    };
+    const html = renderToStaticMarkup(
+      <RestaurantThemeRenderer draft={draft} selection={selection} />,
+    );
+
+    expect(html).not.toContain(hiddenLabel);
+    expect(html).toContain(fixture.integrations[1].label);
+  });
 });

--- a/src/lib/sites.ts
+++ b/src/lib/sites.ts
@@ -101,6 +101,7 @@ export function projectSiteDraft(site: PersistedSiteDraftRecord): LoadedSite {
       label: integration.label,
       provider: integration.provider,
       url: integration.url,
+      enabled: integration.enabled,
       venueId: integration.venueId,
     })),
   });

--- a/src/lib/verticals/restaurant/providers.ts
+++ b/src/lib/verticals/restaurant/providers.ts
@@ -33,6 +33,8 @@ const openTableEmbed: ProviderEmbedDefinition = {
 export const restaurantProviders: ProviderDefinition[] = [
   {
     pattern: /opentable/i,
+    hostnamePattern:
+      /^(?:[a-z0-9-]+\.)*opentable\.(?:com|co\.uk|de|fr|it|nl|ie|ca|com\.au)$/i,
     name: "OpenTable",
     type: "booking",
     classificationPattern: /opentable/i,
@@ -40,79 +42,122 @@ export const restaurantProviders: ProviderDefinition[] = [
   },
   {
     pattern: /sevenrooms/i,
+    hostnamePattern: /^(?:[a-z0-9-]+\.)*sevenrooms\.com$/i,
     name: "SevenRooms",
     type: "booking",
     classificationPattern: /sevenrooms/i,
   },
   {
     pattern: /resy/i,
+    hostnamePattern: /^(?:[a-z0-9-]+\.)*resy\.com$/i,
     name: "Resy",
     type: "booking",
     classificationPattern: /resy/i,
   },
   {
     pattern: /thefork|lafourchette/i,
+    hostnamePattern:
+      /^(?:[a-z0-9-]+\.)*(?:thefork\.(?:com|fr|it|de|es|nl|be|ch)|lafourchette\.com)$/i,
     name: "TheFork",
     type: "booking",
     classificationPattern: /thefork/i,
   },
   {
     pattern: /quandoo/i,
+    hostnamePattern:
+      /^(?:[a-z0-9-]+\.)*quandoo\.(?:com|co\.uk|de|it|fr|nl|ch|at)$/i,
     name: "Quandoo",
     type: "booking",
     classificationPattern: /quandoo/i,
   },
-  { pattern: /bookatable/i, name: "Bookatable", type: "booking" },
+  {
+    pattern: /bookatable/i,
+    hostnamePattern:
+      /^(?:[a-z0-9-]+\.)*bookatable\.(?:com|co\.uk)$/i,
+    name: "Bookatable",
+    type: "booking",
+  },
   {
     pattern: /toasttab/i,
+    hostnamePattern: /^(?:[a-z0-9-]+\.)*toasttab\.com$/i,
     name: "Toast",
     type: "ordering",
     classificationPattern: /toasttab/i,
   },
   {
     pattern: /square\.site|squareup/i,
+    hostnamePattern:
+      /^(?:[a-z0-9-]+\.)*(?:square\.site|squareup\.com)$/i,
     name: "Square",
     type: "ordering",
     classificationPattern: /square/i,
   },
   {
     pattern: /ubereats/i,
+    hostnamePattern: /^(?:[a-z0-9-]+\.)*ubereats\.com$/i,
     name: "Uber Eats",
     type: "delivery",
     classificationPattern: /ubereats/i,
   },
   {
     pattern: /deliveroo/i,
+    hostnamePattern:
+      /^(?:[a-z0-9-]+\.)*deliveroo\.(?:com|co\.uk|fr|it|be|nl|ie|com\.au)$/i,
     name: "Deliveroo",
     type: "delivery",
     classificationPattern: /deliveroo/i,
   },
   {
     pattern: /wolt/i,
+    hostnamePattern: /^(?:[a-z0-9-]+\.)*wolt\.com$/i,
     name: "Wolt",
     type: "delivery",
     classificationPattern: /wolt/i,
   },
   {
     pattern: /just-eat|justeat/i,
+    hostnamePattern:
+      /^(?:[a-z0-9-]+\.)*(?:just-eat|justeat)\.(?:com|co\.uk|fr|it|es|de|ch|ie)$/i,
     name: "Just Eat",
     type: "delivery",
     classificationPattern: /just.?eat/i,
   },
-  { pattern: /zenchef/i, name: "Zenchef", type: "booking" },
+  {
+    pattern: /zenchef/i,
+    hostnamePattern: /^(?:[a-z0-9-]+\.)*zenchef\.com$/i,
+    name: "Zenchef",
+    type: "booking",
+  },
   {
     pattern: /instagram/i,
+    hostnamePattern: /^(?:[a-z0-9-]+\.)*instagram\.com$/i,
     name: "Instagram",
     type: "social",
     classificationPattern: /instagram/i,
   },
   {
     pattern: /facebook/i,
+    hostnamePattern: /^(?:[a-z0-9-]+\.)*facebook\.com$/i,
     name: "Facebook",
     type: "social",
     classificationPattern: /facebook/i,
   },
 ];
+
+export function findRestaurantProviderByUrl(url: string) {
+  let hostname: string;
+  try {
+    hostname = new URL(url).hostname;
+  } catch {
+    return null;
+  }
+  return (
+    restaurantProviders.find((provider) =>
+      provider.hostnamePattern?.test(hostname),
+    ) ??
+    null
+  );
+}
 
 export const restaurantLinkKeywordHints: LinkClassificationHint[] = [
   {

--- a/src/lib/verticals/restaurant/schema.ts
+++ b/src/lib/verticals/restaurant/schema.ts
@@ -5,6 +5,7 @@ import {
   baseSiteTranslationSchema,
   catalogItemSchema,
   catalogSectionSchema,
+  integrationSchema,
   localeSchema,
   translatedCatalogItemSchema,
   translatedCatalogSectionSchema,
@@ -13,6 +14,10 @@ import {
   safeOptionalRestaurantDesignProfileSchema,
   safeOptionalRestaurantThemeSelectionSchema,
 } from "@/lib/site-themes/restaurant/contracts";
+import {
+  findRestaurantProviderByUrl,
+  restaurantProviders,
+} from "@/lib/verticals/restaurant/providers";
 
 /**
  * The engine primitives live in `@/lib/verticals/schema` so a second vertical can
@@ -49,6 +54,55 @@ export const menuItemSchema = catalogItemSchema
 export const menuSectionSchema = catalogSectionSchema.extend({
   items: z.array(menuItemSchema).max(40),
 });
+
+export const restaurantIntegrationSchema = integrationSchema
+  .superRefine((integration, context) => {
+    const provider = findRestaurantProviderByUrl(integration.url);
+    if (provider && provider.type !== integration.type) {
+      context.addIssue({
+        code: "custom",
+        path: ["type"],
+        message: `${provider.name} links must use the ${provider.type} type`,
+      });
+    }
+    if (
+      provider &&
+      integration.provider &&
+      integration.provider !== provider.name
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["provider"],
+        message: `Provider must remain ${provider.name} for this URL`,
+      });
+    }
+    if (!provider && integration.type === "social") {
+      context.addIssue({
+        code: "custom",
+        path: ["url"],
+        message: "Use an approved social provider URL",
+      });
+    }
+    if (
+      !provider &&
+      integration.provider &&
+      restaurantProviders.some(
+        (candidate) => candidate.name === integration.provider,
+      )
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["provider"],
+        message: `${integration.provider} does not match this URL`,
+      });
+    }
+  })
+  .transform((integration) => ({
+    ...integration,
+    provider:
+      findRestaurantProviderByUrl(integration.url)?.name ??
+      integration.provider,
+  }));
 
 export const restaurantTranslationStatusSchema = z.enum([
   "current",
@@ -102,6 +156,7 @@ export const restaurantSiteDraftSchema = z
   .object({
     ...baseSiteDraftCoreShape,
     attributes: restaurantAttributesSchema,
+    integrations: z.array(restaurantIntegrationSchema).max(12),
     translations: z
       .array(restaurantSiteTranslationSchema)
       .max(8)
@@ -127,6 +182,7 @@ export const restaurantDraftSchema = z
   .object({
     ...baseSiteDraftCoreShape,
     ...restaurantAttributesSchema.shape,
+    integrations: z.array(restaurantIntegrationSchema).max(12),
     translations: z.array(restaurantTranslationSchema).max(8).default([]),
     menuSections: z.array(menuSectionSchema).min(1).max(12),
   })

--- a/src/lib/verticals/schema.ts
+++ b/src/lib/verticals/schema.ts
@@ -63,11 +63,40 @@ export const catalogSectionSchema = z.object({
   items: z.array(catalogItemSchema).max(40),
 });
 
+export const safeExternalHttpsUrlSchema = z.url().superRefine((value, context) => {
+  const url = new URL(value);
+  if (url.protocol !== "https:") {
+    context.addIssue({
+      code: "custom",
+      message: "Integration links must use HTTPS",
+    });
+  }
+  if (url.username || url.password) {
+    context.addIssue({
+      code: "custom",
+      message: "Integration links cannot contain credentials",
+    });
+  }
+  if (url.port && url.port !== "443") {
+    context.addIssue({
+      code: "custom",
+      message: "Integration links cannot use a custom port",
+    });
+  }
+  if (isPrivateIntegrationHostname(url.hostname)) {
+    context.addIssue({
+      code: "custom",
+      message: "Integration links must use a public hostname",
+    });
+  }
+});
+
 export const integrationSchema = z.object({
   type: z.enum(["booking", "ordering", "delivery", "social"]),
-  label: z.string().min(1).max(60),
-  provider: z.string().max(60).nullable().default(null),
-  url: z.url(),
+  label: z.string().trim().min(1).max(60),
+  provider: z.string().trim().min(1).max(60).nullable().default(null),
+  url: safeExternalHttpsUrlSchema,
+  enabled: z.boolean().default(true),
   /**
    * The owner's id inside the provider, used to build an embedded booking
    * widget. Bounded here only for storage sanity — the value is never trusted
@@ -76,6 +105,35 @@ export const integrationSchema = z.object({
    */
   venueId: z.string().max(120).nullable().default(null),
 });
+
+function isPrivateIntegrationHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  const ipv6 = normalized.includes(":");
+  if (
+    normalized === "localhost" ||
+    normalized.endsWith(".localhost") ||
+    normalized.endsWith(".local") ||
+    ipv6
+  ) {
+    return true;
+  }
+
+  const octets = normalized.split(".").map(Number);
+  if (
+    octets.length !== 4 ||
+    octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)
+  ) {
+    return false;
+  }
+  return (
+    octets[0] === 10 ||
+    octets[0] === 127 ||
+    octets[0] === 0 ||
+    (octets[0] === 169 && octets[1] === 254) ||
+    (octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31) ||
+    (octets[0] === 192 && octets[1] === 168)
+  );
+}
 
 export const localeSchema = z
   .string()

--- a/src/lib/verticals/types.ts
+++ b/src/lib/verticals/types.ts
@@ -45,6 +45,8 @@ export type ProviderEmbedDefinition = {
 export type ProviderDefinition = {
   name: string;
   pattern: RegExp;
+  /** Anchored allow-list used for owner-edited URLs; never match free-form paths. */
+  hostnamePattern?: RegExp;
   type: IntegrationLinkType;
   classificationPattern?: RegExp;
   embed?: ProviderEmbedDefinition;


### PR DESCRIPTION
Closes #11

Stacked on #69.

## What changed
- replaces the placeholder links tab with full add/edit/remove/reorder/enable-disable controls for booking, ordering, delivery and approved social links
- keeps localized customer labels structurally aligned with canonical links and marks locale copy stale until reviewed
- adds an explicit placement preview, recoverable removals until publish, and publicly hides disabled links without deleting them
- enforces HTTPS-only public URLs, blocks credentials/custom ports/private hosts, validates hostname-anchored provider identity, and hardens booking embed selection
- versions every owner draft save with a monotonic revision and records the authorized actor in an audit event; adds same-origin enforcement to cookie-authorized draft saves
- persists enabled state through PostgreSQL and immutable publish snapshots

## Verification
- `bun test` — 216 passed, 14 PostgreSQL-gated skipped
- `bunx tsc --noEmit`
- `bun run lint` — 0 errors; one pre-existing generated-route warning
- `bun run design:lint`
- `bunx --bun prisma validate`
- `git diff --check`

PostgreSQL integration coverage is included for ordering, disabled-state persistence, draft revisions, audit metadata and unchanged public version pointers. It is gated because this worktree has no `DATABASE_URL`.

## Planning and review state
- planning remained degraded from the already-recorded genfeedai Claude weekly-limit blocker
- per instruction, exact-head Opus was not probed again because external quota state has not changed