### PR TITLE
feat(niche): carry niche branding through create, claim, dashboard and OG images

### DIFF
--- a/src/app/claim/[slug]/page.tsx
+++ b/src/app/claim/[slug]/page.tsx
@@ -8,22 +8,34 @@ import { Button } from "@/components/ui/button";
 import { findSiteView } from "@/lib/sites";
 import { resolveVerticalConfig } from "@/lib/verticals/registry";
 
-export const metadata: Metadata = {
-  title: "Claim this site",
-  robots: { index: false, follow: false },
-};
-
-export default async function ClaimPage({
-  params,
-  searchParams,
-}: {
+type ClaimPageProps = {
   params: Promise<{ slug: string }>;
   searchParams: Promise<{
     checkout?: string;
     session_id?: string;
     claim_id?: string;
   }>;
-}) {
+};
+
+// The site's own vertical, not the Host header, decides the brand here too:
+// an owner can reach their claim link from anywhere.
+export async function generateMetadata({
+  params,
+}: ClaimPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const site = await findSiteView(slug);
+  if (!site) notFound();
+  const brand = resolveVerticalConfig(site.vertical).marketing.brand;
+  return {
+    title: { absolute: `Claim your ${brand.name} site` },
+    robots: { index: false, follow: false },
+  };
+}
+
+export default async function ClaimPage({
+  params,
+  searchParams,
+}: ClaimPageProps) {
   const { slug } = await params;
   const query = await searchParams;
   const site = await findSiteView(slug);

--- a/src/app/create/import-studio.tsx
+++ b/src/app/create/import-studio.tsx
@@ -25,7 +25,7 @@ import type { BrandContext } from "@/lib/brand-context";
 import { sampleSiteDraft } from "@/lib/restaurant";
 import type { ImportUrls } from "@/lib/import-identity";
 import type { SiteDraftView } from "@/lib/site-draft";
-import { listVerticalIds, resolveVerticalConfig } from "@/lib/verticals/registry";
+import { listVerticalIds } from "@/lib/verticals/registry";
 import type { VerticalId } from "@/lib/verticals/types";
 
 type Stage = {
@@ -129,10 +129,12 @@ type ImportResponse =
  * sent them, not a guess. It only seeds the picker: the visitor can still change
  * it here, and whatever is selected at submit is what the lead is attached to.
  *
- * `initialBrand` is the Host header's brand, resolved server-side. It only
- * matters when it is the factory's own (`vertical: null`): the picker still
- * has to default to a real trade to preselect, so `initialVertical` can never
- * itself say "no niche" the way a hostname can.
+ * `initialBrand` is the Host header's brand, resolved server-side, and stays
+ * the rendered brand for the whole session: the page's `generateMetadata`
+ * already committed to it, so the header can't drift from the metadata just
+ * because the visitor toggles the vertical picker. `initialVertical` is a
+ * separate, changeable seed for the picker — it can never itself say "no
+ * niche" the way a hostname can, which is why the two are split.
  */
 export function ImportStudio({
   initialSource,
@@ -162,17 +164,14 @@ export function ImportStudio({
 
   const copy = verticalCopy[vertical];
   const stages = buildStages(copy);
-  // On a niche hostname the studio wears the selected trade's storefront
-  // brand: someone who arrived from restofront.com should not find themselves
-  // talking to the factory's own name halfway through. On the factory's own
-  // hostname there is no niche to wear — the picker still needs a real trade
-  // preselected, but the header stays the factory's regardless of which
-  // button is toggled. The back link stays "/" because host-based routing
-  // already resolves it to whichever site they came from.
-  const brand =
-    initialBrand.vertical === null
-      ? initialBrand
-      : resolveVerticalConfig(vertical).marketing.brand;
+  // The header always wears the request-host brand, not the vertical the
+  // picker currently has selected: `src/app/create/page.tsx` already
+  // resolved `initialBrand` from the Host header for this page's metadata,
+  // and toggling the picker must not make the chrome disagree with it. The
+  // picker still drives the copy and import behavior below via `vertical`.
+  // The back link stays "/" because host-based routing already resolves it
+  // to whichever site they came from.
+  const brand = initialBrand;
 
   async function runImport(value = source) {
     const cleanSource = value.trim();

--- a/src/app/create/import-studio.tsx
+++ b/src/app/create/import-studio.tsx
@@ -21,6 +21,7 @@ import { SiteRenderer } from "@/components/site-renderer";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Progress } from "@/components/ui/progress";
+import type { BrandContext } from "@/lib/brand-context";
 import { sampleSiteDraft } from "@/lib/restaurant";
 import type { ImportUrls } from "@/lib/import-identity";
 import type { SiteDraftView } from "@/lib/site-draft";
@@ -127,13 +128,20 @@ type ImportResponse =
  * `initialVertical` is the niche the lead arrived through — the storefront that
  * sent them, not a guess. It only seeds the picker: the visitor can still change
  * it here, and whatever is selected at submit is what the lead is attached to.
+ *
+ * `initialBrand` is the Host header's brand, resolved server-side. It only
+ * matters when it is the factory's own (`vertical: null`): the picker still
+ * has to default to a real trade to preselect, so `initialVertical` can never
+ * itself say "no niche" the way a hostname can.
  */
 export function ImportStudio({
   initialSource,
   initialVertical,
+  initialBrand,
 }: {
   initialSource: string;
   initialVertical: VerticalId;
+  initialBrand: BrandContext;
 }) {
   const hasInitialSource = Boolean(initialSource.trim());
   const [source, setSource] = useState(initialSource);
@@ -154,11 +162,17 @@ export function ImportStudio({
 
   const copy = verticalCopy[vertical];
   const stages = buildStages(copy);
-  // The studio wears the selected niche's storefront brand rather than the
-  // factory's: someone who arrived from restofront.com should not find themselves
-  // talking to Cornershopdev halfway through. The back link stays "/" because
-  // host-based routing already resolves it to whichever site they came from.
-  const brand = resolveVerticalConfig(vertical).marketing.brand;
+  // On a niche hostname the studio wears the selected trade's storefront
+  // brand: someone who arrived from restofront.com should not find themselves
+  // talking to the factory's own name halfway through. On the factory's own
+  // hostname there is no niche to wear — the picker still needs a real trade
+  // preselected, but the header stays the factory's regardless of which
+  // button is toggled. The back link stays "/" because host-based routing
+  // already resolves it to whichever site they came from.
+  const brand =
+    initialBrand.vertical === null
+      ? initialBrand
+      : resolveVerticalConfig(vertical).marketing.brand;
 
   async function runImport(value = source) {
     const cleanSource = value.trim();

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -1,12 +1,17 @@
+import { headers } from "next/headers";
 import type { Metadata } from "next";
 import { Vertical } from "@/generated/prisma/enums";
 import { ImportStudio } from "@/app/create/import-studio";
+import { brandContextForHeaders } from "@/lib/brand-context";
 import { resolveVerticalBySlug } from "@/lib/verticals/registry";
 
-export const metadata: Metadata = {
-  title: "Build a preview",
-  robots: { index: false, follow: false },
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const brand = brandContextForHeaders(await headers());
+  return {
+    title: { absolute: `Build a preview — ${brand.name}` },
+    robots: { index: false, follow: false },
+  };
+}
 
 export default async function CreatePage({
   searchParams,
@@ -19,5 +24,15 @@ export default async function CreatePage({
   // visitor can still change it in the picker, and losing them over a bad query
   // string would cost a lead for no gain.
   const initialVertical = resolveVerticalBySlug(vertical) ?? Vertical.RESTAURANT;
-  return <ImportStudio initialSource={source} initialVertical={initialVertical} />;
+  // The Host header's brand, independent of which trade is preselected above —
+  // the studio needs both to tell "which niche produced this lead" apart from
+  // "whose storefront is the visitor standing in".
+  const initialBrand = brandContextForHeaders(await headers());
+  return (
+    <ImportStudio
+      initialSource={source}
+      initialVertical={initialVertical}
+      initialBrand={initialBrand}
+    />
+  );
 }

--- a/src/app/dashboard/dashboard.tsx
+++ b/src/app/dashboard/dashboard.tsx
@@ -924,7 +924,7 @@ export function Dashboard({
               <PageHeading
                 eyebrow="Restaurant overview"
                 title={`Good afternoon, ${draft.name}.`}
-                copy="Everything guests see, and everything Cornershopdev is watching."
+                copy={`Everything guests see, and everything ${brand.name} is watching.`}
               />
               <div className="mt-8 grid gap-5 xl:grid-cols-[1.35fr_0.65fr]">
                 <Card className="overflow-hidden py-0">
@@ -1277,7 +1277,7 @@ export function Dashboard({
               <PageHeading
                 eyebrow="Image library"
                 title="Authentic photos, professionally finished."
-                copy="Cornershopdev improves light, colour, crop and clarity without inventing dishes or changing what guests will receive."
+                copy={`${brand.name} improves light, colour, crop and clarity without inventing dishes or changing what guests will receive.`}
                 action={
                   <Button
                     size="sm"
@@ -1443,8 +1443,8 @@ export function Dashboard({
                       Add domain
                     </Button>
                     <p className="mt-4 text-xs leading-5 text-muted-foreground">
-                      Cornershopdev authorizes the domain for automatic SSL before
-                      asking for DNS changes.
+                      {brand.name} authorizes the domain for automatic SSL
+                      before asking for DNS changes.
                     </p>
                   </CardContent>
                 </Card>
@@ -1554,7 +1554,7 @@ export function Dashboard({
                     ) : (
                       <ol className="space-y-5 text-sm">
                         {[
-                          "Cornershopdev authorizes the domain on the production host.",
+                          `${brand.name} authorizes the domain on the production host.`,
                           "The exact DNS record appears here for copying into your DNS provider.",
                           "Once DNS resolves, SSL is issued and the new site becomes live.",
                         ].map((step, index) => (

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -14,10 +14,13 @@ import { getSourceMonitoringDashboard } from "@/lib/source-monitoring";
 import { resolveRequestBrand } from "@/lib/verticals/request-site";
 import { listAccountWorkspaces } from "@/lib/workspaces";
 
-export const metadata: Metadata = {
-  title: "Dashboard",
-  robots: { index: false, follow: false },
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const brand = await resolveRequestBrand();
+  return {
+    title: { absolute: `Dashboard | ${brand.name}` },
+    robots: { index: false, follow: false },
+  };
+}
 
 export default async function DashboardPage({
   searchParams,

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,81 +1,102 @@
 import { ImageResponse } from "next/og";
+import { FACTORY_BRAND } from "@/lib/brand";
+import { resolveRequestMarketing } from "@/lib/verticals/request-site";
 
-export const alt = "Cornershopdev — the website factory for small business";
+// Brand-neutral: this file has no route params to key a static alt string on
+// per niche, so it stays generic rather than always reading "Cornershopdev".
+export const alt = "Website storefront preview";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
-export default function OpenGraphImage() {
+const FACTORY_HEADLINE = "One factory. A storefront for every trade.";
+const FACTORY_SUBHEADLINE = "One engine, one database, one deploy.";
+
+/**
+ * Every route that doesn't define its own `opengraph-image` inherits this
+ * one — including `/create`, `/claim/[slug]` and `/dashboard` on a niche
+ * hostname. Reading the Host header (the same `resolveRequestMarketing` that
+ * already drives sign-in and the dashboard shell) keeps a restofront.com
+ * share card from carrying the factory's own name and copy.
+ */
+export default async function OpenGraphImage() {
+  const marketing = await resolveRequestMarketing();
+  const brand = marketing?.brand ?? FACTORY_BRAND;
+  const headline = marketing?.tagline ?? FACTORY_HEADLINE;
+  const subheadline = marketing?.footerTagline ?? FACTORY_SUBHEADLINE;
+
   return new ImageResponse(
-    <div
-      style={{
-        width: "100%",
-        height: "100%",
-        display: "flex",
-        flexDirection: "column",
-        justifyContent: "space-between",
-        padding: "72px",
-        color: "#1F2622",
-        background: "#F7F1E7",
-        fontFamily: "Arial, sans-serif",
-      }}
-    >
-      <div style={{ display: "flex", alignItems: "center", gap: 18 }}>
-        <div
-          style={{
-            width: 58,
-            height: 58,
-            position: "relative",
-            borderRadius: 14,
-            background: "#0D4A39",
-            color: "#F7F1E7",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            fontSize: 20,
-            fontWeight: 700,
-          }}
-        >
-          C
-          <div
-            style={{
-              position: "absolute",
-              left: 7,
-              top: 0,
-              display: "flex",
-              gap: 3,
-            }}
-          >
-            {[0, 1, 2].map((stripe) => (
-              <div
-                key={stripe}
-                style={{
-                  width: 9,
-                  height: 14,
-                  borderRadius: 3,
-                  background: "#F15A3D",
-                }}
-              />
-            ))}
-          </div>
-        </div>
-        <div style={{ fontSize: 28, fontWeight: 700 }}>Cornershopdev</div>
-      </div>
+    (
       <div
         style={{
+          width: "100%",
+          height: "100%",
           display: "flex",
-          maxWidth: 900,
-          fontFamily: "Georgia, serif",
-          fontSize: 92,
-          lineHeight: 0.9,
-          letterSpacing: "-5px",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          padding: "72px",
+          color: "#1F2622",
+          background: "#F7F1E7",
+          fontFamily: "Arial, sans-serif",
         }}
       >
-        One factory. A storefront for every trade.
+        <div style={{ display: "flex", alignItems: "center", gap: 18 }}>
+          <div
+            style={{
+              width: 58,
+              height: 58,
+              position: "relative",
+              borderRadius: 14,
+              background: "#0D4A39",
+              color: "#F7F1E7",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: 20,
+              fontWeight: 700,
+            }}
+          >
+            {brand.initials}
+            <div
+              style={{
+                position: "absolute",
+                left: 7,
+                top: 0,
+                display: "flex",
+                gap: 3,
+              }}
+            >
+              {[0, 1, 2].map((stripe) => (
+                <div
+                  key={stripe}
+                  style={{
+                    width: 9,
+                    height: 14,
+                    borderRadius: 3,
+                    background: "#F15A3D",
+                  }}
+                />
+              ))}
+            </div>
+          </div>
+          <div style={{ fontSize: 28, fontWeight: 700 }}>{brand.name}</div>
+        </div>
+        <div
+          style={{
+            display: "flex",
+            maxWidth: 900,
+            fontFamily: "Georgia, serif",
+            fontSize: 92,
+            lineHeight: 0.9,
+            letterSpacing: "-5px",
+          }}
+        >
+          {headline}
+        </div>
+        <div style={{ display: "flex", fontSize: 23, color: "#646863" }}>
+          {subheadline}
+        </div>
       </div>
-      <div style={{ display: "flex", fontSize: 23, color: "#646863" }}>
-        One engine, one database, one deploy.
-      </div>
-    </div>,
+    ),
     size,
   );
 }

--- a/src/lib/brand-context.test.ts
+++ b/src/lib/brand-context.test.ts
@@ -39,9 +39,18 @@ describe("brandContextForVertical", () => {
     expect(context.fromAddress).toBe(emailSender(null));
   });
 
-  it("falls back to the factory for a registered vertical with no domain yet", () => {
+  it("falls back to the complete factory identity for a registered vertical with no domain yet", () => {
+    // Salonfront (BEAUTY) has its own wordmark in the registry already, but no
+    // launched domain. The context must not mix that wordmark with the
+    // factory's URL and mailbox — it should read as Cornershopdev throughout,
+    // the same as an explicit `vertical: null` request.
     const context = brandContextForVertical(Vertical.BEAUTY);
+    expect(context.name).toBe(FACTORY_BRAND.name);
+    expect(context.initials).toBe(FACTORY_BRAND.initials);
+    expect(context.vertical).toBeNull();
     expect(context.homeUrl).toBe("https://cornershop.dev");
+    expect(context.supportEmail).toBe(emailReplyTo(null));
+    expect(context.fromAddress).toBe(emailSender(null));
   });
 });
 

--- a/src/lib/brand-context.test.ts
+++ b/src/lib/brand-context.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "bun:test";
+import { Vertical } from "@/generated/prisma/enums";
+import { FACTORY_BRAND } from "@/lib/brand";
+import {
+  brandContextForHeaders,
+  brandContextForHostname,
+  brandContextForSiteVertical,
+  brandContextForVertical,
+} from "@/lib/brand-context";
+import { emailReplyTo, emailSender } from "@/lib/resend";
+import { restaurantMarketing } from "@/lib/verticals/restaurant/marketing";
+
+/**
+ * The core resolver every other function here funnels through. A restaurant
+ * that bought Restofrontapp must see Restofrontapp everywhere in the funnel —
+ * name, home link and mail identity together — and cornershop.dev itself
+ * must see none of it.
+ */
+describe("brandContextForVertical", () => {
+  it("resolves a launched niche's full identity", () => {
+    const context = brandContextForVertical(Vertical.RESTAURANT);
+    expect(context.name).toBe(restaurantMarketing.brand.name);
+    expect(context.initials).toBe(restaurantMarketing.brand.initials);
+    expect(context.vertical).toBe(Vertical.RESTAURANT);
+    expect(context.homeUrl).toBe(`https://${restaurantMarketing.domain}`);
+    expect(context.supportEmail).toBe(restaurantMarketing.email!.replyTo);
+    expect(context.fromAddress).toBe(restaurantMarketing.email!.from);
+  });
+
+  it("falls back to the factory for null, matching FACTORY_BRAND", () => {
+    const context = brandContextForVertical(null);
+    expect(context.name).toBe(FACTORY_BRAND.name);
+    expect(context.initials).toBe(FACTORY_BRAND.initials);
+    expect(context.vertical).toBeNull();
+    expect(context.homeUrl).toBe("https://cornershop.dev");
+    // Same fallback chain resend.ts already owns and tests; this only checks
+    // brand-context did not invent a second one.
+    expect(context.supportEmail).toBe(emailReplyTo(null));
+    expect(context.fromAddress).toBe(emailSender(null));
+  });
+
+  it("falls back to the factory for a registered vertical with no domain yet", () => {
+    const context = brandContextForVertical(Vertical.BEAUTY);
+    expect(context.homeUrl).toBe("https://cornershop.dev");
+  });
+});
+
+/**
+ * The (a) half of issue #95: which niche a request's hostname belongs to,
+ * reusing the registry's own hostname table rather than a second list.
+ */
+describe("brandContextForHostname", () => {
+  it("brands a niche's own marketing domain", () => {
+    expect(brandContextForHostname("restofront.com").name).toBe(
+      "Restofrontapp",
+    );
+    expect(brandContextForHostname("www.restofront.com").vertical).toBe(
+      Vertical.RESTAURANT,
+    );
+  });
+
+  it("normalises case and port before matching", () => {
+    expect(brandContextForHostname("RestoFront.com:443").name).toBe(
+      "Restofrontapp",
+    );
+  });
+
+  it("defaults to Cornershopdev on the factory's own domain", () => {
+    const context = brandContextForHostname("cornershop.dev");
+    expect(context.name).toBe("Cornershopdev");
+    expect(context.vertical).toBeNull();
+  });
+
+  it("defaults to Cornershopdev for an unregistered hostname", () => {
+    expect(brandContextForHostname("pizzeria-luigi.com").name).toBe(
+      "Cornershopdev",
+    );
+  });
+});
+
+/**
+ * Sync core behind `resolveRequestBrandContext`: takes headers as a value so
+ * this stays pure and testable without a real request.
+ */
+describe("brandContextForHeaders", () => {
+  it("prefers the forwarded host, the same precedence requestHostname uses", () => {
+    const context = brandContextForHeaders(
+      new Headers({
+        host: "internal:3000",
+        "x-forwarded-host": "restofront.com",
+      }),
+    );
+    expect(context.name).toBe("Restofrontapp");
+  });
+
+  it("falls back to Cornershopdev when no host header is present", () => {
+    expect(brandContextForHeaders(new Headers()).name).toBe("Cornershopdev");
+  });
+});
+
+/**
+ * The (b) half of issue #95: server code holding a `Site` (and so its
+ * vertical) but no request — a claim link opened from anywhere.
+ */
+describe("brandContextForSiteVertical", () => {
+  it("brands from the site's own vertical, not a hostname", () => {
+    expect(brandContextForSiteVertical(Vertical.RESTAURANT).name).toBe(
+      "Restofrontapp",
+    );
+  });
+});

--- a/src/lib/brand-context.ts
+++ b/src/lib/brand-context.ts
@@ -1,0 +1,96 @@
+import { headers } from "next/headers";
+import { FACTORY_BRAND, type BrandIdentity } from "@/lib/brand";
+import { emailReplyTo, emailSender } from "@/lib/resend";
+import { requestHostname, type HeaderReader } from "@/lib/request-hostname";
+import {
+  resolveVerticalByHostname,
+  resolveVerticalConfig,
+} from "@/lib/verticals/registry";
+import type { VerticalId } from "@/lib/verticals/types";
+
+const FACTORY_HOME_URL = "https://cornershop.dev";
+
+/**
+ * Everything a screen or an outbound email needs to speak as the right
+ * brand — the niche a business bought (Restofrontapp) or the factory that
+ * built it (Cornershopdev), never a mix of the two. A superset of
+ * `BrandIdentity`: `vertical`, `homeUrl`, `supportEmail` and `fromAddress`
+ * are what the funnel (create, claim, dashboard, auth emails) needs beyond
+ * the wordmark and mark `BrandIdentity` already carries.
+ */
+export type BrandContext = BrandIdentity & {
+  /** The niche this context speaks for, or null for the factory itself. */
+  vertical: VerticalId | null;
+  homeUrl: string;
+  supportEmail?: string;
+  fromAddress?: string;
+};
+
+/**
+ * The resolver every other function in this module funnels through, so a
+ * niche's wordmark, home link and mail identity can never drift apart from
+ * one another. `vertical: null` is the factory — the same "no niche claims
+ * this" signal `resolveVerticalByHostname` already returns to its other
+ * callers, so a caller that already has one can hand it straight in.
+ */
+export function brandContextForVertical(
+  vertical: VerticalId | null,
+): BrandContext {
+  const marketing = vertical
+    ? resolveVerticalConfig(vertical).marketing
+    : null;
+  return {
+    ...(marketing?.brand ?? FACTORY_BRAND),
+    vertical,
+    homeUrl: marketing?.domain
+      ? `https://${marketing.domain}`
+      : FACTORY_HOME_URL,
+    supportEmail: emailReplyTo(vertical),
+    fromAddress: emailSender(vertical),
+  };
+}
+
+/**
+ * The (a) half of the issue's brief: which niche a request's hostname
+ * belongs to. Reuses the registry's own hostname table — the same one
+ * `proxy.ts` and `@/lib/verticals/request-site` resolve against — rather
+ * than keeping a second list of domains here.
+ */
+export function brandContextForHostname(hostname: string): BrandContext {
+  return brandContextForVertical(resolveVerticalByHostname(hostname));
+}
+
+/**
+ * Sync core behind `resolveRequestBrandContext`, taking headers as a value
+ * rather than reading them itself so tests can pass a fixed `Headers`
+ * instance instead of depending on a real request.
+ */
+export function brandContextForHeaders(reader: HeaderReader): BrandContext {
+  return brandContextForHostname(requestHostname(reader));
+}
+
+/**
+ * The (a) half for real request-handling code: resolves from the incoming
+ * request's own Host header. Covers the same ground as
+ * `resolveRequestBrand`/`resolveRequestMarketing` in
+ * `@/lib/verticals/request-site`, which already serve sign-in and the
+ * dashboard with the narrower `BrandIdentity`/`VerticalMarketing` shapes
+ * those call sites needed; this covers the funnel's wider needs (home link,
+ * mail identity) without a second hostname walk.
+ */
+export async function resolveRequestBrandContext(): Promise<BrandContext> {
+  return brandContextForHeaders(await headers());
+}
+
+/**
+ * The (b) half of the issue's brief: server code that has a `Site` (and so
+ * its `vertical`) but no request to read a Host header from — a claim link
+ * opened from anywhere, a background job, an email builder. The site itself
+ * knows which niche produced it, which is a stronger signal than any Host
+ * header a claim link happens to be opened from.
+ */
+export function brandContextForSiteVertical(
+  vertical: VerticalId,
+): BrandContext {
+  return brandContextForVertical(vertical);
+}

--- a/src/lib/brand-context.ts
+++ b/src/lib/brand-context.ts
@@ -39,12 +39,25 @@ export function brandContextForVertical(
   const marketing = vertical
     ? resolveVerticalConfig(vertical).marketing
     : null;
+  // No launched domain means no storefront to speak as: hand back the
+  // factory as one complete identity rather than mixing a registered
+  // vertical's (already-designed) wordmark with the factory's own URL and
+  // mailbox. Covers both an explicit factory request (`vertical: null`) and
+  // a registered vertical — Salonfront, say — that has not launched its own
+  // domain yet.
+  if (!marketing?.domain) {
+    return {
+      ...FACTORY_BRAND,
+      vertical: null,
+      homeUrl: FACTORY_HOME_URL,
+      supportEmail: emailReplyTo(null),
+      fromAddress: emailSender(null),
+    };
+  }
   return {
-    ...(marketing?.brand ?? FACTORY_BRAND),
+    ...marketing.brand,
     vertical,
-    homeUrl: marketing?.domain
-      ? `https://${marketing.domain}`
-      : FACTORY_HOME_URL,
+    homeUrl: `https://${marketing.domain}`,
     supportEmail: emailReplyTo(vertical),
     fromAddress: emailSender(vertical),
   };

--- a/src/lib/funnel-brand-strings.test.ts
+++ b/src/lib/funnel-brand-strings.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+import { readdirSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+/**
+ * Issue #95's acceptance criterion in code: nothing under the funnel a lead
+ * actually walks (`/create`, `/claim/[slug]`, `/dashboard`, `/sign-in`) may
+ * hard-code the factory's name. Each of those routes already resolves a
+ * `BrandContext`/`VerticalMarketing` and must interpolate `brand.name`
+ * instead — a literal "Cornershopdev" string is exactly the regression this
+ * guards against (a Restofrontapp lead landing on a page that still reads
+ * like a dev factory).
+ */
+const funnelDirectories = [
+  "src/app/create",
+  "src/app/claim",
+  "src/app/dashboard",
+  "src/app/sign-in",
+];
+
+const repoRoot = path.resolve(import.meta.dir, "../..");
+
+function collectSourceFiles(dir: string): string[] {
+  const absolute = path.join(repoRoot, dir);
+  const files: string[] = [];
+  for (const entry of readdirSync(absolute, { withFileTypes: true })) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectSourceFiles(entryPath));
+    } else if (/\.(ts|tsx)$/.test(entry.name) && !entry.name.endsWith(".test.ts")) {
+      files.push(entryPath);
+    }
+  }
+  return files;
+}
+
+describe("funnel routes stay brand-neutral", () => {
+  const files = funnelDirectories.flatMap(collectSourceFiles);
+
+  it("found the funnel route files to check", () => {
+    // A guard against the check silently checking nothing if the routes move.
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  for (const file of files) {
+    it(`does not hard-code "Cornershopdev" in ${file}`, async () => {
+      const contents = await readFile(path.join(repoRoot, file), "utf8");
+      expect(contents).not.toContain("Cornershopdev");
+    });
+  }
+});

--- a/src/lib/verticals/request-site.ts
+++ b/src/lib/verticals/request-site.ts
@@ -1,5 +1,6 @@
 import { headers } from "next/headers";
 import { FACTORY_BRAND, type BrandIdentity } from "@/lib/brand";
+import { requestHostname } from "@/lib/request-hostname";
 import {
   resolveVerticalByHostname,
   resolveVerticalConfig,
@@ -7,24 +8,6 @@ import {
 import type { VerticalMarketing } from "@/lib/verticals/types";
 
 const FACTORY_ORIGIN = "https://cornershop.dev";
-
-/**
- * The hostname the visitor actually typed. `x-forwarded-host` first, and only
- * its first entry, matching how `proxy.ts` reads it: in production Caddy
- * terminates TLS and `host` is the container's own address, so trusting `host`
- * would make every niche look like the factory the moment this ships behind the
- * reverse proxy.
- */
-async function requestHostname(): Promise<string> {
-  const requestHeaders = await headers();
-  return (
-    requestHeaders.get("x-forwarded-host") ??
-    requestHeaders.get("host") ??
-    ""
-  )
-    .split(",")[0]
-    .trim();
-}
 
 /**
  * Which brand the current request should wear, for the screens that have no
@@ -49,7 +32,7 @@ export async function resolveRequestBrand(): Promise<BrandIdentity> {
  * customer surfaces consume this instead of guessing a trade from the route.
  */
 export async function resolveRequestMarketing(): Promise<VerticalMarketing | null> {
-  const niche = resolveVerticalByHostname(await requestHostname());
+  const niche = resolveVerticalByHostname(requestHostname(await headers()));
   return niche ? resolveVerticalConfig(niche).marketing : null;
 }
 
@@ -62,7 +45,7 @@ export async function resolveRequestMarketing(): Promise<VerticalMarketing | nul
  * hosts, and any niche not yet on a domain — to cornershop.dev.
  */
 export async function resolveRequestOrigin(): Promise<string> {
-  const niche = resolveVerticalByHostname(await requestHostname());
+  const niche = resolveVerticalByHostname(requestHostname(await headers()));
   if (!niche) return FACTORY_ORIGIN;
   const { domain } = resolveVerticalConfig(niche).marketing;
   return domain ? `https://${domain}` : FACTORY_ORIGIN;


### PR DESCRIPTION
## Why
Item 5 of the 2026-08-18 gap review. `src/proxy.ts` only rewrote `/` on restofront.com to `/niche/restaurant`; every other path (create, claim, dashboard, share cards, magic-link emails) still said Cornershopdev. A restaurant owner clicking "claim your new website" from a Restofront email landed on a page branded like a dev factory.

## What changed
- **`src/lib/brand-context.ts`** (new) — shared `BrandContext` resolver (`name`, `initials`, `vertical`, `homeUrl`, `supportEmail`, `fromAddress`) from either a request hostname or a site's own vertical, reusing the registry's existing hostname table rather than a second domain list.
- **`src/lib/verticals/request-site.ts`** — dedupes its hostname-parsing into the new shared `request-hostname.ts` helper.
- **`/create`** (`create/page.tsx`, `create/import-studio.tsx`) — `generateMetadata` and an `initialBrand` prop so the studio's header can represent the factory's own brand on cornershop.dev, distinct from whichever trade is preselected in the picker.
- **`/claim/[slug]`** — `generateMetadata` using the site's own vertical (the body already resolved brand this way; metadata was static).
- **`/dashboard`** — brand-aware `generateMetadata` title, plus the 4 remaining hardcoded "Cornershopdev" copy strings in `dashboard.tsx` (SSL/DNS authorization copy, review page copy) swapped for `${brand.name}` interpolation.
- **`src/app/opengraph-image.tsx`** — converted from a static, factory-only image to an async one that reads the Host header via `resolveRequestMarketing()`, so a restofront.com share card carries Restofrontapp's mark, name and tagline instead of the factory's.
- **`src/lib/funnel-brand-strings.test.ts`** (new) — fails if any source file under `/create`, `/claim`, `/dashboard` or `/sign-in` contains the literal string "Cornershopdev".

## What was already correct (verified, not touched)
- `sign-in` and `sign-in/verify` already used `signInSurface(resolveRequestMarketing())` for both metadata and copy.
- The claim invitation, magic-link and account email builders (`resend.ts`, `claim-invitation-email.ts`, `magic-link-email.ts`) already resolve `from`/`replyTo`/subject/body from the site's vertical, with existing unit test coverage (`resend.test.ts`, `claim-invitation-email.test.ts`, `magic-link-email.test.ts`).
- Stripe (`stripe.ts`, `stripe-subscription.ts`, `billing-plans.ts`, `stripe-webhook.ts`, `billing-access.ts`) has no "Cornershopdev"/"cornershop.dev" strings or `statement_descriptor` usage — nothing to change.
- No `not-found.tsx`/`error.tsx`/`global-error.tsx` exist anywhere in the app, so there is no niche-hostname 404/500 copy to brand.
- Remaining "Cornershopdev" occurrences repo-wide are all legitimate factory-only references: root layout/page defaults, the reserved-hostname API error, operator alert subject lines, scraper User-Agent strings, and the AI provider's `X-Title` header — none of these are customer-facing funnel surfaces.

## Verified
- `bun test` — 306 pass, 20 skip, 0 fail (includes the new `brand-context.test.ts` and `funnel-brand-strings.test.ts`).
- `bun run lint` — 0 errors (1 pre-existing, unrelated warning on a generated `.well-known/workflow` route).
- `bun run design:lint` — 0 errors on both `DESIGN.md` files.
- `bun run build` (with CI `DATABASE_URL`/`BETTER_AUTH_SECRET`) — compiles and typechecks cleanly, including the `<Brand {...brand} />` spread against the new `BrandContext` union type.

Closes #95

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly presentation and metadata; resolvers reuse existing registry hostname tables and existing email fallbacks, with new unit and string-guard tests.
> 
> **Overview**
> **Niche branding through the lead funnel** so visitors on a vertical storefront (e.g. Restofront) no longer see the factory name on create, claim, dashboard, or share previews.
> 
> Introduces **`src/lib/brand-context.ts`** with a single `BrandContext` type (wordmark plus `homeUrl`, mail identity, vertical) resolved from **request hostname**, **headers**, or a **site’s vertical** (for claim links opened off-domain). Unlaunched verticals fall back to the full factory identity so wordmark and URL never mix. **`request-site.ts`** drops duplicated host parsing in favor of shared **`requestHostname`**.
> 
> **`/create`**: dynamic page titles from the Host brand; **`initialBrand`** keeps the header aligned with metadata while the vertical picker still drives import copy. **`/claim/[slug]`**: metadata titles use the site’s vertical, not the host. **`/dashboard`**: branded tab title and remaining hard-coded factory strings in domain/imagery/overview copy use **`${brand.name}`**. **`opengraph-image.tsx`** is async and uses **`resolveRequestMarketing()`** so niche hosts get niche OG art and copy.
> 
> **Tests**: **`brand-context.test.ts`** for resolvers; **`funnel-brand-strings.test.ts`** fails if funnel routes contain the literal `"Cornershopdev"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f10bd59b98c901edfe165ff0cdf78b0a960832f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dynamic branding across claim, create, dashboard, and sign-in experiences based on the requested site or vertical.
  * Dashboard messages now display the appropriate brand name.
  * Open Graph images now use site-specific branding, headlines, and descriptions.
  * Page titles are dynamically branded while retaining existing search-engine privacy settings.

* **Tests**
  * Added coverage for brand resolution, hostname handling, fallbacks, and prevention of hard-coded branding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->