### PR TITLE
Normalize the CornerShop API container name

### DIFF
--- a/deploy/aws/Caddyfile.fragment
+++ b/deploy/aws/Caddyfile.fragment
@@ -2,7 +2,7 @@
 api.cornershop.dev {
 	@workflowHandlers path /.well-known/workflow/v1/flow* /.well-known/workflow/v1/step*
 	respond @workflowHandlers 404
-	reverse_proxy cornershopdev:3000
+	reverse_proxy api-cornershop-dev:3000
 }
 
 domains.cornershop.dev {
@@ -31,6 +31,6 @@ https:// {
 	}
 	@workflowHandlers path /.well-known/workflow/v1/flow* /.well-known/workflow/v1/step*
 	respond @workflowHandlers 404
-	reverse_proxy cornershopdev:3000
+	reverse_proxy api-cornershop-dev:3000
 }
 # END CORNERSHOPDEV

--- a/deploy/aws/bootstrap-host.sh
+++ b/deploy/aws/bootstrap-host.sh
@@ -36,14 +36,15 @@ awk '
 # which would cost each customer domain its issuance and renewal. Retarget only
 # the exact line the old bootstrap wrote and leave operator edits untouched.
 sed -i \
-  's#ask http://restofront:3000/api/domains/authorize#ask http://cornershopdev:3000/api/domains/authorize#' \
+  -e 's#ask http://restofront:3000/api/domains/authorize#ask http://api-cornershop-dev:3000/api/domains/authorize#' \
+  -e 's#ask http://cornershopdev:3000/api/domains/authorize#ask http://api-cornershop-dev:3000/api/domains/authorize#' \
   "$temporary_body"
 
 {
   if ! grep -q "on_demand_tls" "$temporary_body"; then
     printf '%s\n' '{'
     printf '%s\n' '	on_demand_tls {'
-    printf '%s\n' '		ask http://cornershopdev:3000/api/domains/authorize'
+    printf '%s\n' '		ask http://api-cornershop-dev:3000/api/domains/authorize'
     printf '%s\n' '	}'
     printf '%s\n\n' '}'
   fi

--- a/deploy/aws/deploy.sh
+++ b/deploy/aws/deploy.sh
@@ -11,6 +11,9 @@ if [[ ! "$image_name" =~ ^cornershopdev:[0-9a-f]{40}$ ]]; then
   echo "Invalid deployment image name" >&2
   exit 2
 fi
+readonly container="api-cornershop-dev"
+readonly candidate="${container}-candidate"
+readonly previous="${container}-previous"
 
 install -d -m 700 /etc/cornershopdev /var/lib/cornershopdev
 environment_file="/etc/cornershopdev/production.env"
@@ -107,9 +110,9 @@ aws s3 cp "$artifact_uri" "$artifact_file" --region us-west-1 --only-show-errors
 gzip -dc "$artifact_file" | docker load >/dev/null
 docker image inspect "$image_name" >/dev/null
 
-docker rm -f cornershopdev-candidate >/dev/null 2>&1 || true
+docker rm -f "$candidate" >/dev/null 2>&1 || true
 docker run -d \
-  --name cornershopdev-candidate \
+  --name "$candidate" \
   --network shipshit \
   --env-file "$environment_file" \
   --restart no \
@@ -132,31 +135,31 @@ wait_for_health() {
   return 1
 }
 
-wait_for_health cornershopdev-candidate
-docker rm -f cornershopdev-previous >/dev/null 2>&1 || true
-if docker inspect cornershopdev >/dev/null 2>&1; then
-  docker stop cornershopdev >/dev/null
-  docker rename cornershopdev cornershopdev-previous
+wait_for_health "$candidate"
+docker rm -f "$previous" >/dev/null 2>&1 || true
+if docker inspect "$container" >/dev/null 2>&1; then
+  docker stop "$container" >/dev/null
+  docker rename "$container" "$previous"
 fi
-docker rename cornershopdev-candidate cornershopdev
-docker update --restart unless-stopped cornershopdev >/dev/null
+docker rename "$candidate" "$container"
+docker update --restart unless-stopped "$container" >/dev/null
 
 reload_caddy() {
   docker exec shipshit-caddy caddy reload --config /etc/caddy/Caddyfile >/dev/null
 }
 
-if ! reload_caddy || ! wait_for_health cornershopdev; then
+if ! reload_caddy || ! wait_for_health "$container"; then
   echo "Deployment failed after cutover; rolling back" >&2
-  docker rm -f cornershopdev >/dev/null 2>&1 || true
-  if docker inspect cornershopdev-previous >/dev/null 2>&1; then
-    docker rename cornershopdev-previous cornershopdev
-    docker start cornershopdev >/dev/null
+  docker rm -f "$container" >/dev/null 2>&1 || true
+  if docker inspect "$previous" >/dev/null 2>&1; then
+    docker rename "$previous" "$container"
+    docker start "$container" >/dev/null
     reload_caddy
   fi
   exit 1
 fi
 
-docker rm -f cornershopdev-previous >/dev/null 2>&1 || true
+docker rm -f "$previous" >/dev/null 2>&1 || true
 
 monitor_service="/etc/systemd/system/cornershopdev-public-health.service"
 monitor_timer="/etc/systemd/system/cornershopdev-public-health.timer"

--- a/docs/operations/platform-services.md
+++ b/docs/operations/platform-services.md
@@ -70,7 +70,7 @@ Bucket reachability alone does not prove the application write/read path.
 After explicit production authorization, execute:
 
 ```bash
-docker exec cornershopdev \
+docker exec api-cornershop-dev \
   bun run operator:verify-image-storage --environment production --execute
 ```
 
@@ -103,7 +103,7 @@ Useful commands:
 ```bash
 systemctl status cornershopdev-public-health.timer
 journalctl -u cornershopdev-public-health.service --since '30 minutes ago'
-docker exec cornershopdev bun run operator:dispatch-alerts
+docker exec api-cornershop-dev bun run operator:dispatch-alerts
 ```
 
 The repository owner owns primary response; the release operator is backup.
@@ -153,7 +153,7 @@ Le Petit Meunier uses the canonical slug `le-petit-meunier`. Run the dry-run
 inside the healthy production container first:
 
 ```bash
-docker exec cornershopdev \
+docker exec api-cornershop-dev \
   bun run operator:import:le-petit-meunier
 ```
 
@@ -163,7 +163,7 @@ source URL already exists. After confirming the RDS recovery window is healthy,
 execute the same reviewed import:
 
 ```bash
-docker exec cornershopdev \
+docker exec api-cornershop-dev \
   bun run operator:import:le-petit-meunier --execute
 ```
 
@@ -184,14 +184,14 @@ Store `SUPERADMIN_EMAILS` as a SecureString under
 the role change:
 
 ```bash
-docker exec cornershopdev \
+docker exec api-cornershop-dev \
   bun run operator:grant-superadmin --email owner@example.com
 ```
 
 Apply it only after confirming the target:
 
 ```bash
-docker exec cornershopdev \
+docker exec api-cornershop-dev \
   bun run operator:grant-superadmin --email owner@example.com --execute
 ```
 


### PR DESCRIPTION
Persist the live hostname-derived container name `api-cornershop-dev` across candidate/rollback cutover, Caddy, on-demand TLS authorization, and operator commands. Redis and stable infrastructure identifiers remain unchanged.

Verification: Bash syntax, host-launcher test, diff check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated service routing and on-demand TLS authorization to use the correct API service.
  * Improved deployment cutover and rollback behavior for more reliable service updates.

* **Documentation**
  * Updated operational commands to reference the current API service container name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->