### PR TITLE
fix(preview): unfurl customer sites as the business, not the factory

### DIFF
--- a/src/app/preview/[slug]/[locale]/page.tsx
+++ b/src/app/preview/[slug]/[locale]/page.tsx
@@ -2,6 +2,12 @@ import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { SiteRenderer } from "@/components/site-renderer";
+import { FACTORY_BRAND } from "@/lib/brand";
+import {
+  customerHostname,
+  factoryMetadataOrigin,
+  previewMetadata,
+} from "@/lib/preview-metadata";
 import { getSiteLocales, localizeSiteDraft } from "@/lib/site-draft";
 import { liveSiteVersionId } from "@/lib/site-surface";
 import {
@@ -17,44 +23,35 @@ export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
   const { slug, locale } = await params;
-  const versionId = liveSiteVersionId(await headers(), slug);
+  const requestHeaders = await headers();
+  const versionId = liveSiteVersionId(requestHeaders, slug);
   const site = versionId
     ? await findPublishedSiteView(slug, versionId)
     : await findSiteView(slug);
   if (!site) notFound();
-  const liveSurface = versionId !== null;
+  const isLiveSurface = versionId !== null;
   const locales = getSiteLocales(site.draft);
   if (!locales.includes(locale)) notFound();
+  const draft = localizeSiteDraft(site.draft, locale);
 
-  return {
-    title: liveSurface
-      ? site.draft.name
-      : `${site.draft.name} — Private preview`,
-    robots: liveSurface
-      ? { index: true, follow: true }
-      : { index: false, follow: false },
-    alternates: {
-      canonical: liveSurface
-        ? locale === site.draft.defaultLocale
-          ? "/"
-          : `/${locale}`
-        : locale === site.draft.defaultLocale
-          ? `/preview/${slug}`
-          : `/preview/${slug}/${locale}`,
-      languages: Object.fromEntries(
-        locales.map((availableLocale) => [
-          availableLocale,
-          liveSurface
-            ? availableLocale === site.draft.defaultLocale
-              ? "/"
-              : `/${availableLocale}`
-            : availableLocale === site.draft.defaultLocale
-              ? `/preview/${slug}`
-              : `/preview/${slug}/${availableLocale}`,
-        ]),
-      ),
+  return previewMetadata(
+    {
+      name: site.draft.name,
+      description: draft.description,
+      slug: site.draft.slug,
+      defaultLocale: site.draft.defaultLocale,
     },
-  };
+    {
+      isLiveSurface,
+      locale,
+      locales,
+      verifiedHostname: isLiveSurface
+        ? customerHostname(requestHeaders)
+        : null,
+      factoryOrigin: factoryMetadataOrigin(),
+      factoryName: FACTORY_BRAND.name,
+    },
+  );
 }
 
 export default async function LocalizedPreviewPage({ params }: PageProps) {
@@ -64,7 +61,7 @@ export default async function LocalizedPreviewPage({ params }: PageProps) {
     ? await findPublishedSiteView(slug, versionId)
     : await findSiteView(slug);
   if (!site) notFound();
-  const liveSurface = versionId !== null;
+  const isLiveSurface = versionId !== null;
   const locales = getSiteLocales(site.draft);
   if (!locales.includes(locale)) notFound();
 
@@ -74,9 +71,9 @@ export default async function LocalizedPreviewPage({ params }: PageProps) {
       vertical={site.vertical}
       theme={site.theme}
       locale={locale}
-      localeBasePath={liveSurface ? "/" : `/preview/${slug}`}
+      localeBasePath={isLiveSurface ? "/" : `/preview/${slug}`}
       availableLocales={locales}
-      analyticsEnabled={liveSurface}
+      analyticsEnabled={isLiveSurface}
     />
   );
 }

--- a/src/app/preview/[slug]/opengraph-image.tsx
+++ b/src/app/preview/[slug]/opengraph-image.tsx
@@ -1,0 +1,254 @@
+import { ImageResponse } from "next/og";
+import { headers } from "next/headers";
+import { notFound } from "next/navigation";
+import {
+  factoryMetadataOrigin,
+  previewOgCard,
+  type LivePreviewOgCard,
+} from "@/lib/preview-metadata";
+import { liveSiteVersionId } from "@/lib/site-surface";
+import {
+  findPublishedSiteView,
+  findSiteView,
+} from "@/lib/sites";
+
+/**
+ * Social card for a generated customer site. Nested routes inherit the root
+ * `opengraph-image.tsx` unless this segment defines its own, which is how
+ * restaurant URLs unfurled as Cornershopdev.
+ */
+
+export const alt = "Business website";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default async function OpenGraphImage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const versionId = liveSiteVersionId(await headers(), slug);
+  const site = versionId
+    ? await findPublishedSiteView(slug, versionId)
+    : await findSiteView(slug);
+  if (!site) notFound();
+
+  const card = previewOgCard(site.draft, {
+    isLiveSurface: versionId !== null,
+  });
+  if (card.kind === "unpublished") {
+    return new ImageResponse(<UnpublishedCard name={card.name} />, size);
+  }
+
+  if (card.heroImageUrl) {
+    const heroSrc = await loadHeroImageSrc(
+      resolvePublicUrl(card.heroImageUrl, factoryMetadataOrigin()),
+    );
+    if (heroSrc) {
+      return new ImageResponse(
+        <HeroCard card={card} heroSrc={heroSrc} />,
+        size,
+      );
+    }
+  }
+
+  return new ImageResponse(<BrandedCard card={card} />, size);
+}
+
+function UnpublishedCard({ name }: { name: string }) {
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-between",
+        padding: "72px",
+        color: "#2C2F2B",
+        background: "#E8E6E1",
+        fontFamily: "Arial, sans-serif",
+      }}
+    >
+      <div style={{ display: "flex", fontSize: 22, color: "#6B6E68" }}>
+        Private preview
+      </div>
+      <div
+        style={{
+          display: "flex",
+          maxWidth: 960,
+          fontSize: name.length > 28 ? 64 : 84,
+          lineHeight: 0.95,
+          letterSpacing: "-3px",
+          fontWeight: 700,
+        }}
+      >
+        {name}
+      </div>
+      <div style={{ display: "flex", fontSize: 22, color: "#6B6E68" }}>
+        Not yet published
+      </div>
+    </div>
+  );
+}
+
+function BrandedCard({ card }: { card: LivePreviewOgCard }) {
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-between",
+        padding: "72px",
+        color: card.palette.foreground,
+        background: card.palette.background,
+        fontFamily: "Arial, sans-serif",
+      }}
+    >
+      <div
+        style={{
+          width: 58,
+          height: 58,
+          borderRadius: 14,
+          background: card.palette.accent,
+          color: card.palette.background,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontSize: 20,
+          fontWeight: 700,
+          letterSpacing: "-1px",
+        }}
+      >
+        {card.initials}
+      </div>
+      <div
+        style={{
+          display: "flex",
+          maxWidth: 960,
+          fontFamily: "Georgia, serif",
+          fontSize: card.name.length > 28 ? 64 : 92,
+          lineHeight: 0.95,
+          letterSpacing: "-4px",
+        }}
+      >
+        {card.name}
+      </div>
+      <div style={{ display: "flex", fontSize: 23, opacity: 0.72 }}>
+        {card.tagline}
+      </div>
+    </div>
+  );
+}
+
+function HeroCard({
+  card,
+  heroSrc,
+}: {
+  card: LivePreviewOgCard;
+  heroSrc: string;
+}) {
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        position: "relative",
+        background: card.palette.foreground,
+      }}
+    >
+      <img
+        alt=""
+        src={heroSrc}
+        width={size.width}
+        height={size.height}
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          width: "100%",
+          height: "100%",
+          objectFit: "cover",
+        }}
+      />
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "flex-end",
+          width: "100%",
+          height: "100%",
+          padding: "72px",
+          background:
+            "linear-gradient(to top, rgba(0,0,0,0.72) 0%, rgba(0,0,0,0.12) 55%, rgba(0,0,0,0) 100%)",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            color: "#FFFFFF",
+            fontFamily: "Georgia, serif",
+            fontSize: card.name.length > 28 ? 56 : 76,
+            lineHeight: 0.95,
+            letterSpacing: "-3px",
+          }}
+        >
+          {card.name}
+        </div>
+        <div
+          style={{
+            display: "flex",
+            marginTop: 18,
+            color: "rgba(255,255,255,0.86)",
+            fontSize: 26,
+            fontFamily: "Arial, sans-serif",
+          }}
+        >
+          {card.tagline}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function resolvePublicUrl(url: string, origin: string): string {
+  if (url.startsWith("https://") || url.startsWith("http://")) return url;
+  try {
+    return new URL(url, origin).href;
+  } catch {
+    return url;
+  }
+}
+
+async function loadHeroImageSrc(url: string): Promise<string | null> {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+      return null;
+    }
+    const response = await fetch(parsed);
+    if (!response.ok) return null;
+    const mediaType =
+      response.headers.get("content-type")?.split(";")[0]?.trim() ?? "";
+    if (
+      mediaType !== "image/jpeg" &&
+      mediaType !== "image/jpg" &&
+      mediaType !== "image/png" &&
+      mediaType !== "image/gif"
+    ) {
+      return null;
+    }
+    const bytes = Buffer.from(await response.arrayBuffer());
+    if (bytes.byteLength === 0 || bytes.byteLength > 4 * 1024 * 1024) {
+      return null;
+    }
+    const normalizedType = mediaType === "image/jpg" ? "image/jpeg" : mediaType;
+    return `data:${normalizedType};base64,${bytes.toString("base64")}`;
+  } catch {
+    return null;
+  }
+}

