### PR TITLE
feat(themes): add compact gallery previews

### DIFF
--- a/src/app/themes/restaurant/[themeId]/page.tsx
+++ b/src/app/themes/restaurant/[themeId]/page.tsx
@@ -1,7 +1,13 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { ArrowLeft, ArrowRight, Check, X } from "lucide-react";
+import {
+  ArrowLeft,
+  ArrowRight,
+  ArrowUpRight,
+  Check,
+  X,
+} from "lucide-react";
 import { RestaurantThemeRenderer } from "@/components/restaurant-themes/restaurant-theme-renderer";
 import { SiteHeader } from "@/components/site-header";
 import { Badge } from "@/components/ui/badge";
@@ -160,9 +166,25 @@ export default async function RestaurantThemeDetailPage({
                 Fictional restaurant fixture · AI-created preview image
               </p>
             </div>
-            <Badge className="w-fit bg-white/10 text-white">
-              No third-party theme code or assets
-            </Badge>
+            <div className="flex flex-wrap items-center gap-3">
+              <Badge className="w-fit bg-white/10 text-white">
+                No third-party theme code or assets
+              </Badge>
+              <Button
+                render={
+                  <Link
+                    href={`/themes/restaurant/${manifest.id}/preview`}
+                    target="_blank"
+                    rel="noreferrer"
+                  />
+                }
+                nativeButton={false}
+                variant="secondary"
+              >
+                Open full website preview
+                <ArrowUpRight className="size-4" />
+              </Button>
+            </div>
           </div>
           <div className="mx-auto max-w-[1450px] rounded-[1.8rem] border border-white/15 p-2 md:p-3">
             <RestaurantThemeRenderer

--- a/src/app/themes/restaurant/[themeId]/preview/page.tsx
+++ b/src/app/themes/restaurant/[themeId]/preview/page.tsx
@@ -1,0 +1,57 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { RestaurantThemeRenderer } from "@/components/restaurant-themes/restaurant-theme-renderer";
+import {
+  restaurantThemeIdSchema,
+  type RestaurantThemeId,
+} from "@/lib/site-themes/restaurant/contracts";
+import { getRestaurantThemeFixture } from "@/lib/site-themes/restaurant/fixtures";
+import {
+  getRestaurantThemeManifest,
+  listRestaurantThemeManifests,
+} from "@/lib/site-themes/restaurant/registry";
+import { parseRestaurantThemeSelection } from "@/lib/site-themes/restaurant/selection";
+
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return listRestaurantThemeManifests().map(({ id }) => ({ themeId: id }));
+}
+
+function parseThemeId(value: string): RestaurantThemeId | null {
+  const parsed = restaurantThemeIdSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ themeId: string }>;
+}): Promise<Metadata> {
+  const id = parseThemeId((await params).themeId);
+  if (!id) return {};
+
+  const manifest = getRestaurantThemeManifest(id);
+  return {
+    title: { absolute: `${manifest.name} — full restaurant website preview` },
+    description: manifest.description,
+    robots: { index: false, follow: false },
+  };
+}
+
+export default async function RestaurantThemeFullPreviewPage({
+  params,
+}: {
+  params: Promise<{ themeId: string }>;
+}) {
+  const id = parseThemeId((await params).themeId);
+  if (!id) notFound();
+
+  const fixture = getRestaurantThemeFixture(id);
+  const selection = parseRestaurantThemeSelection(
+    fixture.attributes.themeSelection,
+  );
+  if (!selection) notFound();
+
+  return <RestaurantThemeRenderer draft={fixture} selection={selection} />;
+}

--- a/src/app/themes/restaurant/page.tsx
+++ b/src/app/themes/restaurant/page.tsx
@@ -1,15 +1,16 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { notFound } from "next/navigation";
-import { ArrowRight, Check, ShieldCheck } from "lucide-react";
-import { RestaurantThemeRenderer } from "@/components/restaurant-themes/restaurant-theme-renderer";
+import {
+  ArrowRight,
+  ArrowUpRight,
+  Check,
+  ShieldCheck,
+} from "lucide-react";
 import { SiteHeader } from "@/components/site-header";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { restaurantThemeGallerySurface } from "@/lib/theme-gallery-surface";
-import { restaurantThemeFixtures } from "@/lib/site-themes/restaurant/fixtures";
 import { listRestaurantThemeManifests } from "@/lib/site-themes/restaurant/registry";
