### PR TITLE
fix(operations): harden operator alert delivery

### DIFF
--- a/deploy/aws/deploy.sh
+++ b/deploy/aws/deploy.sh
@@ -164,13 +164,17 @@ docker rm -f "$previous" >/dev/null 2>&1 || true
 
 monitor_service="/etc/systemd/system/cornershopdev-public-health.service"
 monitor_timer="/etc/systemd/system/cornershopdev-public-health.timer"
+alert_service="/etc/systemd/system/cornershopdev-operator-alerts.service"
+alert_timer="/etc/systemd/system/cornershopdev-operator-alerts.timer"
 temporary_monitor_service="$(mktemp /etc/systemd/system/cornershopdev-public-health.service.XXXXXX)"
 temporary_monitor_timer="$(mktemp /etc/systemd/system/cornershopdev-public-health.timer.XXXXXX)"
-trap 'rm -f "$temporary_environment" "$artifact_file" "$temporary_monitor_service" "$temporary_monitor_timer"' EXIT
+temporary_alert_service="$(mktemp /etc/systemd/system/cornershopdev-operator-alerts.service.XXXXXX)"
+temporary_alert_timer="$(mktemp /etc/systemd/system/cornershopdev-operator-alerts.timer.XXXXXX)"
+trap 'rm -f "$temporary_environment" "$artifact_file" "$temporary_monitor_service" "$temporary_monitor_timer" "$temporary_alert_service" "$temporary_alert_timer"' EXIT
 
 {
   printf '%s\n' '[Unit]'
-  printf '%s\n' 'Description=Cornershopdev public-site health and operator alert check'
+  printf '%s\n' 'Description=Cornershopdev public-site health check'
   printf '%s\n' 'After=docker.service network-online.target'
   printf '%s\n' 'Wants=network-online.target'
   printf '\n%s\n' '[Service]'
@@ -191,9 +195,35 @@ trap 'rm -f "$temporary_environment" "$artifact_file" "$temporary_monitor_servic
   printf '%s\n' 'WantedBy=timers.target'
 } >"$temporary_monitor_timer"
 
+{
+  printf '%s\n' '[Unit]'
+  printf '%s\n' 'Description=Dispatch due Cornershopdev operator alerts'
+  printf '%s\n' 'After=docker.service network-online.target'
+  printf '%s\n' 'Wants=network-online.target'
+  printf '\n%s\n' '[Service]'
+  printf '%s\n' 'Type=oneshot'
+  printf '%s\n' 'TimeoutStartSec=45s'
+  printf '%s\n' "ExecStart=/usr/bin/docker run --rm --network shipshit --memory 256m --cpus 0.25 --env-file ${environment_file} --entrypoint bun ${image_name} run operator:dispatch-alerts"
+} >"$temporary_alert_service"
+
+{
+  printf '%s\n' '[Unit]'
+  printf '%s\n' 'Description=Dispatch Cornershopdev operator alerts every minute'
+  printf '\n%s\n' '[Timer]'
+  printf '%s\n' 'OnBootSec=1min'
+  printf '%s\n' 'OnUnitActiveSec=1min'
+  printf '%s\n' 'RandomizedDelaySec=15s'
+  printf '%s\n' 'Persistent=true'
+  printf '\n%s\n' '[Install]'
+  printf '%s\n' 'WantedBy=timers.target'
+} >"$temporary_alert_timer"
+
 install -m 644 "$temporary_monitor_service" "$monitor_service"
 install -m 644 "$temporary_monitor_timer" "$monitor_timer"
+install -m 644 "$temporary_alert_service" "$alert_service"
+install -m 644 "$temporary_alert_timer" "$alert_timer"
 systemctl daemon-reload
 systemctl enable --now cornershopdev-public-health.timer >/dev/null
+systemctl enable --now cornershopdev-operator-alerts.timer >/dev/null
 
 echo "Cornershopdev deployment is healthy: ${image_name}"

--- a/docs/operations/platform-services.md
+++ b/docs/operations/platform-services.md
@@ -33,11 +33,11 @@ Inject `PRODUCTION_DATABASE_URL` and `PREVIEW_DATABASE_URL` into that process
 from the approved secret stores; do not put either value in shell history. The
 command first compares normalized host, port, database, and schema identifiers,
 then opens read-only transactions and compares the observed server/database
-identities. It rejects credential-only differences, local hosts, malformed
-values, matching configuration, matching observed identities, and unreachable
-targets. Attach its hash-only JSON output to the release record; never attach
-the input URLs. This proves database identity separation, not provider backup
-policy.
+identities. It rejects credential-only differences, IPv4 and bracketed or
+unbracketed IPv6 loopback hosts, malformed values, matching configuration,
+matching observed identities, and unreachable targets. Attach its hash-only
+JSON output to the release record; never attach the input URLs. This proves
+database identity separation, not provider backup policy.
 
 After configuring production, redeploy it and request `/api/health/ready`. The
 route returns `200` only when the runtime services and billing configuration are
