### PR TITLE
fix(factory): separate niche and workspace surfaces

### DIFF
--- a/src/app/factory-home.module.css
+++ b/src/app/factory-home.module.css
@@ -1,4 +1,21 @@
 .factoryShell {
+  --background: #050505;
+  --foreground: #f7f7f4;
+  --card: #0d0d0d;
+  --card-foreground: #f7f7f4;
+  --popover: #0d0d0d;
+  --popover-foreground: #f7f7f4;
+  --primary: #ff775f;
+  --primary-foreground: #050505;
+  --secondary: #161616;
+  --secondary-foreground: #f7f7f4;
+  --muted: #121212;
+  --muted-foreground: #a3a3a3;
+  --accent: #123e31;
+  --accent-foreground: #c8f5df;
+  --border: rgb(255 255 255 / 0.11);
+  --input: rgb(255 255 255 / 0.14);
+  --ring: #ff775f;
   --factory-bg: #050505;
   --factory-line: rgb(255 255 255 / 0.07);
   background: var(--factory-bg);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,6 @@ import {
   ArrowUpRight,
   Blocks,
   Check,
-  Code2,
   Database,
   GitBranch,
   Globe2,
@@ -18,12 +17,8 @@ import {
 } from "lucide-react";
 import { SiteHeader } from "@/components/site-header";
 import { FACTORY_BRAND } from "@/lib/brand";
+import { factoryProductCatalog } from "@/lib/factory-products";
 import { listRestaurantThemeManifests } from "@/lib/site-themes/restaurant/registry";
-import {
-  listVerticalIds,
-  resolveVerticalConfig,
-  verticalSlug,
-} from "@/lib/verticals/registry";
 import styles from "./factory-home.module.css";
 
 const REPO_URL = "https://github.com/VincentShipsIt/cornershopdev";
@@ -89,18 +84,9 @@ const platform = [
 ];
 
 export default function Home() {
-  const niches = listVerticalIds().map((id) => {
-    const { marketing } = resolveVerticalConfig(id);
-    return {
-      id,
-      slug: verticalSlug(id),
-      marketing,
-      status: marketing.domain ? "live" : "in build",
-    } as const;
-  });
-  const liveNiches = niches.filter(({ marketing }) => marketing.domain);
+  const products = factoryProductCatalog();
   const themes = listRestaurantThemeManifests();
-  const primaryNiche = liveNiches[0] ?? niches[0];
+  const primaryNiche = products.launched[0] ?? products.next;
 
   return (
     <div className={`${styles.factoryShell} min-h-screen`}>
@@ -113,11 +99,7 @@ export default function Home() {
           { href: "/themes/restaurant", label: "Themes" },
           { href: REPO_URL, label: "GitHub" },
         ]}
-        createHref={
-          primaryNiche
-            ? `/niche/${primaryNiche.slug}`
-            : "/create?vertical=restaurant"
-        }
+        createHref="/create"
         ctaLabel="Build a site"
       />
 
@@ -133,32 +115,30 @@ export default function Home() {
                 The system behind your next local website.
               </h1>
               <p className="mt-7 max-w-2xl text-balance text-base leading-7 text-white/58 md:text-lg md:leading-8">
-                Scan an existing business. Recover what matters. Publish a
-                focused website built for its trade—not another blank template
-                wearing different colours.
+                One workspace to scan an existing business, recover what
+                matters, and publish a focused website built for its trade—not
+                another blank template wearing different colours.
               </p>
 
               <div className="mt-9 flex flex-col gap-3 sm:flex-row">
+                <Link
+                  href="/create"
+                  className="inline-flex h-11 items-center justify-center gap-2 rounded-lg bg-white px-5 text-sm font-semibold text-black transition-colors hover:bg-white/82 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+                >
+                  Build a local site
+                  <ArrowRight className="size-4" />
+                </Link>
                 {primaryNiche?.marketing.domain ? (
                   <a
                     href={`https://${primaryNiche.marketing.domain}`}
                     target="_blank"
                     rel="noreferrer noopener"
-                    className="inline-flex h-11 items-center justify-center gap-2 rounded-lg bg-white px-5 text-sm font-semibold text-black transition-colors hover:bg-white/82 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+                    className="inline-flex h-11 items-center justify-center gap-2 rounded-lg border border-white/16 bg-white/[0.035] px-5 text-sm font-medium text-white transition-colors hover:border-white/28 hover:bg-white/[0.07] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black"
                   >
                     Explore {primaryNiche.marketing.brand.name}
                     <ArrowUpRight className="size-4" />
                   </a>
                 ) : null}
-                <a
-                  href={REPO_URL}
-                  target="_blank"
-                  rel="noreferrer noopener"
-                  className="inline-flex h-11 items-center justify-center gap-2 rounded-lg border border-white/16 bg-white/[0.035] px-5 text-sm font-medium text-white transition-colors hover:border-white/28 hover:bg-white/[0.07] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black"
-                >
-                  <Code2 className="size-4 text-[#ff775f]" />
-                  View source
-                </a>
               </div>
 
               <div className="mt-8 flex flex-wrap gap-x-6 gap-y-2 font-mono text-[11px] uppercase tracking-[0.08em] text-white/58">
@@ -235,9 +215,12 @@ export default function Home() {
 
           <div className="border-t border-white/10 bg-black/30">
             <div className="mx-auto grid max-w-7xl divide-y divide-white/10 sm:grid-cols-3 sm:divide-x sm:divide-y-0">
-              <Metric value={liveNiches.length} label="live niche product" />
+              <Metric value={products.launched.length} label="live niche product" />
               <Metric value={themes.length} label="restaurant theme systems" />
-              <Metric value={niches.length} label="verticals in the registry" />
+              <Metric
+                value={products.registeredCount}
+                label="verticals in the registry"
+              />
             </div>
           </div>
         </section>
@@ -250,8 +233,8 @@ export default function Home() {
               copy="Cornershopdev stays behind the curtain. Each niche gets the language, workflows, themes, and domain its customers already understand."
             />
 
-            <div className="mt-12 grid gap-4 lg:grid-cols-2">
-              {niches.map(({ slug, marketing, status }) => (
+            <div className="mt-12 grid gap-4">
+              {products.launched.map(({ slug, marketing }) => (
                 <article
                   key={slug}
                   className="group flex min-h-[360px] flex-col border border-white/10 bg-white/[0.025] p-6 transition-colors hover:border-white/20 hover:bg-white/[0.04] sm:p-8"
@@ -281,14 +264,8 @@ export default function Home() {
                       </div>
                     </div>
                     <span className="inline-flex items-center gap-2 border border-white/10 px-2.5 py-1 font-mono text-[9px] uppercase tracking-[0.12em] text-white/55">
-                      <span
-                        className={
-                          status === "live"
-                            ? styles.statusDot
-                            : "size-1.5 rounded-full bg-white/28"
-                        }
-                      />
-                      {status}
+                      <span className={styles.statusDot} />
+                      live
                     </span>
                   </div>
 
@@ -310,15 +287,7 @@ export default function Home() {
                         Visit product
                         <ArrowUpRight className="size-3.5" />
                       </a>
-                    ) : (
-                      <Link
-                        href={`/niche/${slug}`}
-                        className="inline-flex items-center gap-2 font-medium text-white transition-colors hover:text-white/72"
-                      >
-                        Preview the vertical
-                        <ArrowRight className="size-3.5" />
-                      </Link>
-                    )}
+                    ) : null}
                     {marketing.themeGallery ? (
                       <Link
                         href={marketing.themeGallery.href}
@@ -332,6 +301,33 @@ export default function Home() {
                 </article>
               ))}
             </div>
+
+            {products.next ? (
+              <aside className="mt-4 grid gap-6 border border-dashed border-white/12 bg-white/[0.015] px-6 py-6 sm:grid-cols-[auto_1fr_auto] sm:items-center sm:px-8">
+                <span className="grid size-11 place-items-center rounded-xl border border-white/12 bg-white/[0.035] font-mono text-[11px] font-semibold text-white/72">
+                  {products.next.marketing.brand.initials}
+                </span>
+                <div>
+                  <p className="font-mono text-[9px] uppercase tracking-[0.14em] text-[#ff775f]">
+                    Next niche · in development
+                  </p>
+                  <div className="mt-2 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                    <h3 className="text-lg font-semibold tracking-[-0.025em] text-white">
+                      {products.next.marketing.brand.name}
+                    </h3>
+                    <span className="text-sm text-white/52">
+                      Built for {products.next.marketing.audience}
+                    </span>
+                  </div>
+                  <p className="mt-2 max-w-2xl text-sm leading-6 text-white/58">
+                    {products.next.marketing.tagline}
+                  </p>
+                </div>
+                <span className="w-fit border border-white/10 px-2.5 py-1 font-mono text-[9px] uppercase tracking-[0.12em] text-white/52">
+                  No public preview yet
+                </span>
+              </aside>
+            ) : null}
           </div>
         </section>
 

--- a/src/app/sign-in/auth-shell.tsx
+++ b/src/app/sign-in/auth-shell.tsx
@@ -1,0 +1,55 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { Brand } from "@/components/brand";
+import { Button } from "@/components/ui/button";
+import type { SignInSurface } from "@/lib/sign-in-surface";
+import { cn } from "@/lib/utils";
+import factoryStyles from "../factory-home.module.css";
+
+export function AuthShell({
+  surface,
+  backHref,
+  children,
+}: {
+  surface: SignInSurface;
+  backHref: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <main
+      className={cn(
+        "min-h-screen",
+        surface.inverse && factoryStyles.factoryShell,
+      )}
+    >
+      <header
+        className={cn(
+          "flex h-16 items-center gap-4 border-b px-5",
+          surface.inverse && "border-white/10",
+        )}
+      >
+        <Button
+          render={<Link href={backHref} />}
+          variant="ghost"
+          size="icon-sm"
+          className={
+            surface.inverse
+              ? "text-white hover:bg-white/8 hover:text-white"
+              : undefined
+          }
+        >
+          <ArrowLeft />
+        </Button>
+        <Brand {...surface.brand} inverse={surface.inverse} />
+      </header>
+      <div
+        className={cn(
+          "grid min-h-[calc(100vh-4rem)] place-items-center px-5 py-16",
+          surface.inverse && factoryStyles.factoryGrid,
+        )}
+      >
+        {children}
+      </div>
+    </main>
+  );
+}

--- a/src/app/sign-in/page.tsx
+++ b/src/app/sign-in/page.tsx
@@ -1,36 +1,23 @@
 import type { Metadata } from "next";
-import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
-import { Brand } from "@/components/brand";
+import { AuthShell } from "@/app/sign-in/auth-shell";
 import { SignInForm } from "@/app/sign-in/sign-in-form";
-import { Button } from "@/components/ui/button";
-import { resolveRequestBrand } from "@/lib/verticals/request-site";
+import { signInSurface } from "@/lib/sign-in-surface";
+import { resolveRequestMarketing } from "@/lib/verticals/request-site";
 
-export const metadata: Metadata = {
-  title: "Sign in",
-  robots: { index: false, follow: false },
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const surface = signInSurface(await resolveRequestMarketing());
+  return {
+    title: { absolute: `Sign in | ${surface.brand.name}` },
+    robots: { index: false, follow: false },
+  };
+}
 
 export default async function SignInPage() {
-  // Sign-in is served off whichever niche domain the visitor was already on, so
-  // it wears that storefront's brand rather than the factory's.
-  const brand = await resolveRequestBrand();
+  const surface = signInSurface(await resolveRequestMarketing());
 
   return (
-    <main className="min-h-screen">
-      <header className="flex h-16 items-center gap-4 border-b px-5">
-        <Button
-          render={<Link href="/" />}
-          variant="ghost"
-          size="icon-sm"
-        >
-          <ArrowLeft />
-        </Button>
-        <Brand {...brand} />
-      </header>
-      <div className="grid min-h-[calc(100vh-4rem)] place-items-center px-5 py-16">
-        <SignInForm />
-      </div>
-    </main>
+    <AuthShell surface={surface} backHref="/">
+      <SignInForm copy={surface.copy} inverse={surface.inverse} />
+    </AuthShell>
   );
 }

--- a/src/app/sign-in/sign-in-form.tsx
+++ b/src/app/sign-in/sign-in-form.tsx
@@ -5,8 +5,16 @@ import Link from "next/link";
 import { ArrowRight, Check, LoaderCircle, Mail } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import type { SignInCopy } from "@/lib/sign-in-surface";
+import { cn } from "@/lib/utils";
 
-export function SignInForm() {
+export function SignInForm({
+  copy,
+  inverse,
+}: {
+  copy: SignInCopy;
+  inverse: boolean;
+}) {
   const [email, setEmail] = useState("");
   const [loading, setLoading] = useState(false);
   const [sent, setSent] = useState(false);
@@ -33,17 +41,31 @@ export function SignInForm() {
   }
 
   return (
-    <section className="w-full max-w-md rounded-3xl border bg-card p-7 shadow-xl">
+    <section
+      className={cn(
+        "w-full max-w-md border bg-card p-7",
+        inverse
+          ? "rounded-2xl shadow-[0_28px_80px_rgb(0_0_0/0.56)]"
+          : "rounded-3xl shadow-xl",
+      )}
+    >
       <span className="grid size-10 place-items-center rounded-full bg-primary/10 text-primary">
         {sent ? <Check className="size-5" /> : <Mail className="size-5" />}
       </span>
-      <h1 className="font-display mt-5 text-5xl leading-none tracking-[-0.045em]">
-        {sent ? "Check your inbox." : "Open your restaurant."}
+      <h1
+        className={cn(
+          "mt-5 leading-none tracking-[-0.045em]",
+          inverse
+            ? "text-4xl font-semibold"
+            : "font-display text-5xl",
+        )}
+      >
+        {sent ? "Check your inbox." : copy.title}
       </h1>
       <p className="mt-4 text-sm leading-6 text-muted-foreground">
         {sent
           ? `A secure sign-in link is on its way to ${email}.`
-          : "Enter the owner email used when the website was claimed. No password needed."}
+          : copy.description}
       </p>
       {!sent ? (
         <form onSubmit={submit} className="mt-7 space-y-3">
@@ -51,7 +73,7 @@ export function SignInForm() {
             type="email"
             value={email}
             onChange={(event) => setEmail(event.target.value)}
-            placeholder="owner@restaurant.com"
+            placeholder={copy.emailPlaceholder}
             className="h-11"
             required
           />
@@ -68,9 +90,12 @@ export function SignInForm() {
         </form>
       ) : null}
       <div className="mt-6 border-t pt-5 text-center text-xs text-muted-foreground">
-        No site yet?{" "}
-        <Link href="/create" className="font-semibold text-foreground">
-          Build a preview
+        {copy.emptyPrompt}{" "}
+        <Link
+          href={copy.createHref}
+          className="font-semibold text-foreground"
+        >
+          {copy.createLabel}
         </Link>
       </div>
     </section>

--- a/src/app/sign-in/verify/page.tsx
+++ b/src/app/sign-in/verify/page.tsx
@@ -1,52 +1,58 @@
 import type { Metadata } from "next";
-import Link from "next/link";
-import { ArrowLeft, ArrowRight, ShieldCheck } from "lucide-react";
-import { Brand } from "@/components/brand";
+import { ArrowRight, ShieldCheck } from "lucide-react";
+import { AuthShell } from "@/app/sign-in/auth-shell";
 import { Button } from "@/components/ui/button";
-import { resolveRequestBrand } from "@/lib/verticals/request-site";
+import { signInSurface } from "@/lib/sign-in-surface";
+import { cn } from "@/lib/utils";
+import { resolveRequestMarketing } from "@/lib/verticals/request-site";
 
-export const metadata: Metadata = {
-  title: "Confirm sign in",
-  robots: { index: false, follow: false },
-  referrer: "no-referrer",
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const surface = signInSurface(await resolveRequestMarketing());
+  return {
+    title: { absolute: `Confirm sign in | ${surface.brand.name}` },
+    robots: { index: false, follow: false },
+    referrer: "no-referrer",
+  };
+}
 
 export default async function VerifySignInPage() {
-  const brand = await resolveRequestBrand();
+  const surface = signInSurface(await resolveRequestMarketing());
 
   return (
-    <main className="min-h-screen">
-      <header className="flex h-16 items-center gap-4 border-b px-5">
-        <Button
-          render={<Link href="/sign-in" />}
-          variant="ghost"
-          size="icon-sm"
+    <AuthShell surface={surface} backHref="/sign-in">
+      <section
+        className={cn(
+          "w-full max-w-md border bg-card p-7",
+          surface.inverse
+            ? "rounded-2xl shadow-[0_28px_80px_rgb(0_0_0/0.56)]"
+            : "rounded-3xl shadow-xl",
+        )}
+      >
+        <span className="grid size-10 place-items-center rounded-full bg-primary/10 text-primary">
+          <ShieldCheck className="size-5" />
+        </span>
+        <h1
+          className={cn(
+            "mt-5 leading-none tracking-[-0.045em]",
+            surface.inverse
+              ? "text-4xl font-semibold"
+              : "font-display text-5xl",
+          )}
         >
-          <ArrowLeft />
-        </Button>
-        <Brand {...brand} />
-      </header>
-      <div className="grid min-h-[calc(100vh-4rem)] place-items-center px-5 py-16">
-        <section className="w-full max-w-md rounded-3xl border bg-card p-7 shadow-xl">
-          <span className="grid size-10 place-items-center rounded-full bg-primary/10 text-primary">
-            <ShieldCheck className="size-5" />
-          </span>
-          <h1 className="font-display mt-5 text-5xl leading-none tracking-[-0.045em]">
-            Confirm it&apos;s you.
-          </h1>
-          <p className="mt-4 text-sm leading-6 text-muted-foreground">
-            Your secure link is ready. Continue to open your workspace. This
-            confirmation keeps automated email scanners from using the link
-            before you do.
-          </p>
-          <form action="/api/auth/verify" method="post" className="mt-7">
-            <Button type="submit" className="h-11 w-full">
-              Continue securely
-              <ArrowRight />
-            </Button>
-          </form>
-        </section>
-      </div>
-    </main>
+          Confirm it&apos;s you.
+        </h1>
+        <p className="mt-4 text-sm leading-6 text-muted-foreground">
+          Your secure link is ready. Continue to open your workspace. This
+          confirmation keeps automated email scanners from using the link before
+          you do.
+        </p>
+        <form action="/api/auth/verify" method="post" className="mt-7">
+          <Button type="submit" className="h-11 w-full">
+            Continue securely
+            <ArrowRight />
+          </Button>
+        </form>
+      </section>
+    </AuthShell>
   );
 }

--- a/src/lib/factory-products.test.ts
+++ b/src/lib/factory-products.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "bun:test";
+import { factoryProductCatalog } from "@/lib/factory-products";
+
+describe("factory product catalog", () => {
+  it("keeps unlaunched niches out of the public product cards", () => {
+    const catalog = factoryProductCatalog();
+
+    expect(catalog.launched.map(({ marketing }) => marketing.brand.name)).toEqual(
+      ["Restofrontapp"],
+    );
+    expect(catalog.next?.marketing.brand.name).toBe("Salonfront");
+    expect(catalog.next?.marketing.domain).toBeNull();
+    expect(catalog.registeredCount).toBe(2);
+  });
+});

--- a/src/lib/factory-products.ts
+++ b/src/lib/factory-products.ts
@@ -1,0 +1,29 @@
+import {
+  listMarketingVerticals,
+  listVerticalIds,
+  resolveVerticalConfig,
+  verticalSlug,
+} from "@/lib/verticals/registry";
+
+function factoryProduct(id: ReturnType<typeof listVerticalIds>[number]) {
+  return {
+    id,
+    slug: verticalSlug(id),
+    marketing: resolveVerticalConfig(id).marketing,
+  };
+}
+
+/**
+ * Launched products get full cards. The first registered-but-unlaunched niche
+ * is exposed only as a teaser, never as a public product or preview.
+ */
+export function factoryProductCatalog() {
+  const launchedIds = new Set(listMarketingVerticals());
+  const nextId = listVerticalIds().find((id) => !launchedIds.has(id)) ?? null;
+
+  return {
+    launched: listMarketingVerticals().map(factoryProduct),
+    next: nextId ? factoryProduct(nextId) : null,
+    registeredCount: listVerticalIds().length,
+  };
+}

--- a/src/lib/sign-in-surface.test.ts
+++ b/src/lib/sign-in-surface.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "bun:test";
+import { FACTORY_BRAND } from "@/lib/brand";
+import { signInSurface } from "@/lib/sign-in-surface";
+import { beautyMarketing } from "@/lib/verticals/beauty/marketing";
+import { restaurantMarketing } from "@/lib/verticals/restaurant/marketing";
+
+describe("sign-in surface", () => {
+  it("keeps Cornershopdev neutral and factory-themed", () => {
+    expect(signInSurface(null)).toMatchObject({
+      brand: FACTORY_BRAND,
+      inverse: true,
+      copy: {
+        title: "Open your workspace.",
+        emailPlaceholder: "you@business.com",
+        createLabel: "Build a local-business site",
+        createHref: "/create",
+      },
+    });
+  });
+
+  it("uses restaurant language only on the restaurant storefront", () => {
+    expect(signInSurface(restaurantMarketing)).toMatchObject({
+      brand: restaurantMarketing.brand,
+      inverse: false,
+      copy: {
+        title: "Open your restaurant.",
+        emailPlaceholder: "owner@restaurant.com",
+        createHref: "/create?vertical=restaurant",
+      },
+    });
+  });
+
+  it("lets the next niche own its future workspace language", () => {
+    expect(signInSurface(beautyMarketing)).toMatchObject({
+      brand: beautyMarketing.brand,
+      inverse: false,
+      copy: {
+        title: "Open your salon.",
+        emailPlaceholder: "owner@salon.com",
+        createHref: "/create?vertical=beauty",
+      },
+    });
+  });
+});

--- a/src/lib/sign-in-surface.ts
+++ b/src/lib/sign-in-surface.ts
@@ -1,0 +1,42 @@
+import { FACTORY_BRAND, type BrandIdentity } from "@/lib/brand";
+import type { VerticalMarketing } from "@/lib/verticals/types";
+
+export type SignInCopy = VerticalMarketing["signIn"];
+
+export type SignInSurface = {
+  brand: BrandIdentity;
+  copy: SignInCopy;
+  inverse: boolean;
+};
+
+const factoryCopy: SignInCopy = {
+  title: "Open your workspace.",
+  description:
+    "Manage the sites you own or operate. Enter the email connected to your Cornershopdev workspace—no password needed.",
+  emailPlaceholder: "you@business.com",
+  emptyPrompt: "New to Cornershopdev?",
+  createLabel: "Build a local-business site",
+  createHref: "/create",
+};
+
+/**
+ * Authentication is shared infrastructure, but the hostname owns the product
+ * language and visual shell. Unknown hosts fail closed to the factory.
+ */
+export function signInSurface(
+  marketing: VerticalMarketing | null,
+): SignInSurface {
+  if (marketing) {
+    return {
+      brand: marketing.brand,
+      copy: marketing.signIn,
+      inverse: false,
+    };
+  }
+
+  return {
+    brand: FACTORY_BRAND,
+    copy: factoryCopy,
+    inverse: true,
+  };
+}

--- a/src/lib/verticals/beauty/marketing.ts
+++ b/src/lib/verticals/beauty/marketing.ts
@@ -33,6 +33,15 @@ export const beautyMarketing = {
     submitLabel: "Show my preview",
     pendingLabel: "Opening your salon",
   },
+  signIn: {
+    title: "Open your salon.",
+    description:
+      "Enter the owner email used when the website was claimed. No password needed.",
+    emailPlaceholder: "owner@salon.com",
+    emptyPrompt: "No site yet?",
+    createLabel: "Build a preview",
+    createHref: "/create?vertical=beauty",
+  },
   steps: [
     {
       number: "01",

--- a/src/lib/verticals/request-site.ts
+++ b/src/lib/verticals/request-site.ts
@@ -4,6 +4,7 @@ import {
   resolveVerticalByHostname,
   resolveVerticalConfig,
 } from "@/lib/verticals/registry";
+import type { VerticalMarketing } from "@/lib/verticals/types";
 
 const FACTORY_ORIGIN = "https://cornershop.dev";
 
@@ -40,8 +41,16 @@ async function requestHostname(): Promise<string> {
  * of every screen that needs this.
  */
 export async function resolveRequestBrand(): Promise<BrandIdentity> {
+  return (await resolveRequestMarketing())?.brand ?? FACTORY_BRAND;
+}
+
+/**
+ * The niche marketing contract for the hostname the visitor used. Shared
+ * customer surfaces consume this instead of guessing a trade from the route.
+ */
+export async function resolveRequestMarketing(): Promise<VerticalMarketing | null> {
   const niche = resolveVerticalByHostname(await requestHostname());
-  return niche ? resolveVerticalConfig(niche).marketing.brand : FACTORY_BRAND;
+  return niche ? resolveVerticalConfig(niche).marketing : null;
 }
 
 /**

--- a/src/lib/verticals/restaurant/marketing.ts
+++ b/src/lib/verticals/restaurant/marketing.ts
@@ -40,6 +40,15 @@ export const restaurantMarketing = {
     submitLabel: "Show my preview",
     pendingLabel: "Opening your restaurant",
   },
+  signIn: {
+    title: "Open your restaurant.",
+    description:
+      "Enter the owner email used when the website was claimed. No password needed.",
+    emailPlaceholder: "owner@restaurant.com",
+    emptyPrompt: "No site yet?",
+    createLabel: "Build a preview",
+    createHref: "/create?vertical=restaurant",
+  },
   themeGallery: {
     href: "/themes/restaurant",
     label: "Browse themes",

--- a/src/lib/verticals/types.ts
+++ b/src/lib/verticals/types.ts
@@ -160,6 +160,15 @@ export type VerticalMarketing = {
     submitLabel: string;
     pendingLabel: string;
   };
+  /** Host-specific copy for the shared passwordless customer workspace. */
+  signIn: {
+    title: string;
+    description: string;
+    emailPlaceholder: string;
+    emptyPrompt: string;
+    createLabel: string;
+    createHref: string;
+  };
   /** Optional public library powered by the vertical's registered site themes. */
   themeGallery?: { href: string; label: string };
   steps: { number: string; title: string; copy: string }[];


### PR DESCRIPTION
## Summary
- show only launched niches as full Cornershop product cards and render Salonfront as a non-clickable next-niche teaser
- give Cornershopdev a neutral dark workspace sign-in while keeping restaurant copy and styling on Restofront
- route factory acquisition CTAs to the generic local-business site builder

## Verification
- `bun test src/lib/factory-products.test.ts src/lib/sign-in-surface.test.ts src/lib/verticals/registry.test.ts`
- affected-file ESLint
- `bun run build`
- Brave desktop/mobile smoke tests for Cornershop homepage, Cornershop sign-in, and Restofront sign-in