### PR TITLE
fix(deploy): provide build-only auth secret

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,10 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV WORKFLOW_TARGET_WORLD=@workflow/world-postgres
 COPY . .
-RUN bun run build
+# Runtime secrets are injected by the host environment. Next evaluates auth
+# routes while collecting page data, so the builder gets a non-production
+# placeholder that is not inherited by the runner stage.
+RUN BETTER_AUTH_SECRET=build-only-better-auth-secret-32-bytes bun run build
 RUN bun build scripts/grant-superadmin.ts \
   --target=bun \
   --packages=external \


### PR DESCRIPTION
## Summary
- provide a non-production Better Auth secret only to the Docker builder command
- keep the real runtime secret exclusively in the host-injected SSM environment

## Evidence
- Dockerfile build check passes with no warnings
- local image build passed the previously failing Better Auth page-collection point; Colima later disconnected with an infrastructure EOF
- production was untouched because the failed workflow stopped before artifact upload or cutover