### PR TITLE
fix(ops): bypass domain routing for health probes

### DIFF
--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "bun:test";
+import { NextRequest } from "next/server";
+import { proxy } from "@/proxy";
+
+describe("health endpoint routing", () => {
+  it("bypasses custom-domain resolution for container-local probes", async () => {
+    for (const pathname of ["/api/health/live", "/api/health/ready"]) {
+      const response = await proxy(
+        new NextRequest(`http://127.0.0.1:3000${pathname}`),
+      );
+
+      expect(response.headers.get("x-middleware-next")).toBe("1");
+      expect(response.headers.get("x-middleware-rewrite")).toBeNull();
+    }
+  });
+});

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -45,6 +45,13 @@ export async function proxy(request: NextRequest) {
   upstreamHeaders.delete(LIVE_SITE_SLUG_HEADER);
   upstreamHeaders.delete(LIVE_SITE_VERSION_HEADER);
 
+  // Container and external health probes do not carry a public hostname. Let
+  // the route handlers enforce their own liveness/readiness policy before any
+  // custom-domain lookup can turn the probe into an unknown-host 404.
+  if (request.nextUrl.pathname.startsWith("/api/health/")) {
+    return NextResponse.next({ request: { headers: upstreamHeaders } });
+  }
+
   const hostname = requestHostname(request.headers);
   if (!hostname || platformHostnames().has(hostname)) {
     const response = NextResponse.next({


### PR DESCRIPTION
## What changed
- bypass custom-domain resolution for `/api/health/*`
- preserve removal of caller-supplied live-site headers
- add a regression test for container-local live and ready probes

## Production failure fixed
The all-path proxy matcher treated `Host: 127.0.0.1` health probes as unknown customer-domain traffic and returned 404, leaving the candidate container unhealthy.

## Verification
- `bun test src/proxy.test.ts`
- `bunx eslint src/proxy.ts src/proxy.test.ts`
- `git diff --check`