### PR TITLE
feat(leads): discover local SMBs and persist scored prospects

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,14 @@ S3_PUBLIC_BASE_URL=https://assets.cornershop.dev
 # Authenticates external readiness probes. Generate at least 32 random bytes.
 HEALTHCHECK_TOKEN=
 
+# Laptop-to-API prospect ingest for `bun run leads:discover --execute`.
+# Distinct from HEALTHCHECK_TOKEN. Generate at least 32 random bytes.
+OPERATOR_LEAD_INGEST_TOKEN=
+
+# Optional Google Places API (New) key for local lead discovery.
+# When empty, the runner falls back to OSM/Nominatim.
+GOOGLE_PLACES_API_KEY=
+
 # Stripe subscriptions. Test and live modes have separate keys, prices,
 # Customer Portal configuration, webhook endpoints, and signing secrets.
 STRIPE_SECRET_KEY=

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "operator:import:le-petit-meunier": "bun scripts/import-le-petit-meunier.ts",
     "operator:verify-environment-isolation": "bun scripts/verify-environment-isolation.ts",
     "operator:verify-image-storage": "bun scripts/verify-image-storage-roundtrip.ts",
+    "leads:discover": "bun scripts/discover-leads.ts",
     "operator:dispatch-alerts": "bun scripts/dispatch-operator-alerts.ts",
     "operator:monitor-public-site": "bun scripts/monitor-public-site.ts",
     "workflow:migrate": "bun node_modules/@workflow/world-postgres/bin/setup.js",

--- a/scripts/discover-leads.ts
+++ b/scripts/discover-leads.ts
@@ -1,0 +1,237 @@
+import { Vertical } from "@/generated/prisma/enums";
+import {
+  buildProspectIdentity,
+  fetchHomepageSignals,
+  scoreWebsiteQuality,
+} from "@/lib/lead-discovery";
+import { discoverLocalPlaces } from "@/lib/lead-discovery-places";
+import { auditLocalSeo, renderLocalSeoOutreachEmail } from "@/lib/local-seo-audit";
+
+const usage =
+  "Usage: bun run leads:discover -- --vertical restaurant --city <city> [--limit N] [--api-url https://cornershop.dev] [--execute]";
+
+try {
+  const summary = await main(process.argv.slice(2));
+  console.log(JSON.stringify(summary, null, 2));
+} catch (error) {
+  console.error(error instanceof Error ? error.message : "Lead discovery failed");
+  process.exitCode = 1;
+}
+
+async function main(args: string[]) {
+  const options = parseArguments(args);
+  const discovery = await discoverLocalPlaces({
+    city: options.city,
+    limit: options.limit,
+    googlePlacesApiKey: process.env.GOOGLE_PLACES_API_KEY,
+  });
+
+  const candidates = [];
+  for (const place of discovery.places) {
+    const identity = buildProspectIdentity({
+      websiteUrl: place.websiteUrl,
+      placeId: place.placeId,
+      provider: place.provider,
+    });
+    const homepage = identity.sourceUrl
+      ? await fetchHomepageSignals(identity.sourceUrl)
+      : null;
+    const quality = scoreWebsiteQuality({
+      hasWebsite: Boolean(identity.sourceUrl),
+      homepage,
+    });
+    const audit = auditLocalSeo({
+      name: place.name,
+      address: place.address,
+      phone: place.phone,
+      city: place.city,
+      websiteUrl: identity.sourceUrl,
+      categories: place.categories,
+      hours: place.hours,
+      photoCount: place.photoCount,
+      photoNewestAt: place.photoNewestAt,
+      reviewCount: place.reviewCount,
+      description: place.description,
+      homepage,
+    });
+    const outreach = renderLocalSeoOutreachEmail({
+      name: place.name,
+      previewUrl: "/preview/pending",
+      audit,
+    });
+    candidates.push({
+      name: place.name,
+      city: place.city,
+      placeId: place.placeId,
+      sourceProvider: place.provider,
+      source: identity.source,
+      sourceKey: identity.sourceKey,
+      sourceUrl: identity.sourceUrl,
+      phone: place.phone,
+      address: place.address,
+      rating: place.rating,
+      reviewCount: place.reviewCount,
+      score: quality.score,
+      reasons: quality.reasons,
+      audit,
+      outreachSubject: outreach.subject,
+    });
+  }
+
+  const plan = {
+    command: "leads:discover",
+    mode: options.execute ? "execute" : "dry-run",
+    vertical: options.vertical,
+    city: options.city,
+    limit: options.limit,
+    apiUrl: options.apiUrl,
+    sourceProvider: discovery.provider,
+    fallbackReason: discovery.fallbackReason,
+    candidateCount: candidates.length,
+    candidates: candidates.map((candidate) => ({
+      name: candidate.name,
+      city: candidate.city,
+      sourceKey: candidate.sourceKey,
+      sourceUrl: candidate.sourceUrl,
+      score: candidate.score,
+      reasons: candidate.reasons,
+      auditScore: candidate.audit.score,
+      topFixes: candidate.audit.topFixes.map((fix) => fix.title),
+    })),
+  };
+
+  if (!options.execute) {
+    return { ...plan, preflight: "dry-run" };
+  }
+
+  const token = process.env.OPERATOR_LEAD_INGEST_TOKEN?.trim();
+  if (!token) {
+    throw new Error("OPERATOR_LEAD_INGEST_TOKEN is required with --execute");
+  }
+
+  const results = [];
+  for (const candidate of candidates) {
+    const response = await fetch(new URL("/api/admin/leads/ingest", options.apiUrl), {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({
+        source: candidate.source,
+        vertical: options.vertical,
+        name: candidate.name,
+        phone: candidate.phone,
+        address: candidate.address,
+        city: candidate.city,
+        placeId: candidate.placeId,
+        websiteUrl: candidate.sourceUrl,
+        rating: candidate.rating,
+        reviewCount: candidate.reviewCount,
+        score: candidate.score,
+        reasons: candidate.reasons,
+        sourceProvider: candidate.sourceProvider,
+        audit: candidate.audit,
+      }),
+    });
+    const payload = (await response.json()) as {
+      ok?: boolean;
+      created?: boolean;
+      reopened?: boolean;
+      siteSlug?: string;
+      error?: string;
+    };
+    results.push({
+      sourceKey: candidate.sourceKey,
+      status: response.status,
+      created: Boolean(payload.created),
+      reopened: Boolean(payload.reopened),
+      siteSlug: payload.siteSlug ?? null,
+      error: response.ok ? null : payload.error ?? "ingest failed",
+    });
+  }
+
+  return {
+    ...plan,
+    preflight: "executed",
+    ingested: results.filter((row) => row.error === null).length,
+    failed: results.filter((row) => row.error !== null).length,
+    results,
+  };
+}
+
+function parseArguments(args: string[]): {
+  vertical: typeof Vertical.RESTAURANT;
+  city: string;
+  limit: number;
+  apiUrl: string;
+  execute: boolean;
+} {
+  let vertical: string | undefined;
+  let city: string | undefined;
+  let limit = 50;
+  let apiUrl = "https://cornershop.dev";
+  let execute = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--execute") {
+      if (execute) throw new Error(usage);
+      execute = true;
+      continue;
+    }
+    if (argument === "--vertical") {
+      const value = args[index + 1];
+      if (vertical !== undefined || !value || value.startsWith("--")) {
+        throw new Error(usage);
+      }
+      vertical = value;
+      index += 1;
+      continue;
+    }
+    if (argument === "--city") {
+      const value = args[index + 1];
+      if (city !== undefined || !value || value.startsWith("--")) {
+        throw new Error(usage);
+      }
+      city = value;
+      index += 1;
+      continue;
+    }
+    if (argument === "--limit") {
+      const value = args[index + 1];
+      const parsed = Number(value);
+      if (!value || value.startsWith("--") || !Number.isInteger(parsed)) {
+        throw new Error(usage);
+      }
+      if (parsed < 1 || parsed > 100) {
+        throw new Error("Limit must be an integer between 1 and 100");
+      }
+      limit = parsed;
+      index += 1;
+      continue;
+    }
+    if (argument === "--api-url") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("--")) throw new Error(usage);
+      apiUrl = new URL(value).origin;
+      index += 1;
+      continue;
+    }
+    throw new Error(usage);
+  }
+
+  if (!vertical || !city) throw new Error(usage);
+  if (vertical.toLowerCase() !== "restaurant") {
+    throw new Error("Only --vertical restaurant is supported");
+  }
+
+  return {
+    vertical: Vertical.RESTAURANT,
+    city: city.trim(),
+    limit,
+    apiUrl,
+    execute,
+  };
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -169,10 +169,14 @@ export default async function AdminPage() {
             <CardTitle>All sites</CardTitle>
           </CardHeader>
           <CardContent className="overflow-x-auto p-0">
-            <table className="w-full min-w-[2200px] text-left text-sm">
+            <table className="w-full min-w-[2600px] text-left text-sm">
               <thead className="border-b bg-muted/50 text-xs uppercase tracking-[0.12em] text-muted-foreground">
                 <tr>
                   <th scope="col" className="px-5 py-3 font-medium">Business</th>
+                  <th scope="col" className="px-5 py-3 font-medium">Score</th>
+                  <th scope="col" className="px-5 py-3 font-medium">City</th>
+                  <th scope="col" className="px-5 py-3 font-medium">Discovered</th>
+                  <th scope="col" className="px-5 py-3 font-medium">Local SEO</th>
                   <th scope="col" className="px-5 py-3 font-medium">Lifecycle</th>
                   <th scope="col" className="px-5 py-3 font-medium">Signup</th>
                   <th scope="col" className="px-5 py-3 font-medium">Subscription</th>
@@ -249,6 +253,42 @@ function SiteRow({ site }: { site: OperatorSiteRow }) {
         <p className="mt-1 text-[11px] text-muted-foreground">
           TLS: {humanize(site.tlsReadiness)}
         </p>
+      </td>
+      <td className="px-5 py-4">
+        {site.discovery ? (
+          <>
+            <p className="font-medium">{site.discovery.score}</p>
+            <p className="mt-1 max-w-56 text-[11px] text-muted-foreground">
+              {site.discovery.reasons.slice(0, 2).join(" · ") || "No scoring deductions"}
+            </p>
+          </>
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        )}
+      </td>
+      <td className="px-5 py-4">
+        {site.discovery?.city ?? (
+          <span className="text-muted-foreground">—</span>
+        )}
+      </td>
+      <td className="px-5 py-4 text-muted-foreground">
+        {site.discovery?.discoveredAt
+          ? formatDate(site.discovery.discoveredAt)
+          : "—"}
+      </td>
+      <td className="px-5 py-4">
+        {site.localSeoAudit ? (
+          <div className="grid min-w-52 gap-1">
+            <p className="font-medium">{site.localSeoAudit.score}</p>
+            {site.localSeoAudit.topFixes.slice(0, 5).map((fix) => (
+              <p key={fix.id} className="text-[11px] text-muted-foreground">
+                {fix.title}
+              </p>
+            ))}
+          </div>
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        )}
       </td>
       <td className="px-5 py-4">
         <Badge variant="outline">{humanize(site.status)}</Badge>

--- a/src/app/api/admin/leads/ingest/route.ts
+++ b/src/app/api/admin/leads/ingest/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { Vertical } from "@/generated/prisma/enums";
+import { localSeoAuditResultSchema } from "@/lib/local-seo-audit";
+import { OperatorLeadError } from "@/lib/operator-leads";
+import {
+  ingestOperatorProspectLead,
+} from "@/lib/operator-lead-ingest";
+import { isOperatorLeadIngestAuthorized } from "@/lib/operator-lead-ingest-auth";
+import { limitOperatorLeadIngest } from "@/lib/rate-limit";
+
+export const runtime = "nodejs";
+
+const requestSchema = z.object({
+  source: z.string().trim().min(2).max(500),
+  vertical: z.enum(Vertical).default(Vertical.RESTAURANT),
+  name: z.string().trim().min(1).max(160),
+  phone: z.string().trim().max(40).nullable().optional(),
+  address: z.string().trim().max(240).nullable().optional(),
+  city: z.string().trim().min(1).max(80),
+  placeId: z.string().trim().max(200).nullable().optional(),
+  websiteUrl: z.string().trim().max(500).nullable().optional(),
+  rating: z.number().min(0).max(5).nullable().optional(),
+  reviewCount: z.number().int().min(0).nullable().optional(),
+  score: z.number().int().min(0).max(100),
+  reasons: z.array(z.string().trim().min(1).max(200)).max(20),
+  discoveredAt: z.iso.datetime().optional(),
+  sourceProvider: z.enum(["google_places", "nominatim"]).optional(),
+  audit: localSeoAuditResultSchema.optional(),
+});
+
+export async function POST(request: Request) {
+  if (!isOperatorLeadIngestAuthorized(request)) {
+    return NextResponse.json(
+      { error: "Unauthorized" },
+      {
+        status: 401,
+        headers: {
+          "Cache-Control": "no-store",
+          "WWW-Authenticate": "Bearer",
+        },
+      },
+    );
+  }
+
+  const rateLimit = await limitOperatorLeadIngest(request);
+  if (!rateLimit.success) {
+    return NextResponse.json(
+      {
+        error:
+          rateLimit.reason === "unavailable"
+            ? "Lead ingest is temporarily unavailable."
+            : "Too many lead ingest requests. Try again later.",
+      },
+      { status: rateLimit.reason === "unavailable" ? 503 : 429 },
+    );
+  }
+
+  try {
+    const input = requestSchema.parse(await request.json());
+    const lead = await ingestOperatorProspectLead(input);
+    return NextResponse.json(
+      { ok: true, ...lead },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: error.issues[0]?.message ?? "Check the prospect details." },
+        { status: 400 },
+      );
+    }
+    if (error instanceof OperatorLeadError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: error.status },
+      );
+    }
+    console.error("[operator-lead-ingest] failed", {
+      error: error instanceof Error ? error.message : "unknown",
+    });
+    return NextResponse.json(
+      { error: "The prospect lead could not be ingested." },
+      { status: 503 },
+    );
+  }
+}

