### PR TITLE
fix(restofront): sell the €49 founding plan, not $25

### DIFF
--- a/docs/operations/first-customer-validation.md
+++ b/docs/operations/first-customer-validation.md
@@ -57,11 +57,10 @@ owner uploads, or explicitly permissioned customer imagery may go live.
 | Secure, owner-bound invitation | Upcoming, blocked by #13 | Do not send a claim URL or accept an email as ownership proof. |
 | Durable one-plan billing lifecycle | Upcoming, blocked by #8 and #13 | Do not initiate a live checkout until the authorized claim and webhook lifecycle pass. |
 
-The live Restofront marketing page still advertises `$25` Starter and `$50`
-Growth plans and claims generated imagery. That page conflicts with this offer.
-It must be aligned to the single €49 plan and authentic-image policy before it
-is used in a sales conversation. Until then, this runbook is the source of truth
-for the validation offer.
+Public Restofront marketing and the claim UI sell this same €49/month founding
+plan and authentic-image policy. Live Stripe still has to match: set the Starter
+price to €49 (or equivalent) and SSM `STRIPE_STARTER_PRICE_ID`. Code cannot
+change the Stripe dashboard.
 
 ## Production evidence snapshot
 

--- a/src/app/claim/[slug]/claim-panel.tsx
+++ b/src/app/claim/[slug]/claim-panel.tsx
@@ -14,34 +14,15 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import type { SiteDraftView } from "@/lib/site-draft";
+import { restaurantMarketing } from "@/lib/verticals/restaurant/marketing";
 import type { VerticalId } from "@/lib/verticals/types";
 