--- a/src/app/preview/[slug]/page.tsx
+++ b/src/app/preview/[slug]/page.tsx
@@ -2,6 +2,12 @@ import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { SiteRenderer } from "@/components/site-renderer";
+import { FACTORY_BRAND } from "@/lib/brand";
+import {
+  customerHostname,
+  factoryMetadataOrigin,
+  previewMetadata,
+} from "@/lib/preview-metadata";
 import { getSiteLocales } from "@/lib/site-draft";
 import { liveSiteVersionId } from "@/lib/site-surface";
 import {
@@ -17,36 +23,22 @@ export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
   const { slug } = await params;
-  const versionId = liveSiteVersionId(await headers(), slug);
+  const requestHeaders = await headers();
+  const versionId = liveSiteVersionId(requestHeaders, slug);
   const site = versionId
     ? await findPublishedSiteView(slug, versionId)
     : await findSiteView(slug);
   if (!site) notFound();
-  const liveSurface = versionId !== null;
-  const locales = getSiteLocales(site.draft);
-  return {
-    title: liveSurface
-      ? site.draft.name
-      : `${site.draft.name} — Private preview`,
-    robots: liveSurface
-      ? { index: true, follow: true }
-      : { index: false, follow: false },
-    alternates: {
-      canonical: liveSurface ? "/" : `/preview/${slug}`,
-      languages: Object.fromEntries(
-        locales.map((locale) => [
-          locale,
-          liveSurface
-            ? locale === site.draft.defaultLocale
-              ? "/"
-              : `/${locale}`
-            : locale === site.draft.defaultLocale
-              ? `/preview/${slug}`
-              : `/preview/${slug}/${locale}`,
-        ]),
-      ),
-    },
-  };
+  const isLiveSurface = versionId !== null;
+  return previewMetadata(site.draft, {
+    isLiveSurface,
+    locales: getSiteLocales(site.draft),
+    verifiedHostname: isLiveSurface
+      ? customerHostname(requestHeaders)
+      : null,
+    factoryOrigin: factoryMetadataOrigin(),
+    factoryName: FACTORY_BRAND.name,
+  });
 }
 
 export default async function PreviewPage({ params }: PageProps) {
@@ -56,16 +48,16 @@ export default async function PreviewPage({ params }: PageProps) {
     ? await findPublishedSiteView(slug, versionId)
     : await findSiteView(slug);
   if (!site) notFound();
-  const liveSurface = versionId !== null;
+  const isLiveSurface = versionId !== null;
   return (
     <SiteRenderer
       draft={site.draft}
       vertical={site.vertical}
       theme={site.theme}
       locale={site.draft.defaultLocale}
-      localeBasePath={liveSurface ? "/" : `/preview/${slug}`}
+      localeBasePath={isLiveSurface ? "/" : `/preview/${slug}`}
       availableLocales={getSiteLocales(site.draft)}
-      analyticsEnabled={liveSurface}
+      analyticsEnabled={isLiveSurface}
     />
   );
 }

--- a/src/lib/domain-routing.test.ts
+++ b/src/lib/domain-routing.test.ts
@@ -37,7 +37,7 @@ describe("custom-domain hostname plans", () => {
 });
 
 describe("customer host isolation", () => {
-  it("serves only root, locales and the two public site endpoints", () => {
+  it("serves only root, locales, public site endpoints and the OG image", () => {
     const records = livePair();
     expect(
       decideCustomerHostRoute({
@@ -77,6 +77,24 @@ describe("customer host isolation", () => {
         records,
       }).kind,
     ).toBe("public_api");
+    expect(
+      decideCustomerHostRoute({
+        hostname: "example.com",
+        pathname: "/preview/chez-lea/opengraph-image",
+        records,
+      }),
+    ).toEqual({
+      kind: "opengraph",
+      slug: "chez-lea",
+      versionId: "version_1",
+    });
+    expect(
+      decideCustomerHostRoute({
+        hostname: "example.com",
+        pathname: "/preview/chez-lea/fr/opengraph-image",
+        records,
+      }).kind,
+    ).toBe("opengraph");
 
     for (const pathname of [
       "/dashboard",
@@ -84,6 +102,7 @@ describe("customer host isolation", () => {
       "/sign-in",
       "/create",
       "/preview/chez-lea",
+      "/preview/other-site/opengraph-image",
       "/api/domains",
       "/api/sites/another/booking-requests",
     ]) {

--- a/src/lib/domain-routing.ts
+++ b/src/lib/domain-routing.ts
@@ -40,6 +40,11 @@ export type CustomerHostDecision =
       kind: "public_api";
       slug: string;
       versionId: string;
+    }
+  | {
+      kind: "opengraph";
+      slug: string;
+      versionId: string;
     };
 
 /**
@@ -89,7 +94,9 @@ export function planDomainHostnames(hostname: string): DomainHostnamePlan {
  *
  * All owner/operator routes and unrelated public APIs are denied here before
  * Next's filesystem router can see them. The two public write endpoints remain
- * available because the live renderer needs analytics and booking requests.
+ * available because the live renderer needs analytics and booking requests,
+ * and the generated Open Graph image is passed through so a crawler can fetch
+ * it from the customer host.
  */
 export function decideCustomerHostRoute(input: {
   hostname: string;
@@ -136,6 +143,13 @@ export function decideCustomerHostRoute(input: {
       versionId,
     };
   }
+  if (surface.kind === "opengraph") {
+    return {
+      kind: "opengraph",
+      slug: exact.site.slug,
+      versionId,
+    };
+  }
   return {
     kind: "page",
     slug: exact.site.slug,
@@ -178,6 +192,7 @@ function customerSurface(
 ):
   | { kind: "page"; locale: string | null }
   | { kind: "public_api" }
+  | { kind: "opengraph" }
   | { kind: "blocked" } {
   if (pathname === "/") return { kind: "page", locale: null };
   const locale = pathname.match(/^\/([a-z]{2})\/?$/i)?.[1];
@@ -189,5 +204,23 @@ function customerSurface(
   ) {
     return { kind: "public_api" };
   }
+  // Live metadataBase is the customer host, so crawlers fetch the sibling
+  // `/preview/<slug>/opengraph-image` there. Pass that file through; keep
+  // the HTML preview path itself blocked.
+  if (isSiteOgImagePath(pathname, slug)) return { kind: "opengraph" };
   return { kind: "blocked" };
+}
+
+function isSiteOgImagePath(pathname: string, slug: string): boolean {
+  const segments = pathname.replace(/\/+$/, "").split("/").filter(Boolean);
+  if (segments[0] !== "preview" || segments[1] !== slug) return false;
+  const file = segments.at(-1)?.toLowerCase();
+  const isOgFile =
+    file === "opengraph-image" ||
+    file === "twitter-image" ||
+    file === "opengraph-image.png" ||
+    file === "twitter-image.png";
+  if (!isOgFile) return false;
+  if (segments.length === 3) return true;
+  return segments.length === 4 && /^[a-z]{2}$/i.test(segments[2] ?? "");
 }

--- a/src/lib/preview-metadata.test.ts
+++ b/src/lib/preview-metadata.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "bun:test";
+import { FACTORY_BRAND } from "@/lib/brand";
+import {
+  businessInitials,
+  customerHostname,
+  factoryMetadataOrigin,
+  previewMetadata,
+  previewOgCard,
+} from "@/lib/preview-metadata";
+
+const osteria = {
+  name: "Osteria Luna",
+  description:
+    "A neighbourhood osteria serving handmade pasta, charcoal-grilled fish and the kind of long lunches that quietly become dinner.",
+  slug: "osteria-luna",
+  defaultLocale: "en",
+  eyebrow: "Seasonal Italian kitchen · Valletta",
+  heroImageUrl:
+    "https://images.unsplash.com/photo-1552566626-52f8b828add9?auto=format&fit=crop&w=1800&q=88",
+  palette: {
+    background: "#f4efe5",
+    foreground: "#1d241f",
+    accent: "#a5482d",
+  },
+};
+
+const factoryOrigin = "https://cornershop.dev";
+
+describe("previewMetadata", () => {
+  it("unfurls a live customer host as the business, not the factory", () => {
+    const metadata = previewMetadata(osteria, {
+      isLiveSurface: true,
+      locales: ["en", "fr"],
+      verifiedHostname: "osteria-luna.example",
+      factoryOrigin,
+      factoryName: FACTORY_BRAND.name,
+    });
+
+    expect(metadata.title).toEqual({ absolute: "Osteria Luna" });
+    expect(metadata.description).toBe(osteria.description);
+    expect(metadata.metadataBase).toEqual(
+      new URL("https://osteria-luna.example"),
+    );
+    expect(metadata.robots).toEqual({ index: true, follow: true });
+    expect(metadata.alternates).toEqual({
+      canonical: "/",
+      languages: { en: "/", fr: "/fr" },
+    });
+    expect(metadata.openGraph).toEqual({
+      title: "Osteria Luna",
+      description: osteria.description,
+      siteName: "Osteria Luna",
+      type: "website",
+      url: "https://osteria-luna.example/",
+    });
+    expect(metadata.twitter).toEqual({
+      card: "summary_large_image",
+      title: "Osteria Luna",
+      description: osteria.description,
+    });
+    expect(metadata.openGraph?.siteName).not.toBe("Cornershopdev");
+    expect(metadata.openGraph?.siteName).not.toBe(FACTORY_BRAND.name);
+  });
+
+  it("keeps unpublished and prospect previews noindex on the factory origin", () => {
+    const metadata = previewMetadata(osteria, {
+      isLiveSurface: false,
+      locales: ["en", "fr"],
+      verifiedHostname: "osteria-luna.example",
+      factoryOrigin,
+      factoryName: FACTORY_BRAND.name,
+    });
+
+    expect(metadata.title).toEqual({
+      absolute: "Osteria Luna — Private preview",
+    });
+    expect(metadata.robots).toEqual({ index: false, follow: false });
+    expect(metadata.metadataBase).toEqual(new URL(factoryOrigin));
+    expect(metadata.alternates).toEqual({
+      canonical: "/preview/osteria-luna",
+      languages: {
+        en: "/preview/osteria-luna",
+        fr: "/preview/osteria-luna/fr",
+      },
+    });
+    expect(metadata.openGraph).toEqual({
+      title: "Osteria Luna — Private preview",
+      description: osteria.description,
+      siteName: "Cornershopdev",
+      type: "website",
+      url: "https://cornershop.dev/preview/osteria-luna",
+    });
+    expect(metadata.twitter?.title).toBe("Osteria Luna — Private preview");
+  });
+
+  it("falls back to the factory preview URL when a live site has no verified domain", () => {
+    const metadata = previewMetadata(osteria, {
+      isLiveSurface: true,
+      locale: "fr",
+      locales: ["en", "fr"],
+      verifiedHostname: null,
+      factoryOrigin,
+      factoryName: FACTORY_BRAND.name,
+    });
+
+    expect(metadata.openGraph?.siteName).toBe("Osteria Luna");
+    expect(metadata.metadataBase).toEqual(new URL(factoryOrigin));
+    expect(metadata.alternates?.canonical).toBe("/preview/osteria-luna/fr");
+    expect(metadata.openGraph?.url).toBe(
+      "https://cornershop.dev/preview/osteria-luna/fr",
+    );
+  });
+});
+
+describe("previewOgCard", () => {
+  it("uses the published hero on a live customer surface", () => {
+    expect(
+      previewOgCard(osteria, { isLiveSurface: true }),
+    ).toEqual({
+      kind: "live",
+      name: "Osteria Luna",
+      tagline: "Seasonal Italian kitchen · Valletta",
+      initials: "OL",
+      heroImageUrl: osteria.heroImageUrl,
+      palette: osteria.palette,
+    });
+  });
+
+  it("falls back to a brand-colored card when a live site has no hero", () => {
+    expect(
+      previewOgCard(
+        { ...osteria, heroImageUrl: "  " },
+        { isLiveSurface: true },
+      ),
+    ).toMatchObject({
+      kind: "live",
+      heroImageUrl: null,
+      tagline: osteria.eyebrow,
+      palette: osteria.palette,
+    });
+  });
+
+  it("does not promote an unpublished prospect with a restaurant hero", () => {
+    expect(
+      previewOgCard(osteria, { isLiveSurface: false }),
+    ).toEqual({
+      kind: "unpublished",
+      name: "Osteria Luna",
+    });
+  });
+});
+
+describe("preview metadata helpers", () => {
+  it("reads a customer hostname and ignores factory and niche hosts", () => {
+    expect(
+      customerHostname(
+        new Headers({ "x-forwarded-host": " Osteria-Luna.Example:443 " }),
+      ),
+    ).toBe("osteria-luna.example");
+    expect(
+      customerHostname(new Headers({ host: "cornershop.dev" })),
+    ).toBeNull();
+    expect(
+      customerHostname(new Headers({ host: "restofront.com" })),
+    ).toBeNull();
+  });
+
+  it("derives the factory metadata origin from NEXT_PUBLIC_APP_URL", () => {
+    expect(factoryMetadataOrigin("https://cornershop.dev/dashboard")).toBe(
+      "https://cornershop.dev",
+    );
+    expect(factoryMetadataOrigin("not a url")).toBe("https://cornershop.dev");
+  });
+
+  it("takes initials from the first two words", () => {
+    expect(businessInitials("Le Petit Meunier")).toBe("LP");
+    expect(businessInitials("Noma")).toBe("NO");
+  });
+});

--- a/src/lib/preview-metadata.ts
+++ b/src/lib/preview-metadata.ts
@@ -1,0 +1,194 @@
+import type { Metadata } from "next";
+import { isFactoryHostname } from "@/lib/hostnames";
+import { requestHostname } from "@/lib/request-hostname";
+import type { SitePaletteView } from "@/lib/site-draft";
+
+export type PreviewMetadataDraft = {
+  name: string;
+  description: string;
+  slug: string;
+  defaultLocale: string;
+};
+
+export type PreviewMetadataOptions = {
+  isLiveSurface: boolean;
+  locale?: string;
+  locales: string[];
+  /**
+   * Verified customer hostname from the incoming live request (proxy-attested).
+   * Platform subdomains are a separate issue; this never invents one.
+   */
+  verifiedHostname: string | null;
+  factoryOrigin: string;
+  factoryName: string;
+};
+
+export type PreviewOgDraft = {
+  name: string;
+  description: string;
+  eyebrow: string;
+  heroImageUrl: string | null;
+  palette: SitePaletteView;
+};
+
+export type LivePreviewOgCard = {
+  kind: "live";
+  name: string;
+  tagline: string;
+  initials: string;
+  heroImageUrl: string | null;
+  palette: SitePaletteView;
+};
+
+export type UnpublishedPreviewOgCard = {
+  kind: "unpublished";
+  name: string;
+};
+
+export type PreviewOgCard = LivePreviewOgCard | UnpublishedPreviewOgCard;
+
+const PRIVATE_PREVIEW_SUFFIX = "Private preview";
+
+/**
+ * Customer-site metadata. Nested `openGraph` / `twitter` objects merge
+ * shallowly with the root layout, so both are restated in full — otherwise
+ * `/preview/[slug]` and every customer host rewritten to it inherit the
+ * factory Cornershopdev card.
+ */
+export function previewMetadata(
+  site: PreviewMetadataDraft,
+  options: PreviewMetadataOptions,
+): Metadata {
+  const title = options.isLiveSurface
+    ? site.name
+    : `${site.name} — ${PRIVATE_PREVIEW_SUFFIX}`;
+  const description = site.description.trim() || site.name;
+  const metadataBase = new URL(
+    liveCustomerOrigin(options.verifiedHostname, options.isLiveSurface) ??
+      options.factoryOrigin,
+  );
+  const canonicalPath = previewCanonicalPath(site, options);
+  const canonicalUrl = new URL(canonicalPath, metadataBase).href;
+  const siteName = options.isLiveSurface ? site.name : options.factoryName;
+
+  return {
+    // Absolute so the root "| Cornershopdev" template stays off a live
+    // restaurant tab and off the private-preview title string.
+    title: { absolute: title },
+    description,
+    metadataBase,
+    robots: options.isLiveSurface
+      ? { index: true, follow: true }
+      : { index: false, follow: false },
+    alternates: {
+      canonical: canonicalPath,
+      languages: Object.fromEntries(
+        options.locales.map((locale) => [
+          locale,
+          previewCanonicalPath(site, { ...options, locale }),
+        ]),
+      ),
+    },
+    openGraph: {
+      title,
+      description,
+      siteName,
+      type: "website",
+      url: canonicalUrl,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+    },
+  };
+}
+
+export function previewOgCard(
+  site: PreviewOgDraft,
+  options: { isLiveSurface: boolean },
+): PreviewOgCard {
+  if (!options.isLiveSurface) {
+    return { kind: "unpublished", name: site.name };
+  }
+
+  const heroImageUrl = site.heroImageUrl?.trim() || null;
+  return {
+    kind: "live",
+    name: site.name,
+    tagline: previewTagline(site),
+    initials: businessInitials(site.name),
+    heroImageUrl,
+    palette: site.palette,
+  };
+}
+
+export function factoryMetadataOrigin(
+  configured: string | undefined = process.env.NEXT_PUBLIC_APP_URL,
+): string {
+  try {
+    return new URL(configured ?? "https://cornershop.dev").origin;
+  } catch {
+    return "https://cornershop.dev";
+  }
+}
+
+/**
+ * Hostname a live customer request actually arrived on. Factory and niche
+ * marketing hosts never count — those are not a restaurant's own domain.
+ */
+export function customerHostname(
+  headers: Pick<Headers, "get">,
+): string | null {
+  const hostname = requestHostname(headers);
+  if (!hostname || isFactoryHostname(hostname)) return null;
+  return hostname;
+}
+
+export function businessInitials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length >= 2) {
+    const first = parts[0]?.[0];
+    const second = parts[1]?.[0];
+    if (first && second) return `${first}${second}`.toUpperCase();
+  }
+  const compact = parts[0] ?? "";
+  const initials = compact.slice(0, 2).toUpperCase();
+  return initials || "?";
+}
+
+function liveCustomerOrigin(
+  verifiedHostname: string | null,
+  isLiveSurface: boolean,
+): string | null {
+  if (!isLiveSurface) return null;
+  const hostname = verifiedHostname?.trim().toLowerCase();
+  if (!hostname || isFactoryHostname(hostname)) return null;
+  return `https://${hostname}`;
+}
+
+function previewCanonicalPath(
+  site: PreviewMetadataDraft,
+  options: Pick<
+    PreviewMetadataOptions,
+    "isLiveSurface" | "locale" | "verifiedHostname"
+  >,
+): string {
+  const locale = options.locale ?? site.defaultLocale;
+  const isDefaultLocale = locale === site.defaultLocale;
+  if (liveCustomerOrigin(options.verifiedHostname, options.isLiveSurface)) {
+    return isDefaultLocale ? "/" : `/${locale}`;
+  }
+
+  return isDefaultLocale
+    ? `/preview/${site.slug}`
+    : `/preview/${site.slug}/${locale}`;
+}
+
+function previewTagline(site: PreviewOgDraft): string {
+  const eyebrow = site.eyebrow.trim();
+  if (eyebrow) return eyebrow;
+  const description = site.description.trim();
+  if (description.length <= 160) return description;
+  return `${description.slice(0, 157).trimEnd()}…`;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -130,7 +130,7 @@ export async function proxy(request: NextRequest) {
 
   upstreamHeaders.set(LIVE_SITE_SLUG_HEADER, decision.slug);
   upstreamHeaders.set(LIVE_SITE_VERSION_HEADER, decision.versionId);
-  if (decision.kind === "public_api") {
+  if (decision.kind === "public_api" || decision.kind === "opengraph") {
     return NextResponse.next({ request: { headers: upstreamHeaders } });
   }
   const destination = decision.locale


### PR DESCRIPTION
## Why

Follow-up from #90 (niche storefront cards). `/preview/[slug]` and every customer hostname rewritten to it still inherited the root `opengraph-image.tsx` and Cornershopdev metadata, so a restaurant sharing its own site on WhatsApp/Instagram showed the factory card.

Two causes, same as #90:

1. `generateMetadata` set `title`/`robots`/`alternates` but not `openGraph`/`twitter`, so Next's shallow metadata merge inherited the root layout's objects wholesale (including `siteName: "Cornershopdev"`).
2. The only `opengraph-image.tsx` lived at the app root, which every nested route inherits.

## What

- `generateMetadata` on `/preview/[slug]` and `/preview/[slug]/[locale]` fully restates `openGraph` (title, description, siteName, url, type) and `twitter` (`summary_large_image`). Live customer surfaces use **the business name** as `title`/`siteName` and the verified hostname as `metadataBase`/canonical; unpublished/PROSPECT previews stay `noindex` with a `Private preview` title and factory `siteName`.
- Absolute titles so the root `| Cornershopdev` template stays off a restaurant tab.
- Canonical is the custom domain when the live request arrived on a verified customer host; otherwise the factory `/preview/<slug>` URL. Does not invent platform subdomains (#98).
- New `src/app/preview/[slug]/opengraph-image.tsx` (1200×630), on demand (dynamic slugs, no `generateStaticParams`):
  - Live with a hero: full-bleed hero + name + tagline
  - Live without a hero: palette-colored card with initials, name, tagline
  - Unpublished/PROSPECT: neutral card — not the factory Cornershopdev marketing card, not a fake live restaurant promo
- Customer hosts now pass `/preview/<slug>/opengraph-image` through so crawlers can fetch the sibling image from the same origin as the shared URL. The HTML preview path stays blocked.

Preview-segment OG lives under `src/app/preview/[slug]/` so it does not fight #100's hostname-aware root `opengraph-image.tsx`. `generateMetadata` only adds `openGraph`/`twitter`/`metadataBase` on the preview pages so it can merge with #101 ISR later.

## Verification

- `bun test` — **291 pass / 20 skip / 0 fail**
- `eslint` — clean
- `tsc --noEmit` — same pre-existing `RouteContext` errors as `main`; none in these files
- `next build` — green (CI `DATABASE_URL` / `BETTER_AUTH_SECRET` placeholders)

Closes #99.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches custom-domain allowlists and proxy routing plus public metadata/OG generation; behavior is well-tested but incorrect hostname or OG passthrough could affect SEO or leak factory branding.
> 
> **Overview**
> Customer preview and live custom-domain pages now emit **full** Open Graph and Twitter metadata via shared `previewMetadata`, so shallow merges no longer leave the root layout’s Cornershopdev `siteName` on restaurant shares. **Live** surfaces use the business name, description, absolute title, and—when the request is on a verified customer host—the custom domain as `metadataBase` and canonical; **private previews** stay `noindex` with a “Private preview” title and factory branding.
> 
> A new **`/preview/[slug]/opengraph-image`** route generates per-site social cards (hero overlay, branded palette card, or neutral unpublished card). **Customer hostname routing** and the **proxy** now allow only that OG image path through on custom domains (HTML `/preview/...` stays blocked) so crawlers fetch the image from the same origin as the shared URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6953ff6a3a9e7637b87cd5c10259393187f4d3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->