--- a/src/components/restaurant-themes/restaurant-theme-renderer.tsx
+++ b/src/components/restaurant-themes/restaurant-theme-renderer.tsx
@@ -1,8 +1,9 @@
 import { AfterDarkTheme } from "@/components/restaurant-themes/after-dark";
 import { CounterServiceTheme } from "@/components/restaurant-themes/counter-service";
-import type {
-  RestaurantThemeRendererInputProps,
-  RestaurantThemeRendererProps,
+import {
+  RestaurantStructuredData,
+  type RestaurantThemeRendererInputProps,
+  type RestaurantThemeRendererProps,
 } from "@/components/restaurant-themes/shared";
 import { TerroirEditorialTheme } from "@/components/restaurant-themes/terroir-editorial";
 import { getSiteDictionary } from "@/lib/site-i18n";
@@ -31,6 +32,12 @@ export function RestaurantThemeRenderer(
   const dictionary =
     props.dictionary ?? getSiteDictionary(restaurantConfig, locale);
   return (
-    <Renderer {...props} locale={locale} dictionary={dictionary} />
+    <>
+      <RestaurantStructuredData
+        draft={props.draft}
+        enabled={Boolean(props.analyticsEnabled)}
+      />
+      <Renderer {...props} locale={locale} dictionary={dictionary} />
+    </>
   );
 }

--- a/src/components/restaurant-themes/shared.tsx
+++ b/src/components/restaurant-themes/shared.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { SiteAnalytics } from "@/components/site-analytics";
 import { localizeIntegrationUrl } from "@/lib/site-i18n";
 import { localeHref } from "@/lib/site-surface";
+import { serializeRestaurantJsonLd } from "@/lib/restaurant-json-ld";
 import type { SiteDraftView, SiteIntegrationView } from "@/lib/site-draft";
 import type {
   RestaurantThemeSelection,
@@ -58,6 +59,22 @@ export function ThemeAnalytics({
   enabled: boolean;
 }) {
   return enabled ? <SiteAnalytics siteSlug={draft.slug} /> : null;
+}
+
+export function RestaurantStructuredData({
+  draft,
+  enabled,
+}: {
+  draft: SiteDraftView;
+  enabled: boolean;
+}) {
+  if (!enabled) return null;
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: serializeRestaurantJsonLd(draft) }}
+    />
+  );
 }
 
 export function ThemeHeroImage({

--- a/src/components/site-renderer.tsx
+++ b/src/components/site-renderer.tsx
@@ -9,6 +9,7 @@ import Link from "next/link";
 import { BookingEmbed } from "@/components/booking-embed";
 import { BookingRequestForm } from "@/components/booking-request-form";
 import { RestaurantThemeRenderer } from "@/components/restaurant-themes/restaurant-theme-renderer";
+import { RestaurantStructuredData } from "@/components/restaurant-themes/shared";
 import { SiteAnalytics } from "@/components/site-analytics";
 import { Vertical } from "@/generated/prisma/enums";
 import { resolveBookingEmbed } from "@/lib/booking-embed";
@@ -148,6 +149,9 @@ export function SiteRenderer({
       }
     >
       {analyticsEnabled ? <SiteAnalytics siteSlug={draft.slug} /> : null}
+      {vertical === Vertical.RESTAURANT ? (
+        <RestaurantStructuredData draft={draft} enabled={analyticsEnabled} />
+      ) : null}
       <header
         className={cn(
           "z-20 grid w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-3 p-4 sm:flex sm:justify-between sm:gap-4 sm:p-5 md:p-8",

--- a/src/lib/lead-discovery-places.test.ts
+++ b/src/lib/lead-discovery-places.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "bun:test";
+import { discoverLocalPlaces } from "@/lib/lead-discovery-places";
+
+describe("place discovery", () => {
+  it("uses Google Places when a key is supplied and never requires a live key", async () => {
+    const fetchImpl = async (input: RequestInfo | URL) => {
+      expect(String(input)).toContain("places.googleapis.com");
+      return Response.json({
+        places: [
+          {
+            id: "ChIJ123",
+            displayName: { text: "Chez Mira" },
+            formattedAddress: "12 Rue des Vignes, Lyon, France",
+            websiteUri: "https://www.chezmira.fr/",
+            internationalPhoneNumber: "+33 4 00 00 00 00",
+            rating: 4.4,
+            userRatingCount: 88,
+            types: ["restaurant", "french_restaurant", "point_of_interest"],
+            regularOpeningHours: {
+              weekdayDescriptions: ["Monday: Closed", "Tuesday: 7:00 PM – 10:00 PM"],
+            },
+            photos: [{ name: "places/ChIJ123/photos/1" }],
+            editorialSummary: { overview: "A small Lyonnais dining room." },
+          },
+        ],
+      });
+    };
+
+    const result = await discoverLocalPlaces({
+      city: "Lyon",
+      limit: 10,
+      googlePlacesApiKey: "test-key",
+      fetchImpl,
+    });
+
+    expect(result.provider).toBe("google_places");
+    expect(result.places).toEqual([
+      expect.objectContaining({
+        name: "Chez Mira",
+        websiteUrl: "https://www.chezmira.fr/",
+        placeId: "ChIJ123",
+        city: "Lyon",
+        reviewCount: 88,
+        categories: ["restaurant", "french_restaurant"],
+        hours: [
+          { days: "Monday", hours: "Closed" },
+          { days: "Tuesday", hours: "7:00 PM – 10:00 PM" },
+        ],
+      }),
+    ]);
+  });
+
+  it("falls back to Nominatim when no Google key is configured", async () => {
+    const fetchImpl = async (input: RequestInfo | URL) => {
+      expect(String(input)).toContain("nominatim.openstreetmap.org");
+      return Response.json([
+        {
+          name: "Trattoria Due",
+          display_name: "Trattoria Due, Valletta, Malta",
+          osm_type: "node",
+          osm_id: 42,
+          type: "restaurant",
+          address: { city: "Valletta" },
+          extratags: { website: "https://due.example", phone: "+356 2100 0000" },
+        },
+      ]);
+    };
+
+    const result = await discoverLocalPlaces({
+      city: "Valletta",
+      limit: 5,
+      fetchImpl,
+    });
+
+    expect(result.provider).toBe("nominatim");
+    expect(result.places[0]).toMatchObject({
+      name: "Trattoria Due",
+      placeId: "node/42",
+      websiteUrl: "https://due.example",
+      city: "Valletta",
+    });
+  });
+});

--- a/src/lib/lead-discovery-places.ts
+++ b/src/lib/lead-discovery-places.ts
@@ -1,0 +1,300 @@
+import {
+  LEAD_DISCOVERY_USER_AGENT,
+  type DiscoveryFetch,
+  type LeadDiscoveryProvider,
+} from "@/lib/lead-discovery";
+
+export type DiscoveredPlace = {
+  name: string;
+  websiteUrl: string | null;
+  phone: string | null;
+  address: string | null;
+  city: string;
+  placeId: string;
+  provider: LeadDiscoveryProvider;
+  rating: number | null;
+  reviewCount: number | null;
+  categories: string[];
+  hours: Array<{ days: string; hours: string }>;
+  photoCount: number;
+  photoNewestAt: string | null;
+  description: string | null;
+};
+
+export type PlaceDiscoveryResult = {
+  places: DiscoveredPlace[];
+  provider: LeadDiscoveryProvider;
+  fallbackReason: string | null;
+};
+
+const GOOGLE_TEXT_SEARCH_URL =
+  "https://places.googleapis.com/v1/places:searchText";
+const NOMINATIM_SEARCH_URL = "https://nominatim.openstreetmap.org/search";
+const GENERIC_PLACE_TYPES = new Set([
+  "point_of_interest",
+  "establishment",
+  "food",
+  "store",
+  "place_of_worship",
+]);
+
+export async function discoverLocalPlaces(input: {
+  city: string;
+  limit: number;
+  googlePlacesApiKey?: string | null;
+  fetchImpl?: DiscoveryFetch;
+}): Promise<PlaceDiscoveryResult> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const city = input.city.trim();
+  const limit = Math.min(100, Math.max(1, input.limit));
+  const apiKey = input.googlePlacesApiKey?.trim() || null;
+
+  if (apiKey) {
+    try {
+      const places = await searchGooglePlaces({
+        city,
+        limit,
+        apiKey,
+        fetchImpl,
+      });
+      if (places.length > 0) {
+        return { places, provider: "google_places", fallbackReason: null };
+      }
+      return {
+        places: await searchNominatimPlaces({ city, limit, fetchImpl }),
+        provider: "nominatim",
+        fallbackReason: "Google Places returned no restaurants",
+      };
+    } catch (error) {
+      return {
+        places: await searchNominatimPlaces({ city, limit, fetchImpl }),
+        provider: "nominatim",
+        fallbackReason:
+          error instanceof Error
+            ? error.message
+            : "Google Places request failed",
+      };
+    }
+  }
+
+  return {
+    places: await searchNominatimPlaces({ city, limit, fetchImpl }),
+    provider: "nominatim",
+    fallbackReason: null,
+  };
+}
+
+export async function searchGooglePlaces(input: {
+  city: string;
+  limit: number;
+  apiKey: string;
+  fetchImpl: DiscoveryFetch;
+}): Promise<DiscoveredPlace[]> {
+  const places: DiscoveredPlace[] = [];
+  let pageToken: string | null = null;
+
+  while (places.length < input.limit) {
+    const pageSize = Math.min(20, input.limit - places.length);
+    const body: Record<string, unknown> = {
+      textQuery: `restaurants in ${input.city}`,
+      includedType: "restaurant",
+      pageSize,
+      languageCode: "en",
+    };
+    if (pageToken) body.pageToken = pageToken;
+
+    const response = await input.fetchImpl(GOOGLE_TEXT_SEARCH_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Goog-Api-Key": input.apiKey,
+        "X-Goog-FieldMask": [
+          "places.id",
+          "places.displayName",
+          "places.formattedAddress",
+          "places.nationalPhoneNumber",
+          "places.internationalPhoneNumber",
+          "places.websiteUri",
+          "places.rating",
+          "places.userRatingCount",
+          "places.types",
+          "places.regularOpeningHours.weekdayDescriptions",
+          "places.photos",
+          "places.editorialSummary",
+          "nextPageToken",
+        ].join(","),
+        "User-Agent": LEAD_DISCOVERY_USER_AGENT,
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!response.ok) {
+      throw new Error(`Google Places returned HTTP ${response.status}`);
+    }
+
+    const payload = asRecord(await response.json());
+    const rows = Array.isArray(payload?.places) ? payload.places : [];
+    for (const row of rows) {
+      const place = parseGooglePlace(row, input.city);
+      if (place) places.push(place);
+      if (places.length >= input.limit) break;
+    }
+
+    const next = asString(payload?.nextPageToken);
+    if (!next || rows.length === 0) break;
+    pageToken = next;
+  }
+
+  return places;
+}
+
+export async function searchNominatimPlaces(input: {
+  city: string;
+  limit: number;
+  fetchImpl: DiscoveryFetch;
+}): Promise<DiscoveredPlace[]> {
+  const url = new URL(NOMINATIM_SEARCH_URL);
+  url.searchParams.set("q", `restaurant in ${input.city}`);
+  url.searchParams.set("format", "jsonv2");
+  url.searchParams.set("addressdetails", "1");
+  url.searchParams.set("extratags", "1");
+  url.searchParams.set("limit", String(Math.min(50, input.limit)));
+
+  const response = await input.fetchImpl(url, {
+    headers: {
+      Accept: "application/json",
+      "User-Agent": LEAD_DISCOVERY_USER_AGENT,
+    },
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!response.ok) {
+    throw new Error(`Nominatim returned HTTP ${response.status}`);
+  }
+
+  const rows = await response.json();
+  if (!Array.isArray(rows)) return [];
+  return rows
+    .map((row) => parseNominatimPlace(row, input.city))
+    .filter((place): place is DiscoveredPlace => place !== null)
+    .slice(0, input.limit);
+}
+
+function parseGooglePlace(value: unknown, fallbackCity: string): DiscoveredPlace | null {
+  const record = asRecord(value);
+  if (!record) return null;
+  const placeId = asString(record.id)?.replace(/^places\//, "");
+  const displayName = asRecord(record.displayName);
+  const name = asString(displayName?.text) ?? asString(record.displayName);
+  if (!placeId || !name) return null;
+
+  const hours = Array.isArray(
+    asRecord(record.regularOpeningHours)?.weekdayDescriptions,
+  )
+    ? (
+        asRecord(record.regularOpeningHours)?.weekdayDescriptions as unknown[]
+      ).flatMap((entry) => {
+        if (typeof entry !== "string" || !entry.includes(":")) return [];
+        const separator = entry.indexOf(":");
+        const days = entry.slice(0, separator).trim();
+        const hoursText = entry.slice(separator + 1).trim();
+        return days && hoursText ? [{ days, hours: hoursText }] : [];
+      })
+    : [];
+
+  const types = Array.isArray(record.types)
+    ? record.types.filter(
+        (entry): entry is string =>
+          typeof entry === "string" && !GENERIC_PLACE_TYPES.has(entry),
+      )
+    : [];
+
+  return {
+    name,
+    websiteUrl: asString(record.websiteUri),
+    phone:
+      asString(record.internationalPhoneNumber) ??
+      asString(record.nationalPhoneNumber),
+    address: asString(record.formattedAddress),
+    city: cityFromAddress(asString(record.formattedAddress), fallbackCity),
+    placeId,
+    provider: "google_places",
+    rating: asNumber(record.rating),
+    reviewCount: asInteger(record.userRatingCount),
+    categories: types,
+    hours,
+    photoCount: Array.isArray(record.photos) ? record.photos.length : 0,
+    photoNewestAt: null,
+    description:
+      asString(asRecord(record.editorialSummary)?.overview) ??
+      asString(asRecord(record.editorialSummary)?.text),
+  };
+}
+
+function parseNominatimPlace(
+  value: unknown,
+  fallbackCity: string,
+): DiscoveredPlace | null {
+  const record = asRecord(value);
+  if (!record) return null;
+  const osmType = asString(record.osm_type);
+  const osmId = record.osm_id;
+  const name = asString(record.name) ?? asString(record.display_name);
+  if (!osmType || osmId === undefined || osmId === null || !name) return null;
+
+  const address = asRecord(record.address);
+  const extras = asRecord(record.extratags);
+  const city =
+    asString(address?.city) ??
+    asString(address?.town) ??
+    asString(address?.village) ??
+    asString(address?.municipality) ??
+    fallbackCity;
+  const openingHours = asString(extras?.opening_hours);
+
+  return {
+    name,
+    websiteUrl:
+      asString(extras?.website) ?? asString(extras?.["contact:website"]),
+    phone: asString(extras?.phone) ?? asString(extras?.["contact:phone"]),
+    address: asString(record.display_name),
+    city,
+    placeId: `${osmType}/${String(osmId)}`,
+    provider: "nominatim",
+    rating: null,
+    reviewCount: null,
+    categories: [asString(record.type) ?? "restaurant"].filter(Boolean),
+    hours: openingHours ? [{ days: "Listed hours", hours: openingHours }] : [],
+    photoCount: 0,
+    photoNewestAt: null,
+    description: null,
+  };
+}
+
+function cityFromAddress(address: string | null, fallbackCity: string): string {
+  if (!address) return fallbackCity;
+  if (address.toLocaleLowerCase("en").includes(fallbackCity.toLocaleLowerCase("en"))) {
+    return fallbackCity;
+  }
+  const parts = address.split(",").map((part) => part.trim()).filter(Boolean);
+  return parts.at(-2) ?? fallbackCity;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function asInteger(value: unknown): number | null {
+  const numeric = asNumber(value);
+  return numeric === null ? null : Math.max(0, Math.round(numeric));
+}

--- a/src/lib/lead-discovery.test.ts
+++ b/src/lib/lead-discovery.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "bun:test";
+import {
+  buildProspectIdentity,
+  parseHomepageSignals,
+  scoreWebsiteQuality,
+} from "@/lib/lead-discovery";
+
+describe("prospect identity", () => {
+  it("dedupes equivalent websites onto one sourceKey", () => {
+    const first = buildProspectIdentity({
+      websiteUrl: "https://www.Example.com/menu/?utm_source=maps",
+      placeId: "ChIJ-one",
+      provider: "google_places",
+    });
+    const second = buildProspectIdentity({
+      websiteUrl: "example.com/menu/",
+      placeId: "ChIJ-two",
+      provider: "nominatim",
+    });
+
+    expect(first.sourceKey).toBe("url:example.com/menu");
+    expect(second.sourceKey).toBe(first.sourceKey);
+  });
+
+  it("keeps place-only businesses unique when no website exists", () => {
+    const google = buildProspectIdentity({
+      websiteUrl: null,
+      placeId: "ChIJ123",
+      provider: "google_places",
+    });
+    const osm = buildProspectIdentity({
+      websiteUrl: "  ",
+      placeId: "node/99",
+      provider: "nominatim",
+    });
+
+    expect(google.sourceKey).toBe("name:place:google:chij123");
+    expect(osm.sourceKey).toBe("name:place:osm:node/99");
+    expect(google.sourceKey).not.toBe(osm.sourceKey);
+  });
+});
+
+describe("website quality scoring", () => {
+  it("explains a missing website without claiming a fetch", () => {
+    expect(
+      scoreWebsiteQuality({ hasWebsite: false, homepage: null }),
+    ).toEqual({
+      score: 60,
+      reasons: ["No public website listed"],
+    });
+  });
+
+  it("records the cheap homepage deductions operators can act on", () => {
+    const homepage = parseHomepageSignals(
+      `<html>
+        <head>
+          <meta name="viewport" content="width=1280">
+          <title></title>
+        </head>
+        <body>
+          <frameset></frameset>
+          <script></script><script></script><script></script><script></script>
+          <script></script><script></script><script></script><script></script>
+          <script></script><script></script><script></script><script></script>
+          <script></script><script></script><script></script><script></script>
+          <script></script><script></script><script></script><script></script>
+          <script></script>
+          ${"x".repeat(800_001)}
+        </body>
+      </html>`,
+      new URL("http://bistro.example/"),
+      "Mon, 01 Jan 2018 00:00:00 GMT",
+    );
+
+    const scored = scoreWebsiteQuality({
+      hasWebsite: true,
+      homepage,
+    });
+
+    expect(scored.score).toBe(27);
+    expect(scored.reasons).toEqual([
+      "Homepage is HTTP, not HTTPS",
+      "Viewport looks desktop-only",
+      "Homepage uses frameset or Flash",
+      "No menu link found on the homepage",
+      "No booking or reservation link found",
+      "Homepage title is missing",
+      "Homepage HTML is unusually large",
+      "Homepage loads many scripts",
+      "Homepage Last-Modified is older than two years",
+    ]);
+  });
+
+  it("keeps a modern homepage at 100", () => {
+    const homepage = parseHomepageSignals(
+      `<html>
+        <head>
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+          <title>Chez Lea</title>
+          <script type="application/ld+json">{"@type":"Restaurant"}</script>
+        </head>
+        <body>
+          <a href="/menu">Menu</a>
+          <a href="https://www.opentable.com/r/chez-lea">Reserve</a>
+        </body>
+      </html>`,
+      new URL("https://chez-lea.example/"),
+    );
+
+    expect(scoreWebsiteQuality({ hasWebsite: true, homepage })).toEqual({
+      score: 100,
+      reasons: [],
+    });
+    expect(homepage.hasRestaurantJsonLd).toBe(true);
+  });
+});

--- a/src/lib/lead-discovery.ts
+++ b/src/lib/lead-discovery.ts
@@ -1,0 +1,428 @@
+import {
+  normalizeImportSource,
+  storedImportSource,
+} from "@/lib/import-identity";
+import { restaurantLinkKeywordHints } from "@/lib/verticals/restaurant/providers";
+
+/**
+ * Cheap homepage signals only. A local runner cannot afford Lighthouse or a
+ * headless browser for 50 businesses: no LCP/CLS, no painted layout, and no
+ * JS-rendered menu. Scoring uses the first HTML response, headers, and href
+ * text.
+ */
+export const LEAD_DISCOVERY_CHEAP_CHECKS = [
+  "website listed",
+  "final URL is https",
+  "viewport meta present",
+  "viewport is not a fixed desktop width",
+  "frameset or Flash markup",
+  "menu/carte href or link text",
+  "booking/reservation href, text, or known provider",
+  "document title",
+  "html byte size and script tag count",
+  "Last-Modified header when the origin sends one",
+] as const;
+
+export const LEAD_DISCOVERY_USER_AGENT =
+  "Cornershopdev Lead Discovery/1.0 (+https://cornershop.dev; local restaurant discovery)";
+
+export type LeadDiscoveryProvider = "google_places" | "nominatim";
+
+export type HomepageSignals = {
+  isFetched: boolean;
+  finalUrl: string | null;
+  isHttps: boolean;
+  hasViewport: boolean;
+  isDesktopOnlyViewport: boolean;
+  hasDesktopOnlyMarkup: boolean;
+  hasMenuHint: boolean;
+  hasBookingHint: boolean;
+  hasTitle: boolean;
+  hasMetaDescription: boolean;
+  hasRestaurantJsonLd: boolean;
+  scriptCount: number;
+  htmlBytes: number;
+  lastModifiedAt: string | null;
+  title: string;
+  metaDescription: string;
+  pageText: string;
+};
+
+export type SiteQualityScore = {
+  score: number;
+  reasons: string[];
+};
+
+export type ProspectIdentity = {
+  source: string;
+  sourceKey: string;
+  sourceUrl: string | null;
+};
+
+const MAX_HTML_BYTES = 1_500_000;
+const MAX_REDIRECTS = 3;
+const MAX_PAGE_TEXT_CHARS = 8_000;
+
+export function buildProspectIdentity(input: {
+  websiteUrl: string | null;
+  placeId: string;
+  provider: LeadDiscoveryProvider;
+}): ProspectIdentity {
+  const websiteUrl = normalizeOptionalWebsite(input.websiteUrl);
+  if (websiteUrl) {
+    const source = storedImportSource(websiteUrl);
+    return {
+      source,
+      sourceKey: normalizeImportSource(source),
+      sourceUrl: source,
+    };
+  }
+
+  const providerKey = input.provider === "google_places" ? "google" : "osm";
+  const source = `place:${providerKey}:${input.placeId.trim()}`;
+  return {
+    source,
+    sourceKey: normalizeImportSource(source),
+    sourceUrl: null,
+  };
+}
+
+export function scoreWebsiteQuality(input: {
+  hasWebsite: boolean;
+  homepage: HomepageSignals | null;
+}): SiteQualityScore {
+  const reasons: string[] = [];
+  let score = 100;
+
+  if (!input.hasWebsite) {
+    return clampScore(60, ["No public website listed"]);
+  }
+
+  const homepage = input.homepage;
+  if (!homepage || !homepage.isFetched) {
+    return clampScore(45, [
+      "Website listed but the homepage did not respond",
+    ]);
+  }
+
+  if (!homepage.isHttps) {
+    score -= 15;
+    reasons.push("Homepage is HTTP, not HTTPS");
+  }
+  if (!homepage.hasViewport) {
+    score -= 15;
+    reasons.push("Missing mobile viewport meta");
+  } else if (homepage.isDesktopOnlyViewport) {
+    score -= 12;
+    reasons.push("Viewport looks desktop-only");
+  }
+  if (homepage.hasDesktopOnlyMarkup) {
+    score -= 10;
+    reasons.push("Homepage uses frameset or Flash");
+  }
+  if (!homepage.hasMenuHint) {
+    score -= 8;
+    reasons.push("No menu link found on the homepage");
+  }
+  if (!homepage.hasBookingHint) {
+    score -= 8;
+    reasons.push("No booking or reservation link found");
+  }
+  if (!homepage.hasTitle) {
+    score -= 5;
+    reasons.push("Homepage title is missing");
+  }
+  if (homepage.htmlBytes > 800_000) {
+    score -= 5;
+    reasons.push("Homepage HTML is unusually large");
+  }
+  if (homepage.scriptCount > 20) {
+    score -= 5;
+    reasons.push("Homepage loads many scripts");
+  }
+  if (isStaleLastModified(homepage.lastModifiedAt)) {
+    score -= 5;
+    reasons.push("Homepage Last-Modified is older than two years");
+  }
+
+  return clampScore(score, reasons);
+}
+
+export type DiscoveryFetch = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export async function fetchHomepageSignals(
+  rawUrl: string,
+  fetchImpl: DiscoveryFetch = fetch,
+): Promise<HomepageSignals> {
+  const empty = emptyHomepageSignals();
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return empty;
+  }
+  if (!isPublicHttpUrl(url)) return empty;
+
+  try {
+    for (let redirectCount = 0; redirectCount <= MAX_REDIRECTS; redirectCount += 1) {
+      const response = await fetchImpl(url, {
+        headers: {
+          Accept: "text/html,application/xhtml+xml",
+          "User-Agent": LEAD_DISCOVERY_USER_AGENT,
+        },
+        redirect: "manual",
+        signal: AbortSignal.timeout(8_000),
+      });
+
+      if ([301, 302, 303, 307, 308].includes(response.status)) {
+        const location = response.headers.get("location");
+        if (!location) return empty;
+        const next = new URL(location, url);
+        if (!isPublicHttpUrl(next)) return empty;
+        url = next;
+        continue;
+      }
+
+      if (!response.ok) return empty;
+      const contentType = response.headers.get("content-type") ?? "";
+      if (!contentType.includes("text/html")) return empty;
+
+      const html = await readLimitedBody(response);
+      return parseHomepageSignals(html, url, response.headers.get("last-modified"));
+    }
+  } catch {
+    return empty;
+  }
+
+  return empty;
+}
+
+export function parseHomepageSignals(
+  html: string,
+  finalUrl: URL,
+  lastModifiedHeader: string | null = null,
+): HomepageSignals {
+  const viewport = metaContent(html, "viewport");
+  const title =
+    decodeHtml(html.match(/<title[^>]*>([\s\S]*?)<\/title>/i)?.[1] ?? "") ||
+    metaContent(html, "og:title");
+  const metaDescription =
+    metaContent(html, "description") || metaContent(html, "og:description");
+  const pageText = stripMarkup(html).slice(0, MAX_PAGE_TEXT_CHARS);
+
+  return {
+    isFetched: true,
+    finalUrl: finalUrl.toString(),
+    isHttps: finalUrl.protocol === "https:",
+    hasViewport: viewport.length > 0,
+    isDesktopOnlyViewport: isDesktopOnlyViewport(viewport),
+    hasDesktopOnlyMarkup:
+      /<frameset\b/i.test(html) || /shockwave-flash|application\/x-shockwave-flash/i.test(html),
+    hasMenuHint: detectMenuHint(html),
+    hasBookingHint: detectBookingHint(html),
+    hasTitle: title.length > 0,
+    hasMetaDescription: metaDescription.length > 0,
+    hasRestaurantJsonLd: detectRestaurantJsonLd(html),
+    scriptCount: (html.match(/<script\b/gi) ?? []).length,
+    htmlBytes: new TextEncoder().encode(html).length,
+    lastModifiedAt: lastModifiedHeader,
+    title,
+    metaDescription,
+    pageText,
+  };
+}
+
+function emptyHomepageSignals(): HomepageSignals {
+  return {
+    isFetched: false,
+    finalUrl: null,
+    isHttps: false,
+    hasViewport: false,
+    isDesktopOnlyViewport: false,
+    hasDesktopOnlyMarkup: false,
+    hasMenuHint: false,
+    hasBookingHint: false,
+    hasTitle: false,
+    hasMetaDescription: false,
+    hasRestaurantJsonLd: false,
+    scriptCount: 0,
+    htmlBytes: 0,
+    lastModifiedAt: null,
+    title: "",
+    metaDescription: "",
+    pageText: "",
+  };
+}
+
+function normalizeOptionalWebsite(value: string | null): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  try {
+    const url = new URL(
+      /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`,
+    );
+    if (!isPublicHttpUrl(url)) return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function isPublicHttpUrl(url: URL): boolean {
+  if (!["http:", "https:"].includes(url.protocol)) return false;
+  const hostname = url.hostname.toLowerCase();
+  if (
+    hostname === "localhost" ||
+    hostname.endsWith(".localhost") ||
+    hostname.endsWith(".local")
+  ) {
+    return false;
+  }
+  if (
+    /^(127\.|10\.|192\.168\.|169\.254\.)/.test(hostname) ||
+    /^172\.(1[6-9]|2\d|3[01])\./.test(hostname)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function isDesktopOnlyViewport(content: string): boolean {
+  if (!content) return false;
+  if (/width\s*=\s*device-width/i.test(content)) return false;
+  const width = content.match(/width\s*=\s*(\d+)/i)?.[1];
+  return width ? Number(width) >= 980 : false;
+}
+
+function detectMenuHint(html: string): boolean {
+  const sample = html.slice(0, 250_000);
+  if (
+    /href=["'][^"']*(?:\/menu\b|\/menus\b|\/carte\b|\/speise|\/carta\b)[^"']*["']/i.test(
+      sample,
+    )
+  ) {
+    return true;
+  }
+  return /<a\b[^>]*>[\s\S]{0,80}\b(?:menu|menus|la carte|carte|speisekarte)\b[\s\S]{0,80}<\/a>/i.test(
+    sample,
+  );
+}
+
+function detectBookingHint(html: string): boolean {
+  const sample = html.slice(0, 250_000).toLowerCase();
+  if (
+    restaurantLinkKeywordHints.some(
+      (hint) => hint.type === "booking" && hint.pattern.test(sample),
+    )
+  ) {
+    return true;
+  }
+  return /opentable|sevenrooms|resy|thefork|lafourchette|quandoo|zenchef|bookatable/.test(
+    sample,
+  );
+}
+
+function detectRestaurantJsonLd(html: string): boolean {
+  const scriptPattern =
+    /<script\b[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+  for (const match of html.matchAll(scriptPattern)) {
+    const raw = match[1]?.trim();
+    if (!raw) continue;
+    try {
+      if (jsonLdHasRestaurantType(JSON.parse(raw))) return true;
+    } catch {
+      // Homepage JSON-LD is often invalid; a parse failure is not a restaurant type.
+    }
+  }
+  return false;
+}
+
+function jsonLdHasRestaurantType(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(jsonLdHasRestaurantType);
+  if (typeof value !== "object" || value === null) return false;
+  const record = value as Record<string, unknown>;
+  if (jsonLdHasRestaurantType(record["@graph"])) return true;
+  const type = record["@type"];
+  const types = Array.isArray(type) ? type : [type];
+  return types.some(
+    (entry) =>
+      typeof entry === "string" &&
+      /^(Restaurant|LocalBusiness|FoodEstablishment)$/i.test(entry),
+  );
+}
+
+function isStaleLastModified(value: string | null): boolean {
+  if (!value) return false;
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return false;
+  return Date.now() - parsed > 2 * 365 * 24 * 60 * 60 * 1000;
+}
+
+function clampScore(score: number, reasons: string[]): SiteQualityScore {
+  return {
+    score: Math.min(100, Math.max(0, score)),
+    reasons,
+  };
+}
+
+function metaContent(html: string, key: string): string {
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const patterns = [
+    new RegExp(
+      `<meta[^>]+(?:property|name)=["']${escaped}["'][^>]+content=["']([^"']+)["'][^>]*>`,
+      "i",
+    ),
+    new RegExp(
+      `<meta[^>]+content=["']([^"']+)["'][^>]+(?:property|name)=["']${escaped}["'][^>]*>`,
+      "i",
+    ),
+  ];
+  for (const pattern of patterns) {
+    const match = html.match(pattern);
+    if (match?.[1]) return decodeHtml(match[1]);
+  }
+  return "";
+}
+
+function decodeHtml(value: string): string {
+  return value
+    .replaceAll("&amp;", "&")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&#39;", "'")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function stripMarkup(html: string): string {
+  return decodeHtml(
+    html
+      .replace(/<script[\s\S]*?<\/script>/gi, " ")
+      .replace(/<style[\s\S]*?<\/style>/gi, " ")
+      .replace(/<[^>]+>/g, " "),
+  );
+}
+
+async function readLimitedBody(response: Response): Promise<string> {
+  if (!response.body) return "";
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let bytes = 0;
+  let html = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    bytes += value.byteLength;
+    if (bytes > MAX_HTML_BYTES) {
+      await reader.cancel();
+      break;
+    }
+    html += decoder.decode(value, { stream: true });
+  }
+  return html + decoder.decode();
+}

--- a/src/lib/local-seo-audit.test.ts
+++ b/src/lib/local-seo-audit.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test";
+import { parseHomepageSignals } from "@/lib/lead-discovery";
+import {
+  auditLocalSeo,
+  renderLocalSeoOutreachEmail,
+} from "@/lib/local-seo-audit";
+
+const weakHomepage = parseHomepageSignals(
+  `<html><head><title>Home</title></head><body><p>Welcome</p></body></html>`,
+  new URL("http://old-bistro.example/"),
+);
+
+describe("local SEO audit", () => {
+  it("returns the five highest-weight fixes from the real checklist", () => {
+    const audit = auditLocalSeo({
+      name: "Chez Mira",
+      address: "12 Rue des Vignes, Lyon",
+      phone: "+33 4 00 00 00 00",
+      city: "Lyon",
+      websiteUrl: "http://old-bistro.example/",
+      categories: [],
+      hours: [],
+      photoCount: 0,
+      photoNewestAt: null,
+      reviewCount: 0,
+      description: "Bistro",
+      homepage: weakHomepage,
+    });
+
+    expect(audit.topFixes).toHaveLength(5);
+    expect(audit.topFixes.map((fix) => fix.id)).toEqual([
+      "nap",
+      "hours",
+      "menu",
+      "booking",
+      "categories",
+    ]);
+    expect(audit.score).toBeLessThan(50);
+    expect(audit.checks.every((entry) => entry.isPassed || entry.fix)).toBe(true);
+  });
+
+  it("renders the outreach template from audit data without invented awards", () => {
+    const audit = auditLocalSeo({
+      name: "Chez Mira",
+      address: "12 Rue des Vignes, Lyon",
+      phone: "+33 4 00 00 00 00",
+      city: "Lyon",
+      websiteUrl: "http://old-bistro.example/",
+      categories: [],
+      hours: [],
+      photoCount: 0,
+      photoNewestAt: null,
+      reviewCount: 1,
+      description: "Bistro",
+      homepage: weakHomepage,
+    });
+    const email = renderLocalSeoOutreachEmail({
+      name: "Chez Mira",
+      previewUrl: "https://cornershop.dev/preview/chez-mira",
+      audit,
+    });
+
+    expect(email.subject).toBe("5 things holding back Chez Mira on Google");
+    expect(email.text).toContain("https://cornershop.dev/preview/chez-mira");
+    for (const fix of audit.topFixes) {
+      expect(email.text).toContain(fix.title);
+      expect(email.text).toContain(fix.detail);
+    }
+    expect(email.text).not.toMatch(/michelin|best of|#1 restaurant|tripadvisor winner/i);
+    expect(email.text).toContain("not an award");
+    expect(email.text).not.toContain("guaranteed ranking");
+  });
+});

--- a/src/lib/local-seo-audit.ts
+++ b/src/lib/local-seo-audit.ts
@@ -1,0 +1,329 @@
+import { z } from "zod";
+import type { HomepageSignals } from "@/lib/lead-discovery";
+
+export const localSeoFixSchema = z.object({
+  id: z.string().min(1).max(40),
+  title: z.string().min(1).max(160),
+  detail: z.string().min(1).max(400),
+});
+
+export const localSeoCheckSchema = z.object({
+  id: z.string().min(1).max(40),
+  label: z.string().min(1).max(160),
+  isPassed: z.boolean(),
+  weight: z.number().int().min(1).max(20),
+  detail: z.string().min(1).max(400),
+  fix: localSeoFixSchema.nullable(),
+});
+
+export const localSeoAuditResultSchema = z.object({
+  score: z.number().int().min(0).max(100),
+  checks: z.array(localSeoCheckSchema).max(20),
+  topFixes: z.array(localSeoFixSchema).max(5),
+  auditedAt: z.string().trim().min(1),
+});
+
+export type LocalSeoFix = z.infer<typeof localSeoFixSchema>;
+export type LocalSeoCheck = z.infer<typeof localSeoCheckSchema>;
+export type LocalSeoAuditResult = z.infer<typeof localSeoAuditResultSchema>;
+
+export type LocalSeoAuditInput = {
+  name: string;
+  address: string | null;
+  phone: string | null;
+  city: string;
+  websiteUrl: string | null;
+  categories: string[];
+  hours: Array<{ days: string; hours: string }>;
+  photoCount: number;
+  photoNewestAt: string | null;
+  reviewCount: number | null;
+  description: string | null;
+  homepage: HomepageSignals | null;
+};
+
+export type LocalSeoOutreachEmail = {
+  subject: string;
+  text: string;
+};
+
+const PHOTO_STALE_MS = 90 * 24 * 60 * 60 * 1000;
+
+export function auditLocalSeo(input: LocalSeoAuditInput): LocalSeoAuditResult {
+  const homepage = input.homepage;
+  const pageHaystack = `${homepage?.title ?? ""} ${homepage?.pageText ?? ""}`;
+  const checks: LocalSeoCheck[] = [
+    check({
+      id: "nap",
+      label: "Name, address and phone match the homepage",
+      weight: 12,
+      isPassed: hasConsistentNap(input, pageHaystack),
+      passDetail: "The listing name, city/address, or phone appears on the homepage.",
+      failFix: {
+        title: "Make name, address and phone consistent",
+        detail:
+          "Google uses NAP consistency. Put the same public name, city, and phone on the homepage that appear on the listing.",
+      },
+    }),
+    check({
+      id: "categories",
+      label: "Primary categories are set",
+      weight: 8,
+      isPassed: input.categories.length > 0,
+      passDetail: `Categories: ${input.categories.slice(0, 4).join(", ") || "none"}.`,
+      failFix: {
+        title: "Add specific Google categories",
+        detail:
+          "The listing has no specific restaurant category. Set a primary category such as restaurant or the actual cuisine.",
+      },
+    }),
+    check({
+      id: "hours",
+      label: "Opening hours are published",
+      weight: 10,
+      isPassed: input.hours.length > 0,
+      passDetail: "Hours are present on the listing.",
+      failFix: {
+        title: "Publish opening hours",
+        detail:
+          "Google has no hours for this business. Add weekly hours so maps and search can show when you are open.",
+      },
+    }),
+    check({
+      id: "menu",
+      label: "Menu link is findable",
+      weight: 10,
+      isPassed: Boolean(homepage?.hasMenuHint),
+      passDetail: "A menu or carte link is present on the homepage.",
+      failFix: {
+        title: "Add a visible menu link",
+        detail:
+          "The homepage does not expose a menu/carte link. Google and diners both look for one above the fold.",
+      },
+    }),
+    check({
+      id: "booking",
+      label: "Booking or reservation link is findable",
+      weight: 10,
+      isPassed: Boolean(homepage?.hasBookingHint),
+      passDetail: "A booking or reservation path is present on the homepage.",
+      failFix: {
+        title: "Add a reservation or booking link",
+        detail:
+          "No booking provider or reservation link was found. Keep the existing OpenTable/TheFork/phone flow, but link it from the homepage.",
+      },
+    }),
+    check({
+      id: "photos",
+      label: "Recent listing photos",
+      weight: 8,
+      isPassed: hasAcceptablePhotos(input),
+      passDetail: photoDetail(input),
+      failFix: {
+        title: "Upload recent Google photos",
+        detail:
+          input.photoCount === 0
+            ? "The listing has no photos. Add current interior, exterior, and plate photos from the last 90 days."
+            : "The newest listing photo is older than 90 days. Add a current set so the profile does not look abandoned.",
+      },
+    }),
+    check({
+      id: "reviews",
+      label: "Google reviews are present",
+      weight: 8,
+      isPassed: (input.reviewCount ?? 0) >= 5,
+      passDetail:
+        input.reviewCount === null
+          ? "Review count was not provided by the source."
+          : `${input.reviewCount} Google reviews are listed.`,
+      failFix: {
+        title: "Earn more than a handful of Google reviews",
+        detail:
+          input.reviewCount === null || input.reviewCount === 0
+            ? "No Google review count was found. A thin profile loses local pack trust."
+            : `Only ${input.reviewCount} Google reviews were found. Ask recent diners for a genuine review; do not buy ratings.`,
+      },
+    }),
+    check({
+      id: "description",
+      label: "Business description is long enough",
+      weight: 6,
+      isPassed: descriptionLength(input) >= 80,
+      passDetail: `Description length: ${descriptionLength(input)} characters.`,
+      failFix: {
+        title: "Write a fuller Google description",
+        detail:
+          "The listing or homepage description is under 80 characters. Google has little unique copy to match local searches.",
+      },
+    }),
+    check({
+      id: "title_meta",
+      label: "Homepage title and meta description exist",
+      weight: 8,
+      isPassed: Boolean(homepage?.hasTitle && homepage.hasMetaDescription),
+      passDetail: "Title and meta description are present.",
+      failFix: {
+        title: "Fix the homepage title and meta description",
+        detail: homepage?.isFetched
+          ? "The homepage is missing a title or meta description, so Google has to guess the snippet."
+          : "The homepage could not be fetched, so title and meta could not be confirmed.",
+      },
+    }),
+    check({
+      id: "jsonld",
+      label: "Restaurant or LocalBusiness JSON-LD is present",
+      weight: 8,
+      isPassed: Boolean(homepage?.hasRestaurantJsonLd),
+      passDetail: "Homepage JSON-LD includes Restaurant or LocalBusiness.",
+      failFix: {
+        title: "Add Restaurant structured data",
+        detail:
+          "The homepage does not declare Restaurant/LocalBusiness JSON-LD with hours, menu, or booking URLs.",
+      },
+    }),
+    check({
+      id: "viewport",
+      label: "Mobile viewport is set",
+      weight: 6,
+      isPassed: Boolean(
+        homepage?.hasViewport && !homepage.isDesktopOnlyViewport,
+      ),
+      passDetail: "A mobile viewport is present.",
+      failFix: {
+        title: "Make the website usable on a phone",
+        detail: homepage?.isDesktopOnlyViewport
+          ? "The viewport is locked to a desktop width. Google treats that as a desktop-only site."
+          : "The homepage has no mobile viewport meta tag.",
+      },
+    }),
+    check({
+      id: "https",
+      label: "Homepage is served over HTTPS",
+      weight: 6,
+      isPassed: Boolean(homepage?.isHttps),
+      passDetail: "The fetched homepage is HTTPS.",
+      failFix: {
+        title: "Serve the website over HTTPS",
+        detail: input.websiteUrl
+          ? "The homepage is not HTTPS. Browsers and Google both warn on plaintext restaurant sites."
+          : "No public website was listed, so HTTPS cannot be confirmed.",
+      },
+    }),
+  ];
+
+  const failedWeight = checks
+    .filter((entry) => !entry.isPassed)
+    .reduce((sum, entry) => sum + entry.weight, 0);
+  const topFixes = checks
+    .filter((entry) => !entry.isPassed && entry.fix)
+    .sort((left, right) => right.weight - left.weight)
+    .slice(0, 5)
+    .map((entry) => entry.fix)
+    .filter((fix): fix is LocalSeoFix => fix !== null);
+
+  return localSeoAuditResultSchema.parse({
+    score: Math.min(100, Math.max(0, 100 - failedWeight)),
+    checks,
+    topFixes,
+    auditedAt: new Date().toISOString(),
+  });
+}
+
+export function renderLocalSeoOutreachEmail(input: {
+  name: string;
+  previewUrl: string;
+  audit: LocalSeoAuditResult;
+}): LocalSeoOutreachEmail {
+  const name = input.name.trim() || "your restaurant";
+  const fixes = input.audit.topFixes.slice(0, 5);
+  const lines = [
+    `I looked at how ${name} shows up on Google. These are the gaps on the public listing and homepage:`,
+    "",
+    ...fixes.map(
+      (fix, index) => `${index + 1}. ${fix.title} — ${fix.detail}`,
+    ),
+    "",
+    `I built a mobile-first preview that already covers the on-site items this audit can fix (HTTPS, mobile viewport, Restaurant markup): ${input.previewUrl}`,
+    "",
+    "This is a checklist from public data, not a ranking guarantee and not an award.",
+  ];
+
+  return {
+    subject: `5 things holding back ${name} on Google`,
+    text: lines.join("\n"),
+  };
+}
+
+function check(input: {
+  id: string;
+  label: string;
+  weight: number;
+  isPassed: boolean;
+  passDetail: string;
+  failFix: { title: string; detail: string };
+}): LocalSeoCheck {
+  return {
+    id: input.id,
+    label: input.label,
+    isPassed: input.isPassed,
+    weight: input.weight,
+    detail: input.isPassed ? input.passDetail : input.failFix.detail,
+    fix: input.isPassed
+      ? null
+      : { id: input.id, title: input.failFix.title, detail: input.failFix.detail },
+  };
+}
+
+function hasConsistentNap(input: LocalSeoAuditInput, pageHaystack: string): boolean {
+  if (!pageHaystack.trim()) return false;
+  const haystack = normalizeComparable(pageHaystack);
+  const name = normalizeComparable(input.name);
+  const city = normalizeComparable(input.city);
+  const address = normalizeComparable(input.address ?? "");
+  const phone = digitsOnly(input.phone);
+  const pageDigits = digitsOnly(pageHaystack);
+
+  const hasName = name.length >= 4 && haystack.includes(name);
+  const hasPlace =
+    (city.length >= 3 && haystack.includes(city)) ||
+    (address.length >= 8 && haystack.includes(address.slice(0, 12)));
+  const hasPhone = phone.length >= 8 && pageDigits.includes(phone.slice(-8));
+  return hasName && (hasPlace || hasPhone);
+}
+
+function hasAcceptablePhotos(input: LocalSeoAuditInput): boolean {
+  if (input.photoCount <= 0) return false;
+  if (!input.photoNewestAt) return true;
+  const parsed = Date.parse(input.photoNewestAt);
+  if (!Number.isFinite(parsed)) return true;
+  return Date.now() - parsed <= PHOTO_STALE_MS;
+}
+
+function photoDetail(input: LocalSeoAuditInput): string {
+  if (input.photoCount <= 0) return "No listing photos.";
+  if (!input.photoNewestAt) {
+    return `${input.photoCount} photos are present; recency was not provided by the source.`;
+  }
+  return `${input.photoCount} photos; newest at ${input.photoNewestAt}.`;
+}
+
+function descriptionLength(input: LocalSeoAuditInput): number {
+  const description =
+    input.description?.trim() ||
+    input.homepage?.metaDescription.trim() ||
+    "";
+  return description.length;
+}
+
+function normalizeComparable(value: string): string {
+  return value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLocaleLowerCase("en")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function digitsOnly(value: string | null): string {
+  return (value ?? "").replace(/\D+/g, "");
+}

--- a/src/lib/operator-dashboard.ts
+++ b/src/lib/operator-dashboard.ts
@@ -18,6 +18,13 @@ import {
   type SiteAnalyticsRowDto,
 } from "@/lib/analytics";
 import { getDb } from "@/lib/db";
+import {
+  compareOperatorSitesByDiscoveryScore,
+  toOperatorLeadDiscoveryView,
+  toOperatorLocalSeoAuditView,
+  type OperatorLeadDiscoveryView,
+  type OperatorLocalSeoAuditView,
+} from "@/lib/operator-lead-attributes";
 
 export type OperatorSiteRow = {
   id: string;
@@ -64,6 +71,8 @@ export type OperatorSiteRow = {
   analytics30d: SiteAnalyticsRowDto;
   pendingSourceSuggestionCount: number;
   sourceMonitorLastSuccessAt: Date | null;
+  discovery: OperatorLeadDiscoveryView | null;
+  localSeoAudit: OperatorLocalSeoAuditView | null;
 };
 
 export type OperatorDashboardData = {
@@ -123,6 +132,7 @@ export async function getOperatorDashboardData(): Promise<OperatorDashboardData>
         defaultLocale: true,
         translations: true,
         publishedSiteVersionId: true,
+        attributes: true,
         organization: {
           select: {
             _count: { select: { memberships: true } },
@@ -323,8 +333,10 @@ export async function getOperatorDashboardData(): Promise<OperatorDashboardData>
           site._count.sourceMonitorSuggestions,
         sourceMonitorLastSuccessAt:
           site.sourceMonitorState?.lastSuccessAt ?? null,
+        discovery: toOperatorLeadDiscoveryView(site.attributes),
+        localSeoAudit: toOperatorLocalSeoAuditView(site.attributes),
       };
-    }),
+    }).sort(compareOperatorSitesByDiscoveryScore),
   };
 }
 

--- a/src/lib/operator-lead-attributes.test.ts
+++ b/src/lib/operator-lead-attributes.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "bun:test";
+import {
+  compareOperatorSitesByDiscoveryScore,
+  createLeadDiscoveryRecord,
+  mergeOperatorLeadAttributes,
+  parseLeadDiscovery,
+  resolveProspectIngestAction,
+} from "@/lib/operator-lead-attributes";
+import { auditLocalSeo } from "@/lib/local-seo-audit";
+
+describe("operator lead attributes", () => {
+  it("merges discovery and audit onto the existing attributes bag", () => {
+    const discovery = createLeadDiscoveryRecord({
+      city: "Lyon",
+      placeId: "ChIJ123",
+      sourceProvider: "google_places",
+      score: 42,
+      reasons: ["No menu link found on the homepage"],
+      discoveredAt: "2026-08-19T10:00:00.000Z",
+      websiteUrl: "https://chezmira.fr",
+      rating: 4.2,
+      reviewCount: 12,
+      hasWebsite: true,
+    });
+    const audit = auditLocalSeo({
+      name: "Chez Mira",
+      address: null,
+      phone: null,
+      city: "Lyon",
+      websiteUrl: "https://chezmira.fr",
+      categories: ["restaurant"],
+      hours: [],
+      photoCount: 0,
+      photoNewestAt: null,
+      reviewCount: 12,
+      description: null,
+      homepage: null,
+    });
+
+    const merged = mergeOperatorLeadAttributes(
+      { cuisine: "Lyonnais", showMenuImages: false },
+      discovery,
+      audit,
+    );
+
+    expect(merged.cuisine).toBe("Lyonnais");
+    expect(parseLeadDiscovery(merged)?.score).toBe(42);
+    expect(merged.localSeoAudit).toMatchObject({ score: audit.score });
+  });
+
+  it("reopens mutable leads and refuses claimed ones", () => {
+    expect(resolveProspectIngestAction(null, "RESTAURANT")).toBe("create");
+    expect(
+      resolveProspectIngestAction(
+        { status: "PROSPECT", vertical: "RESTAURANT" },
+        "RESTAURANT",
+      ),
+    ).toBe("update");
+    expect(
+      resolveProspectIngestAction(
+        { status: "CLAIMED", vertical: "RESTAURANT" },
+        "RESTAURANT",
+      ),
+    ).toBe("conflict");
+  });
+
+  it("sorts scored sites worst-first and keeps unscored sites after them", () => {
+    const newest = new Date("2026-08-19T12:00:00.000Z");
+    const older = new Date("2026-08-18T12:00:00.000Z");
+    const rows = [
+      { createdAt: newest, discovery: null },
+      { createdAt: older, discovery: { score: 80 } },
+      { createdAt: newest, discovery: { score: 20 } },
+    ];
+
+    expect(
+      [...rows].sort(compareOperatorSitesByDiscoveryScore).map((row) => row.discovery?.score ?? null),
+    ).toEqual([20, 80, null]);
+  });
+});

--- a/src/lib/operator-lead-attributes.ts
+++ b/src/lib/operator-lead-attributes.ts
@@ -1,0 +1,164 @@
+import { z } from "zod";
+import type { LeadDiscoveryProvider } from "@/lib/lead-discovery";
+import {
+  localSeoAuditResultSchema,
+  type LocalSeoAuditResult,
+} from "@/lib/local-seo-audit";
+
+export const LEAD_DISCOVERY_ATTRIBUTE_KEY = "leadDiscovery";
+export const LOCAL_SEO_AUDIT_ATTRIBUTE_KEY = "localSeoAudit";
+
+export const leadDiscoveryRecordSchema = z.object({
+  city: z.string().trim().min(1).max(80),
+  placeId: z.string().trim().max(200).nullable(),
+  sourceProvider: z.enum(["google_places", "nominatim"]),
+  score: z.number().int().min(0).max(100),
+  reasons: z.array(z.string().trim().min(1).max(200)).max(20),
+  discoveredAt: z.string().trim().min(1),
+  websiteUrl: z.string().trim().max(500).nullable(),
+  rating: z.number().min(0).max(5).nullable(),
+  reviewCount: z.number().int().min(0).nullable(),
+  hasWebsite: z.boolean(),
+});
+
+export type LeadDiscoveryRecord = z.infer<typeof leadDiscoveryRecordSchema>;
+
+export type OperatorLeadDiscoveryView = {
+  score: number;
+  reasons: string[];
+  city: string | null;
+  discoveredAt: Date | null;
+  placeId: string | null;
+};
+
+export type OperatorLocalSeoAuditView = {
+  score: number;
+  topFixes: Array<{ id: string; title: string }>;
+  auditedAt: Date | null;
+};
+
+export function createLeadDiscoveryRecord(input: {
+  city: string;
+  placeId: string | null;
+  sourceProvider: LeadDiscoveryProvider;
+  score: number;
+  reasons: string[];
+  discoveredAt?: string;
+  websiteUrl: string | null;
+  rating: number | null;
+  reviewCount: number | null;
+  hasWebsite: boolean;
+}): LeadDiscoveryRecord {
+  return leadDiscoveryRecordSchema.parse({
+    city: input.city,
+    placeId: input.placeId,
+    sourceProvider: input.sourceProvider,
+    score: input.score,
+    reasons: input.reasons,
+    discoveredAt: input.discoveredAt ?? new Date().toISOString(),
+    websiteUrl: input.websiteUrl,
+    rating: input.rating,
+    reviewCount: input.reviewCount,
+    hasWebsite: input.hasWebsite,
+  });
+}
+
+export function mergeOperatorLeadAttributes(
+  existing: unknown,
+  discovery: LeadDiscoveryRecord,
+  audit: LocalSeoAuditResult | null,
+): Record<string, unknown> {
+  const current = asAttributeRecord(existing);
+  return {
+    ...current,
+    [LEAD_DISCOVERY_ATTRIBUTE_KEY]: discovery,
+    [LOCAL_SEO_AUDIT_ATTRIBUTE_KEY]:
+      audit ?? current[LOCAL_SEO_AUDIT_ATTRIBUTE_KEY] ?? null,
+  };
+}
+
+export function parseLeadDiscovery(
+  attributes: unknown,
+): LeadDiscoveryRecord | null {
+  const parsed = leadDiscoveryRecordSchema.safeParse(
+    asAttributeRecord(attributes)[LEAD_DISCOVERY_ATTRIBUTE_KEY],
+  );
+  return parsed.success ? parsed.data : null;
+}
+
+export function parseLocalSeoAudit(
+  attributes: unknown,
+): LocalSeoAuditResult | null {
+  const parsed = localSeoAuditResultSchema.safeParse(
+    asAttributeRecord(attributes)[LOCAL_SEO_AUDIT_ATTRIBUTE_KEY],
+  );
+  return parsed.success ? parsed.data : null;
+}
+
+export function toOperatorLeadDiscoveryView(
+  attributes: unknown,
+): OperatorLeadDiscoveryView | null {
+  const discovery = parseLeadDiscovery(attributes);
+  if (!discovery) return null;
+  const discoveredAt = Date.parse(discovery.discoveredAt);
+  return {
+    score: discovery.score,
+    reasons: discovery.reasons,
+    city: discovery.city,
+    discoveredAt: Number.isFinite(discoveredAt) ? new Date(discoveredAt) : null,
+    placeId: discovery.placeId,
+  };
+}
+
+export function toOperatorLocalSeoAuditView(
+  attributes: unknown,
+): OperatorLocalSeoAuditView | null {
+  const audit = parseLocalSeoAudit(attributes);
+  if (!audit) return null;
+  const auditedAt = Date.parse(audit.auditedAt);
+  return {
+    score: audit.score,
+    topFixes: audit.topFixes.map((fix) => ({ id: fix.id, title: fix.title })),
+    auditedAt: Number.isFinite(auditedAt) ? new Date(auditedAt) : null,
+  };
+}
+
+export function compareOperatorSitesByDiscoveryScore(
+  left: {
+    discovery: { score: number } | null;
+    createdAt: Date;
+  },
+  right: {
+    discovery: { score: number } | null;
+    createdAt: Date;
+  },
+): number {
+  const leftHasScore = left.discovery !== null;
+  const rightHasScore = right.discovery !== null;
+  if (leftHasScore && rightHasScore && left.discovery && right.discovery) {
+    if (left.discovery.score !== right.discovery.score) {
+      return left.discovery.score - right.discovery.score;
+    }
+  }
+  if (leftHasScore !== rightHasScore) return leftHasScore ? -1 : 1;
+  return right.createdAt.getTime() - left.createdAt.getTime();
+}
+
+export function resolveProspectIngestAction(
+  existing: { status: string; vertical: string } | null,
+  vertical: string,
+): "create" | "update" | "conflict" {
+  if (!existing) return "create";
+  if (existing.vertical !== vertical) return "conflict";
+  if (existing.status === "PROSPECT" || existing.status === "PREVIEW_READY") {
+    return "update";
+  }
+  return "conflict";
+}
+
+function asAttributeRecord(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return {};
+  }
+  return { ...(value as Record<string, unknown>) };
+}

--- a/src/lib/operator-lead-ingest-auth.test.ts
+++ b/src/lib/operator-lead-ingest-auth.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "bun:test";
+import { isOperatorLeadIngestAuthorized } from "@/lib/operator-lead-ingest-auth";
+
+describe("operator lead ingest auth", () => {
+  it("fails closed when the ingest token is missing", () => {
+    const request = new Request("https://cornershop.dev/api/admin/leads/ingest", {
+      method: "POST",
+      headers: { Authorization: "Bearer leftover-healthcheck" },
+    });
+
+    expect(
+      isOperatorLeadIngestAuthorized(request, {
+        ingestToken: "",
+        healthcheckToken: "leftover-healthcheck",
+      }),
+    ).toBe(false);
+    expect(
+      isOperatorLeadIngestAuthorized(request, {
+        ingestToken: undefined,
+        healthcheckToken: "leftover-healthcheck",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not accept HEALTHCHECK_TOKEN as the ingest credential", () => {
+    const reused = "same-token-value-should-never-be-shared";
+    const request = new Request("https://cornershop.dev/api/admin/leads/ingest", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${reused}` },
+    });
+
+    expect(
+      isOperatorLeadIngestAuthorized(request, {
+        ingestToken: reused,
+        healthcheckToken: reused,
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts only the dedicated ingest bearer token", () => {
+    const authorized = new Request(
+      "https://cornershop.dev/api/admin/leads/ingest",
+      {
+        method: "POST",
+        headers: { Authorization: "Bearer ingest-token" },
+      },
+    );
+    const unauthorized = new Request(
+      "https://cornershop.dev/api/admin/leads/ingest",
+      {
+        method: "POST",
+        headers: { Authorization: "Bearer healthcheck-token" },
+      },
+    );
+
+    expect(
+      isOperatorLeadIngestAuthorized(authorized, {
+        ingestToken: "ingest-token",
+        healthcheckToken: "healthcheck-token",
+      }),
+    ).toBe(true);
+    expect(
+      isOperatorLeadIngestAuthorized(unauthorized, {
+        ingestToken: "ingest-token",
+        healthcheckToken: "healthcheck-token",
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/lib/operator-lead-ingest-auth.ts
+++ b/src/lib/operator-lead-ingest-auth.ts
@@ -1,0 +1,27 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+
+export const OPERATOR_LEAD_INGEST_ACTOR = "operator:ingest-token";
+
+export function isOperatorLeadIngestAuthorized(
+  request: Request,
+  tokens: {
+    ingestToken?: string | null;
+    healthcheckToken?: string | null;
+  } = {
+    ingestToken: process.env.OPERATOR_LEAD_INGEST_TOKEN,
+    healthcheckToken: process.env.HEALTHCHECK_TOKEN,
+  },
+): boolean {
+  const ingestToken = tokens.ingestToken?.trim() ?? "";
+  const healthcheckToken = tokens.healthcheckToken?.trim() ?? "";
+  if (!ingestToken) return false;
+  if (healthcheckToken && ingestToken === healthcheckToken) return false;
+
+  const authorization = request.headers.get("authorization");
+  const suppliedToken = authorization?.match(/^Bearer ([^\s]+)$/i)?.[1];
+  if (!suppliedToken) return false;
+
+  const suppliedHash = createHash("sha256").update(suppliedToken).digest();
+  const expectedHash = createHash("sha256").update(ingestToken).digest();
+  return timingSafeEqual(suppliedHash, expectedHash);
+}

--- a/src/lib/operator-lead-ingest.ts
+++ b/src/lib/operator-lead-ingest.ts
@@ -1,0 +1,222 @@
+import "server-only";
+import { Prisma } from "@/generated/prisma/client";
+import { getDb } from "@/lib/db";
+import {
+  buildImportUrls,
+  normalizeImportSource,
+  slugCollisionCandidate,
+  storedImportSource,
+} from "@/lib/import-identity";
+import {
+  createLeadDiscoveryRecord,
+  mergeOperatorLeadAttributes,
+  resolveProspectIngestAction,
+} from "@/lib/operator-lead-attributes";
+import { OperatorLeadError } from "@/lib/operator-leads";
+import { OPERATOR_LEAD_INGEST_ACTOR } from "@/lib/operator-lead-ingest-auth";
+import type { LeadDiscoveryProvider } from "@/lib/lead-discovery";
+import type { LocalSeoAuditResult } from "@/lib/local-seo-audit";
+import { slugify } from "@/lib/verticals/restaurant/schema";
+import type { VerticalId } from "@/lib/verticals/types";
+
+export type IngestOperatorProspectInput = {
+  source: string;
+  vertical: VerticalId;
+  name: string;
+  phone?: string | null;
+  address?: string | null;
+  city: string;
+  placeId?: string | null;
+  websiteUrl?: string | null;
+  rating?: number | null;
+  reviewCount?: number | null;
+  score: number;
+  reasons: string[];
+  discoveredAt?: string;
+  sourceProvider?: LeadDiscoveryProvider;
+  audit?: LocalSeoAuditResult | null;
+};
+
+export type IngestOperatorProspectResult = {
+  siteSlug: string;
+  importJobId: null;
+  created: boolean;
+  reopened: boolean;
+  urls: { preview: string; claim: string };
+};
+
+export async function ingestOperatorProspectLead(
+  input: IngestOperatorProspectInput,
+): Promise<IngestOperatorProspectResult> {
+  const source = input.source.trim();
+  const sourceKey = normalizeImportSource(source);
+  const sourceUrl = looksLikeStoredUrl(source) ? storedImportSource(source) : null;
+  const vertical = input.vertical;
+  const discovery = createLeadDiscoveryRecord({
+    city: input.city,
+    placeId: input.placeId ?? null,
+    sourceProvider: input.sourceProvider ?? "nominatim",
+    score: input.score,
+    reasons: input.reasons,
+    discoveredAt: input.discoveredAt,
+    websiteUrl: input.websiteUrl ?? sourceUrl,
+    rating: input.rating ?? null,
+    reviewCount: input.reviewCount ?? null,
+    hasWebsite: Boolean(input.websiteUrl ?? sourceUrl),
+  });
+  const db = getDb();
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      return await db.$transaction(async (tx) => {
+        const existing = await tx.site.findUnique({
+          where: { sourceKey },
+          select: {
+            id: true,
+            slug: true,
+            status: true,
+            vertical: true,
+            phone: true,
+            address: true,
+            sourceUrl: true,
+            attributes: true,
+          },
+        });
+        const action = resolveProspectIngestAction(existing, vertical);
+        if (action === "conflict") {
+          throw new OperatorLeadError(
+            "This business is already claimed and cannot be reopened as a prospect.",
+            409,
+          );
+        }
+
+        const attributes = mergeOperatorLeadAttributes(
+          existing?.attributes,
+          discovery,
+          input.audit ?? null,
+        ) as Prisma.InputJsonValue;
+        const phone = firstNonEmpty(input.phone, existing?.phone);
+        const address = firstNonEmpty(input.address, existing?.address);
+        const nextSourceUrl =
+          firstNonEmpty(input.websiteUrl, existing?.sourceUrl) ?? sourceUrl;
+
+        if (existing && action === "update") {
+          await tx.site.update({
+            where: { id: existing.id },
+            data: {
+              name: input.name,
+              phone,
+              address,
+              sourceUrl: nextSourceUrl,
+              attributes,
+            },
+          });
+          await tx.auditEvent.create({
+            data: {
+              type: "site.lead.ingest.updated",
+              actor: OPERATOR_LEAD_INGEST_ACTOR,
+              metadata: {
+                sourceKey,
+                city: discovery.city,
+                score: discovery.score,
+                placeId: discovery.placeId,
+                previousStatus: existing.status,
+              },
+              siteId: existing.id,
+            },
+          });
+          return {
+            siteSlug: existing.slug,
+            importJobId: null,
+            created: false,
+            reopened: true,
+            urls: buildImportUrls(existing.slug),
+          };
+        }
+
+        const slug = await reserveProspectSlug(tx, input.name, vertical);
+        const created = await tx.site.create({
+          data: {
+            slug,
+            name: input.name,
+            eyebrow: `${input.city} prospect`,
+            phone,
+            address,
+            sourceUrl: nextSourceUrl,
+            sourceKey,
+            vertical,
+            status: "PROSPECT",
+            attributes,
+          },
+          select: { id: true, slug: true },
+        });
+        await tx.auditEvent.create({
+          data: {
+            type: "site.lead.ingested",
+            actor: OPERATOR_LEAD_INGEST_ACTOR,
+            metadata: {
+              sourceKey,
+              city: discovery.city,
+              score: discovery.score,
+              placeId: discovery.placeId,
+            },
+            siteId: created.id,
+          },
+        });
+        return {
+          siteSlug: created.slug,
+          importJobId: null,
+          created: true,
+          reopened: false,
+          urls: buildImportUrls(created.slug),
+        };
+      });
+    } catch (error) {
+      if (error instanceof OperatorLeadError) throw error;
+      if (attempt < 2 && isRetryablePrismaError(error)) continue;
+      throw error;
+    }
+  }
+
+  throw new OperatorLeadError("The prospect lead could not be ingested.", 503);
+}
+
+async function reserveProspectSlug(
+  tx: Prisma.TransactionClient,
+  name: string,
+  vertical: VerticalId,
+): Promise<string> {
+  const requestedSlug = slugify(name) || vertical.toLowerCase();
+  for (let collisionIndex = 0; collisionIndex < 100; collisionIndex += 1) {
+    const candidate = slugCollisionCandidate(requestedSlug, collisionIndex);
+    const collision = await tx.site.findUnique({
+      where: { slug: candidate },
+      select: { id: true },
+    });
+    if (!collision) return candidate;
+  }
+  throw new OperatorLeadError("A unique preview URL could not be reserved.", 409);
+}
+
+function firstNonEmpty(
+  incoming: string | null | undefined,
+  existing: string | null | undefined,
+): string | null {
+  const next = incoming?.trim();
+  if (next) return next;
+  const current = existing?.trim();
+  return current || null;
+}
+
+function looksLikeStoredUrl(source: string): boolean {
+  return /^(?:https?:\/\/|www\.)/i.test(source.trim());
+}
+
+function isRetryablePrismaError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error.code === "P2002" || error.code === "P2034")
+  );
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -178,6 +178,21 @@ export function limitOperatorLeadMutation(
   });
 }
 
+/**
+ * Laptop discovery posts one prospect per restaurant. A 50-city run plus a
+ * safe retry budget has to fit the hourly window without sharing the cookie
+ * admin-import bucket.
+ */
+export function limitOperatorLeadIngest(
+  request: Request,
+): Promise<RateLimitResult> {
+  return limitByIp(request, {
+    namespace: "operator-lead-ingest",
+    limit: 80,
+    windowMs,
+  });
+}
+
 export function limitMagicLinkRequest(
   request: Request,
 ): Promise<RateLimitResult> {

--- a/src/lib/restaurant-json-ld.test.ts
+++ b/src/lib/restaurant-json-ld.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+import { restaurantThemeFixtures } from "@/lib/site-themes/restaurant/fixtures";
+import { buildRestaurantJsonLd } from "@/lib/restaurant-json-ld";
+
+describe("restaurant JSON-LD", () => {
+  it("emits Restaurant markup with hours, menu, and booking URLs", () => {
+    const fixture = restaurantThemeFixtures["terroir-editorial"];
+    const jsonLd = buildRestaurantJsonLd({
+      ...fixture,
+      sourceUrl: "https://maison-serein.example/",
+      businessHours: [{ days: "Tuesday–Saturday", hours: "19:00–22:30" }],
+    });
+
+    expect(jsonLd).toMatchObject({
+      "@context": "https://schema.org",
+      "@type": "Restaurant",
+      name: fixture.name,
+      telephone: fixture.phone,
+      url: "https://maison-serein.example/",
+      servesCuisine: "Seasonal Mediterranean",
+      menu: "https://maison-serein.example/#menu",
+      acceptsReservations: "https://www.sevenrooms.com",
+      openingHours: ["Tuesday–Saturday 19:00–22:30"],
+    });
+    expect(jsonLd.address).toEqual({
+      "@type": "PostalAddress",
+      streetAddress: fixture.address,
+    });
+  });
+});

--- a/src/lib/restaurant-json-ld.ts
+++ b/src/lib/restaurant-json-ld.ts
@@ -1,0 +1,70 @@
+import type { SiteDraftView } from "@/lib/site-draft";
+
+export type RestaurantJsonLd = {
+  "@context": "https://schema.org";
+  "@type": "Restaurant";
+  name: string;
+  description?: string;
+  telephone?: string;
+  url?: string;
+  servesCuisine?: string;
+  address?: {
+    "@type": "PostalAddress";
+    streetAddress: string;
+  };
+  openingHours?: string[];
+  menu?: string;
+  acceptsReservations?: string | boolean;
+};
+
+export function buildRestaurantJsonLd(draft: SiteDraftView): RestaurantJsonLd {
+  const booking = draft.integrations.find(
+    (integration) => integration.enabled && integration.type === "booking",
+  );
+  const cuisine =
+    typeof draft.attributes.cuisine === "string"
+      ? draft.attributes.cuisine.trim()
+      : "";
+  const canonicalUrl = draft.sourceUrl ?? undefined;
+  const hasMenu = draft.catalogSections.some((section) => section.items.length > 0);
+  const menuUrl = hasMenu && canonicalUrl ? `${stripHash(canonicalUrl)}#menu` : undefined;
+  const hours = draft.businessHours
+    .map((entry) => `${entry.days} ${entry.hours}`.trim())
+    .filter(Boolean);
+
+  const jsonLd: RestaurantJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Restaurant",
+    name: draft.name,
+  };
+  if (draft.description.trim()) jsonLd.description = draft.description.trim();
+  if (draft.phone.trim()) jsonLd.telephone = draft.phone.trim();
+  if (canonicalUrl) jsonLd.url = canonicalUrl;
+  if (cuisine) jsonLd.servesCuisine = cuisine;
+  if (draft.address.trim()) {
+    jsonLd.address = {
+      "@type": "PostalAddress",
+      streetAddress: draft.address.trim(),
+    };
+  }
+  if (hours.length > 0) jsonLd.openingHours = hours;
+  if (menuUrl) jsonLd.menu = menuUrl;
+  if (booking) jsonLd.acceptsReservations = booking.url;
+  else if (hasMenu) jsonLd.acceptsReservations = false;
+
+  return jsonLd;
+}
+
+export function serializeRestaurantJsonLd(draft: SiteDraftView): string {
+  return JSON.stringify(buildRestaurantJsonLd(draft)).replaceAll("<", "\\u003c");
+}
+
+function stripHash(url: string): string {
+  try {
+    const parsed = new URL(url);
+    parsed.hash = "";
+    return parsed.toString();
+  } catch {
+    return url.split("#")[0] ?? url;
+  }
+}


### PR DESCRIPTION
## Why

The operator console still has no way to *find* restaurants. First-customer validation issues assume a list of leads; this PR fills that list from a local runner and a scored GBP/local-SEO audit, then persists lightweight PROSPECT stubs so `/admin` is the single place to work them.

## What shipped

- Local runner: `bun run leads:discover -- --vertical restaurant --city <city> [--limit N] [--api-url https://cornershop.dev] [--execute]`
- Google Places API (New) text search when `GOOGLE_PLACES_API_KEY` is set; OSM/Nominatim fallback with a Cornershopdev User-Agent
- Cheap homepage scoring (0–100) + `reasons[]` without Lighthouse or a headless browser
- Local-SEO audit stored on the lead, top 5 fixes, and a pure `renderLocalSeoOutreachEmail` helper for later outreach PRs
- Admin console columns for score, top reasons, city, discoveredAt, and audit fixes; scored rows sort worst-first inside the existing 200-row cap
- Restaurant/LocalBusiness JSON-LD on the published live surface (theme renderer + legacy restaurant renderer)

## Ingest-token deviation from cookie admin POST

Laptop → production cannot use cookie CSRF admin POST (`isSameOriginMutation(..., { requireOrigin: true })` rejects a CLI). This PR adds `POST /api/admin/leads/ingest`:

- Authorization: `Bearer $OPERATOR_LEAD_INGEST_TOKEN` (new env, empty placeholder in `.env.example`)
- Does **not** reuse `HEALTHCHECK_TOKEN` (fail-closed if they are identical)
- No cookie, no Origin requirement (the token is the credential)
- Redis rate limit via a dedicated `limitOperatorLeadIngest` bucket (80/hour)
- Idempotent on normalized `sourceKey`
- Writes `AuditEvent` actor `operator:ingest-token`
- Never starts Workflow and never sends mail

Discovery metadata lives on existing `Site.attributes` (`leadDiscovery` / `localSeoAudit`) so this does not collide with open PR #102 schema edits.

## How to run

```bash
# dry-run (default, no POST)
bun run leads:discover -- --vertical restaurant --city Valletta --limit 50

# persist to a configured API (not run in this session)
OPERATOR_LEAD_INGEST_TOKEN=... bun run leads:discover -- --vertical restaurant --city Valletta --limit 50 --api-url https://cornershop.dev --execute
```

Env:

- `OPERATOR_LEAD_INGEST_TOKEN` — required for `--execute`
- `GOOGLE_PLACES_API_KEY` — optional; Nominatim is the fallback
- `--api-url` defaults to `https://cornershop.dev`

## Scoring without a browser

Computed from the first HTML response and headers: website listed, HTTPS, viewport meta, desktop-only viewport/frameset/Flash, menu/carte href text, booking/reservation hints, title, HTML size, script count, Last-Modified. Not computed: Lighthouse, LCP/CLS, painted layout, JS-rendered menus, real photo recency unless the source sends a date.

## What is NOT included

- No auto email
- No full AI/crawl import for each hit (operator later imports a URL from `/admin`)
- No owner `/dashboard` Local SEO panel (audit is shown in `/admin`; the template helper is ready for PR #102)
- No schema migration / new columns

## Tests

Focused suites cover sourceKey dedupe, ingest auth fail-closed, scoring reasons, audit top-5, and the outreach template using real audit data.

`bun test` — 298 passed, 20 skipped, 0 failed
`bunx tsc --noEmit --incremental false --pretty false` — passed (after `next typegen`)
`bun run lint` — 0 errors (existing generated Workflow-route warning)

Closes #91
Closes #96

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New bearer-authenticated admin ingest endpoint can create/update prospect records at scale; auth is token-scoped and rate-limited, but misconfiguration or token leak would affect lead data.
> 
> **Overview**
> Adds a **local lead-discovery pipeline** so operators can find restaurant prospects by city, score their public web presence, and (optionally) persist **PROSPECT** stubs into production without cookie-based admin POSTs.
> 
> **`bun run leads:discover`** discovers places via Google Places (New) when `GOOGLE_PLACES_API_KEY` is set, otherwise OSM/Nominatim. For each hit it builds a deduped `sourceKey`, fetches cheap homepage HTML signals, computes a 0–100 website quality score with `reasons[]`, runs a weighted **local SEO audit** (top five fixes), and can dry-run JSON or **`--execute`** POST each candidate to **`POST /api/admin/leads/ingest`** using **`OPERATOR_LEAD_INGEST_TOKEN`** (distinct from `HEALTHCHECK_TOKEN`, timing-safe bearer check, dedicated Redis rate limit). Ingest is idempotent on `sourceKey`, merges `leadDiscovery` / `localSeoAudit` into existing `Site.attributes`, creates or reopens unclaimed prospects, and writes audit events—no workflow or email.
> 
> **`/admin`** gains columns for discovery score, city, discovered date, and local SEO fixes; the sites table sorts **worst discovery scores first** among the existing 200-row cap.
> 
> Published **restaurant** surfaces emit **Restaurant JSON-LD** when analytics is enabled (theme renderer and legacy `SiteRenderer` path).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef03a3cf37b916e6e18d6d3283d16eabb8adceed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->