### PR TITLE
fix(ci): isolate Lighthouse from Workflow Postgres

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,12 @@ jobs:
       - run: bun run lint
       - run: bun run design:lint
       - run: bun run build
-      - run: bun run lighthouse
+      # These static-route audits do not exercise workflows. Keep the server on
+      # the local world instead of inheriting the job's Postgres test backend.
+      - name: Lighthouse budgets
+        env:
+          WORKFLOW_TARGET_WORLD: "local"
+        run: bun run lighthouse
       - name: Show Lighthouse server log
         if: failure()
         run: cat .next/lighthouse-server.log || true

--- a/src/lib/lighthouse-ci-environment.test.ts
+++ b/src/lib/lighthouse-ci-environment.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "bun:test";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const repoRoot = path.resolve(import.meta.dir, "../..");
+
+describe("Lighthouse CI environment", () => {
+  it("uses the local Workflow world instead of inheriting Postgres", async () => {
+    const workflow = await readFile(
+      path.join(repoRoot, ".github/workflows/ci.yml"),
+      "utf8",
+    );
+
+    expect(workflow).toContain(`
+      - name: Lighthouse budgets
+        env:
+          WORKFLOW_TARGET_WORLD: "local"
+        run: bun run lighthouse
+`);
+  });
+});


### PR DESCRIPTION
## Summary
- run Lighthouse with the documented local Workflow world instead of inheriting the verify job Postgres target
- keep the existing performance and LCP assertions unchanged
- add a regression test that pins the Lighthouse step environment contract

## Root cause
The verify job exports WORKFLOW_TARGET_WORLD=@workflow/world-postgres but no WORKFLOW_POSTGRES_URL. The standalone Lighthouse server therefore used the backend default postgres://world:world@localhost:5432/world, producing repeated authentication failures against the CI service and contaminating the performance samples.

## Verification
- bun test: 466 pass, 20 skipped, 0 fail
- bun run lint: 0 errors
- bun run design:lint
- production build with WORKFLOW_TARGET_WORLD=local
- Lighthouse: 6/6 runs passed unchanged assertions; representative performance 0.92 on both routes
- isolated server log contains no Postgres, ECONN, 28P01, or unhandled rejection output
- shellcheck deploy/aws/*.sh
- bash deploy/aws/test-host-launcher.sh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only environment override for Lighthouse; no application, auth, or data-path changes.
> 
> **Overview**
> Stops Lighthouse from inheriting the verify job’s Postgres Workflow backend, which was causing auth failures and noisy performance samples.
> 
> The Lighthouse step now sets `WORKFLOW_TARGET_WORLD=local`. A small test pins that CI env contract so it does not regress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea0c86601639fe84e7332a7453cd63f5bfc81e62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->