### PR TITLE
chore: bypass Vercel image optimization

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -20,6 +20,8 @@ const nextConfig: NextConfig = {
     };
   },
   images: {
+    // Images are delivered by the existing CDN/origin, without Vercel transforms.
+    unoptimized: true,
     remotePatterns: [
       {
         protocol: "https",


### PR DESCRIPTION
## Summary
- serve existing CDN/origin image URLs directly
- bypass Vercel Image Optimization transformations and cache billing
- preserve Next/Image layout behavior

## Verification
- configuration-only change
- full test/build suites deferred to PR CI per MacBook policy