### PR TITLE
fix(deploy): validate candidate Caddyfile inside shipshit-caddy

### DIFF
--- a/deploy/aws/bootstrap-host.sh
+++ b/deploy/aws/bootstrap-host.sh
@@ -53,10 +53,25 @@ sed -i \
   cat "$caddy_fragment_source"
 } >"$temporary_caddyfile"
 
-docker run --rm \
-  --volume "$temporary_caddyfile:/etc/caddy/Caddyfile:ro" \
-  caddy:2 \
-  caddy validate --config /etc/caddy/Caddyfile
+# Validate the candidate in the exact context that will load it. A throwaway
+# caddy:2 container cannot resolve other tenants' managed imports — e.g.
+# dailydraft's `import /config/dailydraft-*.caddy` resolves only inside
+# shipshit-caddy, which made every deploy fail closed between 2026-07-29 and
+# this fix. Run the candidate against the running binary beside the real
+# Caddyfile instead, and keep refusing to touch the live file on any failure.
+candidate_config="/etc/caddy/.cornershopdev-candidate.Caddyfile"
+validated=0
+if docker cp "$temporary_caddyfile" "shipshit-caddy:$candidate_config"; then
+  if docker exec shipshit-caddy caddy validate --config "$candidate_config"; then
+    validated=1
+  fi
+  docker exec shipshit-caddy rm -f "$candidate_config" || true
+fi
+if [[ "$validated" != 1 ]]; then
+  echo "Candidate Caddyfile did not validate inside shipshit-caddy; leaving the live config untouched" >&2
+  exit 1
+fi
+
 # Preserve the inode because the shared Caddy container bind-mounts this file.
 cat "$temporary_caddyfile" >"$caddyfile"
 chmod 644 "$caddyfile"

--- a/deploy/aws/deploy.sh
+++ b/deploy/aws/deploy.sh
@@ -15,7 +15,7 @@ readonly container="api-cornershop-dev"
 readonly candidate="${container}-candidate"
 readonly previous="${container}-previous"
 readonly deployed_sha="${image_name#cornershopdev:}"
-readonly expected_bootstrap_sha256="6bcc109b5e8d64592d31e56bc39b3881b5b7f62168595388d7c73fd966d8a9a3"
+readonly expected_bootstrap_sha256="257af17d1b20743948bb5d674d8dc12675bf45e47c697f987ed596bdcf802532"
 readonly expected_caddy_fragment_sha256="9f0bb5f0c1d9cc0e4b341b2795c6c63563aff918c4e47a8570fcecc23ec72b70"
 readonly expected_host_launcher_sha256="75aa0e06cf621dd7c9c742b6a73e45a1d8c23dc7720feab08547253f1e934abc"
 


### PR DESCRIPTION
## Summary
- The deploy bootstrap validated the merged Caddyfile in a throwaway `caddy:2` container, where other tenants' managed imports cannot resolve. dailydraft's `import /config/dailydraft-*.caddy` (added to the shared Caddyfile 2026-07-29) resolves only inside `shipshit-caddy`, so every release deploy since then failed closed at "File to import not found", aborted, and rolled back — production has been stuck on the pre-v0.3.0 image.
- The candidate is now `docker cp`'d into `shipshit-caddy` and validated with the exact running binary beside the real Caddyfile; on any failure the live config stays untouched and the script exits 1 (fail-closed preserved).
- Re-pinned `expected_bootstrap_sha256`; `test-release-bundle.sh` and `test-host-launcher.sh` pass locally.

## Test plan
- [x] `bash deploy/aws/test-release-bundle.sh` green with new checksum
- [x] `bash deploy/aws/test-host-launcher.sh` green
- [x] shellcheck clean on both modified scripts
- [x] Live-host recon: `shipshit-caddy` validates its current Caddyfile (imports resolve in-container)
- [ ] CI verify + container-runtime green
- [ ] After merge: publish a stable release and confirm `release-state production-deployed` sentinel

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Caddy configuration validation during deployment by testing changes in the active runtime environment.
  * Prevented invalid configurations from replacing the currently working configuration.
  * Added clearer deployment failure handling when validation does not succeed.

* **Chores**
  * Updated the expected integrity checksum for a deployment artifact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->