### PR TITLE
fix(niche): own Open Graph and Twitter cards per niche storefront

### DIFF
--- a/src/app/niche/[vertical]/opengraph-image.tsx
+++ b/src/app/niche/[vertical]/opengraph-image.tsx
@@ -1,0 +1,95 @@
+import { ImageResponse } from "next/og";
+import { notFound } from "next/navigation";
+import {
+  listVerticalIds,
+  resolveVerticalBySlug,
+  resolveVerticalConfig,
+  verticalSlug,
+} from "@/lib/verticals/registry";
+
+/**
+ * The social card for a niche storefront (restofront.com and its successors).
+ *
+ * The factory's root `opengraph-image.tsx` is inherited by every nested route
+ * that does not define its own, which is how restofront.com came to unfurl with
+ * "One factory. A storefront for every trade." Same canvas and palette as that
+ * card so the family reads as one product; the mark, name and copy are the
+ * niche's own, taken from its marketing config rather than hand-written here.
+ */
+
+// A static alt rather than `generateImageMetadata`: Next's wrapper for that
+// export enumerates ids with the parent segments' static params, and nothing
+// above this file declares any for `[vertical]`, so it runs with an undefined
+// slug at build. Same route shape as the root card, one file per niche image.
+export const alt = "Niche storefront card";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export function generateStaticParams() {
+  return listVerticalIds().map((id) => ({ vertical: verticalSlug(id) }));
+}
+
+export default async function OpenGraphImage({
+  params,
+}: {
+  params: Promise<{ vertical: string }>;
+}) {
+  const { vertical } = await params;
+  const id = resolveVerticalBySlug(vertical);
+  if (!id) notFound();
+  const { marketing } = resolveVerticalConfig(id);
+  const { brand, hero, tagline } = marketing;
+
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-between",
+        padding: "72px",
+        color: "#1F2622",
+        background: "#F7F1E7",
+        fontFamily: "Arial, sans-serif",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 18 }}>
+        <div
+          style={{
+            width: 58,
+            height: 58,
+            borderRadius: 14,
+            background: "#0D4A39",
+            color: "#F7F1E7",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontSize: 20,
+            fontWeight: 700,
+            letterSpacing: "-1px",
+          }}
+        >
+          {brand.initials}
+        </div>
+        <div style={{ fontSize: 28, fontWeight: 700 }}>{brand.name}</div>
+      </div>
+      <div
+        style={{
+          display: "flex",
+          maxWidth: 900,
+          fontFamily: "Georgia, serif",
+          fontSize: 92,
+          lineHeight: 0.9,
+          letterSpacing: "-5px",
+        }}
+      >
+        {hero.headline}
+      </div>
+      <div style={{ display: "flex", fontSize: 23, color: "#646863" }}>
+        {tagline}
+      </div>
+    </div>,
+    size,
+  );
+}