-import { parseRestaurantThemeSelection } from "@/lib/site-themes/restaurant/selection";
 import { resolveRequestOrigin } from "@/lib/verticals/request-site";
 import styles from "./theme-gallery.module.css";
 
@@ -74,71 +75,113 @@ export default async function RestaurantThemeGalleryPage() {
 
         <section
           id="themes"
-          className="mx-auto max-w-[1500px] space-y-24 px-4 py-16 md:px-6 lg:py-24"
+          className="mx-auto max-w-7xl px-5 py-16 lg:px-8 lg:py-24"
         >
-          {manifests.map((manifest, index) => {
-            const fixture = restaurantThemeFixtures[manifest.id];
-            const selection = parseRestaurantThemeSelection(
-              fixture.attributes.themeSelection,
-            );
-            if (!selection) notFound();
+          <div className="mb-10 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary">
+                Theme library
+              </p>
+              <h2 className="font-display mt-3 text-5xl leading-[0.9] tracking-[-0.045em] md:text-6xl">
+                Compare the starting points.
+              </h2>
+            </div>
+            <p className="max-w-md text-sm leading-6 text-muted-foreground">
+              Open any theme as a complete fictional restaurant website before
+              you build your own preview.
+            </p>
+          </div>
 
-            return (
-              <article key={manifest.id}>
-                <div className="mx-auto mb-7 grid max-w-7xl gap-7 px-1 lg:grid-cols-[0.7fr_1.3fr] lg:items-end">
-                  <div>
-                    <p className="font-mono text-xs text-primary">
+          <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+            {manifests.map((manifest, index) => {
+              const detailHref = `/themes/restaurant/${manifest.id}`;
+              const previewHref = `${detailHref}/preview`;
+
+              return (
+                <article
+                  key={manifest.id}
+                  className="flex min-w-0 flex-col overflow-hidden rounded-3xl border bg-card shadow-sm"
+                >
+                  <div className={styles.previewViewport}>
+                    <iframe
+                      src={previewHref}
+                      title={`${manifest.name} restaurant website preview`}
+                      tabIndex={-1}
+                      aria-hidden="true"
+                      loading="lazy"
+                      className={styles.previewFrame}
+                    />
+                    <div className={styles.previewShade} />
+                    <span className={styles.previewDisclosure}>
+                      Fictional preview
+                    </span>
+                    <Link
+                      href={previewHref}
+                      target="_blank"
+                      rel="noreferrer"
+                      aria-label={`Open the full ${manifest.name} website preview`}
+                      className={styles.previewLink}
+                    >
+                      <span>
+                        Open full preview
+                        <ArrowUpRight className="size-4" />
+                      </span>
+                    </Link>
+                  </div>
+
+                  <div className="flex flex-1 flex-col p-6">
+                    <p className="font-mono text-[11px] text-primary">
                       0{index + 1} · {manifest.id} · v
                       {manifest.rendererVersion}
                     </p>
-                    <h2 className="font-display mt-3 text-5xl leading-[0.9] tracking-[-0.045em] md:text-6xl">
+                    <h3 className="font-display mt-3 text-4xl leading-[0.9] tracking-[-0.04em]">
                       {manifest.name}
-                    </h2>
-                  </div>
-                  <div className="lg:justify-self-end">
-                    <p className="max-w-xl text-sm leading-7 text-muted-foreground">
+                    </h3>
+                    <p className="mt-4 text-sm leading-6 text-muted-foreground">
                       {manifest.description}
                     </p>
-                    <ul className="mt-4 flex flex-wrap gap-2">
-                      {manifest.bestFor.slice(0, 3).map((fit) => (
+
+                    <ul className="mt-5 space-y-2">
+                      {manifest.bestFor.slice(0, 2).map((fit) => (
                         <li
                           key={fit}
-                          className="inline-flex items-center gap-1.5 rounded-full border bg-card px-3 py-1.5 text-xs"
+                          className="flex items-start gap-2 text-xs leading-5"
                         >
-                          <Check className="size-3 text-primary" />
+                          <Check className="mt-0.5 size-3.5 shrink-0 text-primary" />
                           {fit}
                         </li>
                       ))}
                     </ul>
-                  </div>
-                </div>
 
-                <div className="relative mx-auto max-w-[1450px] rounded-[1.8rem] border bg-[#2b2b2b] p-2 shadow-2xl md:p-3">
-                  <div className="absolute left-5 top-5 z-30 rounded-full border border-white/20 bg-black/60 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-white backdrop-blur">
-                    Fictional preview · AI-created image
+                    <div className="mt-auto grid grid-cols-2 gap-2 pt-6">
+                      <Button
+                        render={<Link href={detailHref} />}
+                        nativeButton={false}
+                        variant="outline"
+                        className="min-w-0"
+                      >
+                        Theme details
+                      </Button>
+                      <Button
+                        render={
+                          <Link
+                            href={previewHref}
+                            target="_blank"
+                            rel="noreferrer"
+                          />
+                        }
+                        nativeButton={false}
+                        className="min-w-0"
+                      >
+                        Full preview
+                        <ArrowUpRight className="size-4" />
+                      </Button>
+                    </div>
                   </div>
-                  <RestaurantThemeRenderer
-                    draft={fixture}
-                    selection={selection}
-                    embedded
-                  />
-                </div>
-
-                <div className="mx-auto mt-6 flex max-w-7xl justify-end">
-                  <Button
-                    render={
-                      <Link href={`/themes/restaurant/${manifest.id}`} />
-                    }
-                    nativeButton={false}
-                    variant="outline"
-                  >
-                    Inspect this theme
-                    <ArrowRight className="size-4" />
-                  </Button>
-                </div>
-              </article>
-            );
-          })}
+                </article>
+              );
+            })}
+          </div>
         </section>
 
         <section

--- a/src/app/themes/restaurant/theme-gallery.module.css
+++ b/src/app/themes/restaurant/theme-gallery.module.css
@@ -48,3 +48,93 @@
   content: "";
   pointer-events: none;
 }
+
+.previewViewport {
+  position: relative;
+  aspect-ratio: 16 / 10;
+  overflow: hidden;
+  border-bottom: 1px solid var(--border);
+  background: #2b2b2b;
+  isolation: isolate;
+}
+
+.previewFrame {
+  position: absolute;
+  inset: 0;
+  width: 200%;
+  height: 200%;
+  border: 0;
+  pointer-events: none;
+  transform: scale(0.5);
+  transform-origin: top left;
+}
+
+.previewShade {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  background: linear-gradient(
+    to top,
+    rgb(0 0 0 / 0.38),
+    transparent 42%,
+    rgb(0 0 0 / 0.05)
+  );
+  pointer-events: none;
+}
+
+.previewDisclosure {
+  position: absolute;
+  top: 0.75rem;
+  left: 0.75rem;
+  z-index: 2;
+  border: 1px solid rgb(255 255 255 / 0.24);
+  border-radius: 999px;
+  background: rgb(0 0 0 / 0.68);
+  padding: 0.35rem 0.6rem;
+  color: white;
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  line-height: 1;
+  text-transform: uppercase;
+  backdrop-filter: blur(8px);
+}
+
+.previewLink {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  padding: 0.75rem;
+}
+
+.previewLink span {
+  display: inline-flex;
+  min-height: 2.25rem;
+  align-items: center;
+  gap: 0.4rem;
+  border: 1px solid rgb(255 255 255 / 0.22);
+  border-radius: 999px;
+  background: rgb(0 0 0 / 0.72);
+  padding: 0.5rem 0.75rem;
+  color: white;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  backdrop-filter: blur(8px);
+  transition:
+    background-color 160ms ease,
+    transform 160ms ease;
+}
+
+.previewLink:hover span {
+  background: rgb(0 0 0 / 0.9);
+  transform: translateY(-2px);
+}
+
+.previewLink:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: -4px;
+}


### PR DESCRIPTION
## Summary
- replace full-height stacked restaurant demos with a compact responsive theme-card gallery
- add a clean full-website preview route for every registered restaurant theme
- link both gallery cards and theme detail pages to the standalone preview

## Verification
- `bunx eslint src/app/themes/restaurant/page.tsx src/app/themes/restaurant/[themeId]/page.tsx src/app/themes/restaurant/[themeId]/preview/page.tsx`
- `bun test src/lib/site-themes/restaurant/theme-registry.test.tsx src/lib/theme-gallery-surface.test.ts`
- `bun run build`
- Brave desktop/mobile verification for Cornershop, Restofront, and a standalone full preview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added full preview pages for restaurant themes, accessible in a new browser tab.
  * Updated the theme gallery with embedded preview windows and clearer “Theme details” and “Full preview” actions.
  * Added preview overlays, disclosure labels, hover effects, and keyboard-focused styling.
  * Added search-engine controls to prevent full preview pages from being indexed.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->