-const plans = [
-  {
-    id: "starter" as const,
-    name: "Starter",
-    price: 25,
-    description: "For restaurants with a menu that changes occasionally.",
-    features: [
-      "Mobile-first website and menu",
-      "Custom domain and SSL",
-      "Existing booking and ordering",
-      "Monthly source checks",
-    ],
-  },
-  {
-    id: "growth" as const,
-    name: "Growth",
-    price: 50,
-    description: "For active restaurants that want the work handled.",
-    features: [
-      "Everything in Starter",
-      "Weekly menu and hours monitoring",
-      "AI-assisted food imagery",
-      "Priority review queue",
-    ],
-  },
-];
+/**
+ * Launch sells one founding plan. Checkout still uses STRIPE_STARTER_PRICE_ID.
+ * Growth remains in configuredBillingPlans for legacy webhook mapping.
+ */
+const CLAIM_CHECKOUT_PLAN_ID = "starter" as const;
+const foundingPlan = restaurantMarketing.pricing.plans[0];
 
 export function ClaimPanel({
   slug,
@@ -58,7 +39,6 @@ export function ClaimPanel({
   } | null;
 }) {
   const draft = fallbackDraft;
-  const [plan, setPlan] = useState<"starter" | "growth">("growth");
   const [email, setEmail] = useState("");
   const [loading, setLoading] = useState(Boolean(checkoutReturn));
   const [invitationSent, setInvitationSent] = useState(false);
@@ -181,7 +161,7 @@ export function ClaimPanel({
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          plan,
+          plan: CLAIM_CHECKOUT_PLAN_ID,
           siteSlug: slug,
           invitationToken,
         }),
@@ -257,49 +237,38 @@ export function ClaimPanel({
             </p>
           ) : null}
 
-          <div className="mt-8 grid gap-3">
-            {plans.map((item) => (
-              <button
-                key={item.id}
-                type="button"
-                onClick={() => setPlan(item.id)}
-                className={`rounded-2xl border p-5 text-left transition ${
-                  plan === item.id
-                    ? "border-primary bg-primary/5 ring-2 ring-primary/12"
-                    : "bg-card hover:border-foreground/25"
-                }`}
-              >
-                <div className="flex items-start justify-between gap-5">
-                  <div>
-                    <div className="flex items-center gap-2">
-                      <span className="font-semibold">{item.name}</span>
-                      {item.id === "growth" ? (
-                        <Badge className="text-[10px]">Recommended</Badge>
-                      ) : null}
-                    </div>
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      {item.description}
-                    </p>
+          <div className="mt-8">
+            <div className="rounded-2xl border border-primary bg-primary/5 p-5 ring-2 ring-primary/12">
+              <div className="flex items-start justify-between gap-5">
+                <div>
+                  <div className="flex items-center gap-2">
+                    <span className="font-semibold">{foundingPlan.name}</span>
+                    {foundingPlan.badge ? (
+                      <Badge className="text-[10px]">{foundingPlan.badge}</Badge>
+                    ) : null}
                   </div>
-                  <span className="font-display text-4xl">
-                    ${item.price}
-                    <small className="font-sans text-xs text-muted-foreground">
-                      /mo
-                    </small>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {foundingPlan.copy}
+                  </p>
+                </div>
+                <span className="font-display text-4xl">
+                  {foundingPlan.price}
+                  <small className="font-sans text-xs text-muted-foreground">
+                    {foundingPlan.cadence}
+                  </small>
+                </span>
+              </div>
+              <div className="mt-4 grid gap-2 sm:grid-cols-2">
+                {foundingPlan.features.map((feature) => (
+                  <span
+                    key={feature}
+                    className="flex items-center gap-1.5 text-xs"
+                  >
+                    <Check className="size-3 text-primary" /> {feature}
                   </span>
-                </div>
-                <div className="mt-4 grid gap-2 sm:grid-cols-2">
-                  {item.features.map((feature) => (
-                    <span
-                      key={feature}
-                      className="flex items-center gap-1.5 text-xs"
-                    >
-                      <Check className="size-3 text-primary" /> {feature}
-                    </span>
-                  ))}
-                </div>
-              </button>
-            ))}
+                ))}
+              </div>
+            </div>
           </div>
 
           {invitationToken ? (

--- a/src/app/create/import-studio.tsx
+++ b/src/app/create/import-studio.tsx
@@ -65,7 +65,7 @@ const verticalCopy = {
     emptyStatePrompt:
       "Start with a website or restaurant name. No account is needed to see the result.",
     claimHint:
-      "Review the menu and existing links, then choose a plan to keep this site current.",
+      "Review the menu and existing links, then claim the founding plan to keep this site current.",
     catalogStage: "Recover menu and details",
     integrationsStage: "Preserve booking and ordering",
   },

--- a/src/app/niche/[vertical]/page.tsx
+++ b/src/app/niche/[vertical]/page.tsx
@@ -316,7 +316,13 @@ export default async function NichePage({
               {marketing.pricing.copy}
             </p>
           </div>
-          <div className="mx-auto mt-12 grid max-w-4xl gap-5 md:grid-cols-2">
+          <div
+            className={`mx-auto mt-12 grid gap-5 ${
+              marketing.pricing.plans.length > 1
+                ? "max-w-4xl md:grid-cols-2"
+                : "max-w-xl"
+            }`}
+          >
             {marketing.pricing.plans.map((plan) => (
               <div
                 key={plan.name}

--- a/src/lib/verticals/restaurant/marketing.test.ts
+++ b/src/lib/verticals/restaurant/marketing.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { beautyMarketing } from "@/lib/verticals/beauty/marketing";
+import { restaurantMarketing } from "@/lib/verticals/restaurant/marketing";
+
+/**
+ * GTM audit + first-customer runbook: launch is one €49/month founding plan.
+ * Headlining $25/$50 or generated food imagery as a paid extra is the
+ * regression these assertions exist to catch.
+ */
+describe("Restofront founding offer", () => {
+  it("sells one €49/month founding plan, not $25 Starter or $50 Growth", () => {
+    expect(restaurantMarketing.hero.proofPoints).toContain("€49/month");
+    expect(restaurantMarketing.hero.proofPoints.join(" ")).not.toContain("$25");
+
+    expect(restaurantMarketing.pricing.plans).toHaveLength(1);
+    const [plan] = restaurantMarketing.pricing.plans;
+    expect(plan).toMatchObject({
+      name: "Founding",
+      price: "€49",
+      cadence: "/month",
+      featured: true,
+    });
+    expect(plan.features.join(" ")).not.toMatch(/AI-assisted|generated food/i);
+    expect(
+      plan.features.some((feature) => /booking|ordering/.test(feature)),
+    ).toBe(true);
+  });
+
+  it("does not advertise generated food imagery as a paid differentiator", () => {
+    const blob = JSON.stringify(restaurantMarketing);
+    expect(blob).not.toMatch(/AI-assisted food imagery/i);
+    expect(blob).not.toMatch(/generate missing editorial/i);
+    expect(blob).not.toMatch(/complementary editorial images/i);
+    expect(restaurantMarketing.imagery.copy.toLowerCase()).toMatch(
+      /existing photography|source/,
+    );
+  });
+
+  it("does not share the restaurant founding price with unlaunched beauty", () => {
+    expect(beautyMarketing.hero.proofPoints).not.toEqual(
+      restaurantMarketing.hero.proofPoints,
+    );
+    expect(beautyMarketing.pricing.plans).not.toEqual(
+      restaurantMarketing.pricing.plans,
+    );
+  });
+
+  it("checks out the founding plan against STRIPE_STARTER_PRICE_ID", async () => {
+    const panel = await readFile(
+      new URL("../../../app/claim/[slug]/claim-panel.tsx", import.meta.url),
+      "utf8",
+    );
+    expect(panel).toContain('CLAIM_CHECKOUT_PLAN_ID = "starter"');
+    expect(panel).toContain("restaurantMarketing.pricing.plans[0]");
+    expect(panel).not.toContain('id: "growth"');
+    expect(panel).not.toContain("price: 25");
+    expect(panel).not.toContain("price: 50");
+    expect(panel).not.toContain("$25");
+  });
+});

--- a/src/lib/verticals/restaurant/marketing.ts
+++ b/src/lib/verticals/restaurant/marketing.ts
@@ -32,7 +32,7 @@ export const restaurantMarketing = {
     headline: "Your front door, always current.",
     subheadline:
       "Give us the restaurant. Get back a polished mobile-first website with the menu already inside—and keep the booking and ordering tools that already work.",
-    proofPoints: ["No setup call", "Private preview first", "From $25/month"],
+    proofPoints: ["No setup call", "Private preview first", "€49/month"],
   },
   form: {
     placeholder: "Restaurant website or name",
@@ -67,7 +67,7 @@ export const restaurantMarketing = {
     {
       number: "03",
       title: "Claim it and go live",
-      copy: "Choose a plan, connect the domain, and keep every booking and ordering system already in place.",
+      copy: "Claim the founding plan, connect the domain, and keep every booking and ordering system already in place.",
     },
   ],
   valueProps: {
@@ -82,8 +82,8 @@ export const restaurantMarketing = {
       },
       {
         icon: "imagery",
-        title: "Food imagery that fits",
-        copy: "Recover the best existing photography and generate missing editorial images without inventing dishes.",
+        title: "The restaurant's own photography",
+        copy: "Live pages use source photos or images the owner has approved—not invented dishes sold as a paid extra.",
       },
       {
         icon: "booking",
@@ -101,9 +101,9 @@ export const restaurantMarketing = {
     imageUrl:
       "https://images.unsplash.com/photo-1515003197210-e0cd71810b5f?auto=format&fit=crop&w=1400&q=85",
     imageAlt: "Restaurant dish photographed in natural light",
-    eyebrow: "Credible imagery, not fantasy food",
-    headline: "Fill the visual gaps without faking the restaurant.",
-    copy: "Restofrontapp prioritises real source photography, then creates complementary editorial images for missing categories. Every generated asset stays reviewable before publishing.",
+    eyebrow: "Real photography, not fantasy food",
+    headline: "Show the restaurant as it is.",
+    copy: "Restofrontapp recovers the restaurant's existing photography. Anything that was not on the source site stays off the live page until the owner approves it.",
     assurances: [
       {
         icon: "shield",
@@ -111,40 +111,29 @@ export const restaurantMarketing = {
       },
       {
         icon: "cursor",
-        copy: "One click to regenerate, replace or remove any image",
+        copy: "Owner review before any image goes live",
       },
     ],
   },
   pricing: {
-    eyebrow: "Simple ongoing care",
+    eyebrow: "The founding offer",
     headline: "Less than one empty table.",
-    copy: "Preview first. Pay only when the restaurant wants to claim and publish it.",
+    copy: "Preview first. Pay only when the restaurant wants to claim and publish it. One plan, no setup fee. VAT is added when applicable.",
     plans: [
       {
-        name: "Starter",
-        price: "$25",
+        name: "Founding",
+        price: "€49",
         cadence: "/month",
-        copy: "The always-current essentials for one independent restaurant.",
+        copy: "One maintained, mobile-first restaurant website on the restaurant's own domain.",
         features: [
           "Mobile-first website and menu",
           "Existing booking and ordering links",
           "Custom domain and SSL",
-          "Monthly source checks",
-        ],
-      },
-      {
-        name: "Growth",
-        price: "$50",
-        cadence: "/month",
-        copy: "For restaurants that change often and want the work handled.",
-        features: [
-          "Everything in Starter",
-          "Weekly menu and hours monitoring",
-          "AI-assisted food imagery",
-          "Priority human review queue",
+          "Owner workspace and menu edits",
+          "Hosting, booking-request inbox, and first-party reporting",
         ],
         featured: true,
-        badge: "Most useful",
+        badge: "Founding offer",
       },
     ],
   },

--- a/src/lib/verticals/types.ts
+++ b/src/lib/verticals/types.ts
@@ -107,6 +107,9 @@ export type MarketingPlan = {
   badge?: string;
 };
 
+/** At least one public plan. A vertical may sell a single featured founding offer. */
+export type MarketingPlans = [MarketingPlan, ...MarketingPlan[]];
+
 /**
  * Everything a niche's own marketing site prints. The whole point is that a new
  * niche domain — nails, barbers, dog grooming — is a config entry and a DNS
@@ -190,7 +193,11 @@ export type VerticalMarketing = {
     eyebrow: string;
     headline: string;
     copy: string;
-    plans: MarketingPlan[];
+    /**
+     * A vertical may sell one featured founding plan. Do not pad a dummy
+     * second tier just to fill a two-column grid.
+     */
+    plans: MarketingPlans;
   };
   closing: { headline: string; copy: string };
   footerTagline: string;


### PR DESCRIPTION
Part of #47. Does **not** close #47 — that issue still needs a real payment.

## Why

`.agents/memory/restaurant-niche-gtm-audit.md` (Pricing) already decided the launch offer:

- Single **€49/month** tier (or ~€399/year later).
- Do **not** headline €25: it sits above €12–€19 DIY competitors while leaving too little margin for DNS, corrections, and support.
- Strongest framing is a country-specific digital **presence custodian**, not an AI website builder. Booking/ordering stay as links.
- Live imagery is restaurant photos or per-image approval — generated food imagery is not a paid differentiator.

`docs/operations/first-customer-validation.md` is the same offer: Restofront Founding Restaurant, €49/month, no second tier. The live restofront.com page still advertised `$25` Starter and `$50` Growth, so emails and sales would have promised the wrong price.

## What changed

- Public Restofront marketing sells one featured **Founding** plan at **€49/month**.
- Claim UI hides Growth and always checkouts `STRIPE_STARTER_PRICE_ID` (`plan: "starter"`).
- Imagery copy matches the authentic-photo policy.
- Marketing plan type allows a single featured plan; the niche pricing grid no longer forces two columns.
- Beauty marketing is unchanged (unlaunched).
- Stripe API wiring is unchanged. `configuredBillingPlans` still maps Growth for legacy webhooks.

## Stripe dashboard (human)

Code cannot change live Stripe. Vincent must set the live **Starter** price to **€49** (or equivalent) and SSM `STRIPE_STARTER_PRICE_ID`. Do not invent a second Stripe product for this offer.

## Verification

- `bun test`: **310 pass**, 20 skip, 0 fail
- `bun run lint`: pass
- `bunx tsc --noEmit`: same 6 pre-existing `RouteContext` errors on untouched API routes as `origin/main`; no new errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Customer-facing pricing and checkout messaging changed; revenue risk if live Stripe Starter price or `STRIPE_STARTER_PRICE_ID` still reflects $25 while UI shows €49.
> 
> **Overview**
> Aligns Restofront GTM with the **€49/month founding offer** from the first-customer runbook: public copy, claim flow, and ops docs no longer advertise **$25 Starter** / **$50 Growth** or AI food imagery as a paid tier.
> 
> **Restaurant marketing** (`restaurantMarketing`) now has one featured **Founding** plan at **€49/month**, updated hero proof points, steps, and imagery/value-prop text that emphasize **source/owner-approved photos** instead of generated food as an upsell.
> 
> **Claim UI** drops the Starter/Growth picker; it renders the founding plan from `restaurantMarketing.pricing.plans[0]` and always posts **`plan: "starter"`** to checkout (still **`STRIPE_STARTER_PRICE_ID`**; Growth remains only for legacy webhook mapping). **Import studio** restaurant copy mentions the founding plan. **Niche pricing** uses a single-column layout when there is only one plan via the new **`MarketingPlans`** tuple type.
> 
> Adds **`marketing.test.ts`** regressions against old $25/$50 and generated-imagery messaging. The runbook now states marketing/claim match the offer and calls out **manual Stripe/SSM** alignment for the live Starter price.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ba6f934179eb9e767d74d4bd1b8d410dd5eefcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->