### PR TITLE
fix(stripe): accept restricted API keys

### DIFF
--- a/.agents/memory/production-deploy.md
+++ b/.agents/memory/production-deploy.md
@@ -12,10 +12,10 @@ Factory repo is `cornershopdev/cornershop.dev`; studio apps live in private
 `shipshitdev`) are connected to `cornershopdev/pro` — pushes to `master`
 deploy Pulse and the Servizo marketing app.
 
-Production deploy for v0.4.0 is blocked on **Stripe**: SSM
-`/shipshit/production/cornershopdev/STRIPE_SECRET_KEY` is a 26-character
-placeholder (`sk_live_…`), not a real secret. Stripe returns 401; live
-`operator:preflight-stripe` fails until a full live key is stored.
+Production deploy for v0.4.0 was blocked on **Stripe**: SSM
+`/shipshit/production/cornershopdev/STRIPE_SECRET_KEY` must be a live standard
+or restricted API key (`sk_live_…` or `rk_live_…`). Publishable keys (`pk_…`)
+are rejected.
 
 ## 2026-08-22 — Restofront inbound receiving verified
 

--- a/scripts/preflight-first-customer-migration.ts
+++ b/scripts/preflight-first-customer-migration.ts
@@ -1,4 +1,5 @@
 import { getDb } from "@/lib/db";
+import { isStripeLiveApiKey } from "@/lib/billing-plans";
 import { fingerprintFirstCustomerIdentifier } from "@/lib/first-customer-evidence";
 import { getStripe } from "@/lib/stripe";
 
@@ -138,7 +139,7 @@ function parseArguments(args: string[]): Mode {
 function assertProductionConfiguration() {
   const databaseUrl = process.env.DATABASE_URL;
   const stripeKey = process.env.STRIPE_SECRET_KEY;
-  if (!databaseUrl || !stripeKey?.startsWith("sk_live_")) {
+  if (!databaseUrl || !isStripeLiveApiKey(stripeKey)) {
     throw new Error("live_configuration_required");
   }
   const database = new URL(databaseUrl);

--- a/scripts/verify-first-customer-production.ts
+++ b/scripts/verify-first-customer-production.ts
@@ -11,6 +11,7 @@ import {
   type FirstCustomerProductionManifest,
 } from "@/lib/first-customer-evidence";
 import { getDb } from "@/lib/db";
+import { isStripeLiveApiKey } from "@/lib/billing-plans";
 import {
   evidenceDigest,
   integrationUrlDigest,
@@ -682,7 +683,7 @@ function assertProductionConfiguration(
   ) {
     throw new VerificationFailure("production_database_invalid");
   }
-  if (!stripeKey.startsWith("sk_live_") || !priceId.startsWith("price_")) {
+  if (!isStripeLiveApiKey(stripeKey) || !priceId.startsWith("price_")) {
     throw new VerificationFailure("live_stripe_configuration_required");
   }
   const publicUrl = new URL(manifest.publicUrl);

--- a/src/lib/billing-plans.test.ts
+++ b/src/lib/billing-plans.test.ts
@@ -97,10 +97,12 @@ describe("Restofront founding Stripe price", () => {
     }
   });
 
-  it("derives expected mode only from an explicit Stripe secret mode", () => {
+  it("derives expected mode from standard and restricted Stripe API keys", () => {
     expect(stripeLivemodeForSecret("sk_live_example")).toBe(true);
+    expect(stripeLivemodeForSecret("rk_live_example")).toBe(true);
     expect(stripeLivemodeForSecret("sk_test_example")).toBe(false);
-    expect(() => stripeLivemodeForSecret("rk_live_example")).toThrow(
+    expect(stripeLivemodeForSecret("rk_test_example")).toBe(false);
+    expect(() => stripeLivemodeForSecret("pk_live_example")).toThrow(
       BillingConfigurationError,
     );
   });

--- a/src/lib/billing-plans.ts
+++ b/src/lib/billing-plans.ts
@@ -118,11 +118,22 @@ export function validateRestofrontFoundingPrice(
   }
 }
 
+const STRIPE_LIVE_KEY_PREFIXES = ["sk_live_", "rk_live_"] as const;
+const STRIPE_TEST_KEY_PREFIXES = ["sk_test_", "rk_test_"] as const;
+
+export function isStripeLiveApiKey(secret: string | undefined): boolean {
+  return STRIPE_LIVE_KEY_PREFIXES.some((prefix) => secret?.startsWith(prefix));
+}
+
+export function isStripeTestApiKey(secret: string | undefined): boolean {
+  return STRIPE_TEST_KEY_PREFIXES.some((prefix) => secret?.startsWith(prefix));
+}
+
 export function stripeLivemodeForSecret(
   secret: string | undefined,
 ): boolean {
-  if (secret?.startsWith("sk_live_")) return true;
-  if (secret?.startsWith("sk_test_")) return false;
+  if (isStripeLiveApiKey(secret)) return true;
+  if (isStripeTestApiKey(secret)) return false;
   throw new BillingConfigurationError("STRIPE_SECRET_KEY is not configured");
 }
 


### PR DESCRIPTION
## Summary
- Recognize `rk_live_` / `rk_test_` Stripe restricted keys alongside standard secrets
- Update first-customer production scripts to use shared `isStripeLiveApiKey` helper

## Test plan
- [x] `bun test src/lib/billing-plans.test.ts src/lib/stripe-billing-preflight.test.ts`

## Note
Live preflight still needs the `cornershop.dev` restricted key to grant **Prices Read** in Stripe, or use the standard secret key.

Made with [Cursor](https://cursor.com)