@@ -119,7 +119,9 @@ The command writes separate `original-hero` and enhanced `hero` fixtures through
 exact SHA-256 content, and deletes both in a `finally` cleanup. Output contains
 only fixture labels, digests, cleanup status, environment, and timestamp—never
 bucket names, keys, URLs, credentials, or provider error bodies. A run without
-`--execute` performs no write. Do not claim the production round trip until the
+`--execute` performs no write. When verification and cleanup both fail, the
+output retains the primary write/read or content-mismatch failure and reports
+`cleanup: failed` separately. Do not claim the production round trip until the
 real command succeeds and cleanup is recorded as `completed`.
 
 ## Runtime operator alerts
@@ -128,21 +130,36 @@ Checkout webhook infrastructure failures, persisted-draft or server publication
 failures, and failed public `/api/health/live` checks create a durable
 `OperatorAlert`. The fingerprint deduplicates each incident for 15 minutes.
 Delivery uses the configured factory sender and `OPERATOR_ALERT_EMAILS`, leases
-each row against concurrent workers, and stops after three attempts (one, five,
-and fifteen-minute retry spacing). Recipient addresses and provider responses
-are absent from alert rows, readiness responses, and command output.
+each row against concurrent workers, and stops after three total attempts:
+immediate delivery, retries after one and five minutes, then terminal exhaustion
+after the third failure. A database or delivery exception for one row is counted
+as pending and does not prevent later alerts in the same batch from running.
+Recipient addresses and provider responses are absent from alert rows,
+readiness responses, and command output.
+
+Stripe webhook failure responses schedule their operator alert with Next.js
+`after`, which sends the response without waiting for Resend while extending the
+request lifecycle until alert capture settles. Do not replace this with a
+floating promise; it may be dropped after the response completes.
 
 Production deploys install a local systemd timer named
 `cornershopdev-public-health.timer`. Every two minutes it starts the exact
-deployed image with the encrypted environment file, retries due alerts, and
-checks the public HTTPS endpoint. This uses the existing host and providers; it
-creates no separate billable monitoring service.
+deployed image with the encrypted environment file and checks the public HTTPS
+endpoint. Alert draining is deliberately isolated in
+`cornershopdev-operator-alerts.timer`, which runs every minute and processes at
+most five rows per invocation. Five worst-case five-second delivery timeouts
+consume 25 seconds inside its 45-second service limit; a saturated alert queue
+therefore cannot delay or terminate the independent public health check. Both
+timers use the existing host and providers; they create no separate billable
+monitoring service.
 
 Useful commands:
 
 ```bash
 systemctl status cornershopdev-public-health.timer
 journalctl -u cornershopdev-public-health.service --since '30 minutes ago'
+systemctl status cornershopdev-operator-alerts.timer
+journalctl -u cornershopdev-operator-alerts.service --since '30 minutes ago'
 docker exec api-cornershop-dev bun run operator:dispatch-alerts
 ```
 

--- a/scripts/monitor-public-site.ts
+++ b/scripts/monitor-public-site.ts
@@ -1,7 +1,4 @@
-import {
-  captureOperatorAlert,
-  dispatchDueOperatorAlerts,
-} from "@/lib/operator-alerts";
+import { captureOperatorAlert } from "@/lib/operator-alerts";
 import { getDb } from "@/lib/db";
 
 const execute = process.argv.slice(2).includes("--execute");
@@ -19,7 +16,6 @@ if (target.protocol !== "https:" && process.env.NODE_ENV === "production") {
   throw new Error("Production public health monitoring requires HTTPS.");
 }
 
