### PR TITLE
chore: update repo URLs and post-org-transfer ops notes

### DIFF
--- a/.agents/memory/production-deploy.md
+++ b/.agents/memory/production-deploy.md
@@ -5,6 +5,18 @@ status: durable
 
 # Production deploy — mechanism and gotchas
 
+## 2026-08-22 — Org transfer + Vercel Pro wiring
+
+Factory repo is `cornershopdev/cornershop.dev`; studio apps live in private
+`cornershopdev/pro`. Vercel projects `servizocom` and `appservizocom` (team
+`shipshitdev`) are connected to `cornershopdev/pro` — pushes to `master`
+deploy Pulse and the Servizo marketing app.
+
+Production deploy for v0.4.0 is blocked on **Stripe**: SSM
+`/shipshit/production/cornershopdev/STRIPE_SECRET_KEY` is a 26-character
+placeholder (`sk_live_…`), not a real secret. Stripe returns 401; live
+`operator:preflight-stripe` fails until a full live key is stored.
+
 ## 2026-08-22 — Restofront inbound receiving verified
 
 `restofront.com` is registered in Resend with receiving enabled (sending
@@ -103,13 +115,13 @@ checks its workflow-supplied SHA-256 digest, and emits a verification sentinel
 before executing it. The workflow requires that sentinel, so a stale launcher
 or unverified script fails closed instead of producing a false-green deploy.
 
-## Gotcha 2 — the OIDC trust policy embeds the repo name
+## Gotcha 2 — the OIDC trust policy embeds the repo owner
 
 `cornershopdev-github-production-deploy` is assumed via GitHub OIDC. GitHub
 emits the immutable-ID subject form:
 
 ```
-repo:VincentShipsIt@1998775/cornershopdev@1304834723:environment:Production
+repo:cornershopdev@319722721/cornershop.dev@1304834723:environment:Production
 ```
 
 The numeric owner ID and repo ID survive a rename; the **name segment does
@@ -117,15 +129,20 @@ not**. The restofront→cornershopdev rename silently invalidated the trust
 policy, and the next deploy failed with `Not authorized to perform
 sts:AssumeRoleWithWebIdentity`.
 
-The policy now wildcards only the name segment via `StringLike`, keeping owner
-ID, repo ID, and the `Production` environment pinned:
+The VincentShipsIt→cornershopdev **org transfer** (2026-08-22) did the same:
+owner ID changed from `1998775` to `319722721` while repo ID `1304834723`
+stayed the same. Update the trust policy when the owner changes.
+
+The policy wildcards only the repo name segment via `StringLike`, keeping
+owner ID, repo ID, and the `Production` environment pinned:
 
 ```
-repo:VincentShipsIt@1998775/*@1304834723:environment:Production
+repo:cornershopdev@319722721/*@1304834723:environment:Production
 ```
 
-A future rename cannot break deploys the same way. Nothing in the repo defines
-this role — it is console/CLI-managed, so it will not show up in a code search.
+A future rename within the org cannot break deploys the same way. Nothing in
+the repo defines this role — it is console/CLI-managed, so it will not show
+up in a code search.
 
 ## Reaching the host
 

--- a/docs/operations/first-customer-validation.md
+++ b/docs/operations/first-customer-validation.md
@@ -2,8 +2,8 @@
 
 **Runbook version:** 2026-08-20
 
-**Issues:** [#20](https://github.com/VincentShipsIt/cornershopdev/issues/20)
-and [#47](https://github.com/VincentShipsIt/cornershopdev/issues/47)
+**Issues:** [#20](https://github.com/cornershopdev/cornershop.dev/issues/20)
+and [#47](https://github.com/cornershopdev/cornershop.dev/issues/47)
 
 **Candidate:** Le Petit Meunier
 

--- a/scripts/bootstrap-cornershopdev-github-org.sh
+++ b/scripts/bootstrap-cornershopdev-github-org.sh
@@ -106,7 +106,6 @@ write_pro_readme() {
   fi
   local workdir
   workdir="$(mktemp -d)"
-  trap 'rm -rf "${workdir}"' EXIT
   gh repo clone "${PRO_TARGET}" "${workdir}/pro" -- --depth=1
   if [[ ! -f "${workdir}/pro/README.md" ]] || ! grep -q "Cornershop Pro" "${workdir}/pro/README.md" 2>/dev/null; then
     cat >"${workdir}/pro/README.md" <<'EOF'
@@ -130,6 +129,7 @@ EOF
     git -C "${workdir}/pro" commit -m "docs: Cornershop Pro monorepo orientation" || true
     git -C "${workdir}/pro" push origin HEAD || true
   fi
+  rm -rf "${workdir}"
 }
 
 main() {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,7 +22,7 @@ import { factoryProductCatalog } from "@/lib/factory-products";
 import { listRestaurantThemeManifests } from "@/lib/site-themes/restaurant/registry";
 import styles from "./factory-home.module.css";
 
-const REPO_URL = "https://github.com/VincentShipsIt/cornershopdev";
+const REPO_URL = "https://github.com/cornershopdev/cornershop.dev";
 
 export const metadata: Metadata = {
   title: "Cornershopdev — one factory for every local business",


### PR DESCRIPTION
## Summary
- Point homepage and runbook links at `cornershopdev/cornershop.dev`
- Document cornershopdev org OIDC trust subject and Stripe deploy blocker in ops memory
- Fix bootstrap script exit trap

## Test plan
- [ ] Verify homepage links resolve to correct org/repo
- [ ] Review ops docs for accuracy
- [ ] Bootstrap script trap behavior unchanged aside from fix

Made with [Cursor](https://cursor.com)