### PR TITLE
feat(domains): serve claimed sites on a platform subdomain

### DIFF
--- a/src/app/api/domains/authorize/route.ts
+++ b/src/app/api/domains/authorize/route.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 import { getDb } from "@/lib/db";
-import { isFactoryHostname } from "@/lib/hostnames";
+import {
+  isFactoryHostname,
+  parsePlatformSubdomain,
+} from "@/lib/hostnames";
 
 const hostnameSchema = z
   .string()
@@ -19,13 +22,24 @@ export async function GET(request: Request) {
   );
   if (!parsed.success) return new Response(null, { status: 403 });
 
-  // The factory's own hostnames and every registered niche domain are authorized
-  // without consulting the domain table, which only ever holds customer domains.
-  // Answering before the database check is also what lets cornershop.dev and a
-  // niche domain renew their certificates while the database is unreachable.
-  if (isFactoryHostname(parsed.data)) return new Response(null, { status: 200 });
+  // Factory and launched-niche apexes are authorized without the domain table
+  // so cornershop.dev / restofront.com can renew TLS while the database is
+  // unreachable. Customer platform subdomains are not: an unused label under
+  // *.restofront.com must not mint Let's Encrypt certificates (shared quota).
+  if (isFactoryHostname(parsed.data)) {
+    return new Response(null, { status: 200 });
+  }
 
   if (!process.env.DATABASE_URL) return new Response(null, { status: 403 });