-const retryOutcomes = await dispatchDueOperatorAlerts().catch(() => null);
 let timeout: ReturnType<typeof setTimeout> | undefined;
 try {
   const response = await Promise.race([
@@ -38,7 +34,6 @@ try {
     JSON.stringify({
       command: "monitor-public-site",
       healthy: true,
-      retryOutcomes,
       checkedOrigin: target.origin,
       checkedAt: new Date().toISOString(),
     }),
@@ -57,7 +52,6 @@ try {
       command: "monitor-public-site",
       healthy: false,
       alertOutcome: outcome,
-      retryOutcomes,
       checkedOrigin: target.origin,
       checkedAt: new Date().toISOString(),
     }),

--- a/scripts/verify-image-storage-roundtrip.ts
+++ b/scripts/verify-image-storage-roundtrip.ts
@@ -9,11 +9,15 @@ import {
   storageObjectKeyFromUrl,
   storeSiteImage,
 } from "@/lib/storage/images";
+import {
+  imageStorageVerificationFailure,
+  type ImageStorageCleanupStatus,
+} from "@/lib/image-storage-verification";
 
 class SafeVerificationError extends Error {
   constructor(
     readonly code: string,
-    readonly cleanup: "not-required" | "completed" | "failed" | "unknown",
+    readonly cleanup: ImageStorageCleanupStatus | "unknown",
   ) {
     super(code);
     this.name = "SafeVerificationError";
@@ -68,7 +72,7 @@ async function verifyRoundTrip(args: string[]) {
   const keys: string[] = [];
   const checks: Array<{ label: string; digest: string }> = [];
   let failure: string | null = null;
-  let cleanup: "not-required" | "completed" | "failed" = "not-required";
+  let cleanup: ImageStorageCleanupStatus = "not-required";
 
   try {
     for (const fixture of fixtures) {
@@ -115,11 +119,17 @@ async function verifyRoundTrip(args: string[]) {
     }
   }
 
-  if (cleanup === "failed") {
-    throw new SafeVerificationError("cleanup_failed", cleanup);
-  }
-  if (failure || checks.length !== 2) {
-    throw new SafeVerificationError(failure ?? "incomplete_roundtrip", cleanup);
+  const verificationFailure = imageStorageVerificationFailure({
+    primaryFailure: failure,
+    cleanup,
+    completedChecks: checks.length,
+    expectedChecks: fixtures.length,
+  });
+  if (verificationFailure) {
+    throw new SafeVerificationError(
+      verificationFailure.failure,
+      verificationFailure.cleanup,
+    );
   }
   return {
     command: "verify-image-storage-roundtrip",

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -1,4 +1,5 @@
 import type Stripe from "stripe";
+import { after } from "next/server";
 import { getDb } from "@/lib/db";
 import { getStripe } from "@/lib/stripe";
 import { processStripeWebhookEvent } from "@/lib/stripe-webhook";
@@ -10,14 +11,16 @@ export async function POST(request: Request) {
   const signature = request.headers.get("stripe-signature");
   const secret = process.env.STRIPE_WEBHOOK_SECRET;
   if (!secret) {
-    await captureOperatorAlert({
-      kind: "CHECKOUT_WEBHOOK_FAILURE",
-      dedupKey: "webhook-configuration",
-      title: "Stripe webhook configuration is missing",
-      message:
-        "A Stripe webhook reached the application without a configured signing secret. Restore the encrypted parameter and redeploy.",
-      context: { category: "configuration" },
-    });
+    after(() =>
+      captureOperatorAlert({
+        kind: "CHECKOUT_WEBHOOK_FAILURE",
+        dedupKey: "webhook-configuration",
+        title: "Stripe webhook configuration is missing",
+        message:
+          "A Stripe webhook reached the application without a configured signing secret. Restore the encrypted parameter and redeploy.",
+        context: { category: "configuration" },
+      }),
+    );
     return Response.json(
       { error: "Stripe webhook is not configured" },
       { status: 400 },
@@ -39,14 +42,16 @@ export async function POST(request: Request) {
   }
 
   if (!process.env.DATABASE_URL) {
-    await captureOperatorAlert({
-      kind: "CHECKOUT_WEBHOOK_FAILURE",
-      dedupKey: "webhook-persistence",
-      title: "Stripe webhook persistence is unavailable",
-      message:
-        "A signed webhook could not reach PostgreSQL. Stripe will retry; restore database availability before replaying events.",
-      context: { category: "database" },
-    });
+    after(() =>
+      captureOperatorAlert({
+        kind: "CHECKOUT_WEBHOOK_FAILURE",
+        dedupKey: "webhook-persistence",
+        title: "Stripe webhook persistence is unavailable",
+        message:
+          "A signed webhook could not reach PostgreSQL. Stripe will retry; restore database availability before replaying events.",
+        context: { category: "database" },
+      }),
+    );
     return Response.json(
       { error: "Webhook persistence is unavailable" },
       { status: 503 },
@@ -66,14 +71,16 @@ export async function POST(request: Request) {
       eventType: event.type,
       error: error instanceof Error ? error.message : "unknown",
     });
-    await captureOperatorAlert({
-      kind: "CHECKOUT_WEBHOOK_FAILURE",
-      dedupKey: `${event.type}:${event.id}`,
-      title: "Stripe webhook processing failed",
-      message:
-        "A signed Stripe event returned a server failure and remains eligible for Stripe retry. Inspect the event ledger, provider status, and application logs.",
-      context: { eventId: event.id, eventType: event.type },
-    });
+    after(() =>
+      captureOperatorAlert({
+        kind: "CHECKOUT_WEBHOOK_FAILURE",
+        dedupKey: `${event.type}:${event.id}`,
+        title: "Stripe webhook processing failed",
+        message:
+          "A signed Stripe event returned a server failure and remains eligible for Stripe retry. Inspect the event ledger, provider status, and application logs.",
+        context: { eventId: event.id, eventType: event.type },
+      }),
+    );
     return Response.json(
       { error: "Webhook processing failed" },
       { status: 500 },

--- a/src/lib/environment-isolation.test.ts
+++ b/src/lib/environment-isolation.test.ts
@@ -29,13 +29,26 @@ describe("database environment isolation evidence", () => {
     ).toThrow("same database identity");
   });
 
-  it("rejects local or malformed deployment values", () => {
+  it("rejects IPv4, IPv6, or malformed local deployment values", () => {
+    for (const productionUrl of [
+      "postgresql://localhost/app",
+      "postgresql://127.0.0.1/app",
+      "postgresql://127.0.0.2/app",
+      "postgresql://[::1]:5432/app",
+    ]) {
+      expect(() =>
+        verifyDatabaseIsolation({
+          productionUrl,
+          previewUrl: "postgresql://preview.example.test/app",
+        }),
+      ).toThrow("local host");
+    }
     expect(() =>
       verifyDatabaseIsolation({
-        productionUrl: "postgresql://localhost/app",
-        previewUrl: "not-a-url",
+        productionUrl: "not-a-url",
+        previewUrl: "postgresql://preview.example.test/app",
       }),
-    ).toThrow();
+    ).toThrow("valid PostgreSQL URLs");
   });
 
   it("fingerprints observed identities without returning their components", () => {

--- a/src/lib/environment-isolation.ts
+++ b/src/lib/environment-isolation.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { normalizeHostname } from "@/lib/request-hostname";
 
 export type DatabaseIsolationEvidence = {
   isolated: true;
@@ -24,6 +25,15 @@ export function verifyDatabaseIsolation(input: {
   };
 }
 
+export function isDatabaseLoopbackHostname(hostname: string): boolean {
+  const normalized = normalizeHostname(hostname);
+  return (
+    normalized === "localhost" ||
+    normalized === "::1" ||
+    normalized.startsWith("127.")
+  );
+}
+
 function databaseIdentity(value: string): string {
   let url: URL;
   try {
@@ -34,7 +44,7 @@ function databaseIdentity(value: string): string {
   if (url.protocol !== "postgresql:" && url.protocol !== "postgres:") {
     throw new Error("Both database values must be PostgreSQL URLs.");
   }
-  if (["localhost", "127.0.0.1", "::1"].includes(url.hostname)) {
+  if (isDatabaseLoopbackHostname(url.hostname)) {
     throw new Error("Deployed database identities cannot use a local host.");
   }
   const database = decodeURIComponent(url.pathname.replace(/^\/+/, ""));

--- a/src/lib/image-storage-verification.test.ts
+++ b/src/lib/image-storage-verification.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import { imageStorageVerificationFailure } from "@/lib/image-storage-verification";
+
+describe("image storage round-trip diagnostics", () => {
+  it("preserves primary and cleanup failure evidence together", () => {
+    expect(
+      imageStorageVerificationFailure({
+        primaryFailure: "original_content_mismatch",
+        cleanup: "failed",
+        completedChecks: 0,
+        expectedChecks: 2,
+      }),
+    ).toEqual({
+      failure: "original_content_mismatch",
+      cleanup: "failed",
+    });
+  });
+
+  it("reports cleanup-only and incomplete verification failures", () => {
+    expect(
+      imageStorageVerificationFailure({
+        primaryFailure: null,
+        cleanup: "failed",
+        completedChecks: 2,
+        expectedChecks: 2,
+      }),
+    ).toEqual({ failure: "cleanup_failed", cleanup: "failed" });
+    expect(
+      imageStorageVerificationFailure({
+        primaryFailure: null,
+        cleanup: "completed",
+        completedChecks: 1,
+        expectedChecks: 2,
+      }),
+    ).toEqual({ failure: "incomplete_roundtrip", cleanup: "completed" });
+  });
+});

--- a/src/lib/image-storage-verification.ts
+++ b/src/lib/image-storage-verification.ts
@@ -1,0 +1,25 @@
+export type ImageStorageCleanupStatus =
+  | "not-required"
+  | "completed"
+  | "failed";
+
+export type ImageStorageVerificationFailure = {
+  failure: string;
+  cleanup: ImageStorageCleanupStatus;
+};
+
+export function imageStorageVerificationFailure(input: {
+  primaryFailure: string | null;
+  cleanup: ImageStorageCleanupStatus;
+  completedChecks: number;
+  expectedChecks: number;
+}): ImageStorageVerificationFailure | null {
+  const failure =
+    input.primaryFailure ??
+    (input.cleanup === "failed"
+      ? "cleanup_failed"
+      : input.completedChecks !== input.expectedChecks
+        ? "incomplete_roundtrip"
+        : null);
+  return failure ? { failure, cleanup: input.cleanup } : null;
+}

--- a/src/lib/operator-alert-deployment.test.ts
+++ b/src/lib/operator-alert-deployment.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+import {
+  OPERATOR_ALERT_DELIVERY_TIMEOUT_MS,
+  OPERATOR_ALERT_DISPATCH_BATCH_SIZE,
+} from "@/lib/operator-alert-policy";
+
+const deployScript = await Bun.file(
+  new URL("../../deploy/aws/deploy.sh", import.meta.url),
+).text();
+const monitorScript = await Bun.file(
+  new URL("../../scripts/monitor-public-site.ts", import.meta.url),
+).text();
+
+describe("operator alert service deployment", () => {
+  it("keeps alert draining out of the public health service", () => {
+    expect(deployScript).toContain(
+      "run operator:monitor-public-site --execute",
+    );
+    expect(deployScript).toContain("run operator:dispatch-alerts");
+    expect(monitorScript).not.toContain("dispatchDueOperatorAlerts");
+    expect(deployScript).toContain(
+      "systemctl enable --now cornershopdev-public-health.timer",
+    );
+    expect(deployScript).toContain(
+      "systemctl enable --now cornershopdev-operator-alerts.timer",
+    );
+  });
+
+  it("keeps a saturated alert batch inside its service timeout", () => {
+    const alertService = deployScript.match(
+      /Description=Dispatch due Cornershopdev operator alerts[\s\S]*?TimeoutStartSec=(\d+)s[\s\S]*?operator:dispatch-alerts/,
+    );
+    expect(alertService).not.toBeNull();
+    const serviceTimeoutMs = Number(alertService?.[1]) * 1_000;
+    const saturatedBatchDeliveryMs =
+      OPERATOR_ALERT_DISPATCH_BATCH_SIZE *
+      OPERATOR_ALERT_DELIVERY_TIMEOUT_MS;
+
+    expect(saturatedBatchDeliveryMs).toBe(25_000);
+    expect(saturatedBatchDeliveryMs).toBeLessThan(serviceTimeoutMs);
+  });
+});

--- a/src/lib/operator-alert-dispatch.test.ts
+++ b/src/lib/operator-alert-dispatch.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+import {
+  dispatchOperatorAlertBatch,
+  OPERATOR_ALERT_DELIVERY_TIMEOUT_MS,
+  OPERATOR_ALERT_DISPATCH_BATCH_SIZE,
+  operatorAlertFailureState,
+} from "@/lib/operator-alert-policy";
+
+describe("operator alert batch dispatch", () => {
+  it("continues after an individual alert raises an error", async () => {
+    const attempted: string[] = [];
+
+    const outcomes = await dispatchOperatorAlertBatch(
+      ["alert_1", "alert_2"],
+      async (id) => {
+        attempted.push(id);
+        if (id === "alert_1") throw new Error("transient claim failure");
+        return "delivered";
+      },
+    );
+
+    expect(attempted).toEqual(["alert_1", "alert_2"]);
+    expect(outcomes.pending).toBe(1);
+    expect(outcomes.delivered).toBe(1);
+  });
+
+  it("exhausts the third failure without an unreachable retry", () => {
+    expect(
+      operatorAlertFailureState(3, new Date("2026-08-20T10:00:00.000Z")),
+    ).toEqual({ status: "EXHAUSTED" });
+  });
+
+  it("bounds a saturated dispatch batch inside the service budget", () => {
+    const saturatedBatchDeliveryMs =
+      OPERATOR_ALERT_DISPATCH_BATCH_SIZE *
+      OPERATOR_ALERT_DELIVERY_TIMEOUT_MS;
+
+    expect(OPERATOR_ALERT_DISPATCH_BATCH_SIZE).toBe(5);
+    expect(saturatedBatchDeliveryMs).toBe(25_000);
+    expect(saturatedBatchDeliveryMs).toBeLessThan(45_000);
+  });
+});

--- a/src/lib/operator-alert-policy.test.ts
+++ b/src/lib/operator-alert-policy.test.ts
@@ -41,11 +41,11 @@ describe("operator alert policy", () => {
     expect(operatorAlertRetryAt(1, now).toISOString()).toBe(
       "2026-07-27T12:01:00.000Z",
     );
-    expect(operatorAlertRetryAt(3, now).toISOString()).toBe(
-      "2026-07-27T12:15:00.000Z",
+    expect(operatorAlertRetryAt(2, now).toISOString()).toBe(
+      "2026-07-27T12:05:00.000Z",
     );
-    expect(operatorAlertRetryAt(99, now).toISOString()).toBe(
-      "2026-07-27T12:15:00.000Z",
+    expect(() => operatorAlertRetryAt(3, now)).toThrow(
+      "No retry is scheduled after terminal attempt 3",
     );
   });
 

--- a/src/lib/operator-alert-policy.ts
+++ b/src/lib/operator-alert-policy.ts
@@ -3,6 +3,10 @@ import { createHash } from "node:crypto";
 export const OPERATOR_ALERT_MAX_ATTEMPTS = 3;
 export const OPERATOR_ALERT_DEDUP_WINDOW_MS = 15 * 60_000;
 export const OPERATOR_ALERT_LEASE_MS = 2 * 60_000;
+export const OPERATOR_ALERT_DISPATCH_BATCH_SIZE = 5;
+export const OPERATOR_ALERT_DELIVERY_TIMEOUT_MS = 5_000;
+
+const OPERATOR_ALERT_RETRY_DELAYS_MS = [60_000, 5 * 60_000] as const;
 
 export type OperatorAlertKind =
   | "CHECKOUT_WEBHOOK_FAILURE"
@@ -10,6 +14,14 @@ export type OperatorAlertKind =
   | "PUBLIC_SITE_HEALTH_FAILURE"
   | "OUTREACH_SEND_FAILURE"
   | "OUTREACH_REPLY";
+
+export type AlertDeliveryOutcome =
+  | "delivered"
+  | "pending"
+  | "exhausted"
+  | "deduplicated"
+  | "fallback-delivered"
+  | "unavailable";
 
 type Environment = Record<string, string | undefined>;
 
@@ -30,8 +42,43 @@ export function operatorAlertRetryAt(
   attempt: number,
   now: Date,
 ): Date {
-  const delays = [60_000, 5 * 60_000, 15 * 60_000];
-  return new Date(now.getTime() + (delays[attempt - 1] ?? delays.at(-1)!));
+  const delay = OPERATOR_ALERT_RETRY_DELAYS_MS[attempt - 1];
+  if (delay === undefined) {
+    throw new Error(
+      `No retry is scheduled after terminal attempt ${OPERATOR_ALERT_MAX_ATTEMPTS}.`,
+    );
+  }
+  return new Date(now.getTime() + delay);
+}
+
+export function operatorAlertFailureState(
+  attempt: number,
+  now: Date,
+):
+  | { status: "PENDING"; nextAttemptAt: Date }
+  | { status: "EXHAUSTED" } {
+  if (attempt >= OPERATOR_ALERT_MAX_ATTEMPTS) {
+    return { status: "EXHAUSTED" };
+  }
+  return {
+    status: "PENDING",
+    nextAttemptAt: operatorAlertRetryAt(attempt, now),
+  };
+}
+
+export async function dispatchOperatorAlertBatch(
+  ids: string[],
+  deliver: (id: string) => Promise<AlertDeliveryOutcome>,
+): Promise<Record<AlertDeliveryOutcome, number>> {
+  const totals = emptyOutcomeTotals();
+  for (const id of ids) {
+    try {
+      totals[await deliver(id)] += 1;
+    } catch {
+      totals.pending += 1;
+    }
+  }
+  return totals;
 }
 
 export function configuredOperatorAlertRecipients(
@@ -66,4 +113,15 @@ export function configuredOperatorAlertRecipients(
 
 export function safeAlertText(value: string, maxLength: number): string {
   return value.replace(/\s+/g, " ").trim().slice(0, maxLength);
+}
+
+function emptyOutcomeTotals(): Record<AlertDeliveryOutcome, number> {
+  return {
+    delivered: 0,
+    pending: 0,
+    exhausted: 0,
+    deduplicated: 0,
+    "fallback-delivered": 0,
+    unavailable: 0,
+  };
 }

--- a/src/lib/operator-alerts.ts
+++ b/src/lib/operator-alerts.ts
@@ -3,11 +3,15 @@ import { Prisma } from "@/generated/prisma/client";
 import { getDb } from "@/lib/db";
 import {
   configuredOperatorAlertRecipients,
+  dispatchOperatorAlertBatch,
+  OPERATOR_ALERT_DELIVERY_TIMEOUT_MS,
+  OPERATOR_ALERT_DISPATCH_BATCH_SIZE,
   OPERATOR_ALERT_LEASE_MS,
   OPERATOR_ALERT_MAX_ATTEMPTS,
+  operatorAlertFailureState,
   operatorAlertFingerprint,
+  type AlertDeliveryOutcome,
   type OperatorAlertKind,
-  operatorAlertRetryAt,
   safeAlertText,
 } from "@/lib/operator-alert-policy";
 import { emailSender, getResend } from "@/lib/resend";
@@ -21,13 +25,7 @@ export type CaptureOperatorAlertInput = {
   occurredAt?: Date;
 };
 
-export type AlertDeliveryOutcome =
-  | "delivered"
-  | "pending"
-  | "exhausted"
-  | "deduplicated"
-  | "fallback-delivered"
-  | "unavailable";
+export type { AlertDeliveryOutcome } from "@/lib/operator-alert-policy";
 
 export async function captureOperatorAlert(
   input: CaptureOperatorAlertInput,
@@ -70,7 +68,7 @@ export async function captureOperatorAlert(
 }
 
 export async function dispatchDueOperatorAlerts(
-  limit = 25,
+  limit = OPERATOR_ALERT_DISPATCH_BATCH_SIZE,
 ): Promise<Record<AlertDeliveryOutcome, number>> {
   const boundedLimit = Math.max(1, Math.min(100, limit));
   const ids = await getDb().operatorAlert.findMany({
@@ -83,11 +81,10 @@ export async function dispatchDueOperatorAlerts(
     take: boundedLimit,
     select: { id: true },
   });
-  const totals = emptyOutcomeTotals();
-  for (const { id } of ids) {
-    totals[await deliverOperatorAlert(id)] += 1;
-  }
-  return totals;
+  return dispatchOperatorAlertBatch(
+    ids.map(({ id }) => id),
+    deliverOperatorAlert,
+  );
 }
 
 async function deliverOperatorAlert(id: string): Promise<AlertDeliveryOutcome> {
@@ -154,19 +151,18 @@ async function deliverOperatorAlert(id: string): Promise<AlertDeliveryOutcome> {
     });
     return "delivered";
   } catch (error) {
-    const exhausted = attempt >= OPERATOR_ALERT_MAX_ATTEMPTS;
+    const failureState = operatorAlertFailureState(attempt, new Date());
     await getDb().operatorAlert.updateMany({
       where: { id, deliveryLeaseToken: leaseToken },
       data: {
-        status: exhausted ? "EXHAUSTED" : "PENDING",
+        ...failureState,
         attempts: attempt,
-        nextAttemptAt: operatorAlertRetryAt(attempt, new Date()),
         lastFailureCode: alertFailureCode(error),
         deliveryLeaseToken: null,
         deliveryLeaseUntil: null,
       },
     });
-    return exhausted ? "exhausted" : "pending";
+    return failureState.status === "EXHAUSTED" ? "exhausted" : "pending";
   }
 }
 
@@ -215,7 +211,7 @@ async function withDeliveryTimeout<T>(delivery: Promise<T>): Promise<T> {
       new Promise<never>((_resolve, reject) => {
         timeout = setTimeout(
           () => reject(new Error("Operator alert delivery timed out")),
-          5_000,
+          OPERATOR_ALERT_DELIVERY_TIMEOUT_MS,
         );
       }),
     ]);
@@ -262,17 +258,6 @@ function alertFailureCode(error: unknown): string {
     return "sender_rejected";
   }
   return "provider_error";
-}
-
-function emptyOutcomeTotals(): Record<AlertDeliveryOutcome, number> {
-  return {
-    delivered: 0,
-    pending: 0,
-    exhausted: 0,
-    deduplicated: 0,
-    "fallback-delivered": 0,
-    unavailable: 0,
-  };
 }
 
 function escapeHtml(value: string): string {

--- a/src/lib/platform-readiness.test.ts
+++ b/src/lib/platform-readiness.test.ts
@@ -118,22 +118,27 @@ describe("checkPlatformReadiness", () => {
   });
 
   it("fails deployed environments that point at a local database", async () => {
-    const serviceProbes = probes();
-    const result = await checkPlatformReadiness(
-      {
-        ...configuredEnvironment,
-        DATABASE_URL: "postgresql://localhost:5432/cornershopdev",
-      },
-      serviceProbes,
-    );
+    for (const databaseUrl of [
+      "postgresql://localhost:5432/cornershopdev",
+      "postgresql://127.0.0.1:5432/cornershopdev",
+      "postgresql://127.0.0.2:5432/cornershopdev",
+      "postgresql://[::1]:5432/cornershopdev",
+    ]) {
+      const serviceProbes = probes();
+      const result = await checkPlatformReadiness(
+        { ...configuredEnvironment, DATABASE_URL: databaseUrl },
+        serviceProbes,
+      );
 
-    expect(result.status).toBe("not_ready");
-    expect(result.services[0]).toEqual({
-      service: "database",
-      status: "misconfigured",
-      message: "DATABASE_URL must use a managed host in deployed environments.",
-    });
-    expect(serviceProbes.database).not.toHaveBeenCalled();
+      expect(result.status).toBe("not_ready");
+      expect(result.services[0]).toEqual({
+        service: "database",
+        status: "misconfigured",
+        message:
+          "DATABASE_URL must use a managed host in deployed environments.",
+      });
+      expect(serviceProbes.database).not.toHaveBeenCalled();
+    }
   });
 
   it("does not expose provider errors or credential values", async () => {

--- a/src/lib/platform-readiness.ts
+++ b/src/lib/platform-readiness.ts
@@ -2,6 +2,7 @@ import { createHash, timingSafeEqual } from "node:crypto";
 import { HeadBucketCommand, S3Client } from "@aws-sdk/client-s3";
 import { configuredBillingPlans } from "@/lib/billing-plans";
 import { getDb } from "@/lib/db";
+import { isDatabaseLoopbackHostname } from "@/lib/environment-isolation";
 import { getRedisClient } from "@/lib/redis";
 import { configuredOperatorAlertRecipients } from "@/lib/operator-alert-policy";
 
@@ -72,7 +73,7 @@ function validateDatabase(
     }
     if (
       isDeployedEnvironment(environment) &&
-      ["localhost", "127.0.0.1", "::1"].includes(url.hostname)
+      isDatabaseLoopbackHostname(url.hostname)
     ) {
       return {
         service: "database",

--- a/src/lib/stripe-webhook-route.test.ts
+++ b/src/lib/stripe-webhook-route.test.ts
@@ -1,0 +1,113 @@
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import type Stripe from "stripe";
+
+type AfterCallback = () => void | Promise<void>;
+
+const scheduledCallbacks: AfterCallback[] = [];
+const captureOperatorAlert = mock(async () => "delivered" as const);
+const constructEvent = mock(
+  () =>
+    ({
+      id: "evt_failed",
+      type: "checkout.session.completed",
+    }) as Stripe.Event,
+);
+
+mock.module("next/server", () => ({
+  after: (callback: AfterCallback) => {
+    scheduledCallbacks.push(callback);
+  },
+}));
+mock.module("@/lib/operator-alerts", () => ({ captureOperatorAlert }));
+mock.module("@/lib/stripe", () => ({
+  getStripe: () => ({ webhooks: { constructEvent } }),
+}));
+mock.module("@/lib/db", () => ({ getDb: () => ({}) }));
+
+const previousDatabaseUrl = process.env.DATABASE_URL;
+const previousWebhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+const { POST } = await import("@/app/api/webhooks/stripe/route");
+
+describe("Stripe webhook operator alert lifecycle", () => {
+  beforeEach(() => {
+    process.env.DATABASE_URL = "postgresql://unused-by-mocked-test.invalid/db";
+    process.env.STRIPE_WEBHOOK_SECRET = "whsec_configured";
+    scheduledCallbacks.length = 0;
+    captureOperatorAlert.mockClear();
+    constructEvent.mockClear();
+  });
+
+  afterAll(() => {
+    restoreEnvironment("DATABASE_URL", previousDatabaseUrl);
+    restoreEnvironment("STRIPE_WEBHOOK_SECRET", previousWebhookSecret);
+  });
+
+  it("extends the response lifecycle for missing configuration alerts", async () => {
+    delete process.env.STRIPE_WEBHOOK_SECRET;
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(400);
+    expect(captureOperatorAlert).not.toHaveBeenCalled();
+    expect(scheduledCallbacks).toHaveLength(1);
+    await scheduledCallbacks[0]!();
+    expect(captureOperatorAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "CHECKOUT_WEBHOOK_FAILURE",
+        dedupKey: "webhook-configuration",
+      }),
+    );
+  });
+
+  it("extends the response lifecycle for missing persistence alerts", async () => {
+    delete process.env.DATABASE_URL;
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(503);
+    expect(captureOperatorAlert).not.toHaveBeenCalled();
+    expect(scheduledCallbacks).toHaveLength(1);
+    await scheduledCallbacks[0]!();
+    expect(captureOperatorAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "CHECKOUT_WEBHOOK_FAILURE",
+        dedupKey: "webhook-persistence",
+      }),
+    );
+  });
+
+  it("extends the response lifecycle for processing failure alerts", async () => {
+    const originalConsoleError = console.error;
+    console.error = mock(() => {});
+    let response: Response;
+    try {
+      response = await POST(request());
+    } finally {
+      console.error = originalConsoleError;
+    }
+
+    expect(response.status).toBe(500);
+    expect(captureOperatorAlert).not.toHaveBeenCalled();
+    expect(scheduledCallbacks).toHaveLength(1);
+    await scheduledCallbacks[0]!();
+    expect(captureOperatorAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "CHECKOUT_WEBHOOK_FAILURE",
+        dedupKey: "checkout.session.completed:evt_failed",
+      }),
+    );
+  });
+});
+
+function request(): Request {
+  return new Request("https://cornershop.dev/api/webhooks/stripe", {
+    method: "POST",
+    headers: { "stripe-signature": "signed" },
+    body: "{}",
+  });
+}
+
+function restoreEnvironment(name: string, value: string | undefined) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}


### PR DESCRIPTION
## Summary
- separate bounded operator-alert draining from public health monitoring with independent systemd services and timers
- preserve primary storage-verification failures alongside cleanup evidence, normalize loopback database hosts, and expose only reachable retry delays
- schedule Stripe webhook alerts through the Next.js response lifecycle and isolate per-alert dispatch exceptions
- document the operational behavior and recovery commands

## Regression coverage
- saturated five-alert batch budget is 25 seconds under the dispatcher 45-second timeout
- webhook configuration, persistence, and processing failures execute through the scheduled response-lifecycle callback
- simultaneous round-trip and cleanup failures retain both signals
- IPv4 loopback range and bracketed IPv6 loopback database URLs are rejected
- terminal attempt three has no unreachable retry and one failed row cannot abort later alerts

## Verification
- bun test: 465 passed, 20 opt-in PostgreSQL tests skipped, 0 failed
- bun run lint
- bunx --bun next typegen and bunx --bun tsc --noEmit
- bun run design:lint
- bun run build
- shellcheck deploy/aws/*.sh
- bash deploy/aws/test-host-launcher.sh

Closes #85

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Stripe webhook post-response alerting and production systemd scheduling for checkout-related failures; scope is operational hardening with tests, not new payment logic.
> 
> **Overview**
> **Operator alerting** is split from public-site health checks: deploy installs a separate **`cornershopdev-operator-alerts`** systemd timer (every minute, **`operator:dispatch-alerts`**) while the two-minute health job only runs **`monitor-public-site`** and no longer drains the queue. Dispatch is capped at **five** rows per run with **5s** delivery timeouts, retries are **1m / 5m** then **EXHAUSTED** on the third failure (no post-terminal retry scheduling), and one row’s DB/delivery error is counted as pending without aborting the rest of the batch.
> 
> **Stripe webhook** failure paths schedule **`captureOperatorAlert`** via Next.js **`after`** so responses return before alert capture finishes.
> 
> **Safety/diagnostics:** shared **`isDatabaseLoopbackHostname`** rejects the full **127.*** range and IPv6 loopback in environment isolation and deployed readiness checks; S3 round-trip verification keeps the **primary** failure code when cleanup also fails. Runbook and regression tests document and lock in the new timers and budgets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e63a054aa4a4842e8a4929bbaaea1a868f29328a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Operator alerts are now processed independently from public health checks every minute.
  * Alert delivery retries after one and five minutes, with batches continuing when individual alerts fail.
  * Stripe webhook failures schedule alerts after the response, preserving webhook processing behavior.

* **Bug Fixes**
  * Improved detection and reporting of local or invalid database configurations.
  * Image-storage verification now distinguishes primary failures, cleanup failures, and incomplete checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->