--- a/src/app/niche/[vertical]/page.tsx
+++ b/src/app/niche/[vertical]/page.tsx
@@ -68,18 +68,37 @@ export async function generateMetadata({
   if (!id) return {};
   const { marketing } = resolveVerticalConfig(id);
   const { mark } = marketing.brand;
+  const title = `${marketing.brand.name} — ${marketing.hero.headline}`;
+  const description = marketing.hero.subheadline;
+  const canonical = marketing.domain ? `https://${marketing.domain}` : undefined;
   return {
     // Absolute so the root layout's "| Cornershopdev" template stays off a niche
     // storefront: a visitor on restofront.com should never see the factory's name
     // in their tab, and this page is the only public, indexed one that inherits it.
-    title: { absolute: `${marketing.brand.name} — ${marketing.hero.headline}` },
-    description: marketing.hero.subheadline,
+    title: { absolute: title },
+    description,
+    // Metadata objects merge shallowly, so a niche that leaves `openGraph` or
+    // `twitter` unset inherits the factory's card wholesale — restofront.com
+    // used to unfurl as "Cornershopdev" on X and Slack for exactly that reason.
+    // Both are restated in full here, and the sibling `opengraph-image.tsx`
+    // supplies the picture, so the card names the niche and nothing else.
+    openGraph: {
+      title,
+      description,
+      siteName: marketing.brand.name,
+      type: "website",
+      ...(canonical ? { url: canonical } : {}),
+    },
+    twitter: { card: "summary_large_image", title, description },
+    // Relative image URLs (the sibling opengraph-image) resolve against this,
+    // so a launched niche's card is fetched from its own domain rather than the
+    // factory's. The proxy passes non-root paths on a niche hostname straight
+    // through, which is what makes that URL reachable there.
+    ...(canonical ? { metadataBase: new URL(canonical) } : {}),
     // A launched niche is served at both its own domain and this internal path.
     // The domain is the one that should rank, so it is declared canonical from
     // whichever of the two a crawler happens to reach.
-    alternates: marketing.domain
-      ? { canonical: `https://${marketing.domain}` }
-      : undefined,
+    alternates: canonical ? { canonical } : undefined,
     // A niche with its own identity also owns its browser chrome. The factory
     // favicon remains the fallback for verticals that have not selected a mark.
     icons: mark


### PR DESCRIPTION
## Why

restofront.com unfurled on X/Slack/iMessage as **"Cornershopdev — the website factory for small business"** with the factory's card image (verified live with a Twitterbot UA: `og:title`/`og:site_name` = Cornershopdev, `og:image` = `https://cornershop.dev/opengraph-image?…`, while `<title>`, description and canonical were already correct).

Two causes:
1. `src/app/niche/[vertical]/page.tsx` `generateMetadata` set `title`/`description` but not `openGraph`/`twitter`, so Next's shallow metadata merge inherited the root layout's objects wholesale.
2. The only `opengraph-image.tsx` lived at the app root, which every nested route inherits.

## What

- `generateMetadata` restates `openGraph` (title, description, siteName, url, type) and `twitter` (`summary_large_image`) from the niche's marketing config, and sets `metadataBase` to the niche domain when it has one so the image URL is served from `restofront.com`, not `cornershop.dev`. The proxy already passes non-root paths on a niche hostname through, so that URL is reachable there.
- New `src/app/niche/[vertical]/opengraph-image.tsx`: same canvas/palette as the factory card, but the niche's initials, name, hero headline and tagline. Static params for every registered vertical → `/niche/restaurant/opengraph-image` and `/niche/beauty/opengraph-image` are prerendered.

## Verification

- `bun test` — 282 pass / 0 fail
- `eslint` — clean
- `next build` — green (with CI's `DATABASE_URL`/`BETTER_AUTH_SECRET`)
- Prerendered `/niche/restaurant` HTML: `og:title` = "Restofrontapp — Your front door, always current.", `og:site_name` = Restofrontapp, `og:url` = https://restofront.com, `og:image` = `https://restofront.com/niche/restaurant/opengraph-image?…` (1200×630 PNG). Beauty (no domain yet) resolves its image against cornershop.dev as before.

## Notes

- Deploy is release-only: this reaches restofront.com after merge + `gh release create`. Re-scrape with X Card Validator / LinkedIn Post Inspector after deploy — crawlers cache old cards.
- Same OG-inheritance gap exists on `src/app/preview/[slug]/page.tsx` (customer sites unfurl as Cornershopdev). Not touched here — separate follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to niche marketing metadata and static OG image generation; no auth, payments, or data-model changes.
> 
> **Overview**
> Niche storefront links (e.g. restofront.com) now unfurl with **that vertical’s** title, description, and image instead of inheriting the factory’s Cornershopdev card from shallow metadata merge and the root `opengraph-image`.
> 
> `generateMetadata` on the niche page **fully sets** `openGraph` and `twitter` from marketing config, and when a niche has a domain it sets **`metadataBase`** so the sibling OG image URL resolves on the niche host (proxy already forwards those paths).
> 
> A new **`niche/[vertical]/opengraph-image`** route prerenders a 1200×630 card per registered vertical using the same visual system as the factory card but niche initials, name, hero headline, and tagline from config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2683d08d6cc232e0844a81a6b4b3785d1f0b9806. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added branded Open Graph images for each niche storefront, including its headline and tagline.
  * Added niche-specific social sharing metadata for Open Graph and Twitter.
  * Improved canonical URLs and metadata handling for custom domains.
  * Unknown niche pages now return a not-found response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->