+
+  const platform = parsePlatformSubdomain(parsed.data);
+  if (platform) {
+    const site = await getDb().site.findUnique({
+      where: { slug: platform.slug },
+      select: { id: true },
+    });
+    return new Response(null, { status: site ? 200 : 403 });
+  }
 
   const domain = await getDb().domain.findUnique({
     where: { hostname: parsed.data },

--- a/src/app/api/domains/route.ts
+++ b/src/app/api/domains/route.ts
@@ -17,12 +17,18 @@ import { getDb } from "@/lib/db";
 import { claimDomainSetForSite } from "@/lib/domain-claim";
 import {
   planDomainHostnames,
+  publicSiteOrigin,
   siteStatusForDomainState,
   type DomainHostnamePlan,
 } from "@/lib/domain-routing";
 import { checkDomainTls } from "@/lib/domain-tls";
-import { isFactoryHostname } from "@/lib/hostnames";
+import {
+  isFactoryHostname,
+  isReservedPlatformHostname,
+  parsePlatformSubdomain,
+} from "@/lib/hostnames";
 import { previewCacheTagFor } from "@/lib/site-surface";
+import type { VerticalId } from "@/lib/verticals/types";
 
 const hostnameSchema = z
   .string()
@@ -67,7 +73,11 @@ export async function POST(request: Request) {
       siteSlug?: string;
     };
     const hostname = hostnameSchema.parse(body.hostname);
-    if (isFactoryHostname(hostname)) {
+    if (
+      isFactoryHostname(hostname) ||
+      parsePlatformSubdomain(hostname) !== null ||
+      isReservedPlatformHostname(hostname)
+    ) {
       return Response.json(
         { error: "This hostname is reserved for Cornershopdev" },
         { status: 409 },
@@ -132,7 +142,15 @@ export async function POST(request: Request) {
     ]);
     if (!site) throw new Error("Site not found");
     return Response.json(
-      domainSetup(plan, rows, target, site.status, access.site.slug, false),
+      domainSetup(
+        plan,
+        rows,
+        target,
+        site.status,
+        access.site.slug,
+        access.site.vertical,
+        false,
+      ),
     );
   } catch (error) {
     return domainFailure(error, "Domain could not be added");
@@ -163,7 +181,13 @@ export async function GET(request: Request) {
       ]);
       if (!site) throw new Error("Site not found");
       return Response.json({
-        domains: domainSetups(rows, target, site.status, access.site.slug),
+        domains: domainSetups(
+          rows,
+          target,
+          site.status,
+          access.site.slug,
+          access.site.vertical,
+        ),
       });
     }
 
@@ -235,7 +259,15 @@ export async function GET(request: Request) {
     revalidateTag(previewCacheTagFor(access.site.slug), { expire: 0 });
 
     return Response.json(
-      domainSetup(plan, checked, target, siteStatus, access.site.slug, true),
+      domainSetup(
+        plan,
+        checked,
+        target,
+        siteStatus,
+        access.site.slug,
+        access.site.vertical,
+        true,
+      ),
     );
   } catch (error) {
     return domainFailure(error, "DNS could not be checked");
@@ -309,6 +341,10 @@ export async function DELETE(request: Request) {
       hostnames: result.hostnames,
       siteStatus: result.siteStatus,
       previewPath: `/preview/${access.site.slug}`,
+      publicUrl: publicSiteOrigin({
+        slug: access.site.slug,
+        vertical: access.site.vertical,
+      }),
     });
   } catch (error) {
     return domainFailure(error, "Domain could not be removed");
@@ -328,6 +364,7 @@ function domainSetups(
   target: ReturnType<typeof getDomainTarget>,
   siteStatus: SiteStatus,
   siteSlug: string,
+  vertical: VerticalId,
 ) {
   const plans = new Map<string, DomainHostnamePlan>();
   for (const row of rows) {
@@ -335,7 +372,7 @@ function domainSetups(
     plans.set(plan.canonicalHostname, plan);
   }
   return [...plans.values()].map((plan) =>
-    domainSetup(plan, rows, target, siteStatus, siteSlug, false),
+    domainSetup(plan, rows, target, siteStatus, siteSlug, vertical, false),
   );
 }
 
@@ -345,18 +382,20 @@ function domainSetup(
   target: ReturnType<typeof getDomainTarget>,
   siteStatus: SiteStatus,
   siteSlug: string,
+  vertical: VerticalId,
   dnsChecked: boolean,
 ) {
   const plannedRows = rows.filter((row) => plan.hostnames.includes(row.hostname));
   const verifiedRows = plannedRows.filter((row) => row.verified);
   const tls = aggregateTls(verifiedRows);
+  const verified =
+    plannedRows.length === plan.hostnames.length &&
+    plannedRows.every((row) => row.verified);
   return {
     hostname: plan.canonicalHostname,
     hostnames: plan.hostnames,
     attached: plannedRows.length === plan.hostnames.length,
-    verified:
-      plannedRows.length === plan.hostnames.length &&
-      plannedRows.every((row) => row.verified),
+    verified,
     dnsChecked,
     records: plan.records.map((record) => ({
       type: record.type,
@@ -366,6 +405,11 @@ function domainSetup(
     tls,
     siteStatus,
     previewPath: `/preview/${siteSlug}`,
+    publicUrl: publicSiteOrigin({
+      slug: siteSlug,
+      vertical,
+      verifiedHostname: verified ? plan.canonicalHostname : null,
+    }),
   };
 }
 

--- a/src/app/dashboard/dashboard.tsx
+++ b/src/app/dashboard/dashboard.tsx
@@ -89,6 +89,7 @@ type DomainSetup = {
   };
   siteStatus: "PROSPECT" | "PREVIEW_READY" | "CLAIMED" | "LIVE" | "PAUSED";
   previewPath: string;
+  publicUrl: string;
 };
 
 type ClientPublicationHistoryItem = Omit<
@@ -115,6 +116,7 @@ export function Dashboard({
   publicationHistory: initialPublicationHistory,
   canSwitchWorkspace,
   sourceMonitoring,
+  platformUrl,
 }: {
   initialDraft: RestaurantDraft;
   email: string;
@@ -127,6 +129,7 @@ export function Dashboard({
   publicationHistory: ClientPublicationHistoryItem[];
   canSwitchWorkspace: boolean;
   sourceMonitoring: SourceMonitoringDashboardDto;
+  platformUrl: string;
 }) {
   const [draft, setDraft] = useState(initialDraft);
   const [saving, setSaving] = useState(false);
@@ -147,6 +150,14 @@ export function Dashboard({
   const [publicationHistory, setPublicationHistory] = useState(
     initialPublicationHistory,
   );
+  const isPublished =
+    publishedVersion !== null ||
+    publicationHistory.some((item) => item.current);
+  const liveUrl =
+    domainSetup?.verified && domainSetup.hostname
+      ? `https://${domainSetup.hostname}`
+      : platformUrl;
+  const siteHref = isPublished ? liveUrl : `/preview/${draft.slug}`;
 
   const themeManifests = listRestaurantThemeManifests();
   const currentThemeSelection = parseRestaurantThemeSelection(
@@ -280,7 +291,7 @@ export function Dashboard({
     }
     if (
       !window.confirm(
-        "Publish this saved draft to the connected public domain now?",
+        "Publish this saved draft to your live site now?",
       )
     ) {
       return;
@@ -655,7 +666,7 @@ export function Dashboard({
     if (
       !domainSetup ||
       !window.confirm(
-        `Remove ${domainSetup.hostname}? The public domain will stop routing here and the preview will remain available.`,
+        `Remove ${domainSetup.hostname}? Guests will use ${platformUrl.replace(/^https:\/\//, "")} instead.`,
       )
     ) {
       return;
@@ -682,7 +693,7 @@ export function Dashboard({
       setDomainSetup(null);
       setDomain("");
       setDomainNotice(
-        "Domain removed. The website is preview-only until another verified domain is connected.",
+        `Domain removed. Guests now use ${platformUrl.replace(/^https:\/\//, "")}.`,
       );
     } catch (caught) {
       setDomainError(
@@ -786,12 +797,13 @@ export function Dashboard({
           </Badge>
           <Button
             render={
-              <Link href={`/preview/${draft.slug}`} target="_blank" />
+              <Link href={siteHref} target="_blank" />
             }
             variant="outline"
             size="sm"
           >
-            View site <ExternalLink />
+            {isPublished ? "View live site" : "View preview"}{" "}
+            <ExternalLink />
           </Button>
           {!demo && billingAccess?.ok ? (
             <Button
@@ -845,8 +857,15 @@ export function Dashboard({
       {checkoutComplete ? (
         <div className="border-b border-emerald-200 bg-emerald-50 px-5 py-3 text-center text-sm text-emerald-800">
           <CircleCheck className="mr-2 inline size-4" />
-          Account created. Your website remains private until the domain is
-          connected.
+          Account created. Publish to make{" "}
+          <Link
+            href={platformUrl}
+            className="font-medium underline"
+            target="_blank"
+          >
+            {platformUrl.replace(/^https:\/\//, "")}
+          </Link>{" "}
+          live. A custom domain is optional.
         </div>
       ) : null}
       {!demo && billingAccess && !billingAccess.ok ? (
@@ -948,14 +967,12 @@ export function Dashboard({
                       <div className="mt-6 flex flex-wrap gap-2">
                         <Button
                           render={
-                            <Link
-                              href={`/preview/${draft.slug}`}
-                              target="_blank"
-                            />
+                            <Link href={siteHref} target="_blank" />
                           }
                           size="sm"
                         >
-                          Open preview <ArrowUpRight />
+                          {isPublished ? "Open live site" : "Open preview"}{" "}
+                          <ArrowUpRight />
                         </Button>
                         <Button variant="outline" size="sm">
                           Edit homepage
@@ -985,7 +1002,8 @@ export function Dashboard({
                       ["Menu imported", true],
                       ["Booking link preserved", true],
                       ["Owner account claimed", !demo],
-                      ["Custom domain connected", false],
+                      ["Site published", isPublished],
+                      ["Custom domain connected", Boolean(domainSetup?.verified)],
                     ].map(([label, done]) => (
                       <div
                         key={label as string}
@@ -1397,13 +1415,31 @@ export function Dashboard({
             <TabsContent value="domain" className="mt-0">
               <PageHeading
                 eyebrow="Go live"
-                title="Connect the restaurant's domain."
-                copy="The old website stays live until these records are changed. Email and booking systems remain untouched."
+                title="Use your own domain (optional)."
+                copy="Your site is already live on a Restofront address. Connect a custom domain when you want guests to type your own name. Email and booking systems remain untouched."
               />
-              <div className="mt-8 grid gap-5 xl:grid-cols-[0.9fr_1.1fr]">
+              <Card className="mt-8">
+                <CardHeader>
+                  <CardTitle className="text-base">Your site is live</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-sm leading-6 text-muted-foreground">
+                    Guests can open this address as soon as you publish. A custom
+                    domain below is optional.
+                  </p>
+                  <p className="mt-3 font-mono text-sm">
+                    <Link href={liveUrl} target="_blank" className="underline">
+                      {liveUrl.replace(/^https:\/\//, "")}
+                    </Link>
+                  </p>
+                </CardContent>
+              </Card>
+              <div className="mt-5 grid gap-5 xl:grid-cols-[0.9fr_1.1fr]">
                 <Card>
                   <CardHeader>
-                    <CardTitle className="text-base">Restaurant domain</CardTitle>
+                    <CardTitle className="text-base">
+                      Use your own domain (optional)
+                    </CardTitle>
                   </CardHeader>
                   <CardContent>
                     <Label htmlFor="domain">Domain name</Label>
@@ -1443,8 +1479,8 @@ export function Dashboard({
                       Add domain
                     </Button>
                     <p className="mt-4 text-xs leading-5 text-muted-foreground">
-                      {brand.name} authorizes the domain for automatic SSL
-                      before asking for DNS changes.
+                      Optional. {brand.name} authorizes the domain for automatic
+                      SSL before asking for DNS changes.
                     </p>
                   </CardContent>
                 </Card>
@@ -1547,8 +1583,9 @@ export function Dashboard({
                           Remove domain
                         </Button>
                         <p className="text-xs leading-5 text-muted-foreground">
-                          Removing the domain immediately revokes public routing.
-                          Your private preview and published version are kept.
+                          Removing the domain sends guests back to your Restofront
+                          address. Your private preview and published version are
+                          kept.
                         </p>
                       </div>
                     ) : (
@@ -1556,7 +1593,7 @@ export function Dashboard({
                         {[
                           `${brand.name} authorizes the domain on the production host.`,
                           "The exact DNS record appears here for copying into your DNS provider.",
-                          "Once DNS resolves, SSL is issued and the new site becomes live.",
+                          "Once DNS resolves, SSL is issued and that custom domain becomes the public address.",
                         ].map((step, index) => (
                           <li key={step} className="flex gap-3">
                             <span className="grid size-6 shrink-0 place-items-center rounded-full border font-mono text-[10px]">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -7,6 +7,7 @@ import { getSiteAccess } from "@/lib/authorization";
 import { getBookingRequestInbox } from "@/lib/booking-request-inbox";
 import { getSiteBillingAccess } from "@/lib/billing-access";
 import { getCurrentSession } from "@/lib/current-session";
+import { publicSiteOrigin } from "@/lib/domain-routing";
 import { getRestaurantDraft } from "@/lib/restaurants";
 import { sampleRestaurant } from "@/lib/restaurant";
 import { getSitePublicationHistory } from "@/lib/site-publication";
@@ -96,6 +97,17 @@ export default async function DashboardPage({
       }))}
       canSwitchWorkspace={workspaces.length > 1}
       sourceMonitoring={sourceMonitoring}
+      platformUrl={
+        access?.ok
+          ? publicSiteOrigin({
+              slug: access.site.slug,
+              vertical: access.site.vertical,
+            })
+          : publicSiteOrigin({
+              slug: sampleRestaurant.slug,
+              vertical: "RESTAURANT",
+            })
+      }
     />
   );
 }

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -16,7 +16,8 @@ import {
 import { createIdempotentAnalyticsEvent } from "@/lib/analytics-idempotency";
 import { analyticsRetentionCutoff } from "@/lib/analytics-retention";
 import { getDb } from "@/lib/db";
-import { isFactoryHostname } from "@/lib/hostnames";
+import { hasPublicPublishedSnapshot } from "@/lib/domain-routing";
+import { isFactoryHostname, parsePlatformSubdomain } from "@/lib/hostnames";
 
 export const LIVE_BOOKING_REQUEST_SOURCE = "live-site-form";
 
@@ -46,6 +47,28 @@ export async function resolveAnalyticsSiteForHeaders(headers: Headers) {
     hostname,
     isFactory: isFactoryHostname,
     lookup: async (verifiedHostname) => {
+      const platform = parsePlatformSubdomain(verifiedHostname);
+      if (platform) {
+        const site = await getDb().site.findUnique({
+          where: { slug: platform.slug },
+          select: {
+            id: true,
+            slug: true,
+            status: true,
+            publishedSiteVersionId: true,
+            publishedSiteVersion: {
+              select: { id: true, siteId: true, publishedAt: true },
+            },
+          },
+        });
+        if (!site) return null;
+        return {
+          id: site.id,
+          slug: site.slug,
+          verified: hasPublicPublishedSnapshot(site),
+        };
+      }
+
       const domain = await getDb().domain.findUnique({
         where: { hostname: verifiedHostname },
         select: {

--- a/src/lib/claim-invitation-email.test.ts
+++ b/src/lib/claim-invitation-email.test.ts
@@ -9,6 +9,7 @@ describe("claim invitation email", () => {
       siteName: 'Chez <Léa> "Bistro"',
       vertical: "RESTAURANT",
       expiresAt: new Date("2026-07-28T12:00:00.000Z"),
+      siteUrl: "https://chez-lea.restofront.com",
     });
 
     expect(email.from).toContain("Restofront");
@@ -16,5 +17,7 @@ describe("claim invitation email", () => {
     expect(email.html).toContain("Chez &lt;Léa&gt; &quot;Bistro&quot;");
     expect(email.html).not.toContain("next=<bad>");
     expect(email.html).toContain("claim_token=secret&amp;next=&lt;bad&gt;");
+    expect(email.html).toContain("https://chez-lea.restofront.com");
+    expect(email.html).not.toContain("/preview/");
   });
 });

--- a/src/lib/claim-invitation-email.ts
+++ b/src/lib/claim-invitation-email.ts
@@ -14,10 +14,12 @@ export function buildClaimInvitationEmail(input: {
   siteName: string;
   vertical: VerticalId;
   expiresAt: Date;
+  siteUrl: string;
 }): ClaimInvitationEmail {
   const brand = resolveVerticalConfig(input.vertical).marketing.brand;
   const siteName = escapeHtml(input.siteName);
   const claimUrl = escapeHtml(input.claimUrl);
+  const siteUrl = escapeHtml(input.siteUrl);
   const expiry = new Intl.DateTimeFormat("en", {
     dateStyle: "medium",
     timeStyle: "short",
@@ -34,6 +36,7 @@ export function buildClaimInvitationEmail(input: {
         <h1 style="font-size:30px;line-height:1.05;margin:18px 0">Verify ${siteName}.</h1>
         <p style="color:#5e5b55;line-height:1.6">This one-time link proves access to the approved owner email before subscription checkout can begin.</p>
         <p style="margin:28px 0"><a href="${claimUrl}" style="background:#a5482d;color:white;text-decoration:none;padding:13px 20px;border-radius:10px;font-weight:700">Continue secure claim</a></p>
+        <p style="color:#5e5b55;line-height:1.6">After you claim and publish, the site is live at <a href="${siteUrl}">${siteUrl.replace(/^https:\/\//, "")}</a>.</p>
         <p style="font-size:12px;color:#858079">The link expires ${expiry} UTC. If you did not request it, ignore this email.</p>
       </div>
     </div>`,

--- a/src/lib/claim-invitations.ts
+++ b/src/lib/claim-invitations.ts
@@ -3,6 +3,7 @@ import { domainToASCII } from "node:url";
 import { normalizeAccountEmail } from "@/lib/account-email";
 import { buildClaimInvitationEmail } from "@/lib/claim-invitation-email";
 import { getDb } from "@/lib/db";
+import { publicSiteOrigin } from "@/lib/domain-routing";
 import { getResend } from "@/lib/resend";
 import { isClaimable } from "@/lib/site-claim";
 import type { VerticalId } from "@/lib/verticals/types";
@@ -519,6 +520,10 @@ export async function deliverClaimInvitation(
     siteName: invitation.site.name,
     vertical: invitation.site.vertical,
     expiresAt: invitation.expiresAt,
+    siteUrl: publicSiteOrigin({
+      slug: invitation.site.slug,
+      vertical: invitation.site.vertical,
+    }),
   });
   const { error } = await getResend().emails.send(
     {

--- a/src/lib/domain-routing.test.ts
+++ b/src/lib/domain-routing.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from "bun:test";
 import {
+  canonicalVerifiedCustomHostname,
   decideCustomerHostRoute,
+  decidePlatformSubdomainRoute,
   planDomainHostnames,
+  publicSiteOrigin,
+  publicSiteUrl,
   siteStatusForDomainState,
+  type PlatformSubdomainSite,
   type PublishedDomainRecord,
 } from "@/lib/domain-routing";
 
@@ -208,6 +213,176 @@ describe("site domain lifecycle", () => {
     ).toBe("PREVIEW_READY");
   });
 });
+
+describe("platform subdomain isolation", () => {
+  it("serves claimed published sites on the niche subdomain", () => {
+    expect(
+      decidePlatformSubdomainRoute({
+        hostname: "chez-lea.restofront.com",
+        pathname: "/",
+        site: claimedSite(),
+      }),
+    ).toEqual({
+      kind: "page",
+      slug: "chez-lea",
+      versionId: "version_1",
+      locale: null,
+    });
+    expect(
+      decidePlatformSubdomainRoute({
+        hostname: "chez-lea.restofront.com",
+        pathname: "/",
+        site: claimedSite({ status: "LIVE" }),
+      }).kind,
+    ).toBe("page");
+    expect(
+      decidePlatformSubdomainRoute({
+        hostname: "chez-lea.restofront.com",
+        pathname: "/fr",
+        site: claimedSite(),
+      }),
+    ).toEqual({
+      kind: "page",
+      slug: "chez-lea",
+      versionId: "version_1",
+      locale: "fr",
+    });
+    expect(
+      decidePlatformSubdomainRoute({
+        hostname: "chez-lea.restofront.com",
+        pathname: "/api/analytics/events",
+        site: claimedSite(),
+      }).kind,
+    ).toBe("public_api");
+  });
+
+  it("blocks owner and operator paths on the platform subdomain", () => {
+    for (const pathname of [
+      "/dashboard",
+      "/admin",
+      "/sign-in",
+      "/create",
+      "/claim",
+      "/preview/chez-lea",
+      "/api/admin",
+      "/api/domains",
+      "/api/sites/another/booking-requests",
+    ]) {
+      expect(
+        decidePlatformSubdomainRoute({
+          hostname: "chez-lea.restofront.com",
+          pathname,
+          site: claimedSite(),
+        }),
+      ).toEqual({ kind: "not_found" });
+    }
+  });
+
+  it("404s unpublished, prospect, paused, and unknown slugs", () => {
+    expect(
+      decidePlatformSubdomainRoute({
+        hostname: "chez-lea.restofront.com",
+        pathname: "/",
+        site: claimedSite({ slug: "someone-else" }),
+      }),
+    ).toEqual({ kind: "not_found" });
+    expect(
+      decidePlatformSubdomainRoute({
+        hostname: "chez-lea.restofront.com",
+        pathname: "/",
+        site: null,
+      }),
+    ).toEqual({ kind: "not_found" });
+    expect(
+      decidePlatformSubdomainRoute({
+        hostname: "chez-lea.restofront.com",
+        pathname: "/",
+        site: claimedSite({
+          status: "PROSPECT",
+          publishedSiteVersionId: null,
+          publishedSiteVersion: null,
+        }),
+      }),
+    ).toEqual({ kind: "not_found" });
+    expect(
+      decidePlatformSubdomainRoute({
+        hostname: "chez-lea.restofront.com",
+        pathname: "/",
+        site: claimedSite({ status: "PREVIEW_READY" }),
+      }),
+    ).toEqual({ kind: "not_found" });
+    expect(
+      decidePlatformSubdomainRoute({
+        hostname: "chez-lea.restofront.com",
+        pathname: "/",
+        site: claimedSite({ status: "PAUSED" }),
+      }),
+    ).toEqual({ kind: "not_found" });
+  });
+
+  it("redirects the platform subdomain to a verified custom domain", () => {
+    expect(
+      decidePlatformSubdomainRoute({
+        hostname: "chez-lea.restofront.com",
+        pathname: "/fr",
+        site: claimedSite({
+          status: "LIVE",
+          verifiedDomains: [
+            { hostname: "example.com", verified: true },
+            { hostname: "www.example.com", verified: true },
+          ],
+        }),
+      }),
+    ).toEqual({
+      kind: "redirect",
+      canonicalHostname: "example.com",
+    });
+  });
+
+  it("prefers the platform subdomain until a custom domain is verified", () => {
+    expect(
+      publicSiteOrigin({ slug: "chez-lea", vertical: "RESTAURANT" }),
+    ).toBe("https://chez-lea.restofront.com");
+    expect(
+      publicSiteOrigin({
+        slug: "chez-lea",
+        vertical: "RESTAURANT",
+        verifiedHostname: "www.example.com",
+      }),
+    ).toBe("https://example.com");
+    expect(
+      publicSiteUrl({
+        slug: "chez-lea",
+        vertical: "RESTAURANT",
+        pathname: "/fr",
+      }),
+    ).toBe("https://chez-lea.restofront.com/fr");
+    expect(
+      canonicalVerifiedCustomHostname([
+        { hostname: "www.example.com", verified: true },
+        { hostname: "example.com", verified: true },
+      ]),
+    ).toBe("example.com");
+  });
+});
+
+function claimedSite(
+  overrides: Partial<PlatformSubdomainSite> = {},
+): PlatformSubdomainSite {
+  return {
+    id: "site_1",
+    slug: "chez-lea",
+    status: "CLAIMED",
+    publishedSiteVersionId: "version_1",
+    publishedSiteVersion: {
+      id: "version_1",
+      siteId: "site_1",
+      publishedAt: new Date("2026-07-27T00:00:00.000Z"),
+    },
+    verifiedDomains: [],
+    ...overrides,
+  };
+}
 
 function livePair(): PublishedDomainRecord[] {
   const site = {

--- a/src/lib/domain-routing.test.ts
+++ b/src/lib/domain-routing.test.ts
@@ -254,6 +254,17 @@ describe("platform subdomain isolation", () => {
         site: claimedSite(),
       }).kind,
     ).toBe("public_api");
+    expect(
+      decidePlatformSubdomainRoute({
+        hostname: "chez-lea.restofront.com",
+        pathname: "/preview/chez-lea/opengraph-image",
+        site: claimedSite(),
+      }),
+    ).toEqual({
+      kind: "opengraph",
+      slug: "chez-lea",
+      versionId: "version_1",
+    });
   });
 
   it("blocks owner and operator paths on the platform subdomain", () => {

--- a/src/lib/domain-routing.ts
+++ b/src/lib/domain-routing.ts
@@ -215,6 +215,13 @@ export function decidePlatformSubdomainRoute(input: {
       versionId,
     };
   }
+  if (surface.kind === "opengraph") {
+    return {
+      kind: "opengraph",
+      slug: input.site.slug,
+      versionId,
+    };
+  }
   return {
     kind: "page",
     slug: input.site.slug,

--- a/src/lib/domain-routing.ts
+++ b/src/lib/domain-routing.ts
@@ -1,3 +1,10 @@
+import {
+  parsePlatformSubdomain,
+  platformSiteHostname,
+  type PlatformSubdomain,
+} from "@/lib/hostnames";
+import type { VerticalId } from "@/lib/verticals/types";
+
 export type DomainHostnamePlan = {
   canonicalHostname: string;
   hostnames: string[];
@@ -46,6 +53,15 @@ export type CustomerHostDecision =
       slug: string;
       versionId: string;
     };
+
+export type PlatformSubdomainSite = {
+  id: string;
+  slug: string;
+  status: PublishedDomainRecord["site"]["status"];
+  publishedSiteVersionId: string | null;
+  publishedSiteVersion: PublishedDomainRecord["site"]["publishedSiteVersion"];
+  verifiedDomains: Array<{ hostname: string; verified: boolean }>;
+};
 
 /**
  * Cornershop's explicit apex/www policy.
@@ -156,6 +172,110 @@ export function decideCustomerHostRoute(input: {
     versionId,
     locale: surface.locale,
   };
+}
+
+/**
+ * Resolves a factory/niche platform subdomain (`<slug>.restofront.com` or
+ * `<slug>.cornershop.dev`) onto the same public surfaces as a verified custom
+ * domain. CLAIMED and LIVE snapshots both serve; unpublished prospects stay
+ * private on the factory `/preview/<slug>` path. A verified custom domain
+ * becomes the canonical host.
+ */
+export function decidePlatformSubdomainRoute(input: {
+  hostname: string;
+  pathname: string;
+  parsed?: PlatformSubdomain | null;
+  site: PlatformSubdomainSite | null;
+}): CustomerHostDecision {
+  const parsed = input.parsed ?? parsePlatformSubdomain(input.hostname);
+  if (!parsed || !input.site || input.site.slug !== parsed.slug) {
+    return { kind: "not_found" };
+  }
+  if (!hasPublicPublishedSnapshot(input.site)) return { kind: "not_found" };
+
+  const surface = customerSurface(input.pathname, input.site.slug);
+  if (surface.kind === "blocked") return { kind: "not_found" };
+
+  const canonicalCustom = canonicalVerifiedCustomHostname(
+    input.site.verifiedDomains,
+  );
+  if (canonicalCustom) {
+    return {
+      kind: "redirect",
+      canonicalHostname: canonicalCustom,
+    };
+  }
+
+  const versionId = input.site.publishedSiteVersionId;
+  if (!versionId) return { kind: "not_found" };
+  if (surface.kind === "public_api") {
+    return {
+      kind: "public_api",
+      slug: input.site.slug,
+      versionId,
+    };
+  }
+  return {
+    kind: "page",
+    slug: input.site.slug,
+    versionId,
+    locale: surface.locale,
+  };
+}
+
+/**
+ * A claimed site is public on its platform subdomain once a snapshot exists.
+ * Custom domains still require LIVE via `hasValidPublishedSite`.
+ */
+export function hasPublicPublishedSnapshot(site: {
+  id: string;
+  status: PublishedDomainRecord["site"]["status"];
+  publishedSiteVersionId: string | null;
+  publishedSiteVersion: PublishedDomainRecord["site"]["publishedSiteVersion"];
+}): boolean {
+  const version = site.publishedSiteVersion;
+  return (
+    (site.status === "CLAIMED" || site.status === "LIVE") &&
+    Boolean(site.publishedSiteVersionId) &&
+    version?.id === site.publishedSiteVersionId &&
+    version.siteId === site.id &&
+    version.publishedAt instanceof Date
+  );
+}
+
+export function canonicalVerifiedCustomHostname(
+  domains: Array<{ hostname: string; verified: boolean }>,
+): string | null {
+  const verified = domains.filter((row) => row.verified);
+  if (!verified.length) return null;
+  const canonicals = verified.filter(
+    (row) =>
+      row.hostname === planDomainHostnames(row.hostname).canonicalHostname,
+  );
+  return canonicals[0]?.hostname ?? verified[0]?.hostname ?? null;
+}
+
+export function publicSiteOrigin(input: {
+  slug: string;
+  vertical?: VerticalId;
+  verifiedHostname?: string | null;
+}): string {
+  if (input.verifiedHostname) {
+    return `https://${planDomainHostnames(input.verifiedHostname).canonicalHostname}`;
+  }
+  return `https://${platformSiteHostname(input.slug, input.vertical)}`;
+}
+
+export function publicSiteUrl(input: {
+  slug: string;
+  vertical?: VerticalId;
+  verifiedHostname?: string | null;
+  pathname?: string;
+}): string {
+  const origin = publicSiteOrigin(input);
+  const pathname = input.pathname ?? "/";
+  if (pathname === "/") return `${origin}/`;
+  return `${origin}${pathname.startsWith("/") ? pathname : `/${pathname}`}`;
 }
 
 export function siteStatusForDomainState(input: {

--- a/src/lib/hostnames.test.ts
+++ b/src/lib/hostnames.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import {
   isFactoryHostname,
+  isOnDemandTlsHostname,
+  isReservedPlatformHostname,
+  parsePlatformSubdomain,
   platformHostnames,
+  platformSiteHostname,
+  platformSubdomainParents,
   requestHostname,
 } from "@/lib/hostnames";
 
@@ -77,6 +82,88 @@ describe("isFactoryHostname", () => {
     expect(isFactoryHostname("pizzeria-luigi.com", "")).toBe(false);
     expect(isFactoryHostname("notcornershop.dev", "")).toBe(false);
     expect(isFactoryHostname("cornershop.dev.evil.com", "")).toBe(false);
+    expect(isFactoryHostname("le-petit-meunier.restofront.com", "")).toBe(
+      false,
+    );
     expect(isFactoryHostname("", "")).toBe(false);
+  });
+});
+
+describe("platform subdomains", () => {
+  it("derives parents from launched niche domains and the factory apex", () => {
+    expect(platformSubdomainParents("")).toEqual([
+      "cornershop.dev",
+      "restofront.com",
+    ]);
+    expect(platformSiteHostname("chez-lea", "RESTAURANT", "")).toBe(
+      "chez-lea.restofront.com",
+    );
+    expect(platformSiteHostname("atelier-coupe", "BEAUTY", "")).toBe(
+      "atelier-coupe.cornershop.dev",
+    );
+  });
+
+  it("parses a customer slug under a launched niche or the factory apex", () => {
+    expect(parsePlatformSubdomain("Chez-Lea.RestoFront.com:443", "")).toEqual({
+      slug: "chez-lea",
+      parentHostname: "restofront.com",
+    });
+    expect(parsePlatformSubdomain("chez-lea.cornershop.dev", "")).toEqual({
+      slug: "chez-lea",
+      parentHostname: "cornershop.dev",
+    });
+  });
+
+  it("never treats apex, reserved, or extra labels as a customer slug", () => {
+    expect(parsePlatformSubdomain("restofront.com", "")).toBeNull();
+    expect(parsePlatformSubdomain("www.restofront.com", "")).toBeNull();
+    expect(parsePlatformSubdomain("api.restofront.com", "")).toBeNull();
+    expect(parsePlatformSubdomain("assets.restofront.com", "")).toBeNull();
+    expect(parsePlatformSubdomain("domains.restofront.com", "")).toBeNull();
+    expect(parsePlatformSubdomain("send.restofront.com", "")).toBeNull();
+    expect(parsePlatformSubdomain("foo.bar.restofront.com", "")).toBeNull();
+    expect(parsePlatformSubdomain("www.cornershop.dev", "")).toBeNull();
+    expect(isReservedPlatformHostname("api.restofront.com", "")).toBe(true);
+    expect(isReservedPlatformHostname("send.restofront.com", "")).toBe(true);
+    expect(isReservedPlatformHostname("chez-lea.restofront.com", "")).toBe(
+      false,
+    );
+  });
+});
+
+/**
+ * This is the gate Caddy asks before issuing a certificate under on-demand TLS.
+ * Apex and www stay 200 so the factory and niche marketing sites keep serving.
+ * A customer slug is 200 even if the Site row does not exist yet, so a brand-new
+ * publish can obtain a cert. Arbitrary extra labels and unrelated hosts stay 403.
+ */
+describe("isOnDemandTlsHostname", () => {
+  it("authorizes factory, niche apex/www, and customer platform slugs", () => {
+    expect(isOnDemandTlsHostname("cornershop.dev", "")).toBe(true);
+    expect(isOnDemandTlsHostname("www.cornershop.dev", "")).toBe(true);
+    expect(isOnDemandTlsHostname("restofront.com", "")).toBe(true);
+    expect(isOnDemandTlsHostname("www.restofront.com", "")).toBe(true);
+    expect(isOnDemandTlsHostname("le-petit-meunier.restofront.com", "")).toBe(
+      true,
+    );
+    expect(isOnDemandTlsHostname("le-petit-meunier.cornershop.dev", "")).toBe(
+      true,
+    );
+  });
+
+  it("does not authorize unrelated hosts or extra labels", () => {
+    expect(isOnDemandTlsHostname("not-a-site.evil.com", "")).toBe(false);
+    expect(isOnDemandTlsHostname("pizzeria-luigi.com", "")).toBe(false);
+    expect(isOnDemandTlsHostname("foo.bar.restofront.com", "")).toBe(false);
+    expect(isOnDemandTlsHostname("cornershop.dev.evil.com", "")).toBe(false);
+  });
+
+  it("does not accidentally open operator hosts on a niche domain", () => {
+    expect(isOnDemandTlsHostname("api.restofront.com", "")).toBe(false);
+    expect(isOnDemandTlsHostname("assets.restofront.com", "")).toBe(false);
+    expect(isOnDemandTlsHostname("domains.restofront.com", "")).toBe(false);
+    expect(isOnDemandTlsHostname("send.restofront.com", "")).toBe(false);
+    expect(isOnDemandTlsHostname("api.cornershop.dev", "")).toBe(true);
+    expect(isOnDemandTlsHostname("domains.cornershop.dev", "")).toBe(true);
   });
 });

--- a/src/lib/hostnames.ts
+++ b/src/lib/hostnames.ts
@@ -1,4 +1,11 @@
-import { resolveVerticalByHostname } from "@/lib/verticals/registry";
+import { normalizeHostname } from "@/lib/request-hostname";
+import {
+  listVerticalIds,
+  resolveVerticalByHostname,
+  resolveVerticalConfig,
+} from "@/lib/verticals/registry";
+import type { VerticalId } from "@/lib/verticals/types";
+
 export { requestHostname } from "@/lib/request-hostname";
 
 /**
@@ -9,6 +16,26 @@ export { requestHostname } from "@/lib/request-hostname";
  */
 const DEFAULT_PLATFORM_HOSTNAMES =
   "cornershop.dev,www.cornershop.dev,api.cornershop.dev,domains.cornershop.dev";
+
+/**
+ * Labels that sit on a launched niche or factory apex but are never a customer
+ * site slug. `www` is the niche marketing alias; `api`/`assets`/`domains` are
+ * operator ingress; `send` is the niche mail domain.
+ */
+const RESERVED_PLATFORM_SLUGS = new Set([
+  "www",
+  "api",
+  "assets",
+  "domains",
+  "send",
+]);
+
+const DNS_LABEL_PATTERN = /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)$/;
+
+export type PlatformSubdomain = {
+  slug: string;
+  parentHostname: string;
+};
 
 export function platformHostnames(
   configured: string | undefined = process.env.PLATFORM_HOSTNAMES,
@@ -22,6 +49,26 @@ export function platformHostnames(
 }
 
 /**
+ * Parents that may host `<slug>.<parent>` customer sites: each launched niche
+ * domain from the registry, plus the two-label factory apex (`cornershop.dev`).
+ * `www`/`api`/`domains` are never parents — `le-petit.www.cornershop.dev` is not
+ * a customer URL.
+ */
+export function platformSubdomainParents(
+  configured: string | undefined = process.env.PLATFORM_HOSTNAMES,
+): string[] {
+  const parents = new Set<string>();
+  for (const hostname of platformHostnames(configured)) {
+    if (hostname.split(".").length === 2) parents.add(hostname);
+  }
+  for (const id of listVerticalIds()) {
+    const domain = resolveVerticalConfig(id).marketing.domain;
+    if (domain) parents.add(domain.trim().toLowerCase());
+  }
+  return [...parents].sort((left, right) => right.length - left.length);
+}
+
+/**
  * Whether a hostname belongs to the factory itself — its own domains, or the
  * marketing domain of a registered niche — as opposed to a customer's.
  *
@@ -32,6 +79,9 @@ export function platformHostnames(
  * certificate, and never serve. Deriving the niche half from the registry means
  * the next niche domain gets its certificate by being registered, the same way
  * it gets its routing.
+ *
+ * Customer platform subdomains (`le-petit-meunier.restofront.com`) are not
+ * factory hosts. Authorizing their certificates is `isOnDemandTlsHostname`.
  */
 export function isFactoryHostname(
   hostname: string,
@@ -43,4 +93,87 @@ export function isFactoryHostname(
     platformHostnames(configured).has(wanted) ||
     resolveVerticalByHostname(wanted) !== null
   );
+}
+
+/**
+ * Parses `<slug>.<niche-or-factory-apex>` into a customer slug. Apex, `www`,
+ * `api`, `assets`, `domains`, and `send` are never slugs. Extra labels
+ * (`foo.bar.restofront.com`) are rejected so they fall through to the custom
+ * Domain table instead of minting a nested platform host.
+ */
+export function parsePlatformSubdomain(
+  hostname: string,
+  configured?: string,
+): PlatformSubdomain | null {
+  const wanted = normalizeHostname(hostname);
+  if (!wanted) return null;
+  for (const parent of platformSubdomainParents(configured)) {
+    const suffix = `.${parent}`;
+    if (!wanted.endsWith(suffix)) continue;
+    const slug = wanted.slice(0, -suffix.length);
+    if (!slug || slug.includes(".")) return null;
+    if (RESERVED_PLATFORM_SLUGS.has(slug)) return null;
+    if (!DNS_LABEL_PATTERN.test(slug)) return null;
+    return { slug, parentHostname: parent };
+  }
+  return null;
+}
+
+/**
+ * Reserved operator/marketing labels under a platform parent. Not a customer
+ * slug, and not automatically a factory host (`api.restofront.com` stays closed).
+ */
+export function isReservedPlatformHostname(
+  hostname: string,
+  configured?: string,
+): boolean {
+  const wanted = normalizeHostname(hostname);
+  if (!wanted) return false;
+  for (const parent of platformSubdomainParents(configured)) {
+    const suffix = `.${parent}`;
+    if (!wanted.endsWith(suffix)) continue;
+    const slug = wanted.slice(0, -suffix.length);
+    if (!slug || slug.includes(".")) return false;
+    return RESERVED_PLATFORM_SLUGS.has(slug);
+  }
+  return false;
+}
+
+/**
+ * Syntactic check for hosts Caddy might ask about. Factory/niche apexes are
+ * issued without a DB row. Customer platform slugs still need a Site row in
+ * `/api/domains/authorize` so unused labels cannot exhaust TLS quota.
+ */
+export function isOnDemandTlsHostname(
+  hostname: string,
+  configured?: string,
+): boolean {
+  return (
+    isFactoryHostname(hostname, configured) ||
+    parsePlatformSubdomain(hostname, configured) !== null
+  );
+}
+
+/**
+ * Public hostname for a claimed site until a verified custom domain exists.
+ * Launched niches use their marketed domain; everyone else falls back to the
+ * factory apex.
+ */
+export function platformSiteHostname(
+  slug: string,
+  vertical?: VerticalId,
+  configured?: string,
+): string {
+  const normalizedSlug = slug.trim().toLowerCase();
+  const domain =
+    vertical === undefined
+      ? null
+      : resolveVerticalConfig(vertical).marketing.domain;
+  const parent =
+    domain?.trim().toLowerCase() ||
+    platformSubdomainParents(configured).find((candidate) =>
+      platformHostnames(configured).has(candidate),
+    ) ||
+    "cornershop.dev";
+  return `${normalizedSlug}.${parent}`;
 }

--- a/src/lib/site-surface.test.ts
+++ b/src/lib/site-surface.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import { previewCacheTagFor } from "@/lib/site-surface";
+import {
+  liveSiteCanonicalPath,
+  previewCacheTagFor,
+} from "@/lib/site-surface";
 
 describe("previewCacheTagFor", () => {
   it("derives a stable tag from the slug", () => {
@@ -19,5 +22,14 @@ describe("previewCacheTagFor", () => {
 
   it("keeps distinct slugs on distinct tags", () => {
     expect(previewCacheTagFor("site-a")).not.toBe(previewCacheTagFor("site-b"));
+  });
+
+  it("builds absolute live canonicals on the public origin", () => {
+    expect(
+      liveSiteCanonicalPath("https://chez-lea.restofront.com", "en", "en"),
+    ).toBe("https://chez-lea.restofront.com/");
+    expect(
+      liveSiteCanonicalPath("https://chez-lea.restofront.com", "fr", "en"),
+    ).toBe("https://chez-lea.restofront.com/fr");
   });
 });

--- a/src/lib/site-surface.ts
+++ b/src/lib/site-surface.ts
@@ -26,6 +26,14 @@ export function localeHref(
   return `${basePath.replace(/\/$/, "")}/${locale}`;
 }
 
+export function liveSiteCanonicalPath(
+  origin: string,
+  locale: string,
+  defaultLocale: string,
+): string {
+  return locale === defaultLocale ? `${origin}/` : `${origin}/${locale}`;
+}
+
 /**
  * The `unstable_cache` tag for a site's cached live-surface data.
  *

--- a/src/lib/sites.ts
+++ b/src/lib/sites.ts
@@ -1,6 +1,10 @@
 import { unstable_cache } from "next/cache";
 import { Prisma } from "@/generated/prisma/client";
 import { Vertical } from "@/generated/prisma/enums";
+import {
+  canonicalVerifiedCustomHostname,
+  publicSiteOrigin,
+} from "@/lib/domain-routing";
 import { getDb } from "@/lib/db";
 import { leadSiteDrafts } from "@/lib/lead-drafts";
 import type {
@@ -166,7 +170,9 @@ export async function findSiteDraft(slug: string): Promise<LoadedSite | null> {
 /**
  * Dereferences the site's one live pointer and validates the immutable snapshot
  * before rendering it. Mutable Site columns and child rows are intentionally not
- * selected, so a Save cannot leak into a public custom domain.
+ * selected, so a Save cannot leak into a public custom domain or platform
+ * subdomain. CLAIMED snapshots are included because a site can be public on
+ * `<slug>.<niche>` before a custom domain makes the row LIVE.
  */
 export async function findPublishedSiteView(
   slug: string,
@@ -181,7 +187,7 @@ export async function findPublishedSiteView(
           publishedAt: { not: null },
           site: {
             slug,
-            status: "LIVE",
+            status: { in: ["CLAIMED", "LIVE"] },
             publishedSiteVersionId: versionId,
           },
         },
@@ -244,6 +250,31 @@ export function getCachedPublishedSiteView(
     },
   );
   return cached();
+}
+
+/**
+ * Canonical origin for a live site surface: verified custom domain when one
+ * exists, otherwise the platform subdomain. Used by `alternates.canonical` and
+ * Open Graph URLs so they follow the same redirect policy as `proxy.ts`.
+ */
+export async function resolveLiveSiteOrigin(
+  slug: string,
+  vertical: VerticalId,
+): Promise<string> {
+  if (!process.env.DATABASE_URL) {
+    return publicSiteOrigin({ slug, vertical });
+  }
+  const rows = await getDb().domain.findMany({
+    where: { verified: true, site: { slug } },
+    select: { hostname: true },
+  });
+  return publicSiteOrigin({
+    slug,
+    vertical,
+    verifiedHostname: canonicalVerifiedCustomHostname(
+      rows.map((row) => ({ hostname: row.hostname, verified: true })),
+    ),
+  });
 }
 
 export function projectPublishedSiteVersion(

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,9 +3,15 @@ import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 import {
   decideCustomerHostRoute,
+  decidePlatformSubdomainRoute,
   planDomainHostnames,
+  type CustomerHostDecision,
 } from "@/lib/domain-routing";
-import { platformHostnames, requestHostname } from "@/lib/hostnames";
+import {
+  parsePlatformSubdomain,
+  platformHostnames,
+  requestHostname,
+} from "@/lib/hostnames";
 import {
   LIVE_SITE_SLUG_HEADER,
   LIVE_SITE_VERSION_HEADER,
@@ -41,7 +47,8 @@ function withEmbedFrameCsp(response: NextResponse) {
 export async function proxy(request: NextRequest) {
   const upstreamHeaders = new Headers(request.headers);
   // Never trust a caller-supplied surface marker. Only the verified-domain
-  // branch below may add it for the rewritten Server Component request.
+  // and platform-subdomain branches below may add it for the rewritten
+  // Server Component request.
   upstreamHeaders.delete(LIVE_SITE_SLUG_HEADER);
   upstreamHeaders.delete(LIVE_SITE_VERSION_HEADER);
 
@@ -86,6 +93,54 @@ export async function proxy(request: NextRequest) {
     return NextResponse.next({ request: { headers: upstreamHeaders } });
   }
 
+  // Claimed sites are reachable at `<slug>.<niche>` (and `<slug>.cornershop.dev`
+  // as a fallback) without the owner touching DNS. This runs before the Domain
+  // table so a platform hostname can never be claimed as a custom domain, and so
+  // a missing Site row 404s instead of falling through to an unknown-host lookup.
+  const platform = parsePlatformSubdomain(hostname);
+  if (platform) {
+    const site = await getDb().site.findUnique({
+      where: { slug: platform.slug },
+      select: {
+        id: true,
+        slug: true,
+        status: true,
+        publishedSiteVersionId: true,
+        publishedSiteVersion: {
+          select: {
+            id: true,
+            siteId: true,
+            publishedAt: true,
+          },
+        },
+        domains: {
+          where: { verified: true },
+          select: { hostname: true, verified: true },
+        },
+      },
+    });
+    return respondForCustomerHost(
+      request,
+      upstreamHeaders,
+      decidePlatformSubdomainRoute({
+        hostname,
+        pathname: request.nextUrl.pathname,
+        parsed: platform,
+        site: site
+          ? {
+              id: site.id,
+              slug: site.slug,
+              status: site.status,
+              publishedSiteVersionId: site.publishedSiteVersionId,
+              publishedSiteVersion: site.publishedSiteVersion,
+              verifiedDomains: site.domains,
+            }
+          : null,
+      }),
+      301,
+    );
+  }
+
   const plan = planDomainHostnames(hostname);
   const domains = await getDb().domain.findMany({
     where: { hostname: { in: plan.hostnames } },
@@ -114,6 +169,15 @@ export async function proxy(request: NextRequest) {
     pathname: request.nextUrl.pathname,
     records: domains,
   });
+  return respondForCustomerHost(request, upstreamHeaders, decision, 308);
+}
+
+function respondForCustomerHost(
+  request: NextRequest,
+  upstreamHeaders: Headers,
+  decision: CustomerHostDecision,
+  redirectStatus: 301 | 308,
+) {
   if (decision.kind === "not_found") {
     return new NextResponse("Not found", {
       status: 404,
@@ -125,7 +189,7 @@ export async function proxy(request: NextRequest) {
     canonical.protocol = "https:";
     canonical.hostname = decision.canonicalHostname;
     canonical.port = "";
-    return NextResponse.redirect(canonical, 308);
+    return NextResponse.redirect(canonical, redirectStatus);
   }
 
   upstreamHeaders.set(LIVE_SITE_SLUG_HEADER, decision.slug);


### PR DESCRIPTION
## Summary

Claimed + published sites now get a live URL with no owner DNS: `https://<slug>.restofront.com` (fallback `https://<slug>.cornershop.dev`). Custom domains stay an optional upgrade and become canonical once verified.

- Parse `<slug>.<launched-niche-domain>` (from the vertical registry) and `<slug>.cornershop.dev`. Apex, `www`, `api`, `assets`, `domains`, and `send` are never customer slugs; extra labels (`foo.bar.restofront.com`) are rejected.
- `src/proxy.ts` rewrites platform subdomains **before** the Domain table lookup, with the same LIVE_SITE headers and owner/operator denylist as custom hosts. Unpublished/PROSPECT/PAUSED sites 404 (private previews stay on `/preview/<slug>` on the factory host).
- Verified custom domain → **301** from the platform subdomain to that domain. `alternates.canonical` and OG url follow.
- `/api/domains/authorize` returns 200 for the pattern even if the Site row does not exist yet, so a brand-new publish can obtain TLS. Operator hosts on the niche (`api.restofront.com`, `send.restofront.com`, …) stay 403.
- Dashboard: platform URL is “Your site is live”; custom domain card is optional. Claim invitation emails link the platform URL, never `/preview/`.

Closes #98.

## DNS / TLS ops gate (not done in this PR)

Do **not** change Route53 or Caddy in this change. Production still needs:

1. Wildcard **A/AAAA** for `*.restofront.com` and `*.cornershop.dev` → existing `PUBLIC_APP_IP` (same target as the apex records).
2. Caddy on-demand TLS already calls `/api/domains/authorize`. After deploy, that endpoint will 200 for customer platform slugs; until wildcard DNS exists, those hostnames will not resolve.

Apex `restofront.com` / `www.restofront.com` / `cornershop.dev` are unchanged.

## Test plan

- [x] `bun test` — 294 pass, 20 skip (postgres integration), 0 fail
- [x] Focused: hostnames, domain-routing (including blocked `/admin` `/dashboard` `/create` `/claim` `/sign-in` `/api/admin`), site-surface, claim invitation email, proxy health/authorize bypass
- [x] `bun run lint`
- [x] `bunx tsc --noEmit --incremental false --pretty false` — no new errors (pre-existing `RouteContext` name errors on main in six unrelated API routes)

## Notes vs open PRs

Stayed on current `main` files. Does not take #87 proxy cache / domains invalidation or #101 domains route invalidation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request routing, TLS authorization, and what is publicly served—security-sensitive ingress—but behavior is heavily tested and platform TLS is gated on Site rows.
> 
> **Overview**
> Claimed, published sites get a **default public URL** on `<slug>.<niche-domain>` (e.g. `chez-lea.restofront.com`) without owner DNS. Custom domains stay optional and become canonical once verified.
> 
> **Routing & hostnames:** New parsing for platform subdomains (reserved labels like `api`/`www` excluded). `proxy.ts` resolves these **before** the custom `Domain` table, serves the same public surfaces as verified hosts, **301** to custom domain when verified, and blocks owner/operator paths. Published snapshots can serve in **CLAIMED** status on the platform host (not only **LIVE** on custom domains).
> 
> **TLS:** `/api/domains/authorize` no longer treats all `*.restofront.com` as factory; platform slugs need an existing **Site** row so unused labels cannot mint certificates. Domain POST rejects platform/reserved hostnames.
> 
> **Product surfaces:** `publicSiteOrigin` / `publicUrl` on domain APIs; dashboard reframes go-live around the platform address; claim invitation emails link the platform URL. Analytics and live canonical URLs follow the same origin rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ed4bb27a8d725e45af75ff19ef9b83ce593d7ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->