### PR TITLE
fix(ops): allow Caddy TLS authorization route

### DIFF
--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -13,4 +13,15 @@ describe("health endpoint routing", () => {
       expect(response.headers.get("x-middleware-rewrite")).toBeNull();
     }
   });
+
+  it("lets Caddy authorize TLS through its internal service hostname", async () => {
+    const response = await proxy(
+      new NextRequest(
+        "http://cornershopdev:3000/api/domains/authorize?domain=cornershop.dev",
+      ),
+    );
+
+    expect(response.headers.get("x-middleware-next")).toBe("1");
+    expect(response.headers.get("x-middleware-rewrite")).toBeNull();
+  });
 });

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -45,10 +45,14 @@ export async function proxy(request: NextRequest) {
   upstreamHeaders.delete(LIVE_SITE_SLUG_HEADER);
   upstreamHeaders.delete(LIVE_SITE_VERSION_HEADER);
 
-  // Container and external health probes do not carry a public hostname. Let
-  // the route handlers enforce their own liveness/readiness policy before any
-  // custom-domain lookup can turn the probe into an unknown-host 404.
-  if (request.nextUrl.pathname.startsWith("/api/health/")) {
+  // Container-local infrastructure calls do not carry a public hostname.
+  // Caddy's on-demand TLS check uses the Docker service name, while health
+  // probes use an IP. Let these route handlers enforce their own authorization
+  // before custom-domain lookup can turn either call into an unknown-host 404.
+  if (
+    request.nextUrl.pathname.startsWith("/api/health/") ||
+    request.nextUrl.pathname === "/api/domains/authorize"
+  ) {
     return NextResponse.next({ request: { headers: upstreamHeaders } });
   }
 


### PR DESCRIPTION
## Incident
The production Caddy catch-all returned TLS internal errors because its on-demand authorization request uses the internal `cornershopdev` Docker hostname. The application proxy treated that as an unknown customer domain and rejected it before `/api/domains/authorize` could validate the requested certificate domain.

## Fix
- bypass custom-domain resolution for the exact TLS authorization route
- keep authorization in the route handler, which validates platform/niche/customer domains
- add a regression test using Caddy's internal service hostname

## Verification
- `bun test src/proxy.test.ts`
- `bunx eslint src/proxy.ts src/proxy.test.ts`