### PR TITLE
feat: add durable source monitoring and review queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,14 @@ the deterministic composer and hero enhancement is skipped.
 - `WORKFLOW_TARGET_WORLD=@workflow/world-postgres`
 - `WORKFLOW_POSTGRES_URL`
 
+With workflow execution enabled, each server instance participates in a
+database-backed due dispatcher. Active Starter subscriptions are checked every
+30 days and Growth subscriptions every 7 days. The due slot and run state are
+persisted before a bounded Workflow run starts, so restarts and duplicate
+dispatchers are safe. Past-due/canceled subscriptions and paused sites perform
+no source fetches. Findings enter the owner/operator review queue and never
+mutate a draft or published version automatically.
+
 ### Authentic image enhancement
 
 Configure the private production S3 bucket and its CloudFront public origin:

--- a/prisma/migrations/20260727073000_source_monitoring/migration.sql
+++ b/prisma/migrations/20260727073000_source_monitoring/migration.sql
@@ -1,0 +1,84 @@
+CREATE TYPE "SourceMonitorRunStatus" AS ENUM ('QUEUED', 'RUNNING', 'SUCCEEDED', 'FAILED', 'SKIPPED');
+CREATE TYPE "SourceMonitorSuggestionField" AS ENUM ('MENU', 'CONTACT', 'HOURS', 'LINKS');
+CREATE TYPE "SourceMonitorSuggestionStatus" AS ENUM ('PENDING', 'ACCEPTED', 'REJECTED');
+
+ALTER TABLE "Site"
+ADD COLUMN "businessHours" JSONB NOT NULL DEFAULT '[]';
+
+CREATE TABLE "SourceMonitorState" (
+  "siteId" TEXT NOT NULL,
+  "cadenceDays" INTEGER NOT NULL,
+  "nextRunAt" TIMESTAMP(3) NOT NULL,
+  "lastRunAt" TIMESTAMP(3),
+  "lastSuccessAt" TIMESTAMP(3),
+  "lastFailureAt" TIMESTAMP(3),
+  "lastFailureCode" TEXT,
+  "lastRunId" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "SourceMonitorState_pkey" PRIMARY KEY ("siteId")
+);
+
+CREATE TABLE "SourceMonitorRun" (
+  "id" TEXT NOT NULL,
+  "idempotencyKey" TEXT NOT NULL,
+  "scheduledFor" TIMESTAMP(3) NOT NULL,
+  "status" "SourceMonitorRunStatus" NOT NULL DEFAULT 'QUEUED',
+  "workflowRunId" TEXT,
+  "startedAt" TIMESTAMP(3),
+  "completedAt" TIMESTAMP(3),
+  "errorCode" TEXT,
+  "checkedSourceCount" INTEGER NOT NULL DEFAULT 0,
+  "failedSourceCount" INTEGER NOT NULL DEFAULT 0,
+  "suggestionCount" INTEGER NOT NULL DEFAULT 0,
+  "notificationSentAt" TIMESTAMP(3),
+  "notificationFailureCode" TEXT,
+  "siteId" TEXT NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "SourceMonitorRun_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "SourceMonitorSuggestion" (
+  "id" TEXT NOT NULL,
+  "fingerprint" TEXT NOT NULL,
+  "field" "SourceMonitorSuggestionField" NOT NULL,
+  "path" TEXT NOT NULL,
+  "currentValue" JSONB NOT NULL,
+  "suggestedValue" JSONB NOT NULL,
+  "editedValue" JSONB,
+  "evidence" JSONB NOT NULL,
+  "status" "SourceMonitorSuggestionStatus" NOT NULL DEFAULT 'PENDING',
+  "reviewedBy" TEXT,
+  "reviewedAt" TIMESTAMP(3),
+  "reviewNote" TEXT,
+  "runId" TEXT NOT NULL,
+  "siteId" TEXT NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "SourceMonitorSuggestion_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "SourceMonitorRun_idempotencyKey_key" ON "SourceMonitorRun"("idempotencyKey");
+CREATE UNIQUE INDEX "SourceMonitorRun_workflowRunId_key" ON "SourceMonitorRun"("workflowRunId");
+CREATE INDEX "SourceMonitorRun_siteId_scheduledFor_idx" ON "SourceMonitorRun"("siteId", "scheduledFor");
+CREATE INDEX "SourceMonitorRun_status_createdAt_idx" ON "SourceMonitorRun"("status", "createdAt");
+CREATE UNIQUE INDEX "SourceMonitorSuggestion_runId_fingerprint_key" ON "SourceMonitorSuggestion"("runId", "fingerprint");
+CREATE INDEX "SourceMonitorSuggestion_siteId_status_createdAt_idx" ON "SourceMonitorSuggestion"("siteId", "status", "createdAt");
+CREATE INDEX "SourceMonitorState_nextRunAt_idx" ON "SourceMonitorState"("nextRunAt");
+
+ALTER TABLE "SourceMonitorState"
+ADD CONSTRAINT "SourceMonitorState_siteId_fkey"
+FOREIGN KEY ("siteId") REFERENCES "Site"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "SourceMonitorRun"
+ADD CONSTRAINT "SourceMonitorRun_siteId_fkey"
+FOREIGN KEY ("siteId") REFERENCES "Site"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "SourceMonitorSuggestion"
+ADD CONSTRAINT "SourceMonitorSuggestion_runId_fkey"
+FOREIGN KEY ("runId") REFERENCES "SourceMonitorRun"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "SourceMonitorSuggestion"
+ADD CONSTRAINT "SourceMonitorSuggestion_siteId_fkey"
+FOREIGN KEY ("siteId") REFERENCES "Site"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -73,6 +73,27 @@ enum ClaimProofMethod {
   OPERATOR_APPROVAL
 }
 
+enum SourceMonitorRunStatus {
+  QUEUED
+  RUNNING
+  SUCCEEDED
+  FAILED
+  SKIPPED
+}
+
+enum SourceMonitorSuggestionField {
+  MENU
+  CONTACT
+  HOURS
+  LINKS
+}
+
+enum SourceMonitorSuggestionStatus {
+  PENDING
+  ACCEPTED
+  REJECTED
+}
+
 model User {
   id           String       @id @default(cuid())
   email        String       @unique
@@ -105,45 +126,49 @@ model Membership {
 }
 
 model Site {
-  id                     String            @id @default(cuid())
-  slug                   String            @unique
-  name                   String
-  eyebrow                String?
-  description            String?
-  address                String?
-  phone                  String?
-  email                  String?
-  sourceUrl              String?
-  sourceKey              String?           @unique
-  logoUrl                String?
-  heroImageUrl           String?
-  heroOriginalImageUrl   String?
-  heroImageProvenance    ImageProvenance?
-  autoEnhanceImages      Boolean           @default(true)
-  defaultLocale          String            @default("en")
-  translations           Json              @default("[]")
-  draftTheme             Json              @default("{}")
-  draftThemeVersion      String            @default("legacy-v1")
-  draftPalette           Json              @default("{}")
-  vertical               Vertical          @default(RESTAURANT)
-  attributes             Json              @default("{}")
-  status                 SiteStatus        @default(PROSPECT)
-  publishedSiteVersionId String?           @unique
-  publishedSiteVersion   SiteVersion?      @relation("PublishedSiteVersion", fields: [publishedSiteVersionId], references: [id], onDelete: SetNull)
-  organizationId         String?
-  organization           Organization?     @relation(fields: [organizationId], references: [id], onDelete: SetNull)
-  createdAt              DateTime          @default(now())
-  updatedAt              DateTime          @updatedAt
-  catalogSections        CatalogSection[]
-  integrations           Integration[]
-  importJobs             ImportJob[]
-  domains                Domain[]
-  siteVersions           SiteVersion[]
-  claimInvitations       ClaimInvitation[]
-  subscription           Subscription?
-  auditEvents            AuditEvent[]
-  bookingRequests        BookingRequest[]
-  analyticsEvents        AnalyticsEvent[]
+  id                       String                    @id @default(cuid())
+  slug                     String                    @unique
+  name                     String
+  eyebrow                  String?
+  description              String?
+  address                  String?
+  phone                    String?
+  email                    String?
+  sourceUrl                String?
+  sourceKey                String?                   @unique
+  logoUrl                  String?
+  heroImageUrl             String?
+  heroOriginalImageUrl     String?
+  heroImageProvenance      ImageProvenance?
+  autoEnhanceImages        Boolean                   @default(true)
+  defaultLocale            String                    @default("en")
+  translations             Json                      @default("[]")
+  businessHours            Json                      @default("[]")
+  draftTheme               Json                      @default("{}")
+  draftThemeVersion        String                    @default("legacy-v1")
+  draftPalette             Json                      @default("{}")
+  vertical                 Vertical                  @default(RESTAURANT)
+  attributes               Json                      @default("{}")
+  status                   SiteStatus                @default(PROSPECT)
+  publishedSiteVersionId   String?                   @unique
+  publishedSiteVersion     SiteVersion?              @relation("PublishedSiteVersion", fields: [publishedSiteVersionId], references: [id], onDelete: SetNull)
+  organizationId           String?
+  organization             Organization?             @relation(fields: [organizationId], references: [id], onDelete: SetNull)
+  createdAt                DateTime                  @default(now())
+  updatedAt                DateTime                  @updatedAt
+  catalogSections          CatalogSection[]
+  integrations             Integration[]
+  importJobs               ImportJob[]
+  domains                  Domain[]
+  siteVersions             SiteVersion[]
+  claimInvitations         ClaimInvitation[]
+  subscription             Subscription?
+  auditEvents              AuditEvent[]
+  bookingRequests          BookingRequest[]
+  analyticsEvents          AnalyticsEvent[]
+  sourceMonitorState       SourceMonitorState?
+  sourceMonitorRuns        SourceMonitorRun[]
+  sourceMonitorSuggestions SourceMonitorSuggestion[]
 }
 
 model CatalogSection {
@@ -334,4 +359,68 @@ model AnalyticsEvent {
 
   @@index([siteId, occurredAt, type])
   @@index([occurredAt])
+}
+
+model SourceMonitorState {
+  siteId          String    @id
+  site            Site      @relation(fields: [siteId], references: [id], onDelete: Cascade)
+  cadenceDays     Int
+  nextRunAt       DateTime
+  lastRunAt       DateTime?
+  lastSuccessAt   DateTime?
+  lastFailureAt   DateTime?
+  lastFailureCode String?
+  lastRunId       String?
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+
+  @@index([nextRunAt])
+}
+
+model SourceMonitorRun {
+  id                      String                    @id @default(cuid())
+  idempotencyKey          String                    @unique
+  scheduledFor            DateTime
+  status                  SourceMonitorRunStatus    @default(QUEUED)
+  workflowRunId           String?                   @unique
+  startedAt               DateTime?
+  completedAt             DateTime?
+  errorCode               String?
+  checkedSourceCount      Int                       @default(0)
+  failedSourceCount       Int                       @default(0)
+  suggestionCount         Int                       @default(0)
+  notificationSentAt      DateTime?
+  notificationFailureCode String?
+  siteId                  String
+  site                    Site                      @relation(fields: [siteId], references: [id], onDelete: Cascade)
+  suggestions             SourceMonitorSuggestion[]
+  createdAt               DateTime                  @default(now())
+  updatedAt               DateTime                  @updatedAt
+
+  @@index([siteId, scheduledFor])
+  @@index([status, createdAt])
+}
+
+model SourceMonitorSuggestion {
+  id             String                        @id @default(cuid())
+  fingerprint    String
+  field          SourceMonitorSuggestionField
+  path           String
+  currentValue   Json
+  suggestedValue Json
+  editedValue    Json?
+  evidence       Json
+  status         SourceMonitorSuggestionStatus @default(PENDING)
+  reviewedBy     String?
+  reviewedAt     DateTime?
+  reviewNote     String?
+  runId          String
+  run            SourceMonitorRun              @relation(fields: [runId], references: [id], onDelete: Cascade)
+  siteId         String
+  site           Site                          @relation(fields: [siteId], references: [id], onDelete: Cascade)
+  createdAt      DateTime                      @default(now())
+  updatedAt      DateTime                      @updatedAt
+
+  @@unique([runId, fingerprint])
+  @@index([siteId, status, createdAt])
 }

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -155,6 +155,7 @@ export default async function AdminPage() {
                   <th scope="col" className="px-5 py-3 font-medium">Lifecycle</th>
                   <th scope="col" className="px-5 py-3 font-medium">Signup</th>
                   <th scope="col" className="px-5 py-3 font-medium">Subscription</th>
+                  <th scope="col" className="px-5 py-3 font-medium">Source monitoring</th>
                   <th scope="col" className="px-5 py-3 font-medium">Import</th>
                   <th scope="col" className="px-5 py-3 font-medium">Booking leads</th>
                   <th scope="col" className="px-5 py-3 font-medium">Visits · 30d</th>
@@ -248,6 +249,22 @@ function SiteRow({ site }: { site: OperatorSiteRow }) {
         ) : (
           <span className="text-muted-foreground">—</span>
         )}
+      </td>
+      <td className="px-5 py-4">
+        <Button
+          render={<Link href={`/admin/source-monitoring/${site.slug}`} />}
+          variant="outline"
+          size="sm"
+        >
+          {site.pendingSourceSuggestionCount > 0
+            ? `${site.pendingSourceSuggestionCount} to review`
+            : "Review"}
+        </Button>
+        <p className="mt-1 text-[11px] text-muted-foreground">
+          {site.sourceMonitorLastSuccessAt
+            ? `Last success ${formatDate(site.sourceMonitorLastSuccessAt)}`
+            : "No successful run"}
+        </p>
       </td>
       <td className="px-5 py-4">
         <p>{site.latestImportStatus ? humanize(site.latestImportStatus) : "—"}</p>

--- a/src/app/admin/source-monitoring/[slug]/page.tsx
+++ b/src/app/admin/source-monitoring/[slug]/page.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { SourceMonitoringPanel } from "@/components/source-monitoring-panel";
+import { Button } from "@/components/ui/button";
+import { getSuperadminAccess } from "@/lib/authorization";
+import { getCurrentSession } from "@/lib/current-session";
+import { getDb } from "@/lib/db";
+import { getSourceMonitoringDashboard } from "@/lib/source-monitoring";
+
+export const dynamic = "force-dynamic";
+
+export default async function OperatorSourceMonitoringPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const session = await getCurrentSession();
+  if (!session) redirect("/sign-in");
+  if (!(await getSuperadminAccess())) notFound();
+
+  const { slug } = await params;
+  const site = await getDb().site.findUnique({
+    where: { slug },
+    select: { id: true, slug: true, name: true },
+  });
+  if (!site) notFound();
+  const monitoring = await getSourceMonitoringDashboard(site.id);
+
+  return (
+    <main className="min-h-screen bg-[#f3f1eb] px-4 py-8 md:px-8">
+      <div className="mx-auto max-w-6xl">
+        <Button render={<Link href="/admin" />} variant="outline" size="sm">
+          Back to operator console
+        </Button>
+        <p className="mt-8 text-xs font-semibold uppercase tracking-[0.18em] text-primary">
+          Operator review · {site.name}
+        </p>
+        <div className="mt-4 rounded-2xl border bg-background p-5 md:p-8">
+          <SourceMonitoringPanel siteSlug={site.slug} initial={monitoring} />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/api/sites/[slug]/source-monitoring/route.ts
+++ b/src/app/api/sites/[slug]/source-monitoring/route.ts
@@ -1,0 +1,21 @@
+import {
+  accessFailureResponse,
+} from "@/lib/authorization";
+import {
+  getSourceMonitoringDashboard,
+} from "@/lib/source-monitoring";
+import { getSourceMonitoringAccess } from "@/lib/source-monitoring-access";
+
+export async function GET(
+  _request: Request,
+  { params }: RouteContext<"/api/sites/[slug]/source-monitoring">,
+) {
+  const { slug } = await params;
+  const access = await getSourceMonitoringAccess(slug);
+  if (!access.ok) return accessFailureResponse(access);
+
+  return Response.json(
+    await getSourceMonitoringDashboard(access.site.id),
+    { headers: { "Cache-Control": "private, no-store" } },
+  );
+}

--- a/src/app/api/sites/[slug]/source-monitoring/suggestions/[suggestionId]/route.ts
+++ b/src/app/api/sites/[slug]/source-monitoring/suggestions/[suggestionId]/route.ts
@@ -1,0 +1,59 @@
+import { z } from "zod";
+import { accessFailureResponse } from "@/lib/authorization";
+import {
+  reviewSourceMonitoringSuggestion,
+  SourceMonitoringConflictError,
+} from "@/lib/source-monitoring";
+import { getSourceMonitoringAccess } from "@/lib/source-monitoring-access";
+
+const reviewSchema = z.object({
+  action: z.enum(["accept", "reject"]),
+  editedValue: z.unknown().optional(),
+  note: z.string().trim().max(500).optional(),
+});
+
+export async function PATCH(
+  request: Request,
+  {
+    params,
+  }: RouteContext<
+    "/api/sites/[slug]/source-monitoring/suggestions/[suggestionId]"
+  >,
+) {
+  const { slug, suggestionId } = await params;
+  const access = await getSourceMonitoringAccess(slug);
+  if (!access.ok) return accessFailureResponse(access);
+
+  const parsed = reviewSchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return Response.json({ error: "Invalid review action" }, { status: 400 });
+  }
+  try {
+    const result = await reviewSourceMonitoringSuggestion({
+      siteId: access.site.id,
+      suggestionId,
+      actor: access.actor,
+      ...parsed.data,
+    });
+    return Response.json(result);
+  } catch (error) {
+    if (error instanceof SourceMonitoringConflictError) {
+      return Response.json({ error: error.message }, { status: 409 });
+    }
+    if (error instanceof z.ZodError) {
+      return Response.json(
+        { error: "The edited suggestion is not valid for this site" },
+        { status: 422 },
+      );
+    }
+    console.error("[source-monitoring] review failed", {
+      slug,
+      suggestionId,
+      error: error instanceof Error ? error.message : "unknown",
+    });
+    return Response.json(
+      { error: "The suggestion could not be reviewed" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/dashboard/dashboard.tsx
+++ b/src/app/dashboard/dashboard.tsx
@@ -30,6 +30,7 @@ import {
   ClientAnalyticsPanel,
   ClientBookingRequestInbox,
 } from "@/components/client-workspace";
+import { SourceMonitoringPanel } from "@/components/source-monitoring-panel";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -42,6 +43,7 @@ import type { BrandIdentity } from "@/lib/brand";
 import type { AnalyticsSummaryDto } from "@/lib/analytics-contract";
 import type { BookingRequestInboxDto } from "@/lib/booking-request-inbox";
 import type { BillingAccess } from "@/lib/billing-access";
+import type { SourceMonitoringDashboardDto } from "@/lib/source-monitoring";
 import {
   formatPrice,
   type RestaurantDraft,
@@ -68,6 +70,7 @@ export function Dashboard({
   analyticsSummary,
   bookingInbox,
   billingAccess,
+  sourceMonitoring,
 }: {
   initialDraft: RestaurantDraft;
   email: string;
@@ -77,6 +80,7 @@ export function Dashboard({
   analyticsSummary: AnalyticsSummaryDto;
   bookingInbox: BookingRequestInboxDto;
   billingAccess: BillingAccess | null;
+  sourceMonitoring: SourceMonitoringDashboardDto;
 }) {
   const [draft, setDraft] = useState(initialDraft);
   const [saving, setSaving] = useState(false);
@@ -377,6 +381,7 @@ export function Dashboard({
                 ["overview", LayoutDashboard, "Overview"],
                 ["analytics", TrendingUp, "Analytics"],
                 ["leads", Mail, "Leads"],
+                ["monitoring", RefreshCcw, "Monitoring"],
                 ["menu", BookOpenText, "Menu"],
                 ["imagery", ImageIcon, "Imagery"],
                 ["integrations", Link2, "Integrations"],
@@ -406,6 +411,7 @@ export function Dashboard({
               <TabsTrigger value="overview">Overview</TabsTrigger>
               <TabsTrigger value="analytics">Analytics</TabsTrigger>
               <TabsTrigger value="leads">Leads</TabsTrigger>
+              <TabsTrigger value="monitoring">Monitoring</TabsTrigger>
               <TabsTrigger value="menu">Menu</TabsTrigger>
               <TabsTrigger value="imagery">Imagery</TabsTrigger>
               <TabsTrigger value="integrations">Links</TabsTrigger>
@@ -501,7 +507,17 @@ export function Dashboard({
               <div className="mt-5 grid gap-5 md:grid-cols-3">
                 <Metric label="Menu items" value={`${draft.menuSections.reduce((sum, section) => sum + section.items.length, 0)}`} detail={`${draft.menuSections.length} sections`} />
                 <Metric label="Preserved systems" value={`${draft.integrations.length}`} detail="No migrations required" />
-                <Metric label="Last source check" value="Just now" detail="No changes detected" />
+                <Metric
+                  label="Last source check"
+                  value={sourceMonitoring.lastSuccessAt ? "Completed" : "Pending"}
+                  detail={
+                    sourceMonitoring.lastSuccessAt
+                      ? new Date(
+                          sourceMonitoring.lastSuccessAt,
+                        ).toLocaleDateString("en", { dateStyle: "medium" })
+                      : "No successful run yet"
+                  }
+                />
               </div>
             </TabsContent>
 
@@ -513,6 +529,14 @@ export function Dashboard({
               <ClientBookingRequestInbox
                 siteSlug={draft.slug}
                 initialInbox={bookingInbox}
+                demo={demo}
+              />
+            </TabsContent>
+
+            <TabsContent value="monitoring" className="mt-0">
+              <SourceMonitoringPanel
+                siteSlug={draft.slug}
+                initial={sourceMonitoring}
                 demo={demo}
               />
             </TabsContent>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -9,6 +9,7 @@ import { getSiteBillingAccess } from "@/lib/billing-access";
 import { getCurrentSession } from "@/lib/current-session";
 import { getRestaurantDraft } from "@/lib/restaurants";
 import { sampleRestaurant } from "@/lib/restaurant";
+import { getSourceMonitoringDashboard } from "@/lib/source-monitoring";
 import { resolveRequestBrand } from "@/lib/verticals/request-site";
 
 export const metadata: Metadata = {
@@ -30,12 +31,19 @@ export default async function DashboardPage({
     session?.siteSlug ? await getSiteAccess(session.siteSlug) : null;
   if (session && (!access || !access.ok)) redirect("/sign-in");
 
-  const [draft, analyticsSummary, bookingInbox, billingAccess] = access?.ok
+  const [
+    draft,
+    analyticsSummary,
+    bookingInbox,
+    billingAccess,
+    sourceMonitoring,
+  ] = access?.ok
     ? await Promise.all([
         getRestaurantDraft(access.site.slug),
         getSiteAnalyticsSummary(access.site.id),
         getBookingRequestInbox(access.site.id),
         getSiteBillingAccess(access.site.id),
+        getSourceMonitoringDashboard(access.site.id),
       ])
     : [
         sampleRestaurant,
@@ -47,6 +55,16 @@ export default async function DashboardPage({
           truncated: false,
         },
         null,
+        {
+          cadenceDays: null,
+          nextRunAt: null,
+          lastRunAt: null,
+          lastSuccessAt: null,
+          lastFailureAt: null,
+          lastFailureCode: null,
+          latestRun: null,
+          suggestions: [],
+        },
       ];
 
   return (
@@ -59,6 +77,7 @@ export default async function DashboardPage({
       analyticsSummary={analyticsSummary}
       bookingInbox={bookingInbox}
       billingAccess={billingAccess}
+      sourceMonitoring={sourceMonitoring}
     />
   );
 }

--- a/src/components/restaurant-themes/after-dark.tsx
+++ b/src/components/restaurant-themes/after-dark.tsx
@@ -5,6 +5,7 @@ import {
   itemBadges,
   themeStyle,
   ThemeAnalytics,
+  ThemeBusinessHours,
   ThemeExternalAction,
   ThemeHeroImage,
   ThemeLocaleNavigation,
@@ -225,9 +226,10 @@ export function AfterDarkTheme({
         </div>
       </section>
 
-      <footer className="flex flex-col gap-3 border-t border-current/15 px-6 py-8 text-xs opacity-55 sm:flex-row sm:justify-between md:px-10">
+      <footer className="grid gap-3 border-t border-current/15 px-6 py-8 text-xs opacity-55 sm:grid-cols-3 md:px-10">
         <span>{draft.name}</span>
-        <span>{draft.address}</span>
+        <ThemeBusinessHours draft={draft} />
+        <span className="sm:text-right">{draft.address}</span>
       </footer>
     </article>
   );

--- a/src/components/restaurant-themes/counter-service.tsx
+++ b/src/components/restaurant-themes/counter-service.tsx
@@ -4,6 +4,7 @@ import {
   itemBadges,
   themeStyle,
   ThemeAnalytics,
+  ThemeBusinessHours,
   ThemeExternalAction,
   ThemeHeroImage,
   ThemeLocaleNavigation,
@@ -197,9 +198,10 @@ export function CounterServiceTheme({
           ordering && !embedded ? "pb-24 md:pb-8" : undefined,
         )}
       >
-        <div className="mx-auto flex max-w-7xl flex-col gap-4 text-sm sm:flex-row sm:items-center sm:justify-between">
+        <div className="mx-auto grid max-w-7xl gap-4 text-sm sm:grid-cols-3 sm:items-start">
           <span className="font-black">{draft.name}</span>
-          <span>{draft.address}</span>
+          <ThemeBusinessHours draft={draft} />
+          <span className="sm:text-right">{draft.address}</span>
         </div>
       </footer>
 

--- a/src/components/restaurant-themes/shared.tsx
+++ b/src/components/restaurant-themes/shared.tsx
@@ -107,6 +107,29 @@ export function ThemeLocation({
   );
 }
 
+export function ThemeBusinessHours({
+  draft,
+  className,
+}: {
+  draft: Pick<SiteDraftView, "businessHours">;
+  className?: string;
+}) {
+  if (draft.businessHours.length === 0) return null;
+  return (
+    <dl className={cn("grid gap-1", className)}>
+      {draft.businessHours.map((row) => (
+        <div
+          key={`${row.days}-${row.hours}`}
+          className="flex flex-wrap justify-between gap-x-4"
+        >
+          <dt>{row.days}</dt>
+          <dd>{row.hours}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
 export function ThemeExternalAction({
   integration,
   locale,

--- a/src/components/restaurant-themes/terroir-editorial.tsx
+++ b/src/components/restaurant-themes/terroir-editorial.tsx
@@ -4,6 +4,7 @@ import {
   itemBadges,
   themeStyle,
   ThemeAnalytics,
+  ThemeBusinessHours,
   ThemeExternalAction,
   ThemeHeroImage,
   ThemeLocaleNavigation,
@@ -206,9 +207,10 @@ export function TerroirEditorialTheme({
         </div>
       </section>
 
-      <footer className="flex flex-col gap-3 border-t border-current/15 px-6 py-7 text-xs opacity-55 sm:flex-row sm:justify-between md:px-10">
+      <footer className="grid gap-3 border-t border-current/15 px-6 py-7 text-xs opacity-55 sm:grid-cols-3 md:px-10">
         <span>{draft.name}</span>
-        <span>{draft.address}</span>
+        <ThemeBusinessHours draft={draft} />
+        <span className="sm:text-right">{draft.address}</span>
       </footer>
     </article>
   );

--- a/src/components/site-renderer.tsx
+++ b/src/components/site-renderer.tsx
@@ -521,11 +521,26 @@ export function SiteRenderer({
         </section>
       ) : null}
 
-      <footer className="flex flex-col gap-5 border-t border-current/15 px-6 py-8 text-sm opacity-75 sm:flex-row sm:items-center sm:justify-between md:px-10">
+      <footer className="grid gap-5 border-t border-current/15 px-6 py-8 text-sm opacity-75 sm:grid-cols-3 sm:items-start md:px-10">
         <span>
           {draft.name} · {draft.address}
         </span>
-        <span>{dictionary.seasonalNotice}</span>
+        {draft.businessHours.length > 0 ? (
+          <dl className="grid gap-1">
+            {draft.businessHours.map((row) => (
+              <div
+                key={`${row.days}-${row.hours}`}
+                className="flex justify-between gap-4"
+              >
+                <dt>{row.days}</dt>
+                <dd>{row.hours}</dd>
+              </div>
+            ))}
+          </dl>
+        ) : (
+          <span />
+        )}
+        <span className="sm:text-right">{dictionary.seasonalNotice}</span>
       </footer>
     </article>
   );

--- a/src/components/source-monitoring-panel.tsx
+++ b/src/components/source-monitoring-panel.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Check,
+  Clock3,
+  ExternalLink,
+  LoaderCircle,
+  X,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Textarea } from "@/components/ui/textarea";
+import type { SourceMonitoringDashboardDto } from "@/lib/source-monitoring";
+
+export function SourceMonitoringPanel({
+  siteSlug,
+  initial,
+  demo = false,
+}: {
+  siteSlug: string;
+  initial: SourceMonitoringDashboardDto;
+  demo?: boolean;
+}) {
+  const [suggestions, setSuggestions] = useState(initial.suggestions);
+  const [editing, setEditing] = useState<Record<string, string>>(() =>
+    Object.fromEntries(
+      initial.suggestions.map((suggestion) => [
+        suggestion.id,
+        JSON.stringify(suggestion.suggestedValue, null, 2),
+      ]),
+    ),
+  );
+  const [updating, setUpdating] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function review(id: string, action: "accept" | "reject") {
+    if (demo) return;
+    setUpdating(id);
+    setError(null);
+    try {
+      const editedValue =
+        action === "accept" ? JSON.parse(editing[id] ?? "null") : undefined;
+      const response = await fetch(
+        `/api/sites/${encodeURIComponent(siteSlug)}/source-monitoring/suggestions/${encodeURIComponent(id)}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ action, editedValue }),
+        },
+      );
+      const result = (await response.json()) as { error?: string };
+      if (!response.ok) {
+        throw new Error(result.error ?? "Suggestion review failed");
+      }
+      setSuggestions((current) =>
+        current.filter((suggestion) => suggestion.id !== id),
+      );
+    } catch (caught) {
+      setError(
+        caught instanceof SyntaxError
+          ? "The edited JSON is not valid."
+          : caught instanceof Error
+            ? caught.message
+            : "Suggestion review failed",
+      );
+    } finally {
+      setUpdating(null);
+    }
+  }
+
+  return (
+    <div>
+      <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-end">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary">
+            Source monitoring
+          </p>
+          <h2 className="font-display mt-2 text-4xl tracking-[-0.04em]">
+            Changes wait for your approval.
+          </h2>
+          <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+            We re-check the original website and known links. Suggestions update
+            only the private draft; publishing always remains a separate action.
+          </p>
+        </div>
+        <Badge variant={suggestions.length > 0 ? "secondary" : "outline"}>
+          {suggestions.length} awaiting review
+        </Badge>
+      </div>
+
+      <div className="mt-8 grid gap-4 md:grid-cols-3">
+        <StatusCard
+          label="Cadence"
+          value={
+            initial.cadenceDays
+              ? `Every ${initial.cadenceDays} days`
+              : "Not scheduled"
+          }
+        />
+        <StatusCard
+          label="Last successful check"
+          value={formatDateTime(initial.lastSuccessAt)}
+        />
+        <StatusCard
+          label="Next check"
+          value={formatDateTime(initial.nextRunAt)}
+        />
+      </div>
+      {initial.lastFailureAt ? (
+        <p className="mt-4 text-xs text-amber-700" role="status">
+          The last failed check was {formatDateTime(initial.lastFailureAt)}.
+          The durable workflow will retry safely.
+        </p>
+      ) : null}
+      {initial.latestRun?.failedSourceCount ? (
+        <p className="mt-4 text-xs text-amber-700" role="status">
+          {initial.latestRun.failedSourceCount} known link
+          {initial.latestRun.failedSourceCount === 1 ? "" : "s"} could not be
+          checked during the latest run. Successful evidence is still available
+          below.
+        </p>
+      ) : null}
+      {initial.latestRun?.notificationFailureCode ? (
+        <p className="mt-4 text-xs text-amber-700" role="status">
+          The review queue is current, but the email notification was not
+          delivered. Operators can still review the same suggestions here.
+        </p>
+      ) : null}
+      {error ? (
+        <p className="mt-4 text-sm text-destructive" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      <div className="mt-8 space-y-5">
+        {suggestions.map((suggestion) => (
+          <Card key={suggestion.id}>
+            <CardHeader className="gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <CardTitle>{fieldLabel(suggestion.field)}</CardTitle>
+                <p className="mt-1 font-mono text-[11px] text-muted-foreground">
+                  {suggestion.path}
+                </p>
+              </div>
+              <Badge variant="outline">Suggestion only</Badge>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <p className="mb-2 text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+                  Proposed private-draft value
+                </p>
+                <Textarea
+                  value={editing[suggestion.id] ?? ""}
+                  onChange={(event) =>
+                    setEditing((current) => ({
+                      ...current,
+                      [suggestion.id]: event.target.value,
+                    }))
+                  }
+                  className="min-h-40 font-mono text-xs"
+                  aria-label={`Edit ${fieldLabel(suggestion.field)} suggestion`}
+                />
+              </div>
+              <div className="rounded-xl border bg-muted/30 p-4">
+                <p className="text-xs font-semibold">Source evidence</p>
+                <div className="mt-3 space-y-3">
+                  {suggestion.evidence.map((evidence, index) => (
+                    <div key={`${evidence.contentDigest}-${index}`}>
+                      <a
+                        href={evidence.url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex items-center gap-1 text-xs font-medium text-primary"
+                      >
+                        Open source <ExternalLink className="size-3" />
+                      </a>
+                      <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                        {evidence.excerpt}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+              <div className="flex flex-wrap justify-end gap-2">
+                <Button
+                  variant="outline"
+                  onClick={() => void review(suggestion.id, "reject")}
+                  disabled={updating === suggestion.id || demo}
+                >
+                  {updating === suggestion.id ? (
+                    <LoaderCircle className="animate-spin" />
+                  ) : (
+                    <X />
+                  )}
+                  Reject
+                </Button>
+                <Button
+                  onClick={() => void review(suggestion.id, "accept")}
+                  disabled={updating === suggestion.id || demo}
+                >
+                  {updating === suggestion.id ? (
+                    <LoaderCircle className="animate-spin" />
+                  ) : (
+                    <Check />
+                  )}
+                  Accept edited value
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+        {suggestions.length === 0 ? (
+          <Card>
+            <CardContent className="flex items-center gap-3 py-8">
+              <Clock3 className="size-5 text-muted-foreground" />
+              <div>
+                <p className="font-medium">Nothing needs review.</p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Real run and success timestamps appear above after the first
+                  scheduled check.
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function StatusCard({ label, value }: { label: string; value: string }) {
+  return (
+    <Card>
+      <CardContent>
+        <p className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+          {label}
+        </p>
+        <p className="mt-2 font-medium">{value}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function formatDateTime(value: string | null) {
+  return value
+    ? new Intl.DateTimeFormat("en", {
+        dateStyle: "medium",
+        timeStyle: "short",
+      }).format(new Date(value))
+    : "No completed run yet";
+}
+
+function fieldLabel(value: string) {
+  return (
+    {
+      MENU: "Menu changes",
+      CONTACT: "Contact details",
+      HOURS: "Business hours",
+      LINKS: "Booking and ordering links",
+    }[value] ?? value
+  );
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -12,4 +12,14 @@ export async function register() {
     const { getWorld } = await import("workflow/runtime");
     await getWorld().start?.();
   }
+
+  if (
+    process.env.DATABASE_URL &&
+    process.env.WORKFLOW_ENABLED === "true"
+  ) {
+    const { startSourceMonitoringScheduler } = await import(
+      "@/lib/source-monitoring-runtime"
+    );
+    startSourceMonitoringScheduler();
+  }
 }

--- a/src/lib/ai/site-generation.ts
+++ b/src/lib/ai/site-generation.ts
@@ -29,6 +29,7 @@ type SiteDraftShape<
   attributes: TAttributes;
   autoEnhanceImages: boolean;
   defaultLocale: string;
+  businessHours: Array<{ days: string; hours: string }>;
   translations: Array<{
     integrationLabels: string[];
   }>;
@@ -54,6 +55,7 @@ export const SHARED_SKELETON = `Rules:
 - Never invent booking, ordering, delivery, address, phone, opening-hour, availability, allergen, service, or price facts.
 - Existing booking, ordering, and delivery systems must remain external links; do not rename their providers.
 - Preserve all factual catalog entries and prices that can be recovered.
+- Put only explicitly stated opening times in businessHours; use [] when none are stated.
 - Set defaultLocale to the canonical source locale using a two-letter language code.
 - When the canonical locale is not English, include one complete "en" translation. When it is English, do not duplicate it in translations.
 - A translation is a linguistic overlay only: its catalog sections, items and integrationLabels must have exactly the same order and counts as the canonical data.
@@ -167,6 +169,7 @@ export function deterministicDraft<
       vertical.deterministicAttributes ?? vertical.attributeDefaults,
     autoEnhanceImages: false,
     defaultLocale: source.sourceLocale ?? "en",
+    businessHours: [],
     translations: [],
     catalogSections: [
       {

--- a/src/lib/importer.ts
+++ b/src/lib/importer.ts
@@ -240,6 +240,40 @@ export async function fetchPublicImage(rawUrl: string): Promise<{
   throw new Error("The source image redirected too many times");
 }
 
+/**
+ * Re-validates a known integration URL through the same SSRF and redirect
+ * boundary as source imports. Monitoring records only status/final URL; it
+ * never downloads third-party response bodies or follows private redirects.
+ */
+export async function inspectPublicLink(rawUrl: string): Promise<{
+  originalUrl: string;
+  finalUrl: string;
+  status: number;
+}> {
+  const originalUrl = new URL(rawUrl).toString();
+  let url = new URL(originalUrl);
+  for (let redirectCount = 0; redirectCount <= MAX_REDIRECTS; redirectCount++) {
+    await assertPublicUrl(url);
+    const response = await fetch(url, {
+      method: "HEAD",
+      redirect: "manual",
+      signal: AbortSignal.timeout(10_000),
+      headers: {
+        "User-Agent":
+          "Cornershopdev Monitor/1.0 (+https://cornershop.dev; source link check)",
+      },
+    });
+    if ([301, 302, 303, 307, 308].includes(response.status)) {
+      const location = response.headers.get("location");
+      if (!location) throw new Error("The link returned an invalid redirect");
+      url = new URL(location, url);
+      continue;
+    }
+    return { originalUrl, finalUrl: url.toString(), status: response.status };
+  }
+  throw new Error("The link redirected too many times");
+}
+
 function decodeHtml(value: string): string {
   return value
     .replaceAll("&amp;", "&")

--- a/src/lib/operator-dashboard.ts
+++ b/src/lib/operator-dashboard.ts
@@ -27,6 +27,8 @@ export type OperatorSiteRow = {
   pendingBookingRequestCount: number;
   verifiedDomain: string | null;
   analytics30d: SiteAnalyticsRowDto;
+  pendingSourceSuggestionCount: number;
+  sourceMonitorLastSuccessAt: Date | null;
 };
 
 export type OperatorDashboardData = {
@@ -91,7 +93,17 @@ export async function getOperatorDashboardData(): Promise<OperatorDashboardData>
           take: 1,
           select: { status: true, createdAt: true },
         },
-        _count: { select: { bookingRequests: true } },
+        _count: {
+          select: {
+            bookingRequests: true,
+            sourceMonitorSuggestions: {
+              where: { status: "PENDING" },
+            },
+          },
+        },
+        sourceMonitorState: {
+          select: { lastSuccessAt: true },
+        },
         domains: {
           where: { verified: true },
           orderBy: { verifiedAt: "desc" },
@@ -149,6 +161,10 @@ export async function getOperatorDashboardData(): Promise<OperatorDashboardData>
         ctaRate: 0,
         leadRate: 0,
       },
+      pendingSourceSuggestionCount:
+        site._count.sourceMonitorSuggestions,
+      sourceMonitorLastSuccessAt:
+        site.sourceMonitorState?.lastSuccessAt ?? null,
     })),
   };
 }

--- a/src/lib/site-draft.ts
+++ b/src/lib/site-draft.ts
@@ -86,6 +86,7 @@ export type SiteDraftView = {
   heroImageUrl: string | null;
   palette: SitePaletteView;
   defaultLocale: string;
+  businessHours: Array<{ days: string; hours: string }>;
   attributes: Record<string, unknown>;
   catalogSections: SiteCatalogSectionView[];
   integrations: SiteIntegrationView[];

--- a/src/lib/site-persistence.ts
+++ b/src/lib/site-persistence.ts
@@ -41,6 +41,7 @@ export type PersistableSiteDraft = {
   attributes: Record<string, unknown>;
   autoEnhanceImages: boolean;
   defaultLocale: string;
+  businessHours: Array<{ days: string; hours: string }>;
   translations: unknown[];
   catalogSections: Array<{
     name: string;
@@ -599,6 +600,7 @@ function editableSiteScalarData(
     draftPalette: draft.palette as Prisma.InputJsonValue,
     autoEnhanceImages: draft.autoEnhanceImages,
     defaultLocale: draft.defaultLocale,
+    businessHours: draft.businessHours as Prisma.InputJsonValue,
     translations: draft.translations as Prisma.InputJsonValue,
   };
 }

--- a/src/lib/site-themes/restaurant/fixtures.ts
+++ b/src/lib/site-themes/restaurant/fixtures.ts
@@ -91,7 +91,8 @@ export const restaurantThemeFixtures: Record<
       foreground: "#20231f",
       accent: "#7f3f2e",
     },
-    defaultLocale: "en",
+  defaultLocale: "en",
+  businessHours: [],
     profile: terroirProfile,
     catalogSections: [
       {
@@ -152,7 +153,8 @@ export const restaurantThemeFixtures: Record<
       foreground: "#172118",
       accent: "#d94028",
     },
-    defaultLocale: "en",
+  defaultLocale: "en",
+  businessHours: [],
     profile: counterProfile,
     catalogSections: [
       {
@@ -234,7 +236,8 @@ export const restaurantThemeFixtures: Record<
       foreground: "#f5efe4",
       accent: "#e85d3f",
     },
-    defaultLocale: "en",
+  defaultLocale: "en",
+  businessHours: [],
     profile: afterDarkProfile,
     catalogSections: [
       {

--- a/src/lib/sites.ts
+++ b/src/lib/sites.ts
@@ -80,6 +80,7 @@ export function projectSiteDraft(site: PersistedSiteDraftRecord): LoadedSite {
     attributes,
     autoEnhanceImages: site.autoEnhanceImages,
     defaultLocale: site.defaultLocale,
+    businessHours: site.businessHours,
     translations: site.translations,
     catalogSections: site.catalogSections.map((section) => ({
       name: section.name,

--- a/src/lib/source-monitoring-access.test.ts
+++ b/src/lib/source-monitoring-access.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+let mode: "owner" | "operator" | "denied" = "denied";
+mock.module("@/lib/authorization", () => ({
+  getSiteAccess: async (slug: string) =>
+    mode === "owner"
+      ? {
+          ok: true,
+          site: { id: "site_1", slug },
+          user: { id: "user_1", email: "owner@example.com" },
+        }
+      : { ok: false, status: 403, message: "Forbidden" },
+  getSuperadminAccess: async () =>
+    mode === "operator"
+      ? { id: "operator_1", email: "ops@example.com" }
+      : null,
+}));
+mock.module("@/lib/db", () => ({
+  getDb: () => ({
+    site: {
+      findUnique: async () => ({ id: "site_1", slug: "example" }),
+    },
+  }),
+}));
+
+const { getSourceMonitoringAccess } = await import(
+  "@/lib/source-monitoring-access"
+);
+
+describe("source monitoring review authorization", () => {
+  beforeEach(() => {
+    mode = "denied";
+  });
+
+  it("allows the owning site member", async () => {
+    mode = "owner";
+    expect(await getSourceMonitoringAccess("example")).toMatchObject({
+      ok: true,
+      actor: { id: "user_1", role: "owner" },
+      site: { id: "site_1" },
+    });
+  });
+
+  it("allows a dual-gated platform operator", async () => {
+    mode = "operator";
+    expect(await getSourceMonitoringAccess("example")).toMatchObject({
+      ok: true,
+      actor: { id: "operator_1", role: "operator" },
+      site: { id: "site_1" },
+    });
+  });
+
+  it("rejects everyone else", async () => {
+    expect(await getSourceMonitoringAccess("example")).toEqual({
+      ok: false,
+      status: 403,
+      message: "Forbidden",
+    });
+  });
+});

--- a/src/lib/source-monitoring-access.ts
+++ b/src/lib/source-monitoring-access.ts
@@ -1,0 +1,59 @@
+import "server-only";
+import {
+  getSiteAccess,
+  getSuperadminAccess,
+  type AccessFailure,
+} from "@/lib/authorization";
+import { getDb } from "@/lib/db";
+
+export type SourceMonitoringAccess =
+  | {
+      ok: true;
+      site: { id: string; slug: string };
+      actor: {
+        id: string;
+        email: string;
+        role: "owner" | "operator";
+      };
+    }
+  | AccessFailure;
+
+export async function getSourceMonitoringAccess(
+  siteSlug: string,
+): Promise<SourceMonitoringAccess> {
+  const owner = await getSiteAccess(siteSlug);
+  if (owner.ok) {
+    return {
+      ok: true,
+      site: { id: owner.site.id, slug: owner.site.slug },
+      actor: {
+        id: owner.user.id,
+        email: owner.user.email,
+        role: "owner",
+      },
+    };
+  }
+
+  const operator = await getSuperadminAccess();
+  if (!operator) return owner;
+  const site = await getDb().site.findUnique({
+    where: { slug: siteSlug },
+    select: { id: true, slug: true },
+  });
+  if (!site) {
+    return {
+      ok: false,
+      status: 403,
+      message: "Site access is required",
+    };
+  }
+  return {
+    ok: true,
+    site,
+    actor: {
+      id: operator.id,
+      email: operator.email,
+      role: "operator",
+    },
+  };
+}

--- a/src/lib/source-monitoring-diff.test.ts
+++ b/src/lib/source-monitoring-diff.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "bun:test";
+import { buildSourceMonitoringDiff } from "@/lib/source-monitoring-diff";
+
+describe("evidence-backed source diffs", () => {
+  it("emits menu, contact, hours and link suggestions with evidence", () => {
+    const current = draft();
+    const proposed = {
+      ...draft(),
+      phone: "+356 9999 0000",
+      businessHours: [{ days: "Monday-Friday", hours: "09:00-18:00" }],
+      catalogSections: [
+        {
+          name: "Lunch",
+          description: "",
+          items: [
+            {
+              name: "New pasta",
+              description: "Tomato",
+              price: 18,
+              currency: "EUR",
+              attributes: {},
+              imageUrl: null,
+            },
+          ],
+        },
+      ],
+    };
+    const result = buildSourceMonitoringDiff({
+      current,
+      proposed,
+      extracted: {
+        source: "example.com",
+        sourceUrl: "https://example.com/",
+        sourceLocale: "en",
+        name: "Example",
+        description: "",
+        address: "",
+        phone: "+356 9999 0000",
+        heroImageUrl: null,
+        pageText:
+          "Contact +356 9999 0000. Monday-Friday 09:00-18:00. Lunch: New pasta, Tomato, €18.",
+        links: [
+          {
+            type: "booking",
+            label: "Book",
+            provider: "Provider",
+            url: "https://book.example.com/",
+          },
+        ],
+      },
+      checkedLinks: [],
+      capturedAt: new Date("2026-07-27T00:00:00.000Z"),
+    });
+    expect(result.map((entry) => entry.field).sort()).toEqual([
+      "CONTACT",
+      "HOURS",
+      "LINKS",
+      "MENU",
+    ]);
+    expect(result.every((entry) => entry.evidence.length > 0)).toBe(true);
+  });
+
+  it("drops AI-proposed facts that are absent from source evidence", () => {
+    const current = draft();
+    const result = buildSourceMonitoringDiff({
+      current,
+      proposed: {
+        ...current,
+        phone: "invented",
+        businessHours: [{ days: "Sunday", hours: "24 hours" }],
+        catalogSections: [
+          {
+            name: "Fantasy",
+            description: "",
+            items: [
+              {
+                name: "Imaginary dish",
+                description: "",
+                price: 99,
+                currency: "EUR",
+                attributes: {},
+                imageUrl: null,
+              },
+            ],
+          },
+        ],
+      },
+      extracted: {
+        source: "example.com",
+        sourceUrl: "https://example.com/",
+        sourceLocale: "en",
+        name: "Example",
+        description: "",
+        address: "",
+        phone: "",
+        heroImageUrl: null,
+        pageText: "Welcome to Example",
+        links: [],
+      },
+      checkedLinks: [],
+      capturedAt: new Date(),
+    });
+    expect(result).toEqual([]);
+  });
+});
+
+function draft() {
+  return {
+    slug: "example",
+    name: "Example",
+    eyebrow: "",
+    description: "A sufficiently long example business description.",
+    address: "",
+    phone: "",
+    sourceUrl: "https://example.com/",
+    heroImageUrl: null,
+    palette: { background: "#fff", foreground: "#000", accent: "#f00" },
+    attributes: {},
+    autoEnhanceImages: false,
+    defaultLocale: "en",
+    businessHours: [],
+    translations: [],
+    catalogSections: [
+      {
+        name: "Menu",
+        description: "",
+        items: [],
+      },
+    ],
+    integrations: [],
+  };
+}

--- a/src/lib/source-monitoring-diff.ts
+++ b/src/lib/source-monitoring-diff.ts
@@ -1,0 +1,282 @@
+import { createHash } from "node:crypto";
+import type { Prisma } from "@/generated/prisma/client";
+import type { ExtractedSite } from "@/lib/importer";
+import type { PersistableSiteDraft } from "@/lib/site-persistence";
+
+export type MonitoringField = "MENU" | "CONTACT" | "HOURS" | "LINKS";
+
+export type SourceEvidence = {
+  url: string;
+  excerpt: string;
+  capturedAt: string;
+  contentDigest: string;
+};
+
+export type MonitoringSuggestionInput = {
+  fingerprint: string;
+  field: MonitoringField;
+  path: string;
+  currentValue: Prisma.InputJsonValue;
+  suggestedValue: Prisma.InputJsonValue;
+  evidence: SourceEvidence[];
+};
+
+export function buildSourceMonitoringDiff(input: {
+  current: PersistableSiteDraft;
+  proposed: PersistableSiteDraft;
+  extracted: ExtractedSite;
+  checkedLinks: Array<{
+    originalUrl: string;
+    finalUrl: string;
+    status: number;
+  }>;
+  capturedAt: Date;
+}): MonitoringSuggestionInput[] {
+  const suggestions: MonitoringSuggestionInput[] = [];
+  const contact = {
+    address: input.proposed.address,
+    phone: input.proposed.phone,
+  };
+  const currentContact = {
+    address: input.current.address,
+    phone: input.current.phone,
+  };
+  const contactEvidence = evidenceForValues(
+    input.extracted,
+    [contact.address, contact.phone],
+    input.capturedAt,
+  );
+  if (
+    !same(currentContact, contact) &&
+    hasEvidenceForEveryValue(
+      input.extracted.pageText,
+      [contact.address, contact.phone],
+    )
+  ) {
+    suggestions.push(
+      suggestion("CONTACT", "contact", currentContact, contact, contactEvidence),
+    );
+  }
+
+  const hoursEvidence = evidenceForValues(
+    input.extracted,
+    input.proposed.businessHours.flatMap((row) => [row.days, row.hours]),
+    input.capturedAt,
+  );
+  if (
+    !same(input.current.businessHours, input.proposed.businessHours) &&
+    input.proposed.businessHours.length > 0 &&
+    hasEvidenceForEveryValue(
+      input.extracted.pageText,
+      input.proposed.businessHours.flatMap((row) => [row.days, row.hours]),
+    )
+  ) {
+    suggestions.push(
+      suggestion(
+        "HOURS",
+        "businessHours",
+        input.current.businessHours,
+        input.proposed.businessHours,
+        hoursEvidence,
+      ),
+    );
+  }
+
+  const proposedItemNames = input.proposed.catalogSections.flatMap((section) =>
+    section.items.map((item) => item.name),
+  );
+  if (
+    !same(input.current.catalogSections, input.proposed.catalogSections) &&
+    proposedItemNames.length > 0 &&
+    hasEvidenceForEveryValue(input.extracted.pageText, proposedItemNames)
+  ) {
+    suggestions.push(
+      suggestion(
+        "MENU",
+        "catalogSections",
+        {
+          catalogSections: input.current.catalogSections,
+          translations: input.current.translations,
+        },
+        {
+          catalogSections: input.proposed.catalogSections,
+          translations: structurallyCompatibleTranslations(
+            input.current.translations,
+            input.proposed.catalogSections,
+          ),
+        },
+        evidenceForValues(
+          input.extracted,
+          proposedItemNames.slice(0, 8),
+          input.capturedAt,
+        ),
+      ),
+    );
+  }
+
+  const proposedLinks = mergeLinks(
+    input.current.integrations,
+    input.extracted.links,
+    input.checkedLinks,
+  );
+  if (!same(input.current.integrations, proposedLinks)) {
+    const digest = contentDigest(input.extracted.pageText);
+    suggestions.push(
+      suggestion(
+        "LINKS",
+        "integrations",
+        {
+          integrations: input.current.integrations,
+          translations: input.current.translations,
+        },
+        {
+          integrations: proposedLinks,
+          translations: integrationCompatibleTranslations(
+            input.current.translations,
+            proposedLinks.map((link) => link.label),
+          ),
+        },
+        proposedLinks.slice(0, 8).map((link) => ({
+          url: input.extracted.sourceUrl ?? input.extracted.source,
+          excerpt: `${link.label}: ${link.url}`.slice(0, 280),
+          capturedAt: input.capturedAt.toISOString(),
+          contentDigest: digest,
+        })),
+      ),
+    );
+  }
+  return suggestions;
+}
+
+function structurallyCompatibleTranslations(
+  translations: unknown[],
+  sections: PersistableSiteDraft["catalogSections"],
+) {
+  return translations.filter((translation) => {
+    if (!isRecord(translation) || !Array.isArray(translation.catalogSections)) {
+      return false;
+    }
+    return (
+      translation.catalogSections.length === sections.length &&
+      translation.catalogSections.every((section, sectionIndex) => {
+        if (!isRecord(section) || !Array.isArray(section.items)) return false;
+        return section.items.length === sections[sectionIndex]?.items.length;
+      })
+    );
+  });
+}
+
+function integrationCompatibleTranslations(
+  translations: unknown[],
+  labels: string[],
+) {
+  return translations.flatMap((translation) => {
+    if (!isRecord(translation)) return [];
+    const currentLabels = Array.isArray(translation.integrationLabels)
+      ? translation.integrationLabels
+      : [];
+    return [
+      {
+        ...translation,
+        integrationLabels: labels.map(
+          (label, index) =>
+            typeof currentLabels[index] === "string"
+              ? currentLabels[index]
+              : label,
+        ),
+      },
+    ];
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function mergeLinks(
+  current: PersistableSiteDraft["integrations"],
+  extracted: ExtractedSite["links"],
+  checked: Array<{ originalUrl: string; finalUrl: string; status: number }>,
+): PersistableSiteDraft["integrations"] {
+  const health = new Map(checked.map((result) => [result.originalUrl, result]));
+  const merged = current.map((link) => {
+    const result = health.get(link.url);
+    return result && result.status >= 200 && result.status < 400
+      ? { ...link, url: result.finalUrl }
+      : link;
+  });
+  for (const link of extracted) {
+    if (
+      !merged.some(
+        (candidate) =>
+          candidate.url === link.url ||
+          (link.provider && candidate.provider === link.provider),
+      )
+    ) {
+      merged.push({ ...link, venueId: null });
+    }
+  }
+  return merged;
+}
+
+function suggestion(
+  field: MonitoringField,
+  path: string,
+  currentValue: unknown,
+  suggestedValue: unknown,
+  evidence: SourceEvidence[],
+): MonitoringSuggestionInput {
+  const serialized = JSON.stringify({ field, path, currentValue, suggestedValue });
+  return {
+    fingerprint: createHash("sha256").update(serialized).digest("hex"),
+    field,
+    path,
+    currentValue: currentValue as Prisma.InputJsonValue,
+    suggestedValue: suggestedValue as Prisma.InputJsonValue,
+    evidence,
+  };
+}
+
+function evidenceForValues(
+  extracted: ExtractedSite,
+  values: string[],
+  capturedAt: Date,
+): SourceEvidence[] {
+  const digest = contentDigest(extracted.pageText);
+  return values
+    .filter(Boolean)
+    .slice(0, 8)
+    .map((value) => ({
+      url: extracted.sourceUrl ?? extracted.source,
+      excerpt: evidenceExcerpt(extracted.pageText, value),
+      capturedAt: capturedAt.toISOString(),
+      contentDigest: digest,
+    }));
+}
+
+function evidenceExcerpt(text: string, value: string): string {
+  const index = normalize(text).indexOf(normalize(value));
+  if (index < 0) return value.slice(0, 280);
+  return text.slice(Math.max(0, index - 80), index + value.length + 120).trim();
+}
+
+function hasEvidenceForEveryValue(text: string, values: string[]): boolean {
+  const haystack = normalize(text);
+  const meaningful = values.map(normalize).filter(Boolean);
+  return (
+    meaningful.length > 0 &&
+    meaningful.every((value) => haystack.includes(value))
+  );
+}
+
+function normalize(value: string): string {
+  return value.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function contentDigest(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function same(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}

--- a/src/lib/source-monitoring-plan.test.ts
+++ b/src/lib/source-monitoring-plan.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+import {
+  monitoringEntitlement,
+  monitoringIdempotencyKey,
+  nextMonitoringTime,
+} from "@/lib/source-monitoring-plan";
+
+const env = {
+  STRIPE_STARTER_PRICE_ID: "price_starter",
+  STRIPE_GROWTH_PRICE_ID: "price_growth",
+};
+
+describe("source monitoring plan cadence", () => {
+  it("checks Starter monthly and Growth weekly", () => {
+    expect(
+      monitoringEntitlement(
+        {
+          status: "ACTIVE",
+          stripePriceId: "price_starter",
+          siteStatus: "LIVE",
+        },
+        env,
+      ),
+    ).toEqual({ active: true, plan: "starter", cadenceDays: 30 });
+    expect(
+      monitoringEntitlement(
+        {
+          status: "ACTIVE",
+          stripePriceId: "price_growth",
+          siteStatus: "CLAIMED",
+        },
+        env,
+      ),
+    ).toEqual({ active: true, plan: "growth", cadenceDays: 7 });
+  });
+
+  it("stops paused, canceled, past-due, and unknown subscriptions", () => {
+    for (const input of [
+      {
+        status: "CANCELED" as const,
+        stripePriceId: "price_starter",
+        siteStatus: "LIVE" as const,
+      },
+      {
+        status: "PAST_DUE" as const,
+        stripePriceId: "price_growth",
+        siteStatus: "LIVE" as const,
+      },
+      {
+        status: "ACTIVE" as const,
+        stripePriceId: "price_starter",
+        siteStatus: "PAUSED" as const,
+      },
+      {
+        status: "ACTIVE" as const,
+        stripePriceId: "price_retired",
+        siteStatus: "LIVE" as const,
+      },
+    ]) {
+      expect(monitoringEntitlement(input, env).active).toBe(false);
+    }
+  });
+
+  it("advances from the durable scheduled time and skips missed intervals", () => {
+    expect(
+      nextMonitoringTime(
+        new Date("2026-06-01T00:00:00.000Z"),
+        7,
+        new Date("2026-07-01T00:00:00.000Z"),
+      ).toISOString(),
+    ).toBe("2026-07-06T00:00:00.000Z");
+    expect(
+      monitoringIdempotencyKey(
+        "site_1",
+        new Date("2026-07-06T00:00:00.000Z"),
+      ),
+    ).toBe("site_1:2026-07-06T00:00:00.000Z");
+  });
+});

--- a/src/lib/source-monitoring-plan.ts
+++ b/src/lib/source-monitoring-plan.ts
@@ -1,0 +1,76 @@
+import type {
+  SiteStatus,
+  SubscriptionStatus,
+} from "@/generated/prisma/enums";
+import {
+  billingPlanForPrice,
+  configuredBillingPlans,
+  type BillingPlanId,
+} from "@/lib/billing-plans";
+
+const DAY_MS = 24 * 60 * 60_000;
+
+export type MonitoringEntitlement =
+  | { active: true; plan: BillingPlanId; cadenceDays: 7 | 30 }
+  | {
+      active: false;
+      reason:
+        | "NO_SUBSCRIPTION"
+        | "INACTIVE_SUBSCRIPTION"
+        | "PAUSED_SITE"
+        | "UNKNOWN_PLAN";
+    };
+
+export function monitoringEntitlement(
+  input: {
+    status: SubscriptionStatus | null;
+    stripePriceId: string | null;
+    siteStatus: SiteStatus;
+  },
+  env: Record<string, string | undefined> = process.env,
+): MonitoringEntitlement {
+  if (!input.status || !input.stripePriceId) {
+    return { active: false, reason: "NO_SUBSCRIPTION" };
+  }
+  if (input.status !== "ACTIVE") {
+    return { active: false, reason: "INACTIVE_SUBSCRIPTION" };
+  }
+  if (input.siteStatus === "PAUSED") {
+    return { active: false, reason: "PAUSED_SITE" };
+  }
+
+  let plan;
+  try {
+    plan = billingPlanForPrice(
+      input.stripePriceId,
+      configuredBillingPlans(env),
+    );
+  } catch {
+    plan = null;
+  }
+  if (!plan) return { active: false, reason: "UNKNOWN_PLAN" };
+  return {
+    active: true,
+    plan: plan.id,
+    cadenceDays: plan.id === "growth" ? 7 : 30,
+  };
+}
+
+export function nextMonitoringTime(
+  scheduledFor: Date,
+  cadenceDays: number,
+  now = new Date(),
+): Date {
+  let next = new Date(scheduledFor.getTime() + cadenceDays * DAY_MS);
+  while (next <= now) {
+    next = new Date(next.getTime() + cadenceDays * DAY_MS);
+  }
+  return next;
+}
+
+export function monitoringIdempotencyKey(
+  siteId: string,
+  scheduledFor: Date,
+): string {
+  return `${siteId}:${scheduledFor.toISOString()}`;
+}

--- a/src/lib/source-monitoring-runtime.ts
+++ b/src/lib/source-monitoring-runtime.ts
@@ -1,0 +1,38 @@
+import "server-only";
+import {
+  dispatchDueSourceMonitoring,
+  SOURCE_MONITORING_SCHEDULER_INTERVAL_MS,
+} from "@/lib/source-monitoring";
+
+const MAX_INITIAL_JITTER_MS = 5 * 60_000;
+
+type MonitoringSchedulerGlobal = typeof globalThis & {
+  __cornershopSourceMonitoringStarted?: boolean;
+};
+
+export function startSourceMonitoringScheduler(): void {
+  const schedulerGlobal = globalThis as MonitoringSchedulerGlobal;
+  if (schedulerGlobal.__cornershopSourceMonitoringStarted) return;
+  schedulerGlobal.__cornershopSourceMonitoringStarted = true;
+
+  const run = () => {
+    void dispatchDueSourceMonitoring()
+      .then((result) => {
+        console.log("[source-monitoring] dispatch complete", result);
+      })
+      .catch((error) => {
+        console.error("[source-monitoring] dispatch failed", {
+          error: error instanceof Error ? error.message : "unknown",
+        });
+      });
+  };
+  const initial = setTimeout(() => {
+    run();
+    const interval = setInterval(
+      run,
+      SOURCE_MONITORING_SCHEDULER_INTERVAL_MS,
+    );
+    interval.unref();
+  }, Math.floor(Math.random() * MAX_INITIAL_JITTER_MS));
+  initial.unref();
+}

--- a/src/lib/source-monitoring.postgres.test.ts
+++ b/src/lib/source-monitoring.postgres.test.ts
@@ -1,0 +1,218 @@
+import { randomUUID } from "node:crypto";
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+const enabled = process.env.SOURCE_MONITORING_POSTGRES_TEST === "1";
+const siteId = `monitor-site-${randomUUID()}`;
+const organizationId = `monitor-org-${randomUUID()}`;
+const userId = `monitor-user-${randomUUID()}`;
+const slug = `monitor-${randomUUID()}`;
+const previousStarter = process.env.STRIPE_STARTER_PRICE_ID;
+const previousGrowth = process.env.STRIPE_GROWTH_PRICE_ID;
+
+let db: ReturnType<typeof import("@/lib/db").getDb>;
+let dispatchDueSourceMonitoring: typeof import("@/lib/source-monitoring").dispatchDueSourceMonitoring;
+let reviewSourceMonitoringSuggestion: typeof import("@/lib/source-monitoring").reviewSourceMonitoringSuggestion;
+let SourceMonitoringConflictError: typeof import("@/lib/source-monitoring").SourceMonitoringConflictError;
+
+describe.skipIf(!enabled)("source monitoring PostgreSQL persistence", () => {
+  beforeAll(async () => {
+    process.env.STRIPE_STARTER_PRICE_ID = "price_monitor_starter";
+    process.env.STRIPE_GROWTH_PRICE_ID = "price_monitor_growth";
+    const database = await import("@/lib/db");
+    const monitoring = await import("@/lib/source-monitoring");
+    db = database.getDb();
+    dispatchDueSourceMonitoring = monitoring.dispatchDueSourceMonitoring;
+    reviewSourceMonitoringSuggestion =
+      monitoring.reviewSourceMonitoringSuggestion;
+    SourceMonitoringConflictError = monitoring.SourceMonitoringConflictError;
+
+    await db.user.create({
+      data: {
+        id: userId,
+        email: `${userId}@example.test`,
+        memberships: {
+          create: {
+            organization: {
+              create: {
+                id: organizationId,
+                name: "Monitoring integration",
+              },
+            },
+          },
+        },
+      },
+    });
+    await db.site.create({
+      data: {
+        id: siteId,
+        slug,
+        name: "Monitoring Cafe",
+        eyebrow: "Cafe",
+        description: "A sufficiently long monitoring integration fixture.",
+        address: "Old address",
+        phone: "1111",
+        sourceUrl: "https://example.com/",
+        draftPalette: {
+          background: "#ffffff",
+          foreground: "#111111",
+          accent: "#aa0000",
+        },
+        attributes: { cuisine: "Cafe", showMenuImages: false },
+        status: "CLAIMED",
+        organizationId,
+        catalogSections: {
+          create: {
+            name: "Menu",
+            description: "",
+            position: 0,
+          },
+        },
+        subscription: {
+          create: {
+            stripeCustomerId: `cus_${randomUUID()}`,
+            stripeSubscriptionId: `sub_${randomUUID()}`,
+            stripePriceId: "price_monitor_starter",
+            status: "ACTIVE",
+            organizationId,
+          },
+        },
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await db.site.deleteMany({ where: { id: siteId } });
+    await db.organization.deleteMany({ where: { id: organizationId } });
+    await db.user.deleteMany({ where: { id: userId } });
+    restoreEnvironment(
+      "STRIPE_STARTER_PRICE_ID",
+      previousStarter,
+    );
+    restoreEnvironment("STRIPE_GROWTH_PRICE_ID", previousGrowth);
+  });
+
+  test("claims one durable run for one schedule slot", async () => {
+    const now = new Date("2026-07-27T10:00:00.000Z");
+    const first = await dispatchDueSourceMonitoring(
+      now,
+      async (runId) => `workflow-${runId}`,
+    );
+    const replay = await dispatchDueSourceMonitoring(
+      now,
+      async (runId) => `workflow-replay-${runId}`,
+    );
+    expect(first).toEqual({ claimed: 1, started: 1, failedToStart: 0 });
+    expect(replay).toEqual({ claimed: 0, started: 0, failedToStart: 0 });
+    expect(
+      await db.sourceMonitorRun.count({ where: { siteId } }),
+    ).toBe(1);
+  });
+
+  test("applies an accepted suggestion to the draft but never publishes", async () => {
+    const run = await db.sourceMonitorRun.create({
+      data: {
+        siteId,
+        idempotencyKey: `${siteId}:manual-accept`,
+        scheduledFor: new Date(),
+        status: "SUCCEEDED",
+        completedAt: new Date(),
+        suggestionCount: 1,
+      },
+    });
+    const suggestion = await db.sourceMonitorSuggestion.create({
+      data: {
+        siteId,
+        runId: run.id,
+        fingerprint: randomUUID(),
+        field: "CONTACT",
+        path: "contact",
+        currentValue: { address: "Old address", phone: "1111" },
+        suggestedValue: { address: "New address", phone: "2222" },
+        evidence: [],
+      },
+    });
+    await reviewSourceMonitoringSuggestion({
+      siteId,
+      suggestionId: suggestion.id,
+      actor: {
+        id: userId,
+        email: `${userId}@example.test`,
+        role: "owner",
+      },
+      action: "accept",
+    });
+    expect(
+      await db.site.findUniqueOrThrow({
+        where: { id: siteId },
+        select: {
+          address: true,
+          phone: true,
+          publishedSiteVersionId: true,
+          _count: { select: { siteVersions: true } },
+        },
+      }),
+    ).toEqual({
+      address: "New address",
+      phone: "2222",
+      publishedSiteVersionId: null,
+      _count: { siteVersions: 0 },
+    });
+  });
+
+  test("rejects stale suggestions instead of overwriting a later owner edit", async () => {
+    const run = await db.sourceMonitorRun.create({
+      data: {
+        siteId,
+        idempotencyKey: `${siteId}:manual-stale`,
+        scheduledFor: new Date(),
+        status: "SUCCEEDED",
+        completedAt: new Date(),
+        suggestionCount: 1,
+      },
+    });
+    const suggestion = await db.sourceMonitorSuggestion.create({
+      data: {
+        siteId,
+        runId: run.id,
+        fingerprint: randomUUID(),
+        field: "CONTACT",
+        path: "contact",
+        currentValue: { address: "Old address", phone: "1111" },
+        suggestedValue: { address: "Bad overwrite", phone: "3333" },
+        evidence: [],
+      },
+    });
+    await expect(
+      reviewSourceMonitoringSuggestion({
+        siteId,
+        suggestionId: suggestion.id,
+        actor: {
+          id: userId,
+          email: `${userId}@example.test`,
+          role: "owner",
+        },
+        action: "accept",
+      }),
+    ).rejects.toBeInstanceOf(SourceMonitoringConflictError);
+    expect(
+      await db.sourceMonitorSuggestion.findUniqueOrThrow({
+        where: { id: suggestion.id },
+        select: { status: true },
+      }),
+    ).toEqual({ status: "PENDING" });
+  });
+});
+
+function restoreEnvironment(name: string, value: string | undefined) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}

--- a/src/lib/source-monitoring.ts
+++ b/src/lib/source-monitoring.ts
@@ -1,0 +1,870 @@
+import "server-only";
+import { Prisma } from "@/generated/prisma/client";
+import type {
+  IntegrationType,
+  SourceMonitorSuggestionField,
+  Vertical,
+} from "@/generated/prisma/enums";
+import { z } from "zod";
+import { configuredSuperadminEmails } from "@/lib/superadmin-config";
+import { getDb } from "@/lib/db";
+import {
+  inspectPublicLink,
+} from "@/lib/importer";
+import { emailReplyTo, emailSender, getResend } from "@/lib/resend";
+import {
+  buildSourceMonitoringDiff,
+  type MonitoringSuggestionInput,
+  type SourceEvidence,
+} from "@/lib/source-monitoring-diff";
+import {
+  monitoringEntitlement,
+  monitoringIdempotencyKey,
+  nextMonitoringTime,
+} from "@/lib/source-monitoring-plan";
+import {
+  type PersistableSiteDraft,
+} from "@/lib/site-persistence";
+import {
+  projectSiteDraft,
+  siteDraftRelations,
+} from "@/lib/sites";
+import {
+  crawlSiteSource,
+  generateDraftForVertical,
+} from "@/lib/site-pipeline";
+import {
+  businessHoursSchema,
+  catalogSectionSchema,
+  integrationSchema,
+} from "@/lib/verticals/schema";
+import { resolveVerticalConfig } from "@/lib/verticals/registry";
+import type { VerticalId } from "@/lib/verticals/types";
+
+const DAY_MS = 24 * 60 * 60_000;
+const MAX_DISPATCH = 200;
+const contactSchema = z.object({
+  address: z.string().max(220),
+  phone: z.string().max(40),
+});
+const menuSchema = z.array(catalogSectionSchema).min(1).max(12);
+const linksSchema = z.array(integrationSchema).max(12);
+const menuSuggestionSchema = z.object({
+  catalogSections: menuSchema,
+  translations: z.array(z.unknown()).max(8),
+});
+const linksSuggestionSchema = z.object({
+  integrations: linksSchema,
+  translations: z.array(z.unknown()).max(8),
+});
+
+export class SourceMonitoringConflictError extends Error {
+  constructor() {
+    super("The draft changed after this suggestion was created");
+    this.name = "SourceMonitoringConflictError";
+  }
+}
+
+export type SourceMonitoringDashboardDto = {
+  cadenceDays: number | null;
+  nextRunAt: string | null;
+  lastRunAt: string | null;
+  lastSuccessAt: string | null;
+  lastFailureAt: string | null;
+  lastFailureCode: string | null;
+  latestRun: {
+    id: string;
+    status: string;
+    scheduledFor: string;
+    completedAt: string | null;
+    suggestionCount: number;
+    checkedSourceCount: number;
+    failedSourceCount: number;
+    notificationFailureCode: string | null;
+  } | null;
+  suggestions: Array<{
+    id: string;
+    field: SourceMonitorSuggestionField;
+    path: string;
+    currentValue: unknown;
+    suggestedValue: unknown;
+    editedValue: unknown;
+    evidence: SourceEvidence[];
+    status: string;
+    createdAt: string;
+  }>;
+};
+
+export async function dispatchDueSourceMonitoring(
+  now = new Date(),
+  startRun: (runId: string) => Promise<string> = startMonitoringWorkflow,
+): Promise<{ claimed: number; started: number; failedToStart: number }> {
+  const db = getDb();
+  const subscriptions = await db.subscription.findMany({
+    where: {
+      status: "ACTIVE",
+      site: {
+        sourceUrl: { not: null },
+        status: { not: "PAUSED" },
+      },
+    },
+    take: MAX_DISPATCH,
+    orderBy: { updatedAt: "asc" },
+    select: {
+      stripePriceId: true,
+      status: true,
+      site: { select: { id: true, status: true } },
+    },
+  });
+
+  const claimedIds: string[] = [];
+  for (const subscription of subscriptions) {
+    const entitlement = monitoringEntitlement({
+      status: subscription.status,
+      stripePriceId: subscription.stripePriceId,
+      siteStatus: subscription.site.status,
+    });
+    if (!entitlement.active) continue;
+
+    const runId = await db.$transaction(
+      async (transaction) => {
+        const state = await transaction.sourceMonitorState.findUnique({
+          where: { siteId: subscription.site.id },
+        });
+        const scheduledFor = state?.nextRunAt ?? now;
+        if (state && scheduledFor > now) {
+          if (state.cadenceDays !== entitlement.cadenceDays) {
+            await transaction.sourceMonitorState.update({
+              where: { siteId: subscription.site.id },
+              data: {
+                cadenceDays: entitlement.cadenceDays,
+                nextRunAt: nextMonitoringTime(
+                  state.lastRunAt ?? now,
+                  entitlement.cadenceDays,
+                  now,
+                ),
+              },
+            });
+          }
+          return null;
+        }
+
+        const run = await transaction.sourceMonitorRun.upsert({
+          where: {
+            idempotencyKey: monitoringIdempotencyKey(
+              subscription.site.id,
+              scheduledFor,
+            ),
+          },
+          update: {},
+          create: {
+            siteId: subscription.site.id,
+            scheduledFor,
+            idempotencyKey: monitoringIdempotencyKey(
+              subscription.site.id,
+              scheduledFor,
+            ),
+          },
+          select: { id: true },
+        });
+        await transaction.sourceMonitorState.upsert({
+          where: { siteId: subscription.site.id },
+          update: {
+            cadenceDays: entitlement.cadenceDays,
+            nextRunAt: nextMonitoringTime(
+              scheduledFor,
+              entitlement.cadenceDays,
+              now,
+            ),
+            lastRunAt: now,
+            lastRunId: run.id,
+          },
+          create: {
+            siteId: subscription.site.id,
+            cadenceDays: entitlement.cadenceDays,
+            nextRunAt: nextMonitoringTime(
+              scheduledFor,
+              entitlement.cadenceDays,
+              now,
+            ),
+            lastRunAt: now,
+            lastRunId: run.id,
+          },
+        });
+        return run.id;
+      },
+      { isolationLevel: "Serializable" },
+    );
+    if (runId) claimedIds.push(runId);
+  }
+
+  const queued = await db.sourceMonitorRun.findMany({
+    where: {
+      status: "QUEUED",
+      workflowRunId: null,
+    },
+    orderBy: { createdAt: "asc" },
+    take: MAX_DISPATCH,
+    select: { id: true },
+  });
+  let started = 0;
+  let failedToStart = 0;
+  for (const run of queued) {
+    try {
+      const workflowRunId = await startRun(run.id);
+      await db.sourceMonitorRun.updateMany({
+        where: {
+          id: run.id,
+          status: "QUEUED",
+          workflowRunId: null,
+        },
+        data: { workflowRunId },
+      });
+      started += 1;
+    } catch {
+      // The durable QUEUED row remains eligible for the next dispatcher pass.
+      failedToStart += 1;
+    }
+  }
+  return { claimed: claimedIds.length, started, failedToStart };
+}
+
+export async function beginSourceMonitoringRun(runId: string) {
+  const db = getDb();
+  return db.$transaction(
+    async (transaction) => {
+      const run = await transaction.sourceMonitorRun.findUnique({
+        where: { id: runId },
+        select: {
+          id: true,
+          status: true,
+          site: {
+            select: {
+              id: true,
+              slug: true,
+              vertical: true,
+              status: true,
+              sourceUrl: true,
+              subscription: {
+                select: { status: true, stripePriceId: true },
+              },
+            },
+          },
+        },
+      });
+      if (!run || run.status !== "QUEUED") return null;
+      const entitlement = monitoringEntitlement({
+        status: run.site.subscription?.status ?? null,
+        stripePriceId: run.site.subscription?.stripePriceId ?? null,
+        siteStatus: run.site.status,
+      });
+      if (!entitlement.active || !run.site.sourceUrl) {
+        await transaction.sourceMonitorRun.update({
+          where: { id: run.id },
+          data: {
+            status: "SKIPPED",
+            completedAt: new Date(),
+            errorCode: entitlement.active
+              ? "SOURCE_MISSING"
+              : entitlement.reason,
+          },
+        });
+        return null;
+      }
+      await transaction.sourceMonitorRun.update({
+        where: { id: run.id },
+        data: { status: "RUNNING", startedAt: new Date(), errorCode: null },
+      });
+      return {
+        runId: run.id,
+        siteId: run.site.id,
+        slug: run.site.slug,
+        vertical: run.site.vertical,
+        sourceUrl: run.site.sourceUrl,
+      };
+    },
+    { isolationLevel: "Serializable" },
+  );
+}
+
+export async function executeSourceMonitoringRun(context: {
+  runId: string;
+  siteId: string;
+  slug: string;
+  vertical: VerticalId;
+  sourceUrl: string;
+}): Promise<{ suggestionCount: number }> {
+  const db = getDb();
+  const existing = await db.sourceMonitorRun.findUnique({
+    where: { id: context.runId },
+    select: { status: true, suggestionCount: true },
+  });
+  if (existing?.status === "SUCCEEDED") {
+    return { suggestionCount: existing.suggestionCount };
+  }
+  if (existing?.status !== "RUNNING") {
+    throw new Error("Source monitoring run is not executable");
+  }
+
+  const site = await db.site.findUnique({
+    where: { id: context.siteId, slug: context.slug },
+    include: siteDraftRelations,
+  });
+  if (!site) throw new Error("Source monitoring site not found");
+  const current = projectSiteDraft(site).draft as PersistableSiteDraft;
+  const extracted = await crawlSiteSource(context.sourceUrl, context.vertical);
+  const proposed = await generateDraftForVertical(
+    extracted,
+    context.vertical,
+  );
+  const linkUrls = [
+    ...new Set([
+      ...current.integrations.map((link) => link.url),
+      ...extracted.links.map((link) => link.url),
+    ]),
+  ];
+  const checkedLinkResults = await Promise.allSettled(
+    linkUrls.map(inspectPublicLink),
+  );
+  const checkedLinks = checkedLinkResults.flatMap((result) =>
+    result.status === "fulfilled" ? [result.value] : [],
+  );
+  const suggestions = buildSourceMonitoringDiff({
+    current,
+    proposed,
+    extracted,
+    checkedLinks,
+    capturedAt: new Date(),
+  });
+
+  await persistSuccessfulRun(
+    context,
+    suggestions,
+    1 + checkedLinks.length,
+    checkedLinkResults.length - checkedLinks.length,
+  );
+  return { suggestionCount: suggestions.length };
+}
+
+export async function failSourceMonitoringRun(
+  runId: string,
+  error: unknown,
+): Promise<void> {
+  const errorCode = safeMonitoringErrorCode(error);
+  const now = new Date();
+  await getDb().$transaction(async (transaction) => {
+    const run = await transaction.sourceMonitorRun.findUnique({
+      where: { id: runId },
+      select: { siteId: true, status: true },
+    });
+    if (!run || !["QUEUED", "RUNNING"].includes(run.status)) return;
+    await transaction.sourceMonitorRun.update({
+      where: { id: runId },
+      data: { status: "FAILED", completedAt: now, errorCode },
+    });
+    await transaction.sourceMonitorState.updateMany({
+      where: { siteId: run.siteId },
+      data: {
+        lastFailureAt: now,
+        lastFailureCode: errorCode,
+      },
+    });
+  });
+}
+
+export async function notifySourceMonitoringReview(
+  runId: string,
+): Promise<boolean> {
+  const db = getDb();
+  const run = await db.sourceMonitorRun.findUnique({
+    where: { id: runId },
+    select: {
+      id: true,
+      status: true,
+      suggestionCount: true,
+      notificationSentAt: true,
+      site: {
+        select: {
+          name: true,
+          slug: true,
+          vertical: true,
+          organization: {
+            select: {
+              memberships: {
+                select: { user: { select: { email: true } } },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+  if (
+    !run ||
+    run.status !== "SUCCEEDED" ||
+    run.suggestionCount === 0 ||
+    run.notificationSentAt
+  ) {
+    return false;
+  }
+  const recipients = [
+    ...new Set([
+      ...(run.site.organization?.memberships.map(
+        (membership) => membership.user.email,
+      ) ?? []),
+      ...configuredSuperadminEmails(),
+    ]),
+  ];
+  if (!process.env.RESEND_API_KEY || recipients.length === 0) {
+    await db.sourceMonitorRun.updateMany({
+      where: { id: run.id, notificationSentAt: null },
+      data: { notificationFailureCode: "NOT_CONFIGURED" },
+    });
+    return false;
+  }
+
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://cornershop.dev";
+  const { error } = await getResend().emails.send(
+    {
+      from: emailSender(run.site.vertical),
+      replyTo: emailReplyTo(run.site.vertical),
+      to: recipients,
+      subject: `${run.suggestionCount} source update${run.suggestionCount === 1 ? "" : "s"} to review for ${run.site.name}`,
+      html: sourceMonitoringEmailHtml({
+        siteName: run.site.name,
+        count: run.suggestionCount,
+        reviewUrl: `${appUrl.replace(/\/$/, "")}/dashboard`,
+      }),
+    },
+    { headers: { "Idempotency-Key": `source-monitor-${run.id}` } },
+  );
+  if (error) {
+    await db.sourceMonitorRun.updateMany({
+      where: { id: run.id, notificationSentAt: null },
+      data: { notificationFailureCode: "DELIVERY_FAILED" },
+    });
+    throw new Error("Source monitoring notification failed");
+  }
+  await db.sourceMonitorRun.updateMany({
+    where: { id: run.id, notificationSentAt: null },
+    data: { notificationSentAt: new Date(), notificationFailureCode: null },
+  });
+  return true;
+}
+
+export async function getSourceMonitoringDashboard(
+  siteId: string,
+): Promise<SourceMonitoringDashboardDto> {
+  const db = getDb();
+  const [state, latestRun, suggestions] = await Promise.all([
+    db.sourceMonitorState.findUnique({ where: { siteId } }),
+    db.sourceMonitorRun.findFirst({
+      where: { siteId },
+      orderBy: [{ scheduledFor: "desc" }, { id: "desc" }],
+      select: {
+        id: true,
+        status: true,
+        scheduledFor: true,
+        completedAt: true,
+        suggestionCount: true,
+        checkedSourceCount: true,
+        failedSourceCount: true,
+        notificationFailureCode: true,
+      },
+    }),
+    db.sourceMonitorSuggestion.findMany({
+      where: { siteId, status: "PENDING" },
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      take: 50,
+      select: {
+        id: true,
+        field: true,
+        path: true,
+        currentValue: true,
+        suggestedValue: true,
+        editedValue: true,
+        evidence: true,
+        status: true,
+        createdAt: true,
+      },
+    }),
+  ]);
+  return {
+    cadenceDays: state?.cadenceDays ?? null,
+    nextRunAt: state?.nextRunAt.toISOString() ?? null,
+    lastRunAt: state?.lastRunAt?.toISOString() ?? null,
+    lastSuccessAt: state?.lastSuccessAt?.toISOString() ?? null,
+    lastFailureAt: state?.lastFailureAt?.toISOString() ?? null,
+    lastFailureCode: state?.lastFailureCode ?? null,
+    latestRun: latestRun
+      ? {
+          ...latestRun,
+          status: latestRun.status,
+          scheduledFor: latestRun.scheduledFor.toISOString(),
+          completedAt: latestRun.completedAt?.toISOString() ?? null,
+        }
+      : null,
+    suggestions: suggestions.map((suggestion) => ({
+      ...suggestion,
+      evidence: suggestion.evidence as SourceEvidence[],
+      createdAt: suggestion.createdAt.toISOString(),
+    })),
+  };
+}
+
+export async function reviewSourceMonitoringSuggestion(input: {
+  siteId: string;
+  suggestionId: string;
+  actor: { id: string; email: string; role: "owner" | "operator" };
+  action: "accept" | "reject";
+  editedValue?: unknown;
+  note?: string;
+}): Promise<{ status: "ACCEPTED" | "REJECTED" }> {
+  const db = getDb();
+  return db.$transaction(
+    async (transaction) => {
+      const suggestion = await transaction.sourceMonitorSuggestion.findFirst({
+        where: {
+          id: input.suggestionId,
+          siteId: input.siteId,
+          status: "PENDING",
+        },
+      });
+      if (!suggestion) throw new Error("Suggestion not found");
+      const reviewedAt = new Date();
+      if (input.action === "reject") {
+        await transaction.sourceMonitorSuggestion.update({
+          where: { id: suggestion.id },
+          data: {
+            status: "REJECTED",
+            reviewedAt,
+            reviewedBy: input.actor.id,
+            reviewNote: input.note?.trim().slice(0, 500) || null,
+          },
+        });
+        await createReviewAudit(
+          transaction,
+          suggestion,
+          input,
+          "REJECTED",
+          false,
+        );
+        return { status: "REJECTED" };
+      }
+
+      const site = await transaction.site.findUnique({
+        where: { id: input.siteId },
+        include: siteDraftRelations,
+      });
+      if (!site) throw new Error("Site not found");
+      const loaded = projectSiteDraft(site);
+      const currentDraft = loaded.draft as PersistableSiteDraft;
+      const currentValue = monitoringFieldValue(
+        currentDraft,
+        suggestion.field,
+      );
+      if (!sameJson(currentValue, suggestion.currentValue)) {
+        throw new SourceMonitoringConflictError();
+      }
+      const proposedValue = parseSuggestionValue(
+        suggestion.field,
+        input.editedValue ?? suggestion.suggestedValue,
+        currentDraft,
+        site.vertical,
+      );
+      await applySuggestionValue(
+        transaction,
+        site.id,
+        site.vertical,
+        suggestion.field,
+        proposedValue,
+      );
+      await transaction.sourceMonitorSuggestion.update({
+        where: { id: suggestion.id },
+        data: {
+          status: "ACCEPTED",
+          editedValue:
+            input.editedValue === undefined
+              ? undefined
+              : (proposedValue as Prisma.InputJsonValue),
+          reviewedAt,
+          reviewedBy: input.actor.id,
+          reviewNote: input.note?.trim().slice(0, 500) || null,
+        },
+      });
+      await createReviewAudit(
+        transaction,
+        suggestion,
+        input,
+        "ACCEPTED",
+        input.editedValue !== undefined,
+      );
+      return { status: "ACCEPTED" };
+    },
+    { isolationLevel: "Serializable" },
+  );
+}
+
+async function persistSuccessfulRun(
+  context: { runId: string; siteId: string },
+  suggestions: MonitoringSuggestionInput[],
+  checkedSourceCount: number,
+  failedSourceCount: number,
+) {
+  const now = new Date();
+  await getDb().$transaction(
+    async (transaction) => {
+      const moved = await transaction.sourceMonitorRun.updateMany({
+        where: { id: context.runId, siteId: context.siteId, status: "RUNNING" },
+        data: {
+          status: "SUCCEEDED",
+          completedAt: now,
+          errorCode: null,
+          checkedSourceCount,
+          failedSourceCount,
+          suggestionCount: suggestions.length,
+        },
+      });
+      if (moved.count === 0) return;
+      if (suggestions.length > 0) {
+        await transaction.sourceMonitorSuggestion.createMany({
+          data: suggestions.map((suggestion) => ({
+            ...suggestion,
+            siteId: context.siteId,
+            runId: context.runId,
+            evidence: suggestion.evidence as unknown as Prisma.InputJsonValue,
+          })),
+          skipDuplicates: true,
+        });
+        await transaction.auditEvent.create({
+          data: {
+            type: "source_monitoring.review_required",
+            actor: "system:source-monitor",
+            siteId: context.siteId,
+            metadata: {
+              runId: context.runId,
+              suggestionCount: suggestions.length,
+              fields: [...new Set(suggestions.map((item) => item.field))],
+            },
+          },
+        });
+      }
+      await transaction.sourceMonitorState.updateMany({
+        where: { siteId: context.siteId },
+        data: {
+          lastSuccessAt: now,
+          lastFailureCode: null,
+        },
+      });
+    },
+    { isolationLevel: "Serializable" },
+  );
+}
+
+function monitoringFieldValue(
+  draft: PersistableSiteDraft,
+  field: SourceMonitorSuggestionField,
+) {
+  if (field === "CONTACT") {
+    return { address: draft.address, phone: draft.phone };
+  }
+  if (field === "HOURS") return draft.businessHours;
+  if (field === "MENU") {
+    return {
+      catalogSections: draft.catalogSections,
+      translations: draft.translations,
+    };
+  }
+  return {
+    integrations: draft.integrations,
+    translations: draft.translations,
+  };
+}
+
+function parseSuggestionValue(
+  field: SourceMonitorSuggestionField,
+  value: unknown,
+  current: PersistableSiteDraft,
+  vertical: Vertical,
+) {
+  const parsed =
+    field === "CONTACT"
+      ? contactSchema.parse(value)
+      : field === "HOURS"
+        ? businessHoursSchema.parse(value)
+        : field === "MENU"
+          ? menuSuggestionSchema.parse(value)
+          : linksSuggestionSchema.parse(value);
+  const config = resolveVerticalConfig(vertical);
+  config.draftSchema.parse({
+    ...current,
+    ...(field === "CONTACT" ? parsed : {}),
+    ...(field === "HOURS" ? { businessHours: parsed } : {}),
+    ...(field === "MENU" ? parsed : {}),
+    ...(field === "LINKS" ? parsed : {}),
+  });
+  return parsed;
+}
+
+async function applySuggestionValue(
+  transaction: Prisma.TransactionClient,
+  siteId: string,
+  vertical: Vertical,
+  field: SourceMonitorSuggestionField,
+  value: unknown,
+) {
+  if (field === "CONTACT") {
+    const contact = contactSchema.parse(value);
+    await transaction.site.update({
+      where: { id: siteId },
+      data: contact,
+    });
+    return;
+  }
+  if (field === "HOURS") {
+    await transaction.site.update({
+      where: { id: siteId },
+      data: {
+        businessHours: businessHoursSchema.parse(value) as Prisma.InputJsonValue,
+      },
+    });
+    return;
+  }
+  if (field === "LINKS") {
+    const { integrations: links, translations } =
+      linksSuggestionSchema.parse(value);
+    await transaction.site.update({
+      where: { id: siteId },
+      data: { translations: translations as Prisma.InputJsonValue },
+    });
+    await transaction.integration.deleteMany({ where: { siteId } });
+    await transaction.integration.createMany({
+      data: links.map((link, position) => ({
+        siteId,
+        type: integrationType(link.type),
+        label: link.label,
+        provider: link.provider,
+        url: link.url,
+        venueId: link.venueId,
+        position,
+      })),
+    });
+    return;
+  }
+
+  const config = resolveVerticalConfig(vertical);
+  const { catalogSections: sections, translations } =
+    menuSuggestionSchema.parse(value);
+  await transaction.site.update({
+    where: { id: siteId },
+    data: { translations: translations as Prisma.InputJsonValue },
+  });
+  await transaction.catalogSection.deleteMany({ where: { siteId } });
+  for (const [position, section] of sections.entries()) {
+    await transaction.catalogSection.create({
+      data: {
+        siteId,
+        name: section.name,
+        description: section.description,
+        position,
+        items: {
+          create: section.items.map((item, itemPosition) => ({
+            name: item.name,
+            description: item.description,
+            price: item.price,
+            currency: item.currency,
+            attributes: config.itemAttributesSchema.parse(
+              item.attributes,
+            ) as Prisma.InputJsonValue,
+            imageUrl: item.imageUrl,
+            originalImageUrl: item.originalImageUrl,
+            imageProvenance: imageProvenance(item.imageProvenance),
+            position: itemPosition,
+          })),
+        },
+      },
+    });
+  }
+}
+
+function integrationType(value: string): IntegrationType {
+  return value.toUpperCase() as IntegrationType;
+}
+
+function imageProvenance(value: string | null | undefined) {
+  if (!value) return null;
+  return value.replaceAll("-", "_").toUpperCase() as
+    | "OFFICIAL"
+    | "OWNER"
+    | "PERMISSIONED_UGC";
+}
+
+async function createReviewAudit(
+  transaction: Prisma.TransactionClient,
+  suggestion: { id: string; runId: string; field: SourceMonitorSuggestionField },
+  input: {
+    siteId: string;
+    actor: { id: string; email: string; role: "owner" | "operator" };
+    note?: string;
+  },
+  status: "ACCEPTED" | "REJECTED",
+  edited: boolean,
+) {
+  await transaction.auditEvent.create({
+    data: {
+      type: `source_monitoring.suggestion_${status.toLowerCase()}`,
+      actor: input.actor.id,
+      siteId: input.siteId,
+      metadata: {
+        suggestionId: suggestion.id,
+        runId: suggestion.runId,
+        field: suggestion.field,
+        reviewerEmail: input.actor.email,
+        reviewerRole: input.actor.role,
+        edited,
+      },
+    },
+  });
+}
+
+async function startMonitoringWorkflow(runId: string): Promise<string> {
+  const [{ start }, { sourceMonitoringWorkflow }] = await Promise.all([
+    import("workflow/api"),
+    import("@/workflows/source-monitoring"),
+  ]);
+  return (await start(sourceMonitoringWorkflow, [runId])).runId;
+}
+
+function safeMonitoringErrorCode(error: unknown) {
+  if (
+    error instanceof Error &&
+    /resolve|network|fetch|HTTP|redirect|website/i.test(error.message)
+  ) {
+    return "SOURCE_FETCH_FAILED";
+  }
+  if (error instanceof z.ZodError) return "SOURCE_PARSE_FAILED";
+  return "MONITORING_FAILED";
+}
+
+function sameJson(left: unknown, right: unknown) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function sourceMonitoringEmailHtml(input: {
+  siteName: string;
+  count: number;
+  reviewUrl: string;
+}) {
+  return `<div style="font-family:Arial,sans-serif;background:#f4efe5;padding:40px"><div style="max-width:520px;margin:0 auto;background:#fffdf8;border-radius:16px;padding:32px"><h1 style="margin:0 0 16px;font-size:22px;color:#2f2a24">Source updates need review</h1><p style="font-size:15px;color:#5c5147">${input.count} evidence-backed update${input.count === 1 ? "" : "s"} were found for ${escapeHtml(input.siteName)}. Nothing has been applied or published.</p><p style="margin-top:24px"><a href="${escapeHtml(input.reviewUrl)}" style="color:#a5482d;font-weight:bold">Review suggestions</a></p></div></div>`;
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+export const SOURCE_MONITORING_SCHEDULER_INTERVAL_MS = DAY_MS;

--- a/src/lib/verticals/restaurant/schema.ts
+++ b/src/lib/verticals/restaurant/schema.ts
@@ -266,6 +266,7 @@ export function toRestaurantDraft(
     showMenuImages: draft.attributes.showMenuImages,
     autoEnhanceImages: draft.autoEnhanceImages,
     defaultLocale: draft.defaultLocale,
+    businessHours: draft.businessHours,
     translations: draft.translations.map((translation) => ({
       locale: translation.locale,
       cuisine: translation.attributes.cuisine,
@@ -323,6 +324,7 @@ export function fromRestaurantDraft(
     palette: draft.palette,
     autoEnhanceImages: draft.autoEnhanceImages,
     defaultLocale: draft.defaultLocale,
+    businessHours: draft.businessHours,
     translations: draft.translations.map((translation) => ({
       locale: translation.locale,
       attributes: {

--- a/src/lib/verticals/schema.ts
+++ b/src/lib/verticals/schema.ts
@@ -65,6 +65,16 @@ export const localeSchema = z
   .string()
   .regex(/^[a-z]{2}(?:-[A-Z]{2})?$/, "Use a BCP 47 language code");
 
+export const businessHoursSchema = z
+  .array(
+    z.object({
+      days: z.string().trim().min(1).max(80),
+      hours: z.string().trim().min(1).max(120),
+    }),
+  )
+  .max(14)
+  .default([]);
+
 export const translatedCatalogItemSchema = z.object({
   name: z.string().min(1).max(120),
   description: z.string().max(320).default(""),
@@ -109,6 +119,7 @@ export const baseSiteDraftCoreShape = {
   }),
   autoEnhanceImages: z.boolean().default(true),
   defaultLocale: localeSchema.default("en"),
+  businessHours: businessHoursSchema,
   integrations: z.array(integrationSchema).max(12),
 };
 

--- a/src/workflows/source-monitoring.ts
+++ b/src/workflows/source-monitoring.ts
@@ -1,0 +1,48 @@
+import {
+  beginSourceMonitoringRun,
+  executeSourceMonitoringRun,
+  failSourceMonitoringRun,
+  notifySourceMonitoringReview,
+} from "@/lib/source-monitoring";
+
+export async function sourceMonitoringWorkflow(runId: string): Promise<void> {
+  "use workflow";
+
+  const context = await beginRun(runId);
+  if (!context) return;
+  try {
+    const result = await inspectSources(context);
+    if (result.suggestionCount > 0) {
+      await notifyReview(runId);
+    }
+  } catch (error) {
+    await recordFailure(runId, error);
+    throw error;
+  }
+}
+
+async function beginRun(runId: string) {
+  "use step";
+  return beginSourceMonitoringRun(runId);
+}
+
+async function inspectSources(
+  context: NonNullable<
+    Awaited<ReturnType<typeof beginSourceMonitoringRun>>
+  >,
+) {
+  "use step";
+  return executeSourceMonitoringRun(context);
+}
+inspectSources.maxRetries = 4;
+
+async function notifyReview(runId: string) {
+  "use step";
+  return notifySourceMonitoringReview(runId);
+}
+notifyReview.maxRetries = 4;
+
+async function recordFailure(runId: string, error: unknown) {
+  "use step";
+  await failSourceMonitoringRun(runId, error);
+}


### PR DESCRIPTION
## Summary
- add durable Starter monthly / Growth weekly source monitoring with persistent scheduling, retry-safe workflow runs, entitlement gating, and observable run state
- generate evidence-backed menu, contact, hours, and link suggestions without overwriting owner edits or publishing changes
- add owner and operator review queues with accept, reject, edit, conflict protection, notifications, and real monitoring status in dashboards
- persist and render structured business hours across restaurant themes

## Verification
- `bun test`: 211 pass, 16 DB-gated skips, 0 fail
- targeted source-monitoring unit tests: 8 pass
- `bunx next typegen && bunx tsc --noEmit`: pass
- focused ESLint for changed files: pass
- full lint: 0 errors, 1 pre-existing generated Workflow warning
- design lint: pass
- Workflow compiler: 16 steps, 2 workflows
- `git diff --check`: pass
- local production build compiled workflows, then remained in Turbopack optimized-build phase for more than 90 seconds and was stopped; CI is the build gate

## Delivery gate
- Exact-head Opus verification is still required before merge. The configured Claude quota/profile state has not changed, so it was not probed again and no approval is inferred.

Refs #14