### PR TITLE
fix(themes): preserve host product branding

### DIFF
--- a/src/app/themes/restaurant/[themeId]/page.tsx
+++ b/src/app/themes/restaurant/[themeId]/page.tsx
@@ -6,6 +6,7 @@ import { RestaurantThemeRenderer } from "@/components/restaurant-themes/restaura
 import { SiteHeader } from "@/components/site-header";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { restaurantThemeGallerySurface } from "@/lib/theme-gallery-surface";
 import {
   restaurantThemeIdSchema,
   type RestaurantThemeId,
@@ -16,7 +17,8 @@ import {
   listRestaurantThemeManifests,
 } from "@/lib/site-themes/restaurant/registry";
 import { parseRestaurantThemeSelection } from "@/lib/site-themes/restaurant/selection";
-import { restaurantMarketing } from "@/lib/verticals/restaurant/marketing";
+import { resolveRequestOrigin } from "@/lib/verticals/request-site";
+import styles from "../theme-gallery.module.css";
 
 export const dynamicParams = false;
 
@@ -37,11 +39,12 @@ export async function generateMetadata({
   const id = parseThemeId((await params).themeId);
   if (!id) return {};
   const manifest = getRestaurantThemeManifest(id);
+  const surface = restaurantThemeGallerySurface(await resolveRequestOrigin());
   return {
-    title: { absolute: `${manifest.name} theme | Restofront` },
+    title: { absolute: `${manifest.name} theme | ${surface.brand.name}` },
     description: manifest.description,
     alternates: {
-      canonical: `https://restofront.com/themes/restaurant/${manifest.id}`,
+      canonical: `${surface.canonicalOrigin}/themes/restaurant/${manifest.id}`,
     },
   };
 }
@@ -60,11 +63,13 @@ export default async function RestaurantThemeDetailPage({
     fixture.attributes.themeSelection,
   );
   if (!selection) notFound();
+  const surface = restaurantThemeGallerySurface(await resolveRequestOrigin());
 
   return (
-    <>
+    <div className={surface.inverse ? styles.factorySurface : undefined}>
       <SiteHeader
-        brand={{ ...restaurantMarketing.brand, href: "/" }}
+        brand={{ ...surface.brand, href: "/" }}
+        inverse={surface.inverse}
         links={[
           { href: "/themes/restaurant", label: "All themes" },
           { href: "#fit", label: "Fit" },
@@ -73,7 +78,9 @@ export default async function RestaurantThemeDetailPage({
         createHref="/create?vertical=restaurant"
       />
       <main>
-        <section className="paper-grid border-b">
+        <section
+          className={`${surface.inverse ? styles.factoryGrid : "paper-grid"} border-b`}
+        >
           <div className="mx-auto max-w-7xl px-5 py-16 lg:px-8 lg:py-24">
             <Link
               href="/themes/restaurant"
@@ -187,6 +194,6 @@ export default async function RestaurantThemeDetailPage({
           </div>
         </section>
       </main>
-    </>
+    </div>
   );
 }

--- a/src/app/themes/restaurant/page.tsx
+++ b/src/app/themes/restaurant/page.tsx
@@ -6,36 +6,45 @@ import { RestaurantThemeRenderer } from "@/components/restaurant-themes/restaura
 import { SiteHeader } from "@/components/site-header";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { restaurantThemeGallerySurface } from "@/lib/theme-gallery-surface";
 import { restaurantThemeFixtures } from "@/lib/site-themes/restaurant/fixtures";
 import { listRestaurantThemeManifests } from "@/lib/site-themes/restaurant/registry";
 import { parseRestaurantThemeSelection } from "@/lib/site-themes/restaurant/selection";
-import { restaurantMarketing } from "@/lib/verticals/restaurant/marketing";
+import { resolveRequestOrigin } from "@/lib/verticals/request-site";
+import styles from "./theme-gallery.module.css";
 
-export const metadata: Metadata = {
-  title: { absolute: "Restaurant themes | Restofront" },
-  description:
-    "Explore three original restaurant website themes built around reservations, ordering and after-dark hospitality.",
-  alternates: {
-    canonical: "https://restofront.com/themes/restaurant",
-  },
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const surface = restaurantThemeGallerySurface(await resolveRequestOrigin());
+  return {
+    title: { absolute: `Restaurant themes | ${surface.brand.name}` },
+    description:
+      "Explore three original restaurant website themes built around reservations, ordering and after-dark hospitality.",
+    alternates: {
+      canonical: `${surface.canonicalOrigin}/themes/restaurant`,
+    },
+  };
+}
 
-export default function RestaurantThemeGalleryPage() {
+export default async function RestaurantThemeGalleryPage() {
   const manifests = listRestaurantThemeManifests();
+  const surface = restaurantThemeGallerySurface(await resolveRequestOrigin());
 
   return (
-    <>
+    <div className={surface.inverse ? styles.factorySurface : undefined}>
       <SiteHeader
-        brand={{ ...restaurantMarketing.brand, href: "/" }}
+        brand={{ ...surface.brand, href: "/" }}
+        inverse={surface.inverse}
         links={[
-          { href: "/", label: "Restofront" },
+          { href: "/", label: surface.brand.name },
           { href: "#themes", label: "Themes" },
-          { href: "/#pricing", label: "Pricing" },
+          { href: surface.pricingHref, label: "Pricing" },
         ]}
         createHref="/create?vertical=restaurant"
       />
       <main>
-        <section className="paper-grid border-b">
+        <section
+          className={`${surface.inverse ? styles.factoryGrid : "paper-grid"} border-b`}
+        >
           <div className="mx-auto max-w-7xl px-5 py-20 lg:px-8 lg:py-28">
             <Badge
               variant="secondary"
@@ -49,8 +58,9 @@ export default function RestaurantThemeGalleryPage() {
               </h1>
               <div className="max-w-xl lg:justify-self-end">
                 <p className="text-lg leading-8 text-muted-foreground">
-                  Restofront matches service model, customer intent, menu shape,
-                  brand character and photography—not cuisine stereotypes.
+                  {surface.brand.name} matches service model, customer intent,
+                  menu shape, brand character and photography—not cuisine
+                  stereotypes.
                 </p>
                 <div className="mt-6 flex items-start gap-3 rounded-2xl border bg-card p-4 text-sm leading-6 text-muted-foreground">
                   <ShieldCheck className="mt-0.5 size-5 shrink-0 text-primary" />
@@ -131,7 +141,11 @@ export default function RestaurantThemeGalleryPage() {
           })}
         </section>
 
-        <section className="border-t bg-[#1d241f] text-white">
+        <section
+          className={`border-t text-white ${
+            surface.inverse ? "bg-[#080808]" : "bg-[#1d241f]"
+          }`}
+        >
           <div className="mx-auto flex max-w-7xl flex-col gap-8 px-5 py-16 md:flex-row md:items-end md:justify-between lg:px-8">
             <div>
               <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[#dc8d6d]">
@@ -153,6 +167,6 @@ export default function RestaurantThemeGalleryPage() {
           </div>
         </section>
       </main>
-    </>
+    </div>
   );
 }

--- a/src/app/themes/restaurant/theme-gallery.module.css
+++ b/src/app/themes/restaurant/theme-gallery.module.css
@@ -1,0 +1,50 @@
+.factorySurface {
+  --background: #050505;
+  --foreground: #f7f7f4;
+  --card: #0d0d0d;
+  --card-foreground: #f7f7f4;
+  --popover: #0d0d0d;
+  --popover-foreground: #f7f7f4;
+  --primary: #ff775f;
+  --primary-foreground: #050505;
+  --secondary: #161616;
+  --secondary-foreground: #f7f7f4;
+  --muted: #121212;
+  --muted-foreground: #a3a3a3;
+  --accent: #123e31;
+  --accent-foreground: #c8f5df;
+  --border: rgb(255 255 255 / 0.11);
+  --input: rgb(255 255 255 / 0.14);
+  --ring: #ff775f;
+  min-height: 100vh;
+  background: #050505;
+  color: #f7f7f4;
+  color-scheme: dark;
+  isolation: isolate;
+}
+
+.factorySurface ::selection {
+  background: #ff775f;
+  color: #050505;
+}
+
+.factoryGrid {
+  position: relative;
+  background-color: #050505;
+  background-image:
+    linear-gradient(to right, rgb(255 255 255 / 0.07) 1px, transparent 1px),
+    linear-gradient(to bottom, rgb(255 255 255 / 0.07) 1px, transparent 1px);
+  background-position: center;
+  background-size: 48px 48px;
+}
+
+.factoryGrid::before {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  background:
+    radial-gradient(circle at 18% 18%, rgb(241 90 61 / 0.11), transparent 28rem),
+    radial-gradient(circle at 78% 42%, rgb(13 74 57 / 0.2), transparent 30rem);
+  content: "";
+  pointer-events: none;
+}

--- a/src/lib/theme-gallery-surface.test.ts
+++ b/src/lib/theme-gallery-surface.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test";
+import { FACTORY_BRAND } from "@/lib/brand";
+import { restaurantThemeGallerySurface } from "@/lib/theme-gallery-surface";
+import { restaurantMarketing } from "@/lib/verticals/restaurant/marketing";
+
+describe("restaurant theme gallery surface", () => {
+  it("keeps the factory identity on cornershop.dev", () => {
+    expect(
+      restaurantThemeGallerySurface("https://cornershop.dev"),
+    ).toMatchObject({
+      brand: FACTORY_BRAND,
+      canonicalOrigin: "https://cornershop.dev",
+      inverse: true,
+      pricingHref: "/niche/restaurant#pricing",
+    });
+  });
+
+  it("uses the restaurant storefront identity on restofront.com", () => {
+    expect(
+      restaurantThemeGallerySurface("https://restofront.com"),
+    ).toMatchObject({
+      brand: restaurantMarketing.brand,
+      canonicalOrigin: "https://restofront.com",
+      inverse: false,
+      pricingHref: "/#pricing",
+    });
+  });
+
+  it("fails closed to the factory identity for an unknown host", () => {
+    expect(
+      restaurantThemeGallerySurface("https://unregistered.example"),
+    ).toMatchObject({
+      brand: FACTORY_BRAND,
+      canonicalOrigin: "https://cornershop.dev",
+      inverse: true,
+    });
+  });
+});

--- a/src/lib/theme-gallery-surface.ts
+++ b/src/lib/theme-gallery-surface.ts
@@ -1,0 +1,39 @@
+import { FACTORY_BRAND, type BrandIdentity } from "@/lib/brand";
+import { restaurantMarketing } from "@/lib/verticals/restaurant/marketing";
+
+const FACTORY_ORIGIN = "https://cornershop.dev";
+const RESTAURANT_ORIGIN = restaurantMarketing.domain
+  ? `https://${restaurantMarketing.domain}`
+  : null;
+
+export type RestaurantThemeGallerySurface = {
+  brand: BrandIdentity;
+  canonicalOrigin: string;
+  inverse: boolean;
+  pricingHref: string;
+};
+
+/**
+ * The restaurant theme library is reachable from both the factory and the
+ * restaurant storefront. The hostname owns the outer product shell; the
+ * previews inside the gallery always keep their registered restaurant themes.
+ */
+export function restaurantThemeGallerySurface(
+  requestOrigin: string,
+): RestaurantThemeGallerySurface {
+  if (RESTAURANT_ORIGIN && requestOrigin === RESTAURANT_ORIGIN) {
+    return {
+      brand: restaurantMarketing.brand,
+      canonicalOrigin: RESTAURANT_ORIGIN,
+      inverse: false,
+      pricingHref: "/#pricing",
+    };
+  }
+
+  return {
+    brand: FACTORY_BRAND,
+    canonicalOrigin: FACTORY_ORIGIN,
+    inverse: true,
+    pricingHref: "/niche/restaurant#pricing",
+  };
+}


### PR DESCRIPTION
## What changed
- make restaurant gallery and detail pages choose their outer product shell from the request hostname
- keep Cornershopdev dark technical chrome, metadata, canonicals, and pricing links on `cornershop.dev`
- keep Restofrontapp cream restaurant chrome, metadata, canonicals, and pricing links on `restofront.com`
- preserve each restaurant theme renderer inside either product shell
- fail unknown hosts closed to the factory identity

## Root cause
The route hardcoded `restaurantMarketing.brand` and Restofront canonicals even when served on `cornershop.dev`; there was no HTTP redirect.

## Verification
- `bun test src/lib/theme-gallery-surface.test.ts`
- focused ESLint
- `bun run build`
- Brave visual checks on gallery and detail pages for both host identities; no console errors or Next.js overlays