### PR TITLE
fix(auth): preserve public origin behind proxy

### DIFF
--- a/src/app/api/auth/[...all]/route.ts
+++ b/src/app/api/auth/[...all]/route.ts
@@ -1,6 +1,7 @@
 import { toNextJsHandler } from "better-auth/next-js";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
+import { authRequestUrl } from "@/lib/auth-request-url";
 import { auth } from "@/lib/better-auth";
 import { isBlockedDirectBetterAuthRoute } from "@/lib/better-auth-route-policy";
 
@@ -9,7 +10,7 @@ const handlers = toNextJsHandler(auth);
 function blocked(request: NextRequest) {
   if (request.method === "GET") {
     return NextResponse.redirect(
-      new URL("/sign-in?error=invalid-link", request.url),
+      authRequestUrl("/sign-in?error=invalid-link", request),
       303,
     );
   }

--- a/src/app/api/auth/checkout/route.ts
+++ b/src/app/api/auth/checkout/route.ts
@@ -2,6 +2,7 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { z } from "zod";
 import { normalizeAccountEmail } from "@/lib/account-email";
+import { authRequestUrl } from "@/lib/auth-request-url";
 import { auth } from "@/lib/better-auth";
 import {
   CHECKOUT_RETURN_COOKIE,
@@ -100,7 +101,7 @@ export async function GET(request: Request) {
   const headers = new Headers(request.headers);
   headers.set("content-type", "application/json");
   return auth.handler(
-    new Request(new URL("/api/auth/checkout/bootstrap", request.url), {
+    new Request(authRequestUrl("/api/auth/checkout/bootstrap", request), {
       method: "POST",
       headers,
       body: JSON.stringify({

--- a/src/app/api/auth/complete/route.ts
+++ b/src/app/api/auth/complete/route.ts
@@ -1,11 +1,12 @@
 import { NextResponse } from "next/server";
+import { authRequestUrl } from "@/lib/auth-request-url";
 import { getCurrentSession } from "@/lib/current-session";
 
 export async function GET(request: Request) {
   const session = await getCurrentSession();
   if (!session) {
     return NextResponse.redirect(
-      new URL("/sign-in?error=invalid-link", request.url),
+      authRequestUrl("/sign-in?error=invalid-link", request),
       303,
     );
   }
@@ -16,7 +17,7 @@ export async function GET(request: Request) {
         ? "/workspace/select"
         : "/dashboard";
   const response = NextResponse.redirect(
-    new URL(destination, request.url),
+    authRequestUrl(destination, request),
     303,
   );
   response.headers.set("Cache-Control", "private, no-store");

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,4 +1,5 @@
 import { recordSessionRevocation } from "@/lib/auth-sessions";
+import { authRequestUrl } from "@/lib/auth-request-url";
 import { auth } from "@/lib/better-auth";
 import { getCurrentSession } from "@/lib/current-session";
 import { isSameOriginMutation } from "@/lib/request-origin";
@@ -11,7 +12,7 @@ export async function POST(request: Request) {
   const headers = new Headers(request.headers);
   headers.set("content-type", "application/json");
   const response = await auth.handler(
-    new Request(new URL("/api/auth/sign-out", request.url), {
+    new Request(authRequestUrl("/api/auth/sign-out", request), {
       method: "POST",
       headers,
       body: "{}",

--- a/src/app/api/auth/verify/route.ts
+++ b/src/app/api/auth/verify/route.ts
@@ -1,5 +1,6 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
+import { authRequestUrl } from "@/lib/auth-request-url";
 import { auth } from "@/lib/better-auth";
 import { markMagicLinkConsumed } from "@/lib/magic-links";
 import { isSameOriginMutation } from "@/lib/request-origin";
@@ -10,7 +11,7 @@ import {
 
 function signInError(request: Request) {
   return NextResponse.redirect(
-    new URL("/sign-in?error=invalid-link", request.url),
+    authRequestUrl("/sign-in?error=invalid-link", request),
     303,
   );
 }
@@ -27,7 +28,7 @@ export async function GET(request: NextRequest) {
   }
 
   const response = NextResponse.redirect(
-    new URL("/sign-in/verify", request.url),
+    authRequestUrl("/sign-in/verify", request),
     303,
   );
   response.cookies.set(
@@ -52,7 +53,7 @@ export async function POST(request: NextRequest) {
     return signInError(request);
   }
 
-  const verifyUrl = new URL("/api/auth/magic-link/verify", request.url);
+  const verifyUrl = authRequestUrl("/api/auth/magic-link/verify", request);
   verifyUrl.searchParams.set("token", token);
   verifyUrl.searchParams.set("callbackURL", "/api/auth/complete");
   verifyUrl.searchParams.set(
@@ -75,7 +76,9 @@ export async function POST(request: NextRequest) {
   }
 
   const location = verification.headers.get("location");
-  const destination = location ? new URL(location, request.url) : null;
+  const destination = location
+    ? new URL(location, authRequestUrl("/", request))
+    : null;
   const verified =
     verification.status >= 300 &&
     verification.status < 400 &&

--- a/src/lib/auth-request-url.test.ts
+++ b/src/lib/auth-request-url.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "bun:test";
+import { resolveAuthRequestOrigin } from "@/lib/auth-request-url";
+
+function request(headers: Record<string, string>, url = "http://0.0.0.0:3000") {
+  return new Request(url, { headers });
+}
+
+describe("auth request origin", () => {
+  it("uses the allow-listed forwarded factory hostname in production", () => {
+    expect(
+      resolveAuthRequestOrigin(
+        request({
+          host: "0.0.0.0:3000",
+          "x-forwarded-host": "cornershop.dev",
+          "x-forwarded-proto": "https",
+        }),
+        {
+          NODE_ENV: "production",
+          NEXT_PUBLIC_APP_URL: "https://cornershop.dev",
+        },
+      ),
+    ).toBe("https://cornershop.dev");
+  });
+
+  it("preserves the allow-listed niche hostname", () => {
+    expect(
+      resolveAuthRequestOrigin(
+        request({
+          host: "0.0.0.0:3000",
+          "x-forwarded-host": "restofront.com",
+        }),
+        {
+          NODE_ENV: "production",
+          NEXT_PUBLIC_APP_URL: "https://cornershop.dev",
+        },
+      ),
+    ).toBe("https://restofront.com");
+  });
+
+  it("falls back instead of trusting an unknown forwarded hostname", () => {
+    expect(
+      resolveAuthRequestOrigin(
+        request({
+          host: "0.0.0.0:3000",
+          "x-forwarded-host": "attacker.example",
+        }),
+        {
+          NODE_ENV: "production",
+          NEXT_PUBLIC_APP_URL: "https://cornershop.dev",
+        },
+      ),
+    ).toBe("https://cornershop.dev");
+  });
+
+  it("keeps a local development port", () => {
+    expect(
+      resolveAuthRequestOrigin(
+        request({
+          host: "127.0.0.1:3000",
+          "x-forwarded-host": "localhost:4444",
+          "x-forwarded-proto": "http",
+        }),
+        {
+          NODE_ENV: "development",
+          NEXT_PUBLIC_APP_URL: "http://localhost:3000",
+        },
+      ),
+    ).toBe("http://localhost:4444");
+  });
+});

--- a/src/lib/auth-request-url.ts
+++ b/src/lib/auth-request-url.ts
@@ -1,0 +1,80 @@
+import { betterAuthAllowedHosts } from "@/lib/better-auth-config";
+import { requestHostname } from "@/lib/request-hostname";
+
+type AuthRequestEnvironment = Record<string, string | undefined>;
+type AuthRequest = Pick<Request, "headers" | "url">;
+
+const FACTORY_ORIGIN = "https://cornershop.dev";
+
+function firstHeaderValue(value: string | null): string {
+  return value?.split(",")[0]?.trim() ?? "";
+}
+
+function fallbackOrigin(environment: AuthRequestEnvironment): string {
+  const configured = environment.NEXT_PUBLIC_APP_URL;
+  if (!configured) return FACTORY_ORIGIN;
+  try {
+    const url = new URL(configured);
+    return url.protocol === "http:" || url.protocol === "https:"
+      ? url.origin
+      : FACTORY_ORIGIN;
+  } catch {
+    return FACTORY_ORIGIN;
+  }
+}
+
+/**
+ * Resolves the browser-facing origin for auth redirects and internal Better Auth
+ * requests. Next sees the container address in `request.url` behind Caddy, so
+ * using that URL directly leaks `0.0.0.0:3000` into Location headers.
+ *
+ * The forwarded hostname is accepted only when it is already in Better Auth's
+ * host allow-list. This keeps proxy metadata from becoming an open redirect.
+ */
+export function resolveAuthRequestOrigin(
+  request: AuthRequest,
+  environment: AuthRequestEnvironment = process.env,
+): string {
+  const hostname = requestHostname(request.headers);
+  const allowedHosts = new Set(betterAuthAllowedHosts(environment));
+  if (!hostname || !allowedHosts.has(hostname)) {
+    return fallbackOrigin(environment);
+  }
+
+  if (environment.NODE_ENV === "production") {
+    return `https://${hostname}`;
+  }
+
+  const forwardedProtocol = firstHeaderValue(
+    request.headers.get("x-forwarded-proto"),
+  );
+  const requestProtocol = (() => {
+    try {
+      return new URL(request.url).protocol.replace(":", "");
+    } catch {
+      return "http";
+    }
+  })();
+  const protocol =
+    forwardedProtocol === "http" || forwardedProtocol === "https"
+      ? forwardedProtocol
+      : requestProtocol === "https"
+        ? "https"
+        : "http";
+  const forwardedHost =
+    firstHeaderValue(request.headers.get("x-forwarded-host")) ||
+    firstHeaderValue(request.headers.get("host"));
+
+  try {
+    const origin = new URL(`${protocol}://${forwardedHost}`);
+    return requestHostname(new Headers({ host: origin.host })) === hostname
+      ? origin.origin
+      : fallbackOrigin(environment);
+  } catch {
+    return fallbackOrigin(environment);
+  }
+}
+
+export function authRequestUrl(path: string, request: AuthRequest): URL {
+  return new URL(path, resolveAuthRequestOrigin(request));
+}


### PR DESCRIPTION
## Summary
- resolve auth redirect origins from allow-listed forwarded hosts
- keep Cornershop and Restofront callbacks on their public domains behind Caddy
- use the same public origin for internal Better Auth handoffs
- reject unknown forwarded hosts and fall back to the configured factory origin

## Verification
- bun test (282 pass, 20 database-gated skips)
- bunx tsc --noEmit
- bun run lint (0 errors; one existing generated workflow warning)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication redirects and verification links across sign-in, checkout, completion, logout, and account verification flows.
  * Ensured authentication URLs use the correct secure browser-facing origin across supported environments.
  * Added safer fallback handling when forwarded host information is missing or invalid.

* **Tests**
  * Added coverage for production host validation, fallback behavior, and local development URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->