### PR TITLE
Document Restofront receiving domain for vincent@restofront.com

### DIFF
--- a/.agents/memory/production-deploy.md
+++ b/.agents/memory/production-deploy.md
@@ -5,6 +5,15 @@ status: durable
 
 # Production deploy — mechanism and gotchas
 
+## 2026-08-22 — Restofront inbound receiving verified
+
+`restofront.com` is registered in Resend with receiving enabled (sending
+disabled on the root; outbound stays on `send.restofront.com`). Route 53 carries
+the root MX (`inbound-smtp.eu-west-1.amazonaws.com`) and DKIM TXT. Resend
+domain status is `verified`, so `operator:preflight-outreach` should pass the
+`senderAndReplyDomains` gate once a release ships. Cut the next production
+release to deploy; no further code change is required for this gate.
+
 ## Release truth audit (2026-08-20)
 
 Production runs `feb674d6a39ea716ab8287aab6eeb42c183cb7b9`, not current main

--- a/docs/operations/platform-services.md
+++ b/docs/operations/platform-services.md
@@ -144,6 +144,17 @@ verified receiving-capable reply-to domain declared by its vertical config.
 An unlaunched vertical with no niche domain/sender remains discoverable and
 previewable but cannot deliver mail.
 
+Restofront uses two Resend domains on the same niche:
+
+| Resend domain | DNS | Role |
+|---------------|-----|------|
+| `send.restofront.com` | `send.send.restofront.com` MX/TXT + DKIM | Outbound `from` |
+| `restofront.com` | root MX + `resend._domainkey` TXT; receiving only | Inbound `replyTo` (`vincent@restofront.com`) |
+
+Inbound mail is webhook-driven (`email.received`); there is no IMAP mailbox.
+Operator threads live in the admin outreach panel and in Postgres, not in a
+traditional mail client.
+
 Before approving a release, run the read-only preflight inside the exact
 candidate image with its deployment env:
 

--- a/src/lib/verticals/restaurant/marketing.ts
+++ b/src/lib/verticals/restaurant/marketing.ts
@@ -19,8 +19,8 @@ export const restaurantMarketing = {
       appleTouchIconSrc: "/brand/restofrontapp/apple-touch-icon.png",
     },
   },
-  // send.restofront.com is the verified sending domain; nobody reads it, so
-  // replies are pointed at the bare domain instead.
+  // send.restofront.com is the verified sending subdomain; replies land on the
+  // niche root domain, which is the Resend receiving domain for this vertical.
   email: {
     from: "Vincent from Restofrontapp <vincent@send.restofront.com>",
     replyTo: "vincent@restofront.com",


### PR DESCRIPTION
## Summary
- Documents the verified two-domain Restofront email setup: `send.restofront.com` for outbound, `restofront.com` for inbound replies.
- Clarifies that outreach mail is webhook-driven (Resend → Postgres/admin), not IMAP.
- Records production deploy note: Resend receiving + Route 53 MX are live; next release should clear the outreach preflight `senderAndReplyDomains` gate.

## Test plan
- [x] `replyTo` remains `vincent@restofront.com` in `restaurantMarketing` (no behavior change)
- [ ] Merge and publish production release (v0.3.4)
- [ ] Confirm `operator:preflight-outreach` passes on the release image


Made with [Cursor](https://cursor.com)