### PR TITLE
feat: launch factory SMB claims

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,7 +89,7 @@ FIRST_CUSTOMER_EVIDENCE_PUBLIC_KEY=
 # The floor, not the identity. A launched niche declares its own sender in
 # `src/lib/verticals/<niche>/marketing.ts` and that always wins — these two only
 # cover a niche with no verified sending domain of its own yet.
-EMAIL_FROM=Cornershopdev <hello@cornershop.dev>
+EMAIL_FROM=Vincent from Cornershopdev <vincent@send.cornershop.dev>
 # Where a reply lands when the fallback above was used. Leave unset and the
 # header is simply omitted.
-EMAIL_REPLY_TO=hello@cornershop.dev
+EMAIL_REPLY_TO=vincent@reply.cornershop.dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,8 @@ jobs:
       STRIPE_API_BASE_URL: http://127.0.0.1:4100
       RESEND_API_KEY: re_test_first_customer_e2e
       RESEND_API_BASE_URL: http://127.0.0.1:4100
-      EMAIL_FROM: Restofront Test <test@restaurant.example.test>
+      EMAIL_FROM: Cornershopdev Test <test@send.cornershop.example.test>
+      EMAIL_REPLY_TO: test@reply.cornershop.example.test
       WORKFLOW_ENABLED: "false"
       WORKFLOW_TARGET_WORLD: "@workflow/world-postgres"
     steps:

--- a/docs/operations/platform-services.md
+++ b/docs/operations/platform-services.md
@@ -10,15 +10,15 @@ Never copy production database or AWS credentials into pull-request builds.
 CI uses non-connecting placeholders; runtime credentials are loaded from
 encrypted SSM parameters on the EC2 host.
 
-| Service | Production isolation | Runtime variables |
-| --- | --- | --- |
-| PostgreSQL | Dedicated database and login on the existing private RDS instance | `DATABASE_URL` |
-| Workflow | PostgreSQL World with a Cornershopdev job prefix and bounded concurrency | `WORKFLOW_*` |
-| Redis | Dedicated container and persistent Docker volume, not published to the host | `REDIS_URL` |
-| Images | Private versioned S3 bucket served through CloudFront OAC | `AWS_REGION`, `S3_BUCKET`, `S3_PUBLIC_BASE_URL` |
-| Billing | Stripe Checkout, signed webhooks, and Customer Portal | `STRIPE_*`, `CLAIM_TOKEN_SECRET` |
-| Operator alerts | Durable PostgreSQL outbox delivered through Resend | `OPERATOR_ALERT_EMAILS`, `RESEND_API_KEY` |
-| Niche outreach | Explicit operator send, Workflow follow-up, separately signed Resend delivery and inbound events | `RESEND_API_KEY`, `RESEND_WEBHOOK_SECRET`, `RESEND_INBOUND_WEBHOOK_SECRET`, `WORKFLOW_*` |
+| Service         | Production isolation                                                                             | Runtime variables                                                                        |
+| --------------- | ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| PostgreSQL      | Dedicated database and login on the existing private RDS instance                                | `DATABASE_URL`                                                                           |
+| Workflow        | PostgreSQL World with a Cornershopdev job prefix and bounded concurrency                         | `WORKFLOW_*`                                                                             |
+| Redis           | Dedicated container and persistent Docker volume, not published to the host                      | `REDIS_URL`                                                                              |
+| Images          | Private versioned S3 bucket served through CloudFront OAC                                        | `AWS_REGION`, `S3_BUCKET`, `S3_PUBLIC_BASE_URL`                                          |
+| Billing         | Stripe Checkout, signed webhooks, and Customer Portal                                            | `STRIPE_*`, `CLAIM_TOKEN_SECRET`                                                         |
+| Operator alerts | Durable PostgreSQL outbox delivered through Resend                                               | `OPERATOR_ALERT_EMAILS`, `RESEND_API_KEY`                                                |
+| Niche outreach  | Explicit operator send, Workflow follow-up, separately signed Resend delivery and inbound events | `RESEND_API_KEY`, `RESEND_WEBHOOK_SECRET`, `RESEND_INBOUND_WEBHOOK_SECRET`, `WORKFLOW_*` |
 
 Preview database provisioning is still an external infrastructure gate. Do not
 mark it complete because a Preview URL exists in a local file or CI placeholder.
@@ -146,10 +146,12 @@ previewable but cannot deliver mail.
 
 Restofront uses two Resend domains on the same niche:
 
-| Resend domain | DNS | Role |
-|---------------|-----|------|
-| `send.restofront.com` | `send.send.restofront.com` MX/TXT + DKIM | Outbound `from` |
-| `restofront.com` | root MX + `resend._domainkey` TXT; receiving only | Inbound `replyTo` (`vincent@restofront.com`) |
+| Resend domain          | DNS                                               | Role                                                           |
+| ---------------------- | ------------------------------------------------- | -------------------------------------------------------------- |
+| `send.restofront.com`  | `send.send.restofront.com` MX/TXT + DKIM          | Outbound `from`                                                |
+| `restofront.com`       | root MX + `resend._domainkey` TXT; receiving only | Inbound `replyTo` (`vincent@restofront.com`)                   |
+| `send.cornershop.dev`  | `send.send.cornershop.dev` MX/TXT + DKIM          | Factory SMB outbound `from`                                    |
+| `reply.cornershop.dev` | receiving MX + DKIM                               | Factory SMB inbound `replyTo` (`vincent@reply.cornershop.dev`) |
 
 Inbound mail is webhook-driven (`email.received`); there is no IMAP mailbox.
 Operator threads live in the admin outreach panel and in Postgres, not in a
@@ -172,7 +174,7 @@ migrations, required tables/columns/indexes (including the private
 `leadContactEmail` boundary), application database, and Workflow database;
 lists Resend delivery/inbound webhook metadata and domain capabilities;
 requires both endpoint-specific secrets to be present and unequal; and
-validates every launched niche's configured sender and reply-to identity plus
+validates every outreach-enabled niche's configured niche or factory sender and reply-to identity plus
 the approved lead-enumeration provider. It performs no database writes,
 configuration changes, or email sends. Output contains only check names,
 booleans, public endpoints, niche names, and timestamps—never database URLs,

--- a/docs/operations/production-release.md
+++ b/docs/operations/production-release.md
@@ -6,29 +6,29 @@ Production truth is not a single checkbox. Cornershopdev tracks these states
 separately so a green merge cannot be reported as a configured, deployed, or
 customer-accepted release.
 
-| State | Meaning | Required evidence |
-| --- | --- | --- |
-| Code merged | The exact release SHA is contained in `origin/main` and CI verification passed. | Stable `vX.Y.Z` tag, merge ancestry check, successful `verify` job. |
-| Production configured | The reviewed Caddy bundle is installed, every required SSM value is present, and the candidate passes semantic outreach and platform checks. | Immutable bundle checksums and candidate preflight output; no screenshots or secret values. |
-| Migrations applied | The candidate image's complete committed migration set is applied to production. | `prisma migrate status` from the exact candidate after its entrypoint migration. |
-| Production deployed | Caddy routes to a healthy container whose Docker image tag is the exact release SHA. | Systems Manager command, immutable deploy-script checksum, deployed-SHA sentinel, public liveness. |
-| Acceptance proven | A real owner/payment/publish/customer-domain journey satisfies #20 and #47. | Customer-authorized evidence listed in `first-customer-validation.md`. Release automation never sets this state. |
+| State                 | Meaning                                                                                                                                      | Required evidence                                                                                                |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Code merged           | The exact release SHA is contained in `origin/main` and CI verification passed.                                                              | Stable `vX.Y.Z` tag, merge ancestry check, successful `verify` job.                                              |
+| Production configured | The reviewed Caddy bundle is installed, every required SSM value is present, and the candidate passes semantic outreach and platform checks. | Immutable bundle checksums and candidate preflight output; no screenshots or secret values.                      |
+| Migrations applied    | The candidate image's complete committed migration set is applied to production.                                                             | `prisma migrate status` from the exact candidate after its entrypoint migration.                                 |
+| Production deployed   | Caddy routes to a healthy container whose Docker image tag is the exact release SHA.                                                         | Systems Manager command, immutable deploy-script checksum, deployed-SHA sentinel, public liveness.               |
+| Acceptance proven     | A real owner/payment/publish/customer-domain journey satisfies #20 and #47.                                                                  | Customer-authorized evidence listed in `first-customer-validation.md`. Release automation never sets this state. |
 
 ## 2026-08-20 production audit
 
-| Check | Evidence | Verdict |
-| --- | --- | --- |
-| Latest merged code | `origin/main` = `3f398556a7b849aceb222a1cca12a6663b468681`; refresh this SHA and its required CI once more immediately before cutting the release. | `CODE_MERGED`, not deployed. |
-| Running production image | SSM inspection `6a4d128d-5f53-4f3c-af67-b8c683da74c5` found `cornershopdev:feb674d6a39ea716ab8287aab6eeb42c183cb7b9`, healthy since 2026-07-27. | 15 commits behind main. |
-| Published release | Latest stable release is `v0.2.0` at `2abae11cb4205a2ca600d73ca9389be98637e6f2`. Later production changes were manual workflow dispatches. | Release history alone does not identify the running image. |
-| Schema | The running image reports 15 migrations and “up to date”; main contains 18. | Up to date only for the old image, not for main. |
-| Outreach | The running image has no `operator:preflight-outreach` command. Metadata-only SSM checks find neither `RESEND_WEBHOOK_SECRET` nor `RESEND_INBOUND_WEBHOOK_SECRET`; the configured sender is `Vincent from Restofront`, not the required `Vincent from Restofrontapp`. | Not configured or deployed. |
-| Authentication secret | SSM lacks `BETTER_AUTH_SECRET`; the old image uses the claim-secret rollout fallback. | Explicit production auth configuration not ready. |
-| First-customer evidence | SSM has `SUPERADMIN_EMAILS`, but lacks `FIRST_CUSTOMER_EVIDENCE_PUBLIC_KEY`. | Evidence verification configuration not ready. |
-| Photo policy | SSM lacks `OPENROUTER_IMAGE_MODEL`, `PHOTO_ENHANCEMENT_MODEL`, and all documented `PHOTO_*` cost/concurrency controls. | The next image would silently use code defaults unless the reviewed policy is pinned. |
-| Platform wildcard DNS | Random labels under `*.restofront.com` and `*.cornershop.dev` return no A records; neither hosted zone contains a wildcard. | Not ready. |
-| Caddy on-demand TLS | Caddy validates successfully and its loaded JSON uses `http://api-cornershop-dev:3000/api/domains/authorize` as the on-demand permission endpoint. | Caddy policy ready; wildcard DNS and new application authorization are not. |
-| Customer acceptance | No settled first payment, owner edit/publish, owner-authorized custom domain, second qualified lead, or +30-day decision record is attached to #20/#47. | Not proven. |
+| Check                    | Evidence                                                                                                                                                                                                                                                              | Verdict                                                                               |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Latest merged code       | `origin/main` = `3f398556a7b849aceb222a1cca12a6663b468681`; refresh this SHA and its required CI once more immediately before cutting the release.                                                                                                                    | `CODE_MERGED`, not deployed.                                                          |
+| Running production image | SSM inspection `6a4d128d-5f53-4f3c-af67-b8c683da74c5` found `cornershopdev:feb674d6a39ea716ab8287aab6eeb42c183cb7b9`, healthy since 2026-07-27.                                                                                                                       | 15 commits behind main.                                                               |
+| Published release        | Latest stable release is `v0.2.0` at `2abae11cb4205a2ca600d73ca9389be98637e6f2`. Later production changes were manual workflow dispatches.                                                                                                                            | Release history alone does not identify the running image.                            |
+| Schema                   | The running image reports 15 migrations and “up to date”; main contains 18.                                                                                                                                                                                           | Up to date only for the old image, not for main.                                      |
+| Outreach                 | The running image has no `operator:preflight-outreach` command. Metadata-only SSM checks find neither `RESEND_WEBHOOK_SECRET` nor `RESEND_INBOUND_WEBHOOK_SECRET`; the configured sender is `Vincent from Restofront`, not the required `Vincent from Restofrontapp`. | Not configured or deployed.                                                           |
+| Authentication secret    | SSM lacks `BETTER_AUTH_SECRET`; the old image uses the claim-secret rollout fallback.                                                                                                                                                                                 | Explicit production auth configuration not ready.                                     |
+| First-customer evidence  | SSM has `SUPERADMIN_EMAILS`, but lacks `FIRST_CUSTOMER_EVIDENCE_PUBLIC_KEY`.                                                                                                                                                                                          | Evidence verification configuration not ready.                                        |
+| Photo policy             | SSM lacks `OPENROUTER_IMAGE_MODEL`, `PHOTO_ENHANCEMENT_MODEL`, and all documented `PHOTO_*` cost/concurrency controls.                                                                                                                                                | The next image would silently use code defaults unless the reviewed policy is pinned. |
+| Platform wildcard DNS    | Random labels under `*.restofront.com` and `*.cornershop.dev` return no A records; neither hosted zone contains a wildcard.                                                                                                                                           | Not ready.                                                                            |
+| Caddy on-demand TLS      | Caddy validates successfully and its loaded JSON uses `http://api-cornershop-dev:3000/api/domains/authorize` as the on-demand permission endpoint.                                                                                                                    | Caddy policy ready; wildcard DNS and new application authorization are not.           |
+| Customer acceptance      | No settled first payment, owner edit/publish, owner-authorized custom domain, second qualified lead, or +30-day decision record is attached to #20/#47.                                                                                                               | Not proven.                                                                           |
 
 This audit authorizes no production deploy, DNS change, email, customer charge,
 or customer-domain change.
@@ -130,16 +130,27 @@ PHOTO_ENHANCEMENT_PER_SITE_CEILING_MICROS=500000
 PHOTO_POLICY
 ```
 
-### 4. Correct the production sender identity
+### 4. Configure the factory sender identity
 
 ```bash
 aws ssm put-parameter \
   --region us-east-1 \
   --name /shipshit/production/cornershopdev/EMAIL_FROM \
   --type String \
-  --value 'Vincent from Restofrontapp <vincent@send.restofront.com>' \
+  --value 'Vincent from Cornershopdev <vincent@send.cornershop.dev>' \
+  --overwrite
+
+aws ssm put-parameter \
+  --region us-east-1 \
+  --name /shipshit/production/cornershopdev/EMAIL_REPLY_TO \
+  --type String \
+  --value 'vincent@reply.cornershop.dev' \
   --overwrite
 ```
+
+Restofront keeps its niche-specific `send.restofront.com` / `restofront.com`
+identity. Factory-claimed Food Retail and Local Service sites use the
+generic Cornershopdev sender and receiving-only reply subdomain above.
 
 In Resend, enable both exact HTTPS endpoints:
 
@@ -183,12 +194,12 @@ publishing a replacement tag solely to hide a failed gate is not.
 
 The evidence above implies these issue states:
 
-| Issue | Correct state | Reason |
-| --- | --- | --- |
-| #47 | Open / In Progress | The offer is documented, but no first settled payment, published custom domain, support-cost record, second qualified lead, or scheduled/completed review is proven. |
-| #98 | Open / In Progress | Code is merged, but wildcard DNS, production deployment, and valid-TLS site evidence are absent. |
-| #20 | Open / Todo | The paid-owner end-to-end exit has not begun with an authorized customer. |
-| #10 | Open / In Progress | Production services run, but Preview DB isolation and the production image round trip remain unproven; current alert code is not deployed. |
-| #16 | Open / In Progress | Main contains substantial auth work, but production config/deployment and a real owner receive/use exercise remain open. |
-| #17 | Open / In Progress | Main contains operator/outreach work, but the production operator journey and blocker rollup acceptance remain unproven. |
-| #88 | Closed | PR #87 merged as `09e2e73`, main CI passed, the security reviewer passed, and every referenced review thread is resolved. |
+| Issue | Correct state      | Reason                                                                                                                                                               |
+| ----- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| #47   | Open / In Progress | The offer is documented, but no first settled payment, published custom domain, support-cost record, second qualified lead, or scheduled/completed review is proven. |
+| #98   | Open / In Progress | Code is merged, but wildcard DNS, production deployment, and valid-TLS site evidence are absent.                                                                     |
+| #20   | Open / Todo        | The paid-owner end-to-end exit has not begun with an authorized customer.                                                                                            |
+| #10   | Open / In Progress | Production services run, but Preview DB isolation and the production image round trip remain unproven; current alert code is not deployed.                           |
+| #16   | Open / In Progress | Main contains substantial auth work, but production config/deployment and a real owner receive/use exercise remain open.                                             |
+| #17   | Open / In Progress | Main contains operator/outreach work, but the production operator journey and blocker rollup acceptance remain unproven.                                             |
+| #88   | Closed             | PR #87 merged as `09e2e73`, main CI passed, the security reviewer passed, and every referenced review thread is resolved.                                            |

--- a/docs/operations/stripe-billing.md
+++ b/docs/operations/stripe-billing.md
@@ -15,8 +15,8 @@ The deployment requires all of:
 - `CLAIM_TOKEN_SECRET`
 - `RESEND_API_KEY`
 
-The launch Checkout offers exactly one plan: the Restofront founding
-subscription at USD 49.00 per month. Its Stripe Price and Product must be live,
+The launch Checkout offers exactly one plan for every claim-enabled vertical:
+the Cornershopdev founding subscription at USD 49.00 per month. Its Stripe Price and Product must be live,
 active, non-metered, tax-exclusive, and recurring monthly. Test mode and live mode have separate keys,
 prices, Customer Portal configurations, webhook endpoints, and signing secrets.
 Never copy a test identifier into Production or a live identifier into local
@@ -159,6 +159,7 @@ durable release evidence:
    ```
 
    Select only the seven event types listed above.
+
 4. Store the live secret key, endpoint signing secret, the one live Price ID, and
    a randomly generated claim-token secret of at least 32 characters as
    encrypted Production parameters under
@@ -228,6 +229,7 @@ migration itself.
   WHERE "status" = 'REJECTED'
   ORDER BY "processedAt" DESC;
   ```
+
 - Infrastructure and Stripe API failures return `500`, leaving no committed
   event-ledger row so a retry can process the event.
 - Those runtime failures also create a deduplicated durable operator alert.

--- a/docs/verticals/food-retail.md
+++ b/docs/verticals/food-retail.md
@@ -89,33 +89,32 @@ carry the vertical data, so no existing rows are rewritten and the migration
 does not seed product facts. The owner PUT route parses FOOD_RETAIL drafts with
 the registered schema before the shared optimistic-revision persistence path.
 
-## Public launch gate
+## Factory claim and standalone launch gates
 
-The code ships with all public launch selectors closed:
+Standalone niche marketing stays closed:
 
 - `marketing.hostnames = []`
 - `marketing.domain = null`
 - `marketing.email = null`
-- `publicationEnabled = false`
+- `claimMode = "factory"`
+- `publicationEnabled = true`
 
-Do not change those values or expose a priced public plan until the PR/release
-contains reviewable evidence for every item below:
+An approved private preview can claim the shared Cornershopdev $49 plan and
+publish at `<slug>.cornershop.dev`. That factory path requires:
 
-- [ ] production domain is owned, resolves to the intended ingress and is
-      covered by the customer/niche routing policy;
-- [ ] sending domain is verified with the mail provider, with a niche-specific
-      `from` and monitored `replyTo` address;
-- [ ] production billing product/price and checkout configuration are present in
+- [x] platform wildcard DNS and on-demand TLS cover the shared public URL;
+- [x] `send.cornershop.dev` and the receiving-only `reply.cornershop.dev`
+      identities are provider-verified;
+- [x] production billing product/price and checkout configuration are present in
       the reviewed environment without secret values entering git;
-- [ ] production readiness covers database migration status, Redis, storage,
+- [x] production readiness covers database migration status, Redis, storage,
       billing, email and alerting;
-- [ ] English and French fixture/import/renderer/dashboard tests pass;
-- [ ] a real pilot shop has owner-confirmed products, prices, hours, pickup
-      wording, images and any allergens before public publication.
+- [x] English and French fixture/import/renderer/dashboard tests pass;
+- [ ] the specific owner has reviewed every product, price, hours, pickup
+      wording, image, stock statement, translation and allergen source before
+      publishing that business.
 
-Until those gates have evidence, FOOD_RETAIL remains usable for private imports,
-previews and owner review only; it is excluded from `listMarketingVerticals()`.
-The shared publish and rollback services reject it before billing or database
-mutation, the owner dashboard exposes no publication actions, and public reads
-ignore any legacy FOOD_RETAIL snapshot pointer until the capability is reviewed
-and enabled.
+FOOD_RETAIL remains excluded from `listMarketingVerticals()` until it owns a
+standalone niche domain and sender. That does not block an evidence-reviewed
+owner from claiming through the factory, editing with revision protection and
+publishing an immutable snapshot on the platform subdomain.

--- a/docs/verticals/local-service.md
+++ b/docs/verticals/local-service.md
@@ -14,18 +14,18 @@ images, palette, locale, translations, hours, catalog sections, and external
 integrations. Trade-only facts stay in the existing validated JSON attribute
 bags:
 
-| Concern | Bounded representation |
-| --- | --- |
-| Trade | `plumber`, `electrician`, `builder`, `repair`, `artisan`, or `general-trades` |
-| Services | Shared catalog sections and items; per-service pricing posture, optional unit, and emergency eligibility |
-| Service areas | Up to 24 explicit place names; no inferred radius |
-| Availability | Closed posture enum with `not-stated` as the deterministic default |
-| Credentials | Up to 16 name/issuer/reference records |
-| Insurance | `not-stated`, `insured`, or `not-insured`, plus one bounded evidence detail |
-| Trust signals | Up to 16 label/evidence records |
-| Projects | Up to 24 title/description/location/HTTPS-or-local-image records |
-| Conversion | Shared phone plus `contact`, `quote`, `booking`, and `social` HTTPS integrations |
-| Hours | Shared bounded business-hours rows |
+| Concern       | Bounded representation                                                                                   |
+| ------------- | -------------------------------------------------------------------------------------------------------- |
+| Trade         | `plumber`, `electrician`, `builder`, `repair`, `artisan`, or `general-trades`                            |
+| Services      | Shared catalog sections and items; per-service pricing posture, optional unit, and emergency eligibility |
+| Service areas | Up to 24 explicit place names; no inferred radius                                                        |
+| Availability  | Closed posture enum with `not-stated` as the deterministic default                                       |
+| Credentials   | Up to 16 name/issuer/reference records                                                                   |
+| Insurance     | `not-stated`, `insured`, or `not-insured`, plus one bounded evidence detail                              |
+| Trust signals | Up to 16 label/evidence records                                                                          |
+| Projects      | Up to 24 title/description/location/HTTPS-or-local-image records                                         |
+| Conversion    | Shared phone plus `contact`, `quote`, `booking`, and `social` HTTPS integrations                         |
+| Hours         | Shared bounded business-hours rows                                                                       |
 
 Integration allowlists are vertical-owned even though storage uses one enum:
 Restaurant retains booking/ordering/delivery/social, Beauty accepts only
@@ -86,23 +86,26 @@ hours, trade and availability posture, service areas, insurance evidence,
 credentials, trust signals, services, projects, and external tools. Save uses
 the existing optimistic draft revision, organization membership, same-origin
 mutation, relation-replacement, and audit boundaries. Publication and rollback
-are disabled server-side and absent from the editor while the vertical remains
-a private pilot.
+use the shared billing, same-origin, optimistic-revision, immutable snapshot,
+and audit boundaries. The editor saves before publication and requires a
+3–280 character change summary plus explicit confirmation.
 
 ## Launch gate
 
-Tradefront is deliberately registered but unlaunched. Its marketing config has
-no hostname, domain, or sender. `verticalLaunchReadiness` requires all of the
-following before a niche can appear as launched:
+Tradefront has no standalone niche storefront. Its marketing config therefore
+keeps hostname, domain, and niche sender empty, while `claimMode: "factory"`
+allows an approved private preview to use Cornershopdev's verified sender,
+shared $49 checkout, and `<slug>.cornershop.dev` public URL. A future standalone
+niche still must satisfy `verticalLaunchReadiness`:
 
 1. a configured public domain;
 2. that exact domain registered in the proxy hostname list;
 3. a configured sender and reply-to address;
 4. both mail domains equal to, or subdomains of, the niche domain.
 
-Adding templates, enabling AI, or setting only a domain cannot launch the
-product. DNS, sender verification, and the committed config must be reviewed as
-one release gate.
+The factory claim lane does not enable model generation or bypass review.
+Standalone DNS, sender verification, and committed niche config remain one
+separate release gate.
 
 ## Verification evidence
 

--- a/scripts/preflight-stripe-billing.ts
+++ b/scripts/preflight-stripe-billing.ts
@@ -1,11 +1,11 @@
 import { getStripe } from "@/lib/stripe";
-import { preflightRestofrontBilling } from "@/lib/stripe-billing-preflight";
+import { preflightFoundingBilling } from "@/lib/stripe-billing-preflight";
 
 let requiredMode: "test" | "live" | "invalid" = "invalid";
 
 try {
   requiredMode = parseArguments(process.argv.slice(2));
-  const evidence = await preflightRestofrontBilling({
+  const evidence = await preflightFoundingBilling({
     stripe: getStripe(),
     requiredMode,
   });
@@ -13,7 +13,7 @@ try {
 } catch {
   console.error(
     JSON.stringify({
-      check: "restofront-founding-billing",
+      check: "cornershop-founding-billing",
       ready: false,
       mode: requiredMode,
       failure: "configuration_or_provider_resource_mismatch",

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -2,9 +2,9 @@ import { cookies } from "next/headers";
 import { z } from "zod";
 import {
   configuredBillingPlan,
-  RESTOFRONT_FOUNDING_PLAN_ID,
+  FOUNDING_PLAN_ID,
   stripeLivemodeForSecret,
-  validateRestofrontFoundingPrice,
+  validateFoundingPrice,
 } from "@/lib/billing-plans";
 import { alertCheckoutStartFailure } from "@/lib/billing-operator-alerts";
 import {
@@ -31,7 +31,7 @@ import { secureCookieRequired } from "@/lib/first-customer-test-mode";
 import { isVerticalClaimEnabled } from "@/lib/verticals/registry";
 
 const requestSchema = z.object({
-  plan: z.literal(RESTOFRONT_FOUNDING_PLAN_ID),
+  plan: z.literal(FOUNDING_PLAN_ID),
   siteSlug: z.string().trim().min(2).max(80),
   invitationToken: z
     .string()
@@ -89,7 +89,7 @@ export async function POST(request: Request) {
     const price = await stripe.prices.retrieve(priceId, {
       expand: ["product"],
     });
-    validateRestofrontFoundingPrice(price, {
+    validateFoundingPrice(price, {
       expectedPriceId: priceId,
       expectedLivemode: stripeLivemodeForSecret(process.env.STRIPE_SECRET_KEY),
     });

--- a/src/app/create/import-studio.tsx
+++ b/src/app/create/import-studio.tsx
@@ -112,13 +112,13 @@ const verticalCopy = {
     placeholder: "trade website or business name",
     opening: "Opening the trade business",
     idlePrompt:
-      "Paste a plumber, electrician, builder, repair trade or artisan website. The result remains a private pilot preview; claiming and payment are not available yet.",
+      "Paste a plumber, electrician, builder, repair trade or artisan website. The first draft is deterministic and stays private until the owner claims it.",
     recovering:
       "The shape is already here. We are recovering sourced services, branding, hours, service evidence and existing contact links now.",
     emptyStatePrompt:
       "Start with a trade website or business name. No account is needed to see the result.",
     claimHint:
-      "Review every service, availability statement, credential, project and contact link in this private pilot preview.",
+      "Review every service, availability statement, credential, project and contact link, then claim the $49 founding plan.",
     catalogStage: "Recover services and evidence",
     integrationsStage: "Preserve phone, WhatsApp and quote links",
     previewCatalogLabel: "Services",
@@ -134,13 +134,13 @@ const verticalCopy = {
     placeholder: "bakery.com or shop name",
     opening: "Opening the shop",
     idlePrompt:
-      "Paste a bakery, pâtisserie, butcher, deli or local food shop website. The result remains a private pilot preview; claiming and payment are not available yet.",
+      "Paste a bakery, pâtisserie, butcher, deli or local food shop website. The first storefront stays private until the owner claims it.",
     recovering:
       "The shape is already here. We are recovering real product ranges, seasonal notes, hours, pickup details and existing order links now.",
     emptyStatePrompt:
       "Start with a food shop website or name. No account is needed to see the result.",
     claimHint:
-      "Review every product, price, availability note, allergen source and ordering link in this private pilot preview.",
+      "Review every product, price, availability note, allergen source and ordering link, then claim the $49 founding plan.",
     catalogStage: "Recover product ranges and prices",
     integrationsStage: "Preserve preorder, pickup and delivery links",
     previewCatalogLabel: "Product ranges",

--- a/src/app/dashboard/food-retail-dashboard.tsx
+++ b/src/app/dashboard/food-retail-dashboard.tsx
@@ -2,7 +2,16 @@
 
 import { useRef, useState } from "react";
 import Link from "next/link";
-import { Check, ExternalLink, Languages, Plus, Save, Trash2 } from "lucide-react";
+import {
+  Check,
+  ExternalLink,
+  Languages,
+  LoaderCircle,
+  Plus,
+  Rocket,
+  Save,
+  Trash2,
+} from "lucide-react";
 import { AccountActions } from "@/components/account-actions";
 import { Brand } from "@/components/brand";
 import { SiteRenderer } from "@/components/site-renderer";
@@ -19,23 +28,31 @@ import {
   appendFoodRetailIntegrationTranslations,
   appendFoodRetailItemTranslations,
   FOOD_RETAIL_NEW_LINK_LABEL,
+  hasUnreviewedFoodRetailTranslations,
   markFoodRetailTranslationReviewed,
   markFoodRetailTranslationsStale,
   reconcileFoodRetailDraftAfterSave,
   updateFoodRetailTranslation,
 } from "@/lib/verticals/food-retail/editor";
-import { foodRetailSiteDraftSchema, type FoodRetailSiteDraft } from "@/lib/verticals/food-retail/schema";
+import {
+  foodRetailSiteDraftSchema,
+  type FoodRetailSiteDraft,
+} from "@/lib/verticals/food-retail/schema";
 
 export function FoodRetailDashboard({
   email,
   brand,
   initialDraft,
   initialRevision,
+  initiallyPublished,
+  platformUrl,
 }: {
   email: string;
   brand: BrandIdentity;
   initialDraft: FoodRetailSiteDraft;
   initialRevision: number;
+  initiallyPublished: boolean;
+  platformUrl: string;
 }) {
   const [draft, setDraftState] = useState(initialDraft);
   const draftRef = useRef(initialDraft);
@@ -44,13 +61,15 @@ export function FoodRetailDashboard({
       | FoodRetailSiteDraft
       | ((current: FoodRetailSiteDraft) => FoodRetailSiteDraft),
   ) {
-    const resolved =
-      typeof next === "function" ? next(draftRef.current) : next;
+    const resolved = typeof next === "function" ? next(draftRef.current) : next;
     draftRef.current = resolved;
     setDraftState(resolved);
   }
   const [revision, setRevision] = useState(initialRevision);
   const [saving, setSaving] = useState(false);
+  const [publishing, setPublishing] = useState(false);
+  const [publishedVersion, setPublishedVersion] = useState<number | null>(null);
+  const [published, setPublished] = useState(initiallyPublished);
   const [notice, setNotice] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -77,30 +96,34 @@ export function FoodRetailDashboard({
   }
 
   function removeSection(sectionIndex: number) {
-    setDraft((current) => markFoodRetailTranslationsStale({
-      ...current,
-      catalogSections: current.catalogSections.filter(
-        (_, index) => index !== sectionIndex,
-      ),
-      translations: current.translations.map((translation) => ({
-        ...translation,
-        catalogSections: translation.catalogSections.filter(
+    setDraft((current) =>
+      markFoodRetailTranslationsStale({
+        ...current,
+        catalogSections: current.catalogSections.filter(
           (_, index) => index !== sectionIndex,
         ),
-      })),
-    }));
+        translations: current.translations.map((translation) => ({
+          ...translation,
+          catalogSections: translation.catalogSections.filter(
+            (_, index) => index !== sectionIndex,
+          ),
+        })),
+      }),
+    );
   }
 
   function addSection() {
     const name = window.prompt("Enter the sourced category name:")?.trim();
     if (!name) return;
-    setDraft((current) => appendFoodRetailCategoryTranslations({
-      ...current,
-      catalogSections: [
-        ...current.catalogSections,
-        { name, description: "", items: [] },
-      ],
-    }));
+    setDraft((current) =>
+      appendFoodRetailCategoryTranslations({
+        ...current,
+        catalogSections: [
+          ...current.catalogSections,
+          { name, description: "", items: [] },
+        ],
+      }),
+    );
   }
 
   function removeItem(sectionIndex: number, itemIndex: number) {
@@ -141,44 +164,48 @@ export function FoodRetailDashboard({
   }
 
   function addIntegration() {
-    setDraft((current) => appendFoodRetailIntegrationTranslations({
-      ...current,
-      integrations: [
-        ...current.integrations,
-        {
-          type: "ordering",
-          label: FOOD_RETAIL_NEW_LINK_LABEL,
-          provider: null,
-          url: "",
-          enabled: true,
-          venueId: null,
-        },
-      ],
-    }));
+    setDraft((current) =>
+      appendFoodRetailIntegrationTranslations({
+        ...current,
+        integrations: [
+          ...current.integrations,
+          {
+            type: "ordering",
+            label: FOOD_RETAIL_NEW_LINK_LABEL,
+            provider: null,
+            url: "",
+            enabled: true,
+            venueId: null,
+          },
+        ],
+      }),
+    );
   }
 
   function removeIntegration(integrationIndex: number) {
-    setDraft((current) => markFoodRetailTranslationsStale({
-      ...current,
-      integrations: current.integrations.filter(
-        (_, index) => index !== integrationIndex,
-      ),
-      translations: current.translations.map((translation) => ({
-        ...translation,
-        integrationLabels: translation.integrationLabels.filter(
+    setDraft((current) =>
+      markFoodRetailTranslationsStale({
+        ...current,
+        integrations: current.integrations.filter(
           (_, index) => index !== integrationIndex,
         ),
-      })),
-    }));
+        translations: current.translations.map((translation) => ({
+          ...translation,
+          integrationLabels: translation.integrationLabels.filter(
+            (_, index) => index !== integrationIndex,
+          ),
+        })),
+      }),
+    );
   }
 
   function changeTranslation(
     locale: string,
-    updater: (
-      translation: FoodRetailSiteDraft["translations"][number],
-    ) => void,
+    updater: (translation: FoodRetailSiteDraft["translations"][number]) => void,
   ) {
-    setDraft((current) => updateFoodRetailTranslation(current, locale, updater));
+    setDraft((current) =>
+      updateFoodRetailTranslation(current, locale, updater),
+    );
     setNotice(null);
     setError(null);
   }
@@ -189,7 +216,9 @@ export function FoodRetailDashboard({
       setNotice(`${locale.toUpperCase()} translation reviewed.`);
       setError(null);
     } catch {
-      setError("Complete every required translated name and label before review.");
+      setError(
+        "Complete every required translated name and label before review.",
+      );
     }
   }
 
@@ -225,11 +254,7 @@ export function FoodRetailDashboard({
       }
       const hadNewerEdits = draftRef.current !== submittedDraft;
       setDraft((current) =>
-        reconcileFoodRetailDraftAfterSave(
-          submittedDraft,
-          parsed.data,
-          current,
-        ),
+        reconcileFoodRetailDraftAfterSave(submittedDraft, parsed.data, current),
       );
       setRevision(result.revision);
       if (hadNewerEdits) {
@@ -248,13 +273,60 @@ export function FoodRetailDashboard({
     }
   }
 
+  async function publishDraft() {
+    if (hasUnreviewedFoodRetailTranslations(draftRef.current)) {
+      setError("Review every draft or stale translation before publishing.");
+      return;
+    }
+    const changeSummary = window
+      .prompt(
+        "Summarize what will change on the public site:",
+        "Publish reviewed storefront",
+      )
+      ?.trim();
+    if (!changeSummary) return;
+    if (changeSummary.length < 3 || changeSummary.length > 280) {
+      setError("Use a change summary between 3 and 280 characters.");
+      return;
+    }
+    if (!window.confirm("Publish this reviewed storefront now?")) return;
+
+    setPublishing(true);
+    setError(null);
+    try {
+      const expectedRevision = await saveDraft();
+      if (expectedRevision === null) return;
+      const response = await fetch(`/api/sites/${draft.slug}/publish`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ changeSummary, expectedRevision }),
+      });
+      const result = (await response.json()) as {
+        error?: string;
+        published?: { version: number };
+      };
+      if (!response.ok || !result.published) {
+        throw new Error(result.error ?? "Publish failed");
+      }
+      setPublished(true);
+      setPublishedVersion(result.published.version);
+      setNotice(`Published version ${result.published.version}.`);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Publish failed");
+    } finally {
+      setPublishing(false);
+    }
+  }
+
   return (
     <div className="min-h-screen bg-muted/35 text-foreground">
       <header className="border-b bg-background">
         <div className="mx-auto flex max-w-[1500px] items-center justify-between gap-4 px-5 py-4">
           <Brand {...brand} />
           <div className="flex items-center gap-3">
-            <span className="hidden text-xs text-muted-foreground sm:inline">{email}</span>
+            <span className="hidden text-xs text-muted-foreground sm:inline">
+              {email}
+            </span>
             <AccountActions canSwitch />
           </div>
         </div>
@@ -265,86 +337,613 @@ export function FoodRetailDashboard({
           <Card>
             <CardHeader className="flex-row items-center justify-between gap-4">
               <div>
-                <p className="text-xs font-semibold uppercase tracking-[0.14em] text-primary">Food retail owner workspace</p>
-                <CardTitle className="mt-1">Products, pickup and hours</CardTitle>
+                <p className="text-xs font-semibold uppercase tracking-[0.14em] text-primary">
+                  Food retail owner workspace
+                </p>
+                <CardTitle className="mt-1">
+                  Products, pickup and hours
+                </CardTitle>
                 <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
-                  Private pilot: save and review changes here. Public publishing and rollback stay unavailable until launch configuration is approved.
+                  Save privately, review every sourced fact and translation,
+                  then publish to the business&apos;s platform URL.
                 </p>
               </div>
               <div className="flex flex-wrap justify-end gap-2">
-                <Button render={<Link href={`/preview/${draft.slug}`} target="_blank" />} nativeButton={false} variant="outline">
-                  Preview <ExternalLink />
+                <Button
+                  render={
+                    <Link
+                      href={published ? platformUrl : `/preview/${draft.slug}`}
+                      target="_blank"
+                    />
+                  }
+                  nativeButton={false}
+                  variant="outline"
+                >
+                  {published ? "View live" : "Preview"} <ExternalLink />
                 </Button>
-                <Button variant="outline" disabled={saving} onClick={() => void saveDraft()}>
+                <Button
+                  variant="outline"
+                  disabled={saving || publishing}
+                  onClick={() => void saveDraft()}
+                >
                   <Save /> {saving ? "Saving…" : "Save"}
+                </Button>
+                <Button
+                  disabled={saving || publishing}
+                  onClick={() => void publishDraft()}
+                >
+                  {publishing ? (
+                    <LoaderCircle className="animate-spin" />
+                  ) : (
+                    <Rocket />
+                  )}
+                  {publishedVersion
+                    ? `Published v${publishedVersion}`
+                    : "Publish"}
                 </Button>
               </div>
             </CardHeader>
             <CardContent>
-              {notice ? <p role="status" className="text-sm text-emerald-700">{notice}</p> : null}
-              {error ? <p role="alert" className="text-sm text-destructive">{error}</p> : null}
+              {notice ? (
+                <p role="status" className="text-sm text-emerald-700">
+                  {notice}
+                </p>
+              ) : null}
+              {error ? (
+                <p role="alert" className="text-sm text-destructive">
+                  {error}
+                </p>
+              ) : null}
             </CardContent>
           </Card>
 
           <Card>
-            <CardHeader><CardTitle>Shop details</CardTitle></CardHeader>
+            <CardHeader>
+              <CardTitle>Shop details</CardTitle>
+            </CardHeader>
             <CardContent className="grid gap-4 sm:grid-cols-2">
-              <Field label="Business name"><Input value={draft.name} onChange={(event) => setDraft({ ...draft, name: event.target.value })} /></Field>
+              <Field label="Business name">
+                <Input
+                  value={draft.name}
+                  onChange={(event) =>
+                    setDraft({ ...draft, name: event.target.value })
+                  }
+                />
+              </Field>
               <Field label="Shop type">
-                <select className="h-9 w-full rounded-lg border bg-background px-3 text-sm" value={draft.attributes.shopType} onChange={(event) => setDraft({ ...draft, attributes: { ...draft.attributes, shopType: event.target.value as FoodRetailSiteDraft["attributes"]["shopType"] } })}>
-                  <option value="bakery">Bakery</option><option value="patisserie">Patisserie</option><option value="butcher">Butcher</option><option value="deli">Deli</option><option value="cheesemonger">Cheesemonger</option><option value="grocer">Grocer</option><option value="local-food-shop">Local food shop</option>
+                <select
+                  className="h-9 w-full rounded-lg border bg-background px-3 text-sm"
+                  value={draft.attributes.shopType}
+                  onChange={(event) =>
+                    setDraft({
+                      ...draft,
+                      attributes: {
+                        ...draft.attributes,
+                        shopType: event.target
+                          .value as FoodRetailSiteDraft["attributes"]["shopType"],
+                      },
+                    })
+                  }
+                >
+                  <option value="bakery">Bakery</option>
+                  <option value="patisserie">Patisserie</option>
+                  <option value="butcher">Butcher</option>
+                  <option value="deli">Deli</option>
+                  <option value="cheesemonger">Cheesemonger</option>
+                  <option value="grocer">Grocer</option>
+                  <option value="local-food-shop">Local food shop</option>
                 </select>
               </Field>
-              <Field label="Address"><Input value={draft.address} onChange={(event) => setDraft({ ...draft, address: event.target.value })} /></Field>
-              <Field label="Phone"><Input value={draft.phone} onChange={(event) => setDraft({ ...draft, phone: event.target.value })} /></Field>
-              <Field label="Pickup details" className="sm:col-span-2"><Textarea value={draft.attributes.pickupDetails} onChange={(event) => setDraft((current) => markFoodRetailTranslationsStale({ ...current, attributes: { ...current.attributes, pickupDetails: event.target.value } }))} /></Field>
-              <Field label="Description" className="sm:col-span-2"><Textarea value={draft.description} onChange={(event) => setDraft((current) => markFoodRetailTranslationsStale({ ...current, description: event.target.value }))} /></Field>
+              <Field label="Address">
+                <Input
+                  value={draft.address}
+                  onChange={(event) =>
+                    setDraft({ ...draft, address: event.target.value })
+                  }
+                />
+              </Field>
+              <Field label="Phone">
+                <Input
+                  value={draft.phone}
+                  onChange={(event) =>
+                    setDraft({ ...draft, phone: event.target.value })
+                  }
+                />
+              </Field>
+              <Field label="Pickup details" className="sm:col-span-2">
+                <Textarea
+                  value={draft.attributes.pickupDetails}
+                  onChange={(event) =>
+                    setDraft((current) =>
+                      markFoodRetailTranslationsStale({
+                        ...current,
+                        attributes: {
+                          ...current.attributes,
+                          pickupDetails: event.target.value,
+                        },
+                      }),
+                    )
+                  }
+                />
+              </Field>
+              <Field label="Description" className="sm:col-span-2">
+                <Textarea
+                  value={draft.description}
+                  onChange={(event) =>
+                    setDraft((current) =>
+                      markFoodRetailTranslationsStale({
+                        ...current,
+                        description: event.target.value,
+                      }),
+                    )
+                  }
+                />
+              </Field>
               <div className="flex items-center justify-between gap-4 sm:col-span-2">
-                <div><Label htmlFor="show-product-images">Show product gallery</Label><p className="text-xs text-muted-foreground">Only source or owner-approved images are rendered.</p></div>
-                <Switch id="show-product-images" checked={draft.attributes.showProductImages} onCheckedChange={(checked) => setDraft({ ...draft, attributes: { ...draft.attributes, showProductImages: checked } })} />
+                <div>
+                  <Label htmlFor="show-product-images">
+                    Show product gallery
+                  </Label>
+                  <p className="text-xs text-muted-foreground">
+                    Only source or owner-approved images are rendered.
+                  </p>
+                </div>
+                <Switch
+                  id="show-product-images"
+                  checked={draft.attributes.showProductImages}
+                  onCheckedChange={(checked) =>
+                    setDraft({
+                      ...draft,
+                      attributes: {
+                        ...draft.attributes,
+                        showProductImages: checked,
+                      },
+                    })
+                  }
+                />
               </div>
             </CardContent>
           </Card>
 
           <Card>
-            <CardHeader className="flex-row items-center justify-between"><CardTitle>Store hours</CardTitle><Button size="sm" variant="outline" onClick={() => setDraft({ ...draft, businessHours: [...draft.businessHours, { days: "", hours: "" }] })}><Plus /> Add hours</Button></CardHeader>
+            <CardHeader className="flex-row items-center justify-between">
+              <CardTitle>Store hours</CardTitle>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() =>
+                  setDraft({
+                    ...draft,
+                    businessHours: [
+                      ...draft.businessHours,
+                      { days: "", hours: "" },
+                    ],
+                  })
+                }
+              >
+                <Plus /> Add hours
+              </Button>
+            </CardHeader>
             <CardContent className="space-y-3">
-              {draft.businessHours.map((row, index) => <div key={index} className="grid grid-cols-[1fr_1fr_auto] gap-2"><Input aria-label={`Days ${index + 1}`} placeholder="Monday–Friday" value={row.days} onChange={(event) => setDraft({ ...draft, businessHours: draft.businessHours.map((candidate, candidateIndex) => candidateIndex === index ? { ...candidate, days: event.target.value } : candidate) })} /><Input aria-label={`Hours ${index + 1}`} placeholder="07:00–16:00" value={row.hours} onChange={(event) => setDraft({ ...draft, businessHours: draft.businessHours.map((candidate, candidateIndex) => candidateIndex === index ? { ...candidate, hours: event.target.value } : candidate) })} /><Button size="icon-sm" variant="ghost" aria-label={`Remove hours ${index + 1}`} onClick={() => setDraft({ ...draft, businessHours: draft.businessHours.filter((_, candidateIndex) => candidateIndex !== index) })}><Trash2 /></Button></div>)}
+              {draft.businessHours.map((row, index) => (
+                <div
+                  key={index}
+                  className="grid grid-cols-[1fr_1fr_auto] gap-2"
+                >
+                  <Input
+                    aria-label={`Days ${index + 1}`}
+                    placeholder="Monday–Friday"
+                    value={row.days}
+                    onChange={(event) =>
+                      setDraft({
+                        ...draft,
+                        businessHours: draft.businessHours.map(
+                          (candidate, candidateIndex) =>
+                            candidateIndex === index
+                              ? { ...candidate, days: event.target.value }
+                              : candidate,
+                        ),
+                      })
+                    }
+                  />
+                  <Input
+                    aria-label={`Hours ${index + 1}`}
+                    placeholder="07:00–16:00"
+                    value={row.hours}
+                    onChange={(event) =>
+                      setDraft({
+                        ...draft,
+                        businessHours: draft.businessHours.map(
+                          (candidate, candidateIndex) =>
+                            candidateIndex === index
+                              ? { ...candidate, hours: event.target.value }
+                              : candidate,
+                        ),
+                      })
+                    }
+                  />
+                  <Button
+                    size="icon-sm"
+                    variant="ghost"
+                    aria-label={`Remove hours ${index + 1}`}
+                    onClick={() =>
+                      setDraft({
+                        ...draft,
+                        businessHours: draft.businessHours.filter(
+                          (_, candidateIndex) => candidateIndex !== index,
+                        ),
+                      })
+                    }
+                  >
+                    <Trash2 />
+                  </Button>
+                </div>
+              ))}
             </CardContent>
           </Card>
 
           {draft.catalogSections.map((section, sectionIndex) => (
             <Card key={sectionIndex}>
               <CardHeader className="flex-row items-start justify-between gap-4">
-                <div className="grid flex-1 gap-2"><Input aria-label={`Category ${sectionIndex + 1} name`} value={section.name} onChange={(event) => updateSection(sectionIndex, (next) => { next.name = event.target.value; })} /><Input aria-label={`Category ${sectionIndex + 1} description`} placeholder="Category description" value={section.description} onChange={(event) => updateSection(sectionIndex, (next) => { next.description = event.target.value; })} /></div>
-                <Button size="icon-sm" variant="ghost" aria-label={`Remove category ${sectionIndex + 1}`} disabled={draft.catalogSections.length === 1} onClick={() => removeSection(sectionIndex)}><Trash2 /></Button>
+                <div className="grid flex-1 gap-2">
+                  <Input
+                    aria-label={`Category ${sectionIndex + 1} name`}
+                    value={section.name}
+                    onChange={(event) =>
+                      updateSection(sectionIndex, (next) => {
+                        next.name = event.target.value;
+                      })
+                    }
+                  />
+                  <Input
+                    aria-label={`Category ${sectionIndex + 1} description`}
+                    placeholder="Category description"
+                    value={section.description}
+                    onChange={(event) =>
+                      updateSection(sectionIndex, (next) => {
+                        next.description = event.target.value;
+                      })
+                    }
+                  />
+                </div>
+                <Button
+                  size="icon-sm"
+                  variant="ghost"
+                  aria-label={`Remove category ${sectionIndex + 1}`}
+                  disabled={draft.catalogSections.length === 1}
+                  onClick={() => removeSection(sectionIndex)}
+                >
+                  <Trash2 />
+                </Button>
               </CardHeader>
               <CardContent className="space-y-4">
                 {section.items.map((item, itemIndex) => (
-                  <div key={itemIndex} className="space-y-3 rounded-xl border p-4">
-                    <div className="grid gap-3 sm:grid-cols-[1fr_120px_auto]"><Input aria-label={`Product ${itemIndex + 1} name`} placeholder="Product name" value={item.name} onChange={(event) => updateItem(sectionIndex, itemIndex, (next) => { next.name = event.target.value; })} /><Input aria-label={`Product ${itemIndex + 1} price`} type="number" min="0" step="0.01" placeholder="No price" value={item.price ?? ""} onChange={(event) => updateItem(sectionIndex, itemIndex, (next) => { next.price = event.target.value === "" ? null : Number(event.target.value); })} /><Button size="icon-sm" variant="ghost" aria-label={`Remove product ${itemIndex + 1}`} onClick={() => removeItem(sectionIndex, itemIndex)}><Trash2 /></Button></div>
-                    <Textarea aria-label={`Product ${itemIndex + 1} description`} placeholder="Sourced product description" value={item.description} onChange={(event) => updateItem(sectionIndex, itemIndex, (next) => { next.description = event.target.value; })} />
-                    <div className="flex items-center justify-between gap-4 rounded-lg bg-muted/55 px-3 py-2"><div><Label htmlFor={`visible-${sectionIndex}-${itemIndex}`}>Show product on storefront</Label><p className="text-xs text-muted-foreground">This controls catalog visibility, not current stock.</p></div><Switch id={`visible-${sectionIndex}-${itemIndex}`} checked={item.attributes.visible} onCheckedChange={(checked) => updateItem(sectionIndex, itemIndex, (next) => { next.attributes.visible = checked; })} /></div>
-                    <div className="grid gap-3 sm:grid-cols-[180px_1fr]"><select aria-label={`Product ${itemIndex + 1} stock status`} className="h-9 rounded-lg border bg-background px-2 text-sm" value={item.available === null ? "unknown" : item.available ? "in-stock" : "out-of-stock"} onChange={(event) => updateItem(sectionIndex, itemIndex, (next) => { next.available = event.target.value === "unknown" ? null : event.target.value === "in-stock"; if (next.available === null) next.attributes.stockSourceUrl = null; })}><option value="unknown">Stock unknown</option><option value="in-stock">In stock (sourced)</option><option value="out-of-stock">Out of stock (sourced)</option></select><Input aria-label={`Product ${itemIndex + 1} stock source`} type="url" placeholder="Required source URL for a stock claim" value={item.attributes.stockSourceUrl ?? ""} disabled={item.available === null} onChange={(event) => updateItem(sectionIndex, itemIndex, (next) => { next.attributes.stockSourceUrl = event.target.value || null; })} /></div>
-                    <div className="grid gap-3 sm:grid-cols-[1fr_150px_1fr]"><Input aria-label={`Product ${itemIndex + 1} seasonal availability`} placeholder="Seasonal availability (only if sourced)" value={item.attributes.seasonalAvailability} onChange={(event) => updateItem(sectionIndex, itemIndex, (next) => { next.attributes.seasonalAvailability = event.target.value; })} /><select aria-label={`Product ${itemIndex + 1} preorder requirement`} className="h-9 rounded-lg border bg-background px-2 text-sm" value={item.attributes.preorderRequired === null ? "unknown" : item.attributes.preorderRequired ? "required" : "not-required"} onChange={(event) => updateItem(sectionIndex, itemIndex, (next) => { next.attributes.preorderRequired = event.target.value === "unknown" ? null : event.target.value === "required"; })}><option value="unknown">Preorder unknown</option><option value="required">Preorder required</option><option value="not-required">No preorder required</option></select><Input aria-label={`Product ${itemIndex + 1} preorder note`} placeholder="Preorder note (only if sourced)" value={item.attributes.preorderNote} onChange={(event) => updateItem(sectionIndex, itemIndex, (next) => { next.attributes.preorderNote = event.target.value; })} /></div>
-                    <div className="grid gap-3 sm:grid-cols-2"><Input aria-label={`Product ${itemIndex + 1} allergens`} placeholder="Allergens, comma separated" value={item.attributes.allergens.join(", ")} onChange={(event) => updateItem(sectionIndex, itemIndex, (next) => { next.attributes.allergens = event.target.value.split(",").map((value) => value.trim()).filter(Boolean); })} /><Input aria-label={`Product ${itemIndex + 1} allergen source`} type="url" placeholder="Required source URL for allergens" value={item.attributes.allergenSourceUrl ?? ""} onChange={(event) => updateItem(sectionIndex, itemIndex, (next) => { next.attributes.allergenSourceUrl = event.target.value || null; })} /></div>
-                    <div className="grid gap-3 sm:grid-cols-[1fr_180px]"><Input aria-label={`Product ${itemIndex + 1} image`} type="url" placeholder="Approved product image URL" value={item.imageUrl ?? ""} onChange={(event) => updateItem(sectionIndex, itemIndex, (next) => { next.imageUrl = event.target.value || null; if (!next.imageUrl) next.imageProvenance = null; })} /><select aria-label={`Product ${itemIndex + 1} image provenance`} className="h-9 rounded-lg border bg-background px-2 text-sm" value={item.imageProvenance ?? ""} onChange={(event) => updateItem(sectionIndex, itemIndex, (next) => { next.imageProvenance = (event.target.value || null) as "official" | "owner" | "permissioned-ugc" | null; })}><option value="">Choose image source</option><option value="official">Official source</option><option value="owner">Owner supplied</option><option value="permissioned-ugc">Permissioned UGC</option></select></div>
+                  <div
+                    key={itemIndex}
+                    className="space-y-3 rounded-xl border p-4"
+                  >
+                    <div className="grid gap-3 sm:grid-cols-[1fr_120px_auto]">
+                      <Input
+                        aria-label={`Product ${itemIndex + 1} name`}
+                        placeholder="Product name"
+                        value={item.name}
+                        onChange={(event) =>
+                          updateItem(sectionIndex, itemIndex, (next) => {
+                            next.name = event.target.value;
+                          })
+                        }
+                      />
+                      <Input
+                        aria-label={`Product ${itemIndex + 1} price`}
+                        type="number"
+                        min="0"
+                        step="0.01"
+                        placeholder="No price"
+                        value={item.price ?? ""}
+                        onChange={(event) =>
+                          updateItem(sectionIndex, itemIndex, (next) => {
+                            next.price =
+                              event.target.value === ""
+                                ? null
+                                : Number(event.target.value);
+                          })
+                        }
+                      />
+                      <Button
+                        size="icon-sm"
+                        variant="ghost"
+                        aria-label={`Remove product ${itemIndex + 1}`}
+                        onClick={() => removeItem(sectionIndex, itemIndex)}
+                      >
+                        <Trash2 />
+                      </Button>
+                    </div>
+                    <Textarea
+                      aria-label={`Product ${itemIndex + 1} description`}
+                      placeholder="Sourced product description"
+                      value={item.description}
+                      onChange={(event) =>
+                        updateItem(sectionIndex, itemIndex, (next) => {
+                          next.description = event.target.value;
+                        })
+                      }
+                    />
+                    <div className="flex items-center justify-between gap-4 rounded-lg bg-muted/55 px-3 py-2">
+                      <div>
+                        <Label htmlFor={`visible-${sectionIndex}-${itemIndex}`}>
+                          Show product on storefront
+                        </Label>
+                        <p className="text-xs text-muted-foreground">
+                          This controls catalog visibility, not current stock.
+                        </p>
+                      </div>
+                      <Switch
+                        id={`visible-${sectionIndex}-${itemIndex}`}
+                        checked={item.attributes.visible}
+                        onCheckedChange={(checked) =>
+                          updateItem(sectionIndex, itemIndex, (next) => {
+                            next.attributes.visible = checked;
+                          })
+                        }
+                      />
+                    </div>
+                    <div className="grid gap-3 sm:grid-cols-[180px_1fr]">
+                      <select
+                        aria-label={`Product ${itemIndex + 1} stock status`}
+                        className="h-9 rounded-lg border bg-background px-2 text-sm"
+                        value={
+                          item.available === null
+                            ? "unknown"
+                            : item.available
+                              ? "in-stock"
+                              : "out-of-stock"
+                        }
+                        onChange={(event) =>
+                          updateItem(sectionIndex, itemIndex, (next) => {
+                            next.available =
+                              event.target.value === "unknown"
+                                ? null
+                                : event.target.value === "in-stock";
+                            if (next.available === null)
+                              next.attributes.stockSourceUrl = null;
+                          })
+                        }
+                      >
+                        <option value="unknown">Stock unknown</option>
+                        <option value="in-stock">In stock (sourced)</option>
+                        <option value="out-of-stock">
+                          Out of stock (sourced)
+                        </option>
+                      </select>
+                      <Input
+                        aria-label={`Product ${itemIndex + 1} stock source`}
+                        type="url"
+                        placeholder="Required source URL for a stock claim"
+                        value={item.attributes.stockSourceUrl ?? ""}
+                        disabled={item.available === null}
+                        onChange={(event) =>
+                          updateItem(sectionIndex, itemIndex, (next) => {
+                            next.attributes.stockSourceUrl =
+                              event.target.value || null;
+                          })
+                        }
+                      />
+                    </div>
+                    <div className="grid gap-3 sm:grid-cols-[1fr_150px_1fr]">
+                      <Input
+                        aria-label={`Product ${itemIndex + 1} seasonal availability`}
+                        placeholder="Seasonal availability (only if sourced)"
+                        value={item.attributes.seasonalAvailability}
+                        onChange={(event) =>
+                          updateItem(sectionIndex, itemIndex, (next) => {
+                            next.attributes.seasonalAvailability =
+                              event.target.value;
+                          })
+                        }
+                      />
+                      <select
+                        aria-label={`Product ${itemIndex + 1} preorder requirement`}
+                        className="h-9 rounded-lg border bg-background px-2 text-sm"
+                        value={
+                          item.attributes.preorderRequired === null
+                            ? "unknown"
+                            : item.attributes.preorderRequired
+                              ? "required"
+                              : "not-required"
+                        }
+                        onChange={(event) =>
+                          updateItem(sectionIndex, itemIndex, (next) => {
+                            next.attributes.preorderRequired =
+                              event.target.value === "unknown"
+                                ? null
+                                : event.target.value === "required";
+                          })
+                        }
+                      >
+                        <option value="unknown">Preorder unknown</option>
+                        <option value="required">Preorder required</option>
+                        <option value="not-required">
+                          No preorder required
+                        </option>
+                      </select>
+                      <Input
+                        aria-label={`Product ${itemIndex + 1} preorder note`}
+                        placeholder="Preorder note (only if sourced)"
+                        value={item.attributes.preorderNote}
+                        onChange={(event) =>
+                          updateItem(sectionIndex, itemIndex, (next) => {
+                            next.attributes.preorderNote = event.target.value;
+                          })
+                        }
+                      />
+                    </div>
+                    <div className="grid gap-3 sm:grid-cols-2">
+                      <Input
+                        aria-label={`Product ${itemIndex + 1} allergens`}
+                        placeholder="Allergens, comma separated"
+                        value={item.attributes.allergens.join(", ")}
+                        onChange={(event) =>
+                          updateItem(sectionIndex, itemIndex, (next) => {
+                            next.attributes.allergens = event.target.value
+                              .split(",")
+                              .map((value) => value.trim())
+                              .filter(Boolean);
+                          })
+                        }
+                      />
+                      <Input
+                        aria-label={`Product ${itemIndex + 1} allergen source`}
+                        type="url"
+                        placeholder="Required source URL for allergens"
+                        value={item.attributes.allergenSourceUrl ?? ""}
+                        onChange={(event) =>
+                          updateItem(sectionIndex, itemIndex, (next) => {
+                            next.attributes.allergenSourceUrl =
+                              event.target.value || null;
+                          })
+                        }
+                      />
+                    </div>
+                    <div className="grid gap-3 sm:grid-cols-[1fr_180px]">
+                      <Input
+                        aria-label={`Product ${itemIndex + 1} image`}
+                        type="url"
+                        placeholder="Approved product image URL"
+                        value={item.imageUrl ?? ""}
+                        onChange={(event) =>
+                          updateItem(sectionIndex, itemIndex, (next) => {
+                            next.imageUrl = event.target.value || null;
+                            if (!next.imageUrl) next.imageProvenance = null;
+                          })
+                        }
+                      />
+                      <select
+                        aria-label={`Product ${itemIndex + 1} image provenance`}
+                        className="h-9 rounded-lg border bg-background px-2 text-sm"
+                        value={item.imageProvenance ?? ""}
+                        onChange={(event) =>
+                          updateItem(sectionIndex, itemIndex, (next) => {
+                            next.imageProvenance = (event.target.value ||
+                              null) as
+                              "official" | "owner" | "permissioned-ugc" | null;
+                          })
+                        }
+                      >
+                        <option value="">Choose image source</option>
+                        <option value="official">Official source</option>
+                        <option value="owner">Owner supplied</option>
+                        <option value="permissioned-ugc">
+                          Permissioned UGC
+                        </option>
+                      </select>
+                    </div>
                   </div>
                 ))}
-                <Button size="sm" variant="outline" onClick={() => addItem(sectionIndex)}><Plus /> Add sourced product</Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => addItem(sectionIndex)}
+                >
+                  <Plus /> Add sourced product
+                </Button>
               </CardContent>
             </Card>
           ))}
 
-          <Button variant="outline" onClick={addSection}><Plus /> Add product category</Button>
+          <Button variant="outline" onClick={addSection}>
+            <Plus /> Add product category
+          </Button>
 
           <Card>
-            <CardHeader className="flex-row items-center justify-between"><CardTitle>Preorder and delivery links</CardTitle><Button size="sm" variant="outline" onClick={addIntegration}><Plus /> Add link</Button></CardHeader>
+            <CardHeader className="flex-row items-center justify-between">
+              <CardTitle>Preorder and delivery links</CardTitle>
+              <Button size="sm" variant="outline" onClick={addIntegration}>
+                <Plus /> Add link
+              </Button>
+            </CardHeader>
             <CardContent className="space-y-3">
-              {draft.integrations.filter((integration) => integration.type !== "social").map((integration) => {
-                const integrationIndex = draft.integrations.indexOf(integration);
-                return <div key={integrationIndex} className="grid gap-2 rounded-xl border p-3 sm:grid-cols-[130px_1fr_1.4fr_auto]"><select aria-label={`Link ${integrationIndex + 1} type`} className="h-9 rounded-lg border bg-background px-2 text-sm" value={integration.type} onChange={(event) => setDraft({ ...draft, integrations: draft.integrations.map((candidate, index) => index === integrationIndex ? { ...candidate, type: event.target.value as "ordering" | "delivery" } : candidate) })}><option value="ordering">Preorder</option><option value="delivery">Delivery</option></select><Input aria-label={`Link ${integrationIndex + 1} label`} placeholder="Order for pickup" value={integration.label} onChange={(event) => setDraft((current) => markFoodRetailTranslationsStale({ ...current, integrations: current.integrations.map((candidate, index) => index === integrationIndex ? { ...candidate, label: event.target.value } : candidate) }))} /><Input aria-label={`Link ${integrationIndex + 1} URL`} type="url" placeholder="https://…" value={integration.url} onChange={(event) => setDraft({ ...draft, integrations: draft.integrations.map((candidate, index) => index === integrationIndex ? { ...candidate, url: event.target.value } : candidate) })} /><Button size="icon-sm" variant="ghost" aria-label={`Remove link ${integrationIndex + 1}`} onClick={() => removeIntegration(integrationIndex)}><Trash2 /></Button></div>;
-              })}
+              {draft.integrations
+                .filter((integration) => integration.type !== "social")
+                .map((integration) => {
+                  const integrationIndex =
+                    draft.integrations.indexOf(integration);
+                  return (
+                    <div
+                      key={integrationIndex}
+                      className="grid gap-2 rounded-xl border p-3 sm:grid-cols-[130px_1fr_1.4fr_auto]"
+                    >
+                      <select
+                        aria-label={`Link ${integrationIndex + 1} type`}
+                        className="h-9 rounded-lg border bg-background px-2 text-sm"
+                        value={integration.type}
+                        onChange={(event) =>
+                          setDraft({
+                            ...draft,
+                            integrations: draft.integrations.map(
+                              (candidate, index) =>
+                                index === integrationIndex
+                                  ? {
+                                      ...candidate,
+                                      type: event.target.value as
+                                        "ordering" | "delivery",
+                                    }
+                                  : candidate,
+                            ),
+                          })
+                        }
+                      >
+                        <option value="ordering">Preorder</option>
+                        <option value="delivery">Delivery</option>
+                      </select>
+                      <Input
+                        aria-label={`Link ${integrationIndex + 1} label`}
+                        placeholder="Order for pickup"
+                        value={integration.label}
+                        onChange={(event) =>
+                          setDraft((current) =>
+                            markFoodRetailTranslationsStale({
+                              ...current,
+                              integrations: current.integrations.map(
+                                (candidate, index) =>
+                                  index === integrationIndex
+                                    ? {
+                                        ...candidate,
+                                        label: event.target.value,
+                                      }
+                                    : candidate,
+                              ),
+                            }),
+                          )
+                        }
+                      />
+                      <Input
+                        aria-label={`Link ${integrationIndex + 1} URL`}
+                        type="url"
+                        placeholder="https://…"
+                        value={integration.url}
+                        onChange={(event) =>
+                          setDraft({
+                            ...draft,
+                            integrations: draft.integrations.map(
+                              (candidate, index) =>
+                                index === integrationIndex
+                                  ? { ...candidate, url: event.target.value }
+                                  : candidate,
+                            ),
+                          })
+                        }
+                      />
+                      <Button
+                        size="icon-sm"
+                        variant="ghost"
+                        aria-label={`Remove link ${integrationIndex + 1}`}
+                        onClick={() => removeIntegration(integrationIndex)}
+                      >
+                        <Trash2 />
+                      </Button>
+                    </div>
+                  );
+                })}
             </CardContent>
           </Card>
 
@@ -354,50 +953,203 @@ export function FoodRetailDashboard({
                 <div>
                   <div className="flex items-center gap-2">
                     <Languages className="size-4" />
-                    <CardTitle>{translation.locale.toUpperCase()} localized copy</CardTitle>
+                    <CardTitle>
+                      {translation.locale.toUpperCase()} localized copy
+                    </CardTitle>
                   </div>
                   <p className="mt-2 max-w-2xl text-xs leading-5 text-muted-foreground">
-                    New entries temporarily reuse the canonical source wording so the private draft stays saveable without inventing a translation. Translate the wording below, then review it before any future launch. Prices, stock, links and source evidence stay canonical.
+                    New entries temporarily reuse the canonical source wording
+                    so the private draft stays saveable without inventing a
+                    translation. Translate the wording below, then review it
+                    before any future launch. Prices, stock, links and source
+                    evidence stay canonical.
                   </p>
                 </div>
                 <div className="flex items-center gap-2">
-                  <span className="rounded-full border px-2 py-1 text-xs capitalize">{translation.status}</span>
-                  <Button size="sm" disabled={translation.status === "current"} onClick={() => reviewTranslation(translation.locale)}><Check /> Mark reviewed</Button>
+                  <span className="rounded-full border px-2 py-1 text-xs capitalize">
+                    {translation.status}
+                  </span>
+                  <Button
+                    size="sm"
+                    disabled={translation.status === "current"}
+                    onClick={() => reviewTranslation(translation.locale)}
+                  >
+                    <Check /> Mark reviewed
+                  </Button>
                 </div>
               </CardHeader>
               <CardContent className="space-y-5">
                 <div className="grid gap-3 sm:grid-cols-2">
-                  <Field label="Eyebrow"><Input aria-label={`${translation.locale} eyebrow`} value={translation.eyebrow} onChange={(event) => changeTranslation(translation.locale, (next) => { next.eyebrow = event.target.value; })} /></Field>
-                  <Field label="Pickup details"><Input aria-label={`${translation.locale} pickup details`} value={translation.attributes.pickupDetails} onChange={(event) => changeTranslation(translation.locale, (next) => { next.attributes.pickupDetails = event.target.value; })} /></Field>
-                  <Field label="Description" className="sm:col-span-2"><Textarea aria-label={`${translation.locale} description`} value={translation.description} onChange={(event) => changeTranslation(translation.locale, (next) => { next.description = event.target.value; })} /></Field>
+                  <Field label="Eyebrow">
+                    <Input
+                      aria-label={`${translation.locale} eyebrow`}
+                      value={translation.eyebrow}
+                      onChange={(event) =>
+                        changeTranslation(translation.locale, (next) => {
+                          next.eyebrow = event.target.value;
+                        })
+                      }
+                    />
+                  </Field>
+                  <Field label="Pickup details">
+                    <Input
+                      aria-label={`${translation.locale} pickup details`}
+                      value={translation.attributes.pickupDetails}
+                      onChange={(event) =>
+                        changeTranslation(translation.locale, (next) => {
+                          next.attributes.pickupDetails = event.target.value;
+                        })
+                      }
+                    />
+                  </Field>
+                  <Field label="Description" className="sm:col-span-2">
+                    <Textarea
+                      aria-label={`${translation.locale} description`}
+                      value={translation.description}
+                      onChange={(event) =>
+                        changeTranslation(translation.locale, (next) => {
+                          next.description = event.target.value;
+                        })
+                      }
+                    />
+                  </Field>
                 </div>
 
-                {translation.catalogSections.map((translatedSection, sectionIndex) => (
-                  <div key={sectionIndex} className="space-y-3 rounded-xl border p-4">
-                    <p className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">Category {sectionIndex + 1}</p>
-                    <div className="grid gap-3 sm:grid-cols-2">
-                      <Input aria-label={`${translation.locale} category ${sectionIndex + 1} name`} value={translatedSection.name} onChange={(event) => changeTranslation(translation.locale, (next) => { next.catalogSections[sectionIndex].name = event.target.value; })} />
-                      <Input aria-label={`${translation.locale} category ${sectionIndex + 1} description`} placeholder="Localized category description" value={translatedSection.description} onChange={(event) => changeTranslation(translation.locale, (next) => { next.catalogSections[sectionIndex].description = event.target.value; })} />
-                    </div>
-                    {translatedSection.items.map((translatedItem, itemIndex) => (
-                      <div key={itemIndex} className="grid gap-3 rounded-lg bg-muted/45 p-3 sm:grid-cols-2">
-                        <Input aria-label={`${translation.locale} product ${itemIndex + 1} name`} value={translatedItem.name} onChange={(event) => changeTranslation(translation.locale, (next) => { next.catalogSections[sectionIndex].items[itemIndex].name = event.target.value; })} />
-                        <Input aria-label={`${translation.locale} product ${itemIndex + 1} description`} placeholder="Localized product description" value={translatedItem.description} onChange={(event) => changeTranslation(translation.locale, (next) => { next.catalogSections[sectionIndex].items[itemIndex].description = event.target.value; })} />
-                        <Input aria-label={`${translation.locale} product ${itemIndex + 1} seasonal availability`} placeholder="Localized sourced seasonal wording" value={translatedItem.attributes.seasonalAvailability} onChange={(event) => changeTranslation(translation.locale, (next) => { next.catalogSections[sectionIndex].items[itemIndex].attributes.seasonalAvailability = event.target.value; })} />
-                        <Input aria-label={`${translation.locale} product ${itemIndex + 1} preorder note`} placeholder="Localized sourced preorder note" value={translatedItem.attributes.preorderNote} onChange={(event) => changeTranslation(translation.locale, (next) => { next.catalogSections[sectionIndex].items[itemIndex].attributes.preorderNote = event.target.value; })} />
-                        {translatedItem.attributes.allergens.length > 0 ? <p className="text-xs text-muted-foreground sm:col-span-2">Sourced allergen terms remain unchanged: {translatedItem.attributes.allergens.join(", ")}</p> : null}
+                {translation.catalogSections.map(
+                  (translatedSection, sectionIndex) => (
+                    <div
+                      key={sectionIndex}
+                      className="space-y-3 rounded-xl border p-4"
+                    >
+                      <p className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+                        Category {sectionIndex + 1}
+                      </p>
+                      <div className="grid gap-3 sm:grid-cols-2">
+                        <Input
+                          aria-label={`${translation.locale} category ${sectionIndex + 1} name`}
+                          value={translatedSection.name}
+                          onChange={(event) =>
+                            changeTranslation(translation.locale, (next) => {
+                              next.catalogSections[sectionIndex].name =
+                                event.target.value;
+                            })
+                          }
+                        />
+                        <Input
+                          aria-label={`${translation.locale} category ${sectionIndex + 1} description`}
+                          placeholder="Localized category description"
+                          value={translatedSection.description}
+                          onChange={(event) =>
+                            changeTranslation(translation.locale, (next) => {
+                              next.catalogSections[sectionIndex].description =
+                                event.target.value;
+                            })
+                          }
+                        />
                       </div>
-                    ))}
-                  </div>
-                ))}
+                      {translatedSection.items.map(
+                        (translatedItem, itemIndex) => (
+                          <div
+                            key={itemIndex}
+                            className="grid gap-3 rounded-lg bg-muted/45 p-3 sm:grid-cols-2"
+                          >
+                            <Input
+                              aria-label={`${translation.locale} product ${itemIndex + 1} name`}
+                              value={translatedItem.name}
+                              onChange={(event) =>
+                                changeTranslation(
+                                  translation.locale,
+                                  (next) => {
+                                    next.catalogSections[sectionIndex].items[
+                                      itemIndex
+                                    ].name = event.target.value;
+                                  },
+                                )
+                              }
+                            />
+                            <Input
+                              aria-label={`${translation.locale} product ${itemIndex + 1} description`}
+                              placeholder="Localized product description"
+                              value={translatedItem.description}
+                              onChange={(event) =>
+                                changeTranslation(
+                                  translation.locale,
+                                  (next) => {
+                                    next.catalogSections[sectionIndex].items[
+                                      itemIndex
+                                    ].description = event.target.value;
+                                  },
+                                )
+                              }
+                            />
+                            <Input
+                              aria-label={`${translation.locale} product ${itemIndex + 1} seasonal availability`}
+                              placeholder="Localized sourced seasonal wording"
+                              value={
+                                translatedItem.attributes.seasonalAvailability
+                              }
+                              onChange={(event) =>
+                                changeTranslation(
+                                  translation.locale,
+                                  (next) => {
+                                    next.catalogSections[sectionIndex].items[
+                                      itemIndex
+                                    ].attributes.seasonalAvailability =
+                                      event.target.value;
+                                  },
+                                )
+                              }
+                            />
+                            <Input
+                              aria-label={`${translation.locale} product ${itemIndex + 1} preorder note`}
+                              placeholder="Localized sourced preorder note"
+                              value={translatedItem.attributes.preorderNote}
+                              onChange={(event) =>
+                                changeTranslation(
+                                  translation.locale,
+                                  (next) => {
+                                    next.catalogSections[sectionIndex].items[
+                                      itemIndex
+                                    ].attributes.preorderNote =
+                                      event.target.value;
+                                  },
+                                )
+                              }
+                            />
+                            {translatedItem.attributes.allergens.length > 0 ? (
+                              <p className="text-xs text-muted-foreground sm:col-span-2">
+                                Sourced allergen terms remain unchanged:{" "}
+                                {translatedItem.attributes.allergens.join(", ")}
+                              </p>
+                            ) : null}
+                          </div>
+                        ),
+                      )}
+                    </div>
+                  ),
+                )}
 
                 {translation.integrationLabels.length > 0 ? (
                   <div className="grid gap-3 sm:grid-cols-2">
-                    {translation.integrationLabels.map((label, integrationIndex) => (
-                      <Field key={integrationIndex} label={`Link ${integrationIndex + 1} label`}>
-                        <Input aria-label={`${translation.locale} link ${integrationIndex + 1} label`} value={label} onChange={(event) => changeTranslation(translation.locale, (next) => { next.integrationLabels[integrationIndex] = event.target.value; })} />
-                      </Field>
-                    ))}
+                    {translation.integrationLabels.map(
+                      (label, integrationIndex) => (
+                        <Field
+                          key={integrationIndex}
+                          label={`Link ${integrationIndex + 1} label`}
+                        >
+                          <Input
+                            aria-label={`${translation.locale} link ${integrationIndex + 1} label`}
+                            value={label}
+                            onChange={(event) =>
+                              changeTranslation(translation.locale, (next) => {
+                                next.integrationLabels[integrationIndex] =
+                                  event.target.value;
+                              })
+                            }
+                          />
+                        </Field>
+                      ),
+                    )}
                   </div>
                 ) : null}
               </CardContent>
@@ -407,7 +1159,11 @@ export function FoodRetailDashboard({
 
         <div className="xl:sticky xl:top-6 xl:h-[calc(100vh-3rem)]">
           <div className="h-full overflow-auto rounded-[2rem] border-[8px] border-[#171914] bg-white shadow-2xl">
-            <SiteRenderer draft={draft} vertical={Vertical.FOOD_RETAIL} embedded />
+            <SiteRenderer
+              draft={draft}
+              vertical={Vertical.FOOD_RETAIL}
+              embedded
+            />
           </div>
         </div>
       </main>
@@ -415,6 +1171,19 @@ export function FoodRetailDashboard({
   );
 }
 
-function Field({ label, className, children }: { label: string; className?: string; children: React.ReactNode }) {
-  return <div className={className}><Label className="mb-2">{label}</Label>{children}</div>;
+function Field({
+  label,
+  className,
+  children,
+}: {
+  label: string;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={className}>
+      <Label className="mb-2">{label}</Label>
+      {children}
+    </div>
+  );
 }

--- a/src/app/dashboard/local-service-dashboard.tsx
+++ b/src/app/dashboard/local-service-dashboard.tsx
@@ -6,6 +6,7 @@ import {
   ExternalLink,
   LoaderCircle,
   Plus,
+  Rocket,
   Save,
   Trash2,
 } from "lucide-react";
@@ -73,18 +74,25 @@ export function LocalServiceDashboard({
   email,
   brand,
   canSwitchWorkspace,
+  initiallyPublished,
+  platformUrl,
 }: {
   initialDraft: LocalServiceSiteDraft;
   initialRevision: number;
   email: string;
   brand: BrandIdentity;
   canSwitchWorkspace: boolean;
+  initiallyPublished: boolean;
+  platformUrl: string;
 }) {
   const [draft, setDraftState] = useState(initialDraft);
   const draftRef = useRef(initialDraft);
   const mutationVersionRef = useRef(0);
   const [dirty, setDirty] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [publishing, setPublishing] = useState(false);
+  const [publishedVersion, setPublishedVersion] = useState<number | null>(null);
+  const [published, setPublished] = useState(initiallyPublished);
   const [savedRevision, setSavedRevision] = useState(initialRevision);
   const savedRevisionRef = useRef(initialRevision);
   const [notice, setNotice] = useState<string | null>(null);
@@ -101,7 +109,7 @@ export function LocalServiceDashboard({
     setError(null);
   }
 
-  async function save(): Promise<boolean> {
+  async function save(): Promise<number | null> {
     const submittedDraft = draftRef.current;
     const submittedMutationVersion = mutationVersionRef.current;
     const parsed = localServiceSiteDraftSchema.safeParse(submittedDraft);
@@ -112,7 +120,7 @@ export function LocalServiceDashboard({
           .map((issue) => `${issue.path.join(".")}: ${issue.message}`)
           .join(" · "),
       );
-      return false;
+      return null;
     }
     setSaving(true);
     setError(null);
@@ -154,12 +162,53 @@ export function LocalServiceDashboard({
           ? `Draft revision ${reconciled.revision} saved; newer edits remain unsaved`
           : "Private draft saved",
       );
-      return true;
+      return reconciled.hadNewerEdits ? null : reconciled.revision;
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : "Save failed");
-      return false;
+      return null;
     } finally {
       setSaving(false);
+    }
+  }
+
+  async function publish() {
+    const changeSummary = window
+      .prompt(
+        "Summarize what will change on the public site:",
+        "Publish reviewed service website",
+      )
+      ?.trim();
+    if (!changeSummary) return;
+    if (changeSummary.length < 3 || changeSummary.length > 280) {
+      setError("Use a change summary between 3 and 280 characters.");
+      return;
+    }
+    if (!window.confirm("Publish this reviewed service website now?")) return;
+
+    setPublishing(true);
+    setError(null);
+    try {
+      const expectedRevision = await save();
+      if (expectedRevision === null) return;
+      const response = await fetch(`/api/sites/${draft.slug}/publish`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ changeSummary, expectedRevision }),
+      });
+      const result = (await response.json()) as {
+        error?: string;
+        published?: { version: number };
+      };
+      if (!response.ok || !result.published) {
+        throw new Error(result.error ?? "Publish failed");
+      }
+      setPublished(true);
+      setPublishedVersion(result.published.version);
+      setNotice(`Published version ${result.published.version}.`);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Publish failed");
+    } finally {
+      setPublishing(false);
     }
   }
 
@@ -169,7 +218,9 @@ export function LocalServiceDashboard({
         <div className="mx-auto flex max-w-7xl items-center justify-between gap-4 px-6 py-4">
           <Brand {...brand} />
           <div className="flex items-center gap-3">
-            <span className="hidden text-xs text-muted-foreground sm:inline">{email}</span>
+            <span className="hidden text-xs text-muted-foreground sm:inline">
+              {email}
+            </span>
             <AccountActions canSwitch={canSwitchWorkspace} />
           </div>
         </div>
@@ -178,94 +229,475 @@ export function LocalServiceDashboard({
       <main className="mx-auto max-w-7xl px-6 py-10">
         <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
           <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-primary">Local-service editor</p>
-            <h1 className="font-display mt-2 text-5xl leading-none tracking-[-0.045em]">Services, proof and contact.</h1>
-            <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">Edit only facts the business can support. Phone, WhatsApp and quote links stay external; this vertical remains a private pilot with publishing disabled.</p>
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-primary">
+              Local-service editor
+            </p>
+            <h1 className="font-display mt-2 text-5xl leading-none tracking-[-0.045em]">
+              Services, proof and contact.
+            </h1>
+            <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+              Edit only facts the business can support. Phone, WhatsApp and
+              quote links stay external; publish only after the owner has
+              reviewed every claim.
+            </p>
           </div>
           <div className="flex flex-wrap gap-2">
-            <Button render={<Link href={`/preview/${draft.slug}`} target="_blank" />} nativeButton={false} variant="outline">
-              Preview <ExternalLink />
+            <Button
+              render={
+                <Link
+                  href={published ? platformUrl : `/preview/${draft.slug}`}
+                  target="_blank"
+                />
+              }
+              nativeButton={false}
+              variant="outline"
+            >
+              {published ? "View live" : "Preview"} <ExternalLink />
             </Button>
-            <Button onClick={() => void save()} disabled={saving || !dirty}>
+            <Button
+              onClick={() => void save()}
+              disabled={saving || publishing || !dirty}
+            >
               {saving ? <LoaderCircle className="animate-spin" /> : <Save />}
               {dirty ? "Save draft" : "Saved"}
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => void publish()}
+              disabled={saving || publishing}
+            >
+              {publishing ? (
+                <LoaderCircle className="animate-spin" />
+              ) : (
+                <Rocket />
+              )}
+              {publishedVersion ? `Published v${publishedVersion}` : "Publish"}
             </Button>
           </div>
         </div>
 
         <div className="mt-5 flex flex-wrap items-center gap-2 text-xs">
-          <Badge variant={dirty ? "outline" : "secondary"}>{dirty ? "Unsaved changes" : `Draft revision ${savedRevision}`}</Badge>
-          <Badge variant="outline">Private pilot · publishing disabled</Badge>
-          {notice ? <span role="status" className="text-emerald-700">{notice}</span> : null}
+          <Badge variant={dirty ? "outline" : "secondary"}>
+            {dirty ? "Unsaved changes" : `Draft revision ${savedRevision}`}
+          </Badge>
+          <Badge variant="outline">
+            {published ? "Live on platform URL" : "Private draft"}
+          </Badge>
+          {notice ? (
+            <span role="status" className="text-emerald-700">
+              {notice}
+            </span>
+          ) : null}
         </div>
-        {error ? <p role="alert" className="mt-4 rounded-xl border border-destructive/25 bg-destructive/5 p-4 text-sm text-destructive">{error}</p> : null}
+        {error ? (
+          <p
+            role="alert"
+            className="mt-4 rounded-xl border border-destructive/25 bg-destructive/5 p-4 text-sm text-destructive"
+          >
+            {error}
+          </p>
+        ) : null}
 
         <div className="mt-8 grid gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
           <Card>
-            <CardHeader><CardTitle>Business essentials</CardTitle></CardHeader>
+            <CardHeader>
+              <CardTitle>Business essentials</CardTitle>
+            </CardHeader>
             <CardContent className="grid gap-4 md:grid-cols-2">
-              <Field label="Business name"><Input value={draft.name} onChange={(event) => change((next) => { next.name = event.target.value; })} /></Field>
-              <Field label="Phone"><Input value={draft.phone} onChange={(event) => change((next) => { next.phone = event.target.value; })} /></Field>
-              <Field label="Hero eyebrow"><Input value={draft.eyebrow} onChange={(event) => change((next) => { next.eyebrow = event.target.value; })} /></Field>
-              <Field label="Address"><Input value={draft.address} onChange={(event) => change((next) => { next.address = event.target.value; })} /></Field>
-              <Field label="Description" className="md:col-span-2"><Textarea value={draft.description} onChange={(event) => change((next) => { next.description = event.target.value; })} /></Field>
-              <Field label="Hours — one “days | hours” row per line" className="md:col-span-2"><Textarea value={draft.businessHours.map((row) => `${row.days} | ${row.hours}`).join("\n")} onChange={(event) => change((next) => { next.businessHours = parsePairs(event.target.value).map(([days, hours]) => ({ days, hours })); })} /></Field>
+              <Field label="Business name">
+                <Input
+                  value={draft.name}
+                  onChange={(event) =>
+                    change((next) => {
+                      next.name = event.target.value;
+                    })
+                  }
+                />
+              </Field>
+              <Field label="Phone">
+                <Input
+                  value={draft.phone}
+                  onChange={(event) =>
+                    change((next) => {
+                      next.phone = event.target.value;
+                    })
+                  }
+                />
+              </Field>
+              <Field label="Hero eyebrow">
+                <Input
+                  value={draft.eyebrow}
+                  onChange={(event) =>
+                    change((next) => {
+                      next.eyebrow = event.target.value;
+                    })
+                  }
+                />
+              </Field>
+              <Field label="Address">
+                <Input
+                  value={draft.address}
+                  onChange={(event) =>
+                    change((next) => {
+                      next.address = event.target.value;
+                    })
+                  }
+                />
+              </Field>
+              <Field label="Description" className="md:col-span-2">
+                <Textarea
+                  value={draft.description}
+                  onChange={(event) =>
+                    change((next) => {
+                      next.description = event.target.value;
+                    })
+                  }
+                />
+              </Field>
+              <Field
+                label="Hours — one “days | hours” row per line"
+                className="md:col-span-2"
+              >
+                <Textarea
+                  value={draft.businessHours
+                    .map((row) => `${row.days} | ${row.hours}`)
+                    .join("\n")}
+                  onChange={(event) =>
+                    change((next) => {
+                      next.businessHours = parsePairs(event.target.value).map(
+                        ([days, hours]) => ({ days, hours }),
+                      );
+                    })
+                  }
+                />
+              </Field>
             </CardContent>
           </Card>
 
           <Card>
-            <CardHeader><CardTitle>Trade posture</CardTitle></CardHeader>
+            <CardHeader>
+              <CardTitle>Trade posture</CardTitle>
+            </CardHeader>
             <CardContent className="grid gap-4 md:grid-cols-2">
-              <Field label="Trade type"><select className="h-8 w-full rounded-lg border bg-background px-2.5 text-sm" value={draft.attributes.tradeType} onChange={(event) => change((next) => { next.attributes.tradeType = event.target.value as LocalServiceAttributes["tradeType"]; })}>{tradeTypes.map((value) => <option key={value}>{value}</option>)}</select></Field>
-              <Field label="Availability"><select className="h-8 w-full rounded-lg border bg-background px-2.5 text-sm" value={draft.attributes.availabilityPosture} onChange={(event) => change((next) => { next.attributes.availabilityPosture = event.target.value as LocalServiceAttributes["availabilityPosture"]; })}>{availabilityPostures.map((value) => <option key={value}>{value}</option>)}</select></Field>
-              <Field label="Service areas — one per line"><Textarea value={draft.attributes.serviceAreas.join("\n")} onChange={(event) => change((next) => { next.attributes.serviceAreas = lines(event.target.value); })} /></Field>
-              <Field label="Insurance posture"><select className="h-8 w-full rounded-lg border bg-background px-2.5 text-sm" value={draft.attributes.insuranceStatus} onChange={(event) => change((next) => { next.attributes.insuranceStatus = event.target.value as LocalServiceAttributes["insuranceStatus"]; })}><option>not-stated</option><option>insured</option><option>not-insured</option></select><Input className="mt-2" value={draft.attributes.insuranceDetail} placeholder="Evidence-backed detail" onChange={(event) => change((next) => { next.attributes.insuranceDetail = event.target.value; })} /></Field>
-              <Field label="Credentials — name | issuer | reference" className="md:col-span-2"><Textarea value={draft.attributes.credentials.map((item) => [item.name, item.issuer, item.reference].join(" | ")).join("\n")} onChange={(event) => change((next) => { next.attributes.credentials = parseTriples(event.target.value).map(([name, issuer, reference]) => ({ name, issuer, reference })); })} /></Field>
-              <Field label="Trust signals — label | evidence" className="md:col-span-2"><Textarea value={draft.attributes.trustSignals.map((item) => [item.label, item.detail].join(" | ")).join("\n")} onChange={(event) => change((next) => { next.attributes.trustSignals = parsePairs(event.target.value).map(([label, detail]) => ({ label, detail })); })} /></Field>
+              <Field label="Trade type">
+                <select
+                  className="h-8 w-full rounded-lg border bg-background px-2.5 text-sm"
+                  value={draft.attributes.tradeType}
+                  onChange={(event) =>
+                    change((next) => {
+                      next.attributes.tradeType = event.target
+                        .value as LocalServiceAttributes["tradeType"];
+                    })
+                  }
+                >
+                  {tradeTypes.map((value) => (
+                    <option key={value}>{value}</option>
+                  ))}
+                </select>
+              </Field>
+              <Field label="Availability">
+                <select
+                  className="h-8 w-full rounded-lg border bg-background px-2.5 text-sm"
+                  value={draft.attributes.availabilityPosture}
+                  onChange={(event) =>
+                    change((next) => {
+                      next.attributes.availabilityPosture = event.target
+                        .value as LocalServiceAttributes["availabilityPosture"];
+                    })
+                  }
+                >
+                  {availabilityPostures.map((value) => (
+                    <option key={value}>{value}</option>
+                  ))}
+                </select>
+              </Field>
+              <Field label="Service areas — one per line">
+                <Textarea
+                  value={draft.attributes.serviceAreas.join("\n")}
+                  onChange={(event) =>
+                    change((next) => {
+                      next.attributes.serviceAreas = lines(event.target.value);
+                    })
+                  }
+                />
+              </Field>
+              <Field label="Insurance posture">
+                <select
+                  className="h-8 w-full rounded-lg border bg-background px-2.5 text-sm"
+                  value={draft.attributes.insuranceStatus}
+                  onChange={(event) =>
+                    change((next) => {
+                      next.attributes.insuranceStatus = event.target
+                        .value as LocalServiceAttributes["insuranceStatus"];
+                    })
+                  }
+                >
+                  <option>not-stated</option>
+                  <option>insured</option>
+                  <option>not-insured</option>
+                </select>
+                <Input
+                  className="mt-2"
+                  value={draft.attributes.insuranceDetail}
+                  placeholder="Evidence-backed detail"
+                  onChange={(event) =>
+                    change((next) => {
+                      next.attributes.insuranceDetail = event.target.value;
+                    })
+                  }
+                />
+              </Field>
+              <Field
+                label="Credentials — name | issuer | reference"
+                className="md:col-span-2"
+              >
+                <Textarea
+                  value={draft.attributes.credentials
+                    .map((item) =>
+                      [item.name, item.issuer, item.reference].join(" | "),
+                    )
+                    .join("\n")}
+                  onChange={(event) =>
+                    change((next) => {
+                      next.attributes.credentials = parseTriples(
+                        event.target.value,
+                      ).map(([name, issuer, reference]) => ({
+                        name,
+                        issuer,
+                        reference,
+                      }));
+                    })
+                  }
+                />
+              </Field>
+              <Field
+                label="Trust signals — label | evidence"
+                className="md:col-span-2"
+              >
+                <Textarea
+                  value={draft.attributes.trustSignals
+                    .map((item) => [item.label, item.detail].join(" | "))
+                    .join("\n")}
+                  onChange={(event) =>
+                    change((next) => {
+                      next.attributes.trustSignals = parsePairs(
+                        event.target.value,
+                      ).map(([label, detail]) => ({ label, detail }));
+                    })
+                  }
+                />
+              </Field>
             </CardContent>
           </Card>
         </div>
 
-        <EditorSection title="Services" actionLabel="Add service group" onAdd={() => change((next) => {
-          next.catalogSections.push({ name: "New service group", description: "", items: [] });
-          next.translations.forEach((translation) => {
-            translation.catalogSections.push({ name: "New service group", description: "", items: [] });
-          });
-        })}>
+        <EditorSection
+          title="Services"
+          actionLabel="Add service group"
+          onAdd={() =>
+            change((next) => {
+              next.catalogSections.push({
+                name: "New service group",
+                description: "",
+                items: [],
+              });
+              next.translations.forEach((translation) => {
+                translation.catalogSections.push({
+                  name: "New service group",
+                  description: "",
+                  items: [],
+                });
+              });
+            })
+          }
+        >
           {draft.catalogSections.map((section, sectionIndex) => (
             <Card key={`section-${sectionIndex}`}>
               <CardContent className="space-y-4 pt-2">
                 <div className="grid gap-3 md:grid-cols-[1fr_1.5fr_auto]">
-                  <Input aria-label="Service group name" value={section.name} onChange={(event) => change((next) => { next.catalogSections[sectionIndex].name = event.target.value; })} />
-                  <Input aria-label="Service group description" value={section.description} onChange={(event) => change((next) => { next.catalogSections[sectionIndex].description = event.target.value; })} />
-                  <Button variant="destructive" size="icon" aria-label={`Delete ${section.name}`} disabled={draft.catalogSections.length === 1} onClick={() => change((next) => {
-                    next.catalogSections.splice(sectionIndex, 1);
-                    next.translations.forEach((translation) => {
-                      translation.catalogSections.splice(sectionIndex, 1);
-                    });
-                  })}><Trash2 /></Button>
+                  <Input
+                    aria-label="Service group name"
+                    value={section.name}
+                    onChange={(event) =>
+                      change((next) => {
+                        next.catalogSections[sectionIndex].name =
+                          event.target.value;
+                      })
+                    }
+                  />
+                  <Input
+                    aria-label="Service group description"
+                    value={section.description}
+                    onChange={(event) =>
+                      change((next) => {
+                        next.catalogSections[sectionIndex].description =
+                          event.target.value;
+                      })
+                    }
+                  />
+                  <Button
+                    variant="destructive"
+                    size="icon"
+                    aria-label={`Delete ${section.name}`}
+                    disabled={draft.catalogSections.length === 1}
+                    onClick={() =>
+                      change((next) => {
+                        next.catalogSections.splice(sectionIndex, 1);
+                        next.translations.forEach((translation) => {
+                          translation.catalogSections.splice(sectionIndex, 1);
+                        });
+                      })
+                    }
+                  >
+                    <Trash2 />
+                  </Button>
                 </div>
                 {section.items.map((item, itemIndex) => (
-                  <div key={`service-${sectionIndex}-${itemIndex}`} className="grid gap-3 rounded-xl border p-4 md:grid-cols-2">
-                    <Field label="Service"><Input value={item.name} onChange={(event) => change((next) => { next.catalogSections[sectionIndex].items[itemIndex].name = event.target.value; })} /></Field>
-                    <Field label="Description"><Input value={item.description} onChange={(event) => change((next) => { next.catalogSections[sectionIndex].items[itemIndex].description = event.target.value; })} /></Field>
-                    <Field label="Pricing model"><select className="h-8 w-full rounded-lg border bg-background px-2.5 text-sm" value={item.attributes.pricingModel} onChange={(event) => change((next) => { next.catalogSections[sectionIndex].items[itemIndex].attributes.pricingModel = event.target.value as typeof item.attributes.pricingModel; })}><option>not-stated</option><option>fixed</option><option>from</option><option>hourly</option><option>quote</option></select></Field>
-                    <Field label="Price / unit"><div className="grid grid-cols-2 gap-2"><Input type="number" min="0" value={item.price ?? ""} placeholder="No price" onChange={(event) => change((next) => { next.catalogSections[sectionIndex].items[itemIndex].price = event.target.value === "" ? null : Number(event.target.value); })} /><Input value={item.attributes.priceUnit} placeholder="per hour" onChange={(event) => change((next) => { next.catalogSections[sectionIndex].items[itemIndex].attributes.priceUnit = event.target.value; })} /></div></Field>
-                    <label className="flex items-center gap-2 text-sm"><input type="checkbox" checked={item.attributes.emergencyEligible} onChange={(event) => change((next) => { next.catalogSections[sectionIndex].items[itemIndex].attributes.emergencyEligible = event.target.checked; })} /> Emergency-eligible</label>
-                    <Button variant="destructive" size="sm" onClick={() => change((next) => {
-                      next.catalogSections[sectionIndex].items.splice(itemIndex, 1);
-                      next.translations.forEach((translation) => {
-                        translation.catalogSections[sectionIndex]?.items.splice(itemIndex, 1);
-                      });
-                    })}><Trash2 /> Remove service</Button>
+                  <div
+                    key={`service-${sectionIndex}-${itemIndex}`}
+                    className="grid gap-3 rounded-xl border p-4 md:grid-cols-2"
+                  >
+                    <Field label="Service">
+                      <Input
+                        value={item.name}
+                        onChange={(event) =>
+                          change((next) => {
+                            next.catalogSections[sectionIndex].items[
+                              itemIndex
+                            ].name = event.target.value;
+                          })
+                        }
+                      />
+                    </Field>
+                    <Field label="Description">
+                      <Input
+                        value={item.description}
+                        onChange={(event) =>
+                          change((next) => {
+                            next.catalogSections[sectionIndex].items[
+                              itemIndex
+                            ].description = event.target.value;
+                          })
+                        }
+                      />
+                    </Field>
+                    <Field label="Pricing model">
+                      <select
+                        className="h-8 w-full rounded-lg border bg-background px-2.5 text-sm"
+                        value={item.attributes.pricingModel}
+                        onChange={(event) =>
+                          change((next) => {
+                            next.catalogSections[sectionIndex].items[
+                              itemIndex
+                            ].attributes.pricingModel = event.target
+                              .value as typeof item.attributes.pricingModel;
+                          })
+                        }
+                      >
+                        <option>not-stated</option>
+                        <option>fixed</option>
+                        <option>from</option>
+                        <option>hourly</option>
+                        <option>quote</option>
+                      </select>
+                    </Field>
+                    <Field label="Price / unit">
+                      <div className="grid grid-cols-2 gap-2">
+                        <Input
+                          type="number"
+                          min="0"
+                          value={item.price ?? ""}
+                          placeholder="No price"
+                          onChange={(event) =>
+                            change((next) => {
+                              next.catalogSections[sectionIndex].items[
+                                itemIndex
+                              ].price =
+                                event.target.value === ""
+                                  ? null
+                                  : Number(event.target.value);
+                            })
+                          }
+                        />
+                        <Input
+                          value={item.attributes.priceUnit}
+                          placeholder="per hour"
+                          onChange={(event) =>
+                            change((next) => {
+                              next.catalogSections[sectionIndex].items[
+                                itemIndex
+                              ].attributes.priceUnit = event.target.value;
+                            })
+                          }
+                        />
+                      </div>
+                    </Field>
+                    <label className="flex items-center gap-2 text-sm">
+                      <input
+                        type="checkbox"
+                        checked={item.attributes.emergencyEligible}
+                        onChange={(event) =>
+                          change((next) => {
+                            next.catalogSections[sectionIndex].items[
+                              itemIndex
+                            ].attributes.emergencyEligible =
+                              event.target.checked;
+                          })
+                        }
+                      />{" "}
+                      Emergency-eligible
+                    </label>
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      onClick={() =>
+                        change((next) => {
+                          next.catalogSections[sectionIndex].items.splice(
+                            itemIndex,
+                            1,
+                          );
+                          next.translations.forEach((translation) => {
+                            translation.catalogSections[
+                              sectionIndex
+                            ]?.items.splice(itemIndex, 1);
+                          });
+                        })
+                      }
+                    >
+                      <Trash2 /> Remove service
+                    </Button>
                   </div>
                 ))}
-                <Button variant="outline" size="sm" onClick={() => change((next) => {
-                  next.catalogSections[sectionIndex].items.push({ name: "New service", description: "", price: null, currency: "EUR", available: null, imageUrl: null, attributes: { pricingModel: "not-stated", priceUnit: "", emergencyEligible: false } });
-                  next.translations.forEach((translation) => {
-                    translation.catalogSections[sectionIndex]?.items.push({ name: "New service", description: "", attributes: {} });
-                  });
-                })}><Plus /> Add service</Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() =>
+                    change((next) => {
+                      next.catalogSections[sectionIndex].items.push({
+                        name: "New service",
+                        description: "",
+                        price: null,
+                        currency: "EUR",
+                        available: null,
+                        imageUrl: null,
+                        attributes: {
+                          pricingModel: "not-stated",
+                          priceUnit: "",
+                          emergencyEligible: false,
+                        },
+                      });
+                      next.translations.forEach((translation) => {
+                        translation.catalogSections[sectionIndex]?.items.push({
+                          name: "New service",
+                          description: "",
+                          attributes: {},
+                        });
+                      });
+                    })
+                  }
+                >
+                  <Plus /> Add service
+                </Button>
               </CardContent>
             </Card>
           ))}
@@ -274,42 +706,182 @@ export function LocalServiceDashboard({
         <EditorSection
           title="Projects"
           actionLabel="Add project"
-          onAdd={() => change((next) => {
-            next.attributes.projects.push({ title: "New project", description: "", imageUrl: null, location: "" });
-            next.attributes.showProjectGallery = true;
-          })}
+          onAdd={() =>
+            change((next) => {
+              next.attributes.projects.push({
+                title: "New project",
+                description: "",
+                imageUrl: null,
+                location: "",
+              });
+              next.attributes.showProjectGallery = true;
+            })
+          }
         >
           <label className="mb-4 flex items-center gap-2 text-sm">
             <input
               type="checkbox"
               checked={draft.attributes.showProjectGallery}
-              onChange={(event) => change((next) => {
-                next.attributes.showProjectGallery = event.target.checked;
-              })}
+              onChange={(event) =>
+                change((next) => {
+                  next.attributes.showProjectGallery = event.target.checked;
+                })
+              }
             />
             Show project gallery
           </label>
           <div className="grid gap-4 md:grid-cols-2">
             {draft.attributes.projects.map((project, index) => (
-              <Card key={`project-${index}`}><CardContent className="grid gap-3 pt-2"><Input aria-label="Project title" value={project.title} onChange={(event) => change((next) => { next.attributes.projects[index].title = event.target.value; })} /><Input aria-label="Project location" value={project.location} placeholder="Location" onChange={(event) => change((next) => { next.attributes.projects[index].location = event.target.value; })} /><Textarea aria-label="Project description" value={project.description} onChange={(event) => change((next) => { next.attributes.projects[index].description = event.target.value; })} /><Input aria-label="Project image URL" value={project.imageUrl ?? ""} placeholder="https://…" onChange={(event) => change((next) => { next.attributes.projects[index].imageUrl = event.target.value || null; })} /><Button variant="destructive" size="sm" onClick={() => change((next) => { next.attributes.projects.splice(index, 1); })}><Trash2 /> Remove project</Button></CardContent></Card>
+              <Card key={`project-${index}`}>
+                <CardContent className="grid gap-3 pt-2">
+                  <Input
+                    aria-label="Project title"
+                    value={project.title}
+                    onChange={(event) =>
+                      change((next) => {
+                        next.attributes.projects[index].title =
+                          event.target.value;
+                      })
+                    }
+                  />
+                  <Input
+                    aria-label="Project location"
+                    value={project.location}
+                    placeholder="Location"
+                    onChange={(event) =>
+                      change((next) => {
+                        next.attributes.projects[index].location =
+                          event.target.value;
+                      })
+                    }
+                  />
+                  <Textarea
+                    aria-label="Project description"
+                    value={project.description}
+                    onChange={(event) =>
+                      change((next) => {
+                        next.attributes.projects[index].description =
+                          event.target.value;
+                      })
+                    }
+                  />
+                  <Input
+                    aria-label="Project image URL"
+                    value={project.imageUrl ?? ""}
+                    placeholder="https://…"
+                    onChange={(event) =>
+                      change((next) => {
+                        next.attributes.projects[index].imageUrl =
+                          event.target.value || null;
+                      })
+                    }
+                  />
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={() =>
+                      change((next) => {
+                        next.attributes.projects.splice(index, 1);
+                      })
+                    }
+                  >
+                    <Trash2 /> Remove project
+                  </Button>
+                </CardContent>
+              </Card>
             ))}
           </div>
         </EditorSection>
 
-        <EditorSection title="External tools" actionLabel="Add link" onAdd={() => change((next) => {
-          next.integrations.push({ type: "quote", label: "Request a quote", provider: null, url: "https://example.com", enabled: true, venueId: null });
-          next.translations.forEach((translation) => {
-            translation.integrationLabels.push("Request a quote");
-          });
-        })}>
+        <EditorSection
+          title="External tools"
+          actionLabel="Add link"
+          onAdd={() =>
+            change((next) => {
+              next.integrations.push({
+                type: "quote",
+                label: "Request a quote",
+                provider: null,
+                url: "https://example.com",
+                enabled: true,
+                venueId: null,
+              });
+              next.translations.forEach((translation) => {
+                translation.integrationLabels.push("Request a quote");
+              });
+            })
+          }
+        >
           <div className="grid gap-4 md:grid-cols-2">
             {draft.integrations.map((integration, index) => (
-              <Card key={`link-${index}`}><CardContent className="grid gap-3 pt-2 md:grid-cols-2"><Field label="Type"><select className="h-8 w-full rounded-lg border bg-background px-2.5 text-sm" value={integration.type} onChange={(event) => change((next) => { next.integrations[index].type = event.target.value as typeof integration.type; })}>{linkTypes.map((value) => <option key={value}>{value}</option>)}</select></Field><Field label="Label"><Input value={integration.label} onChange={(event) => change((next) => { next.integrations[index].label = event.target.value; })} /></Field><Field label="HTTPS destination" className="md:col-span-2"><Input type="url" value={integration.url} onChange={(event) => change((next) => { next.integrations[index].url = event.target.value; })} /></Field><label className="flex items-center gap-2 text-sm"><input type="checkbox" checked={integration.enabled} onChange={(event) => change((next) => { next.integrations[index].enabled = event.target.checked; })} /> Visible in preview</label><Button variant="destructive" size="sm" onClick={() => change((next) => {
-                next.integrations.splice(index, 1);
-                next.translations.forEach((translation) => {
-                  translation.integrationLabels.splice(index, 1);
-                });
-              })}><Trash2 /> Remove link</Button></CardContent></Card>
+              <Card key={`link-${index}`}>
+                <CardContent className="grid gap-3 pt-2 md:grid-cols-2">
+                  <Field label="Type">
+                    <select
+                      className="h-8 w-full rounded-lg border bg-background px-2.5 text-sm"
+                      value={integration.type}
+                      onChange={(event) =>
+                        change((next) => {
+                          next.integrations[index].type = event.target
+                            .value as typeof integration.type;
+                        })
+                      }
+                    >
+                      {linkTypes.map((value) => (
+                        <option key={value}>{value}</option>
+                      ))}
+                    </select>
+                  </Field>
+                  <Field label="Label">
+                    <Input
+                      value={integration.label}
+                      onChange={(event) =>
+                        change((next) => {
+                          next.integrations[index].label = event.target.value;
+                        })
+                      }
+                    />
+                  </Field>
+                  <Field label="HTTPS destination" className="md:col-span-2">
+                    <Input
+                      type="url"
+                      value={integration.url}
+                      onChange={(event) =>
+                        change((next) => {
+                          next.integrations[index].url = event.target.value;
+                        })
+                      }
+                    />
+                  </Field>
+                  <label className="flex items-center gap-2 text-sm">
+                    <input
+                      type="checkbox"
+                      checked={integration.enabled}
+                      onChange={(event) =>
+                        change((next) => {
+                          next.integrations[index].enabled =
+                            event.target.checked;
+                        })
+                      }
+                    />{" "}
+                    Visible in preview
+                  </label>
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={() =>
+                      change((next) => {
+                        next.integrations.splice(index, 1);
+                        next.translations.forEach((translation) => {
+                          translation.integrationLabels.splice(index, 1);
+                        });
+                      })
+                    }
+                  >
+                    <Trash2 /> Remove link
+                  </Button>
+                </CardContent>
+              </Card>
             ))}
           </div>
         </EditorSection>
@@ -318,16 +890,52 @@ export function LocalServiceDashboard({
   );
 }
 
-function EditorSection({ title, actionLabel, onAdd, children }: { title: string; actionLabel: string; onAdd: () => void; children: React.ReactNode }) {
-  return <section className="mt-10"><div className="mb-4 flex items-center justify-between gap-4"><h2 className="font-display text-3xl tracking-[-0.035em]">{title}</h2><Button variant="outline" size="sm" onClick={onAdd}><Plus /> {actionLabel}</Button></div>{children}</section>;
+function EditorSection({
+  title,
+  actionLabel,
+  onAdd,
+  children,
+}: {
+  title: string;
+  actionLabel: string;
+  onAdd: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="mt-10">
+      <div className="mb-4 flex items-center justify-between gap-4">
+        <h2 className="font-display text-3xl tracking-[-0.035em]">{title}</h2>
+        <Button variant="outline" size="sm" onClick={onAdd}>
+          <Plus /> {actionLabel}
+        </Button>
+      </div>
+      {children}
+    </section>
+  );
 }
 
-function Field({ label, className, children }: { label: string; className?: string; children: React.ReactNode }) {
-  return <div className={className}><Label className="mb-2 block">{label}</Label>{children}</div>;
+function Field({
+  label,
+  className,
+  children,
+}: {
+  label: string;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={className}>
+      <Label className="mb-2 block">{label}</Label>
+      {children}
+    </div>
+  );
 }
 
 function lines(value: string): string[] {
-  return value.split("\n").map((item) => item.trim()).filter(Boolean);
+  return value
+    .split("\n")
+    .map((item) => item.trim())
+    .filter(Boolean);
 }
 
 function parsePairs(value: string): Array<[string, string]> {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -43,13 +43,18 @@ export default async function DashboardPage({
   if (session?.purpose === "ADMIN") redirect("/admin");
   if (session && session.purpose !== "SITE") redirect("/sign-in");
 
-  const access =
-    session?.siteSlug ? await getSiteAccess(session.siteSlug) : null;
+  const access = session?.siteSlug
+    ? await getSiteAccess(session.siteSlug)
+    : null;
   if (session && (!access || !access.ok)) redirect("/sign-in");
 
   if (access?.ok && access.site.vertical === Vertical.FOOD_RETAIL) {
-    const loaded = await findSiteDraft(access.site.slug);
-    if (!loaded || loaded.vertical !== Vertical.FOOD_RETAIL) redirect("/sign-in");
+    const [loaded, publicationHistory] = await Promise.all([
+      findSiteDraft(access.site.slug),
+      getSitePublicationHistory(access.site.id),
+    ]);
+    if (!loaded || loaded.vertical !== Vertical.FOOD_RETAIL)
+      redirect("/sign-in");
     return (
       <EditorialFontScope>
         <FoodRetailDashboard
@@ -57,15 +62,21 @@ export default async function DashboardPage({
           brand={await resolveRequestBrand()}
           initialDraft={loaded.draft as FoodRetailSiteDraft}
           initialRevision={loaded.revision}
+          initiallyPublished={publicationHistory.some((item) => item.current)}
+          platformUrl={publicSiteOrigin({
+            slug: access.site.slug,
+            vertical: access.site.vertical,
+          })}
         />
       </EditorialFontScope>
     );
   }
 
   if (access?.ok && access.site.vertical === Vertical.LOCAL_SERVICE) {
-    const [loaded, workspaces] = await Promise.all([
+    const [loaded, workspaces, publicationHistory] = await Promise.all([
       findSiteDraft(access.site.slug),
       listAccountWorkspaces(access.session.userId),
+      getSitePublicationHistory(access.site.id),
     ]);
     if (!loaded || loaded.vertical !== Vertical.LOCAL_SERVICE) {
       redirect("/sign-in");
@@ -78,6 +89,11 @@ export default async function DashboardPage({
           initialDraft={loaded.draft as LocalServiceSiteDraft}
           initialRevision={loaded.revision}
           canSwitchWorkspace={workspaces.length > 1}
+          initiallyPublished={publicationHistory.some((item) => item.current)}
+          platformUrl={publicSiteOrigin({
+            slug: access.site.slug,
+            vertical: access.site.vertical,
+          })}
         />
       </EditorialFontScope>
     );

--- a/src/lib/billing-plans.test.ts
+++ b/src/lib/billing-plans.test.ts
@@ -5,7 +5,7 @@ import {
   configuredBillingPlan,
   configuredBillingPriceId,
   stripeLivemodeForSecret,
-  validateRestofrontFoundingPrice,
+  validateFoundingPrice,
 } from "@/lib/billing-plans";
 
 const configured = { STRIPE_PRICE_ID: "price_founding" };
@@ -24,7 +24,7 @@ describe("configuredBillingPlan", () => {
   });
 });
 
-describe("Restofront founding Stripe price", () => {
+describe("Cornershopdev founding Stripe price", () => {
   const price = {
     id: "price_founding",
     active: true,
@@ -43,7 +43,7 @@ describe("Restofront founding Stripe price", () => {
 
   it("accepts only the approved live $49 USD monthly exclusive-tax offer", () => {
     expect(() =>
-      validateRestofrontFoundingPrice(price, {
+      validateFoundingPrice(price, {
         expectedPriceId: "price_founding",
         expectedLivemode: true,
       }),
@@ -60,7 +60,7 @@ describe("Restofront founding Stripe price", () => {
       { ...price, product: "prod_unexpanded" },
     ]) {
       expect(() =>
-        validateRestofrontFoundingPrice(candidate, {
+        validateFoundingPrice(candidate, {
           expectedPriceId: "price_founding",
           expectedLivemode: true,
         }),

--- a/src/lib/billing-plans.ts
+++ b/src/lib/billing-plans.ts
@@ -1,6 +1,6 @@
-export const RESTOFRONT_FOUNDING_PLAN_ID = "founding" as const;
+export const FOUNDING_PLAN_ID = "founding" as const;
 
-export type BillingPlanId = typeof RESTOFRONT_FOUNDING_PLAN_ID;
+export type BillingPlanId = typeof FOUNDING_PLAN_ID;
 
 type BillingEnvironment = Record<string, string | undefined>;
 
@@ -9,7 +9,7 @@ export type BillingPlan = {
   priceId: string;
 };
 
-export const RESTOFRONT_FOUNDING_PRICE = {
+export const FOUNDING_PRICE = {
   currency: "usd",
   unitAmount: 4_900,
   interval: "month",
@@ -44,7 +44,7 @@ export function configuredBillingPlan(
   env: BillingEnvironment = process.env,
 ): BillingPlan {
   return {
-    id: RESTOFRONT_FOUNDING_PLAN_ID,
+    id: FOUNDING_PLAN_ID,
     priceId: validatePriceId(env.STRIPE_PRICE_ID, "STRIPE_PRICE_ID"),
   };
 }
@@ -67,7 +67,7 @@ export function configuredBillingPriceId(
  * resource immediately before Checkout and in the operator preflight so a
  * wrong mode, amount, cadence, tax treatment, or archived Product fails closed.
  */
-export function validateRestofrontFoundingPrice(
+export function validateFoundingPrice(
   price: StripePriceConfiguration,
   input: { expectedPriceId: string; expectedLivemode: boolean },
 ): void {
@@ -81,16 +81,16 @@ export function validateRestofrontFoundingPrice(
     price.livemode === input.expectedLivemode &&
     price.active &&
     price.type === "recurring" &&
-    price.currency.toLowerCase() === RESTOFRONT_FOUNDING_PRICE.currency &&
-    price.unit_amount === RESTOFRONT_FOUNDING_PRICE.unitAmount &&
-    price.tax_behavior === RESTOFRONT_FOUNDING_PRICE.taxBehavior &&
-    recurring?.interval === RESTOFRONT_FOUNDING_PRICE.interval &&
-    recurring.interval_count === RESTOFRONT_FOUNDING_PRICE.intervalCount &&
+    price.currency.toLowerCase() === FOUNDING_PRICE.currency &&
+    price.unit_amount === FOUNDING_PRICE.unitAmount &&
+    price.tax_behavior === FOUNDING_PRICE.taxBehavior &&
+    recurring?.interval === FOUNDING_PRICE.interval &&
+    recurring.interval_count === FOUNDING_PRICE.intervalCount &&
     recurring.usage_type !== "metered" &&
     productActive;
   if (!valid) {
     throw new BillingConfigurationError(
-      "The Restofront founding Stripe price does not match the approved offer",
+      "The Cornershopdev founding Stripe price does not match the approved offer",
     );
   }
 }
@@ -106,18 +106,13 @@ export function isStripeTestApiKey(secret: string | undefined): boolean {
   return STRIPE_TEST_KEY_PREFIXES.some((prefix) => secret?.startsWith(prefix));
 }
 
-export function stripeLivemodeForSecret(
-  secret: string | undefined,
-): boolean {
+export function stripeLivemodeForSecret(secret: string | undefined): boolean {
   if (isStripeLiveApiKey(secret)) return true;
   if (isStripeTestApiKey(secret)) return false;
   throw new BillingConfigurationError("STRIPE_SECRET_KEY is not configured");
 }
 
-function validatePriceId(
-  value: string | undefined,
-  variable: string,
-): string {
+function validatePriceId(value: string | undefined, variable: string): string {
   if (!value?.startsWith("price_") || value.length < 8) {
     throw new BillingConfigurationError(`${variable} is not configured`);
   }

--- a/src/lib/booking-requests.ts
+++ b/src/lib/booking-requests.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { getDb } from "@/lib/db";
-import { emailSender, getResend } from "@/lib/resend";
+import { emailSender } from "@/lib/email-identity";
+import { getResend } from "@/lib/resend";
 import { resolveVerticalConfig } from "@/lib/verticals/registry";
 import type { VerticalId } from "@/lib/verticals/types";
 

--- a/src/lib/brand-context.test.ts
+++ b/src/lib/brand-context.test.ts
@@ -7,7 +7,7 @@ import {
   brandContextForSiteVertical,
   brandContextForVertical,
 } from "@/lib/brand-context";
-import { emailReplyTo, emailSender } from "@/lib/resend";
+import { emailReplyTo, emailSender } from "@/lib/email-identity";
 import { restaurantMarketing } from "@/lib/verticals/restaurant/marketing";
 
 /**

--- a/src/lib/brand-context.ts
+++ b/src/lib/brand-context.ts
@@ -1,6 +1,6 @@
 import { headers } from "next/headers";
 import { FACTORY_BRAND, type BrandIdentity } from "@/lib/brand";
-import { emailReplyTo, emailSender } from "@/lib/resend";
+import { emailReplyTo, emailSender } from "@/lib/email-identity";
 import { requestHostname, type HeaderReader } from "@/lib/request-hostname";
 import {
   resolveVerticalByHostname,
@@ -36,9 +36,7 @@ export type BrandContext = BrandIdentity & {
 export function brandContextForVertical(
   vertical: VerticalId | null,
 ): BrandContext {
-  const marketing = vertical
-    ? resolveVerticalConfig(vertical).marketing
-    : null;
+  const marketing = vertical ? resolveVerticalConfig(vertical).marketing : null;
   // No launched domain means no storefront to speak as: hand back the
   // factory as one complete identity rather than mixing a registered
   // vertical's (already-designed) wordmark with the factory's own URL and

--- a/src/lib/claim-invitation-email.ts
+++ b/src/lib/claim-invitation-email.ts
@@ -1,4 +1,4 @@
-import { emailReplyTo, emailSender } from "@/lib/resend";
+import { emailReplyTo, emailSender } from "@/lib/email-identity";
 import { resolveVerticalConfig } from "@/lib/verticals/registry";
 import type { VerticalId } from "@/lib/verticals/types";
 

--- a/src/lib/claim-invitations.postgres.test.ts
+++ b/src/lib/claim-invitations.postgres.test.ts
@@ -8,8 +8,8 @@ const suffix = randomUUID();
 const siteId = `claim-retry-site-${suffix}`;
 const slug = `claim-retry-${suffix}`;
 const email = `owner@claim-retry-${suffix}.example.test`;
-const foodSiteId = `claim-food-private-site-${suffix}`;
-const foodSlug = `claim-food-private-${suffix}`;
+const foodSiteId = `claim-food-factory-site-${suffix}`;
+const foodSlug = `claim-food-factory-${suffix}`;
 const outreachSiteId = `claim-outreach-site-${suffix}`;
 const outreachSlug = `claim-outreach-${suffix}`;
 const outreachEmail = `owner@claim-outreach-${suffix}.example.test`;
@@ -39,8 +39,8 @@ describe.skipIf(!enabled)("claim invitation PostgreSQL replacement CAS", () => {
       data: {
         id: foodSiteId,
         slug: foodSlug,
-        name: "Private food-retail claim fixture",
-        description: "An unlaunched food-retail claim gate fixture.",
+        name: "Factory food-retail claim fixture",
+        description: "A reviewed food-retail factory claim fixture.",
         email: `owner@${foodSlug}.example.test`,
         sourceUrl: `https://${foodSlug}.example.test/`,
         vertical: "FOOD_RETAIL",
@@ -85,18 +85,45 @@ describe.skipIf(!enabled)("claim invitation PostgreSQL replacement CAS", () => {
     }
   });
 
-  test("rejects FOOD_RETAIL invitation issuance before any claim can charge", async () => {
-    await expect(
+  test("serializes concurrent FOOD_RETAIL factory claims to one active invitation", async () => {
+    const invitations = await Promise.all([
       claim.issueClaimInvitation({
         siteSlug: foodSlug,
         email: `owner@${foodSlug}.example.test`,
         proofMethod: "DOMAIN_EMAIL",
-        actor: "claimant:self-serve",
+        actor: "claimant:first-tab",
       }),
-    ).rejects.toMatchObject({ code: "not_claimable", status: 409 });
+      claim.issueClaimInvitation({
+        siteSlug: foodSlug,
+        email: `owner@${foodSlug}.example.test`,
+        proofMethod: "DOMAIN_EMAIL",
+        actor: "claimant:second-tab",
+      }),
+    ]);
+
+    expect(invitations).toHaveLength(2);
     expect(
-      await db.claimInvitation.count({ where: { siteId: foodSiteId } }),
-    ).toBe(0);
+      invitations.every(
+        (invitation) => invitation.site.vertical === "FOOD_RETAIL",
+      ),
+    ).toBe(true);
+    const stored = await db.claimInvitation.findMany({
+      where: { siteId: foodSiteId },
+      select: {
+        id: true,
+        acceptedAt: true,
+        revokedAt: true,
+        checkoutSessionId: true,
+      },
+    });
+    expect(stored).toHaveLength(2);
+    expect(stored.filter((invitation) => !invitation.revokedAt)).toHaveLength(
+      1,
+    );
+    expect(stored.every((invitation) => !invitation.acceptedAt)).toBe(true);
+    expect(stored.every((invitation) => !invitation.checkoutSessionId)).toBe(
+      true,
+    );
   });
 
   test("rechecks channel evidence before outreach claim issuance", async () => {

--- a/src/lib/dashboard-tabs-surface.test.ts
+++ b/src/lib/dashboard-tabs-surface.test.ts
@@ -9,6 +9,9 @@ const dashboardPage = await Bun.file(
 const foodRetailDashboard = await Bun.file(
   new URL("../app/dashboard/food-retail-dashboard.tsx", import.meta.url),
 ).text();
+const localServiceDashboard = await Bun.file(
+  new URL("../app/dashboard/local-service-dashboard.tsx", import.meta.url),
+).text();
 const restaurantSaveRoute = await Bun.file(
   new URL("../app/api/sites/[slug]/route.ts", import.meta.url),
 ).text();
@@ -60,36 +63,33 @@ describe("dashboard tab and settings surface", () => {
       "initialDraftRevision={ownerDraft?.revision ?? 0}",
     );
     expect(dashboardPage).toContain("initialRevision={loaded.revision}");
-    expect(dashboard).toContain(
-      "useState(initialDraftRevision)",
-    );
+    expect(dashboard).toContain("useState(initialDraftRevision)");
     expect(dashboard).toContain("expectedRevision: savedRevision");
     expect(restaurantSaveRoute).toContain("saveAuthorizedSiteDraft");
     expect(ownerSiteSave).toContain('code: "EXPECTED_REVISION_REQUIRED"');
     expect(dashboard).toContain("expectedRevision: revisionToPublish");
     expect(foodRetailDashboard).toContain("expectedRevision: revision");
-    expect(restaurantPublishRoute).toContain(
-      'code: "DRAFT_REVISION_CONFLICT"',
-    );
+    expect(restaurantPublishRoute).toContain('code: "DRAFT_REVISION_CONFLICT"');
   });
 
-  it("keeps food retail review private at the UI, API and service boundaries", () => {
+  it("publishes reviewed food-retail and local-service drafts through the guarded route", () => {
+    expect(foodRetailDashboard).toContain("publishDraft");
+    expect(foodRetailDashboard).toContain("/publish");
     expect(foodRetailDashboard).toContain(
-      "Public publishing and rollback stay unavailable",
+      "hasUnreviewedFoodRetailTranslations",
     );
-    expect(foodRetailDashboard).not.toContain("publishDraft");
-    expect(foodRetailDashboard).not.toContain("/publish");
+    expect(localServiceDashboard).toContain("async function publish()");
+    expect(localServiceDashboard).toContain("/publish");
     expect(restaurantPublishRoute).toContain(
       "publicationCapabilityFailureResponse",
     );
-    expect(rollbackRoute).toContain(
-      "publicationCapabilityFailureResponse",
-    );
-    expect(sitePublication.match(/assertVerticalPublicationEnabled\(input\.vertical\)/g))
-      .toHaveLength(2);
-    expect(sites).toContain(
-      "!isVerticalPublicationEnabled(version.vertical)",
-    );
+    expect(rollbackRoute).toContain("publicationCapabilityFailureResponse");
+    expect(
+      sitePublication.match(
+        /assertVerticalPublicationEnabled\(input\.vertical\)/g,
+      ),
+    ).toHaveLength(2);
+    expect(sites).toContain("!isVerticalPublicationEnabled(version.vertical)");
   });
 
   it("carries the universal draft revision through auxiliary owner mutations", () => {
@@ -106,9 +106,7 @@ describe("dashboard tab and settings surface", () => {
     expect(sourceMonitoringReviewRoute).toContain(
       "expectedRevision: z.number().int().min(0)",
     );
-    expect(sourceMonitoringPanel).toContain(
-      "expectedRevision: draftRevision",
-    );
+    expect(sourceMonitoringPanel).toContain("expectedRevision: draftRevision");
     expect(dashboard).toContain(
       "onAcceptedDraft={applyAcceptedSourceMonitoringDraft}",
     );

--- a/src/lib/email-identity.ts
+++ b/src/lib/email-identity.ts
@@ -1,0 +1,30 @@
+import { resolveVerticalConfig } from "@/lib/verticals/registry";
+import type { VerticalId } from "@/lib/verticals/types";
+
+type EmailEnvironment = Record<string, string | undefined>;
+
+function nicheEmail(vertical: VerticalId | null | undefined) {
+  return vertical ? resolveVerticalConfig(vertical).marketing.email : null;
+}
+
+/** Resolve the site owner's sending identity without loading a mail provider. */
+export function emailSender(
+  vertical?: VerticalId | null,
+  environment: EmailEnvironment = process.env,
+): string {
+  return (
+    nicheEmail(vertical)?.from ||
+    environment.EMAIL_FROM ||
+    "Cornershopdev <onboarding@resend.dev>"
+  );
+}
+
+/** Resolve the monitored reply mailbox without loading a mail provider. */
+export function emailReplyTo(
+  vertical?: VerticalId | null,
+  environment: EmailEnvironment = process.env,
+): string | undefined {
+  return (
+    nicheEmail(vertical)?.replyTo || environment.EMAIL_REPLY_TO || undefined
+  );
+}

--- a/src/lib/food-retail-claim-gate.test.ts
+++ b/src/lib/food-retail-claim-gate.test.ts
@@ -12,7 +12,7 @@ const checkoutRoute = await Bun.file(
   new URL("../app/api/checkout/route.ts", import.meta.url),
 ).text();
 
-describe("food retail public claim gate", () => {
+describe("food retail factory claim gate", () => {
   it("keeps the unpersisted food demo inside Import Studio", () => {
     expect(importStudio).toContain(
       "setExternalPreviewAvailable(previewAvailable)",
@@ -26,8 +26,8 @@ describe("food retail public claim gate", () => {
     );
   });
 
-  it("cannot expose Food checkout while retaining the Restaurant flow", () => {
-    expect(isVerticalClaimEnabled(Vertical.FOOD_RETAIL)).toBe(false);
+  it("exposes the reviewed factory checkout through the shared claim guards", () => {
+    expect(isVerticalClaimEnabled(Vertical.FOOD_RETAIL)).toBe(true);
     expect(isVerticalClaimEnabled(Vertical.RESTAURANT)).toBe(true);
     expect(importStudio).toContain(
       "{isVerticalClaimEnabled(site.vertical) ? (",

--- a/src/lib/food-retail-editor.test.tsx
+++ b/src/lib/food-retail-editor.test.tsx
@@ -100,6 +100,8 @@ describe("food-retail bilingual dashboard editing", () => {
         brand={FACTORY_BRAND}
         initialDraft={draftWithUiAdditions()}
         initialRevision={7}
+        initiallyPublished={false}
+        platformUrl="https://bakery.cornershop.dev"
       />,
     );
 

--- a/src/lib/lead-generation/adapters.test.ts
+++ b/src/lib/lead-generation/adapters.test.ts
@@ -1,16 +1,26 @@
 import { describe, expect, it } from "bun:test";
+import { Vertical } from "@/generated/prisma/enums";
 import { foodRetailLeadDiscovery } from "@/lib/lead-generation/food-retail";
 import { localServiceLeadDiscovery } from "@/lib/lead-generation/local-service";
+import { listOutreachVerticals } from "@/lib/lead-generation/registry";
 
 describe("incoming SMB lead discovery adapters", () => {
+  it("enables reviewed outreach for every registered SMB vertical", () => {
+    expect(listOutreachVerticals()).toEqual([
+      Vertical.RESTAURANT,
+      Vertical.LOCAL_SERVICE,
+      Vertical.FOOD_RETAIL,
+    ]);
+  });
+
   it("models food retailers as product-and-pickup storefronts", () => {
     expect(foodRetailLeadDiscovery.placeSearch.googleQuery("Valletta")).toBe(
       "bakeries, pastry shops, butchers, delis, cheesemongers and grocers in Valletta",
     );
     expect(foodRetailLeadDiscovery.placeSearch.googleIncludedType).toBeNull();
-    expect(foodRetailLeadDiscovery.eligibility.categoryPattern.test("bakery")).toBe(
-      true,
-    );
+    expect(
+      foodRetailLeadDiscovery.eligibility.categoryPattern.test("bakery"),
+    ).toBe(true);
     expect(
       foodRetailLeadDiscovery.homepage.catalogPattern.test(
         '<a href="/products">Today’s breads and pastries</a>',

--- a/src/lib/magic-link-email.ts
+++ b/src/lib/magic-link-email.ts
@@ -1,5 +1,5 @@
 import { FACTORY_BRAND } from "@/lib/brand";
-import { emailReplyTo, emailSender } from "@/lib/resend";
+import { emailReplyTo, emailSender } from "@/lib/email-identity";
 import { resolveVerticalConfig } from "@/lib/verticals/registry";
 import type { VerticalId } from "@/lib/verticals/types";
 
@@ -39,7 +39,7 @@ export function buildMagicLinkEmail(input: {
     ? "operator console"
     : multipleWorkspaces
       ? "workspace chooser"
-    : `${input.site!.name} dashboard`;
+      : `${input.site!.name} dashboard`;
   const escapedAccountName = escapeHtml(accountName);
   const actionLabel = input.isSuperadmin
     ? "Open console"

--- a/src/lib/operator-alerts.ts
+++ b/src/lib/operator-alerts.ts
@@ -14,7 +14,8 @@ import {
   type OperatorAlertKind,
   safeAlertText,
 } from "@/lib/operator-alert-policy";
-import { emailSender, getResend } from "@/lib/resend";
+import { emailSender } from "@/lib/email-identity";
+import { getResend } from "@/lib/resend";
 
 export type CaptureOperatorAlertInput = {
   kind: OperatorAlertKind;
@@ -97,10 +98,7 @@ async function deliverOperatorAlert(id: string): Promise<AlertDeliveryOutcome> {
       status: "PENDING",
       attempts: { lt: OPERATOR_ALERT_MAX_ATTEMPTS },
       nextAttemptAt: { lte: now },
-      OR: [
-        { deliveryLeaseUntil: null },
-        { deliveryLeaseUntil: { lt: now } },
-      ],
+      OR: [{ deliveryLeaseUntil: null }, { deliveryLeaseUntil: { lt: now } }],
     },
     data: { deliveryLeaseToken: leaseToken, deliveryLeaseUntil: leaseUntil },
   });
@@ -134,7 +132,9 @@ async function deliverOperatorAlert(id: string): Promise<AlertDeliveryOutcome> {
           subject: `[Cornershopdev] ${alert.title}`,
           html: alertEmailHtml(alert),
         },
-        { headers: { "Idempotency-Key": `operator-alert-${alert.fingerprint}` } },
+        {
+          headers: { "Idempotency-Key": `operator-alert-${alert.fingerprint}` },
+        },
       ),
     );
     if (error) throw new Error(error.message);
@@ -248,7 +248,10 @@ function alertEmailHtml(alert: {
 
 function alertFailureCode(error: unknown): string {
   const message = error instanceof Error ? error.message.toLowerCase() : "";
-  if (message.includes("operator_alert_emails") || message.includes("resend_api_key")) {
+  if (
+    message.includes("operator_alert_emails") ||
+    message.includes("resend_api_key")
+  ) {
     return "configuration_missing";
   }
   if (message.includes("rate") || message.includes("429")) {

--- a/src/lib/operator-outreach-route.test.ts
+++ b/src/lib/operator-outreach-route.test.ts
@@ -472,14 +472,22 @@ describe("explicit operator outreach action", () => {
     ]);
   });
 
-  it.each(["BEAUTY", "FOOD_RETAIL", "LOCAL_SERVICE"])(
-    "never dispatches the private %s vertical",
-    async (privateVertical) => {
-      vertical = privateVertical;
+  it("never dispatches a claim-disabled vertical", async () => {
+    vertical = "BEAUTY";
+    const response = await POST(request("https://cornershop.dev"), context());
+
+    expect(response.status).toBe(409);
+    expect(workflowStart).not.toHaveBeenCalled();
+  });
+
+  it.each(["FOOD_RETAIL", "LOCAL_SERVICE"])(
+    "dispatches reviewed factory claims for %s",
+    async (factoryVertical) => {
+      vertical = factoryVertical;
       const response = await POST(request("https://cornershop.dev"), context());
 
-      expect(response.status).toBe(409);
-      expect(workflowStart).not.toHaveBeenCalled();
+      expect(response.status).toBe(202);
+      expect(workflowStart).toHaveBeenCalledTimes(1);
     },
   );
 

--- a/src/lib/outreach-inbound.ts
+++ b/src/lib/outreach-inbound.ts
@@ -13,7 +13,7 @@ import {
   type InboundAddressFields,
 } from "@/lib/outreach-thread";
 import { fetchReceivedResendEmail } from "@/lib/resend-receiving";
-import { emailReplyTo } from "@/lib/resend";
+import { emailReplyTo } from "@/lib/email-identity";
 import { listOutreachVerticals } from "@/lib/lead-generation/registry";
 import type { VerticalId } from "@/lib/verticals/types";
 import { lockOutreachDelivery, lockOutreachSite } from "@/lib/outreach-lock";

--- a/src/lib/outreach-readiness.test.ts
+++ b/src/lib/outreach-readiness.test.ts
@@ -19,6 +19,8 @@ const configuredEnvironment = {
   OUTREACH_LEGAL_CONTROLLER: "Corner Shop Labs Ltd",
   GOOGLE_PLACES_API_KEY: "test-google-places-key",
   NEXT_PUBLIC_APP_URL: "https://cornershop.dev",
+  EMAIL_FROM: "Vincent from Cornershopdev <vincent@send.cornershop.dev>",
+  EMAIL_REPLY_TO: "vincent@reply.cornershop.dev",
   WORKFLOW_ENABLED: "true",
   WORKFLOW_TARGET_WORLD: "@workflow/world-postgres",
   WORKFLOW_POSTGRES_URL: "postgresql://workflow:private@example.test/workflow",
@@ -59,6 +61,18 @@ describe("outreach environment readiness", () => {
         {
           vertical: "RESTAURANT",
           brand: "Restofrontapp",
+          senderConfigured: true,
+          replyToConfigured: true,
+        },
+        {
+          vertical: "LOCAL_SERVICE",
+          brand: "Tradefront",
+          senderConfigured: true,
+          replyToConfigured: true,
+        },
+        {
+          vertical: "FOOD_RETAIL",
+          brand: "Shopfront Food",
           senderConfigured: true,
           replyToConfigured: true,
         },
@@ -106,6 +120,24 @@ describe("outreach environment readiness", () => {
     );
   });
 
+  it("requires the generic factory identity for claim-enabled SMB verticals", () => {
+    const readiness = evaluateOutreachEnvironment({
+      ...configuredEnvironment,
+      EMAIL_FROM: undefined,
+      EMAIL_REPLY_TO: undefined,
+    });
+
+    expect(readiness.ready).toBe(false);
+    expect(readiness.checks.sender).toBe(false);
+    expect(readiness.checks.replyTo).toBe(false);
+    expect(readiness.missingOrInvalid).toEqual(
+      expect.arrayContaining([
+        "VERTICAL_OR_FACTORY_EMAIL_FROM",
+        "VERTICAL_OR_FACTORY_EMAIL_REPLY_TO",
+      ]),
+    );
+  });
+
   it("rejects a shared delivery and inbound signing secret without exposing it", () => {
     const readiness = evaluateOutreachEnvironment({
       ...configuredEnvironment,
@@ -120,7 +152,9 @@ describe("outreach environment readiness", () => {
     expect(readiness.missingOrInvalid).toContain(
       "RESEND_INBOUND_WEBHOOK_SECRET (present and distinct)",
     );
-    expect(serialized).not.toContain(configuredEnvironment.RESEND_WEBHOOK_SECRET);
+    expect(serialized).not.toContain(
+      configuredEnvironment.RESEND_WEBHOOK_SECRET,
+    );
   });
 
   it("rejects a preview origin when production requires the canonical origin", () => {
@@ -305,32 +339,58 @@ describe("production outreach deployment", () => {
 describe("Resend niche identity readiness", () => {
   it("requires verified sending and receiving capabilities without sending mail", () => {
     expect(
-      hasRequiredResendDomains([
-        {
-          name: "send.restofront.com",
-          status: "verified",
-          capabilities: { sending: "enabled", receiving: "disabled" },
-        },
-        {
-          name: "restofront.com",
-          status: "verified",
-          capabilities: { sending: "disabled", receiving: "enabled" },
-        },
-      ]),
+      hasRequiredResendDomains(
+        [
+          {
+            name: "send.restofront.com",
+            status: "verified",
+            capabilities: { sending: "enabled", receiving: "disabled" },
+          },
+          {
+            name: "restofront.com",
+            status: "verified",
+            capabilities: { sending: "disabled", receiving: "enabled" },
+          },
+          {
+            name: "send.cornershop.dev",
+            status: "verified",
+            capabilities: { sending: "enabled", receiving: "disabled" },
+          },
+          {
+            name: "reply.cornershop.dev",
+            status: "verified",
+            capabilities: { sending: "disabled", receiving: "enabled" },
+          },
+        ],
+        configuredEnvironment,
+      ),
     ).toBe(true);
     expect(
-      hasRequiredResendDomains([
-        {
-          name: "send.restofront.com",
-          status: "verified",
-          capabilities: { sending: "enabled", receiving: "disabled" },
-        },
-        {
-          name: "restofront.com",
-          status: "pending",
-          capabilities: { sending: "disabled", receiving: "enabled" },
-        },
-      ]),
+      hasRequiredResendDomains(
+        [
+          {
+            name: "send.restofront.com",
+            status: "verified",
+            capabilities: { sending: "enabled", receiving: "disabled" },
+          },
+          {
+            name: "restofront.com",
+            status: "pending",
+            capabilities: { sending: "disabled", receiving: "enabled" },
+          },
+          {
+            name: "send.cornershop.dev",
+            status: "verified",
+            capabilities: { sending: "enabled", receiving: "disabled" },
+          },
+          {
+            name: "reply.cornershop.dev",
+            status: "verified",
+            capabilities: { sending: "disabled", receiving: "enabled" },
+          },
+        ],
+        configuredEnvironment,
+      ),
     ).toBe(false);
   });
 });

--- a/src/lib/outreach-readiness.ts
+++ b/src/lib/outreach-readiness.ts
@@ -85,15 +85,18 @@ export function evaluateOutreachEnvironment(
   );
   const verticals = listOutreachVerticals().map((vertical) => {
     const marketing = resolveVerticalConfig(vertical).marketing;
+    const declaredSender = marketing.email?.from ?? env.EMAIL_FROM?.trim();
+    const declaredReplyTo =
+      marketing.email?.replyTo ?? env.EMAIL_REPLY_TO?.trim();
     return {
       vertical,
       brand: marketing.brand.name,
       senderConfigured:
-        Boolean(marketing.email?.from) &&
-        emailSender(vertical, env) === marketing.email?.from,
+        Boolean(declaredSender) &&
+        emailSender(vertical, env) === declaredSender,
       replyToConfigured:
-        Boolean(marketing.email?.replyTo) &&
-        emailReplyTo(vertical, env) === marketing.email?.replyTo,
+        Boolean(declaredReplyTo) &&
+        emailReplyTo(vertical, env) === declaredReplyTo,
     };
   });
   const checks = {
@@ -140,8 +143,8 @@ export function evaluateOutreachEnvironment(
       "GOOGLE_PLACES_API_KEY|LEAD_DISCOVERY_NOMINATIM_BASE_URL",
     workflow: "WORKFLOW_*",
     appOrigin: "NEXT_PUBLIC_APP_URL",
-    sender: "VERTICAL_MARKETING_EMAIL_FROM",
-    replyTo: "VERTICAL_MARKETING_EMAIL_REPLY_TO",
+    sender: "VERTICAL_OR_FACTORY_EMAIL_FROM",
+    replyTo: "VERTICAL_OR_FACTORY_EMAIL_REPLY_TO",
   } satisfies Record<keyof typeof checks, string>;
   const missingOrInvalid = Object.entries(checks).flatMap(([name, ready]) =>
     ready ? [] : [variableByCheck[name as keyof typeof variableByCheck]],
@@ -159,12 +162,12 @@ export function evaluateOutreachEnvironment(
 
 export function hasRequiredResendDomains(
   domains: ResendDomainSummary[],
+  env: Environment = process.env,
 ): boolean {
   return listOutreachVerticals().every((vertical) => {
-    const email = resolveVerticalConfig(vertical).marketing.email;
-    if (!email) return false;
-    const senderDomain = emailDomain(email.from);
-    const replyDomain = emailDomain(email.replyTo);
+    const senderDomain = emailDomain(emailSender(vertical, env));
+    const replyTo = emailReplyTo(vertical, env);
+    const replyDomain = replyTo ? emailDomain(replyTo) : null;
     if (!senderDomain || !replyDomain) return false;
     return (
       domains.some(

--- a/src/lib/outreach-readiness.ts
+++ b/src/lib/outreach-readiness.ts
@@ -1,4 +1,4 @@
-import { emailReplyTo, emailSender } from "@/lib/resend";
+import { emailReplyTo, emailSender } from "@/lib/email-identity";
 import { listOutreachVerticals } from "@/lib/lead-generation/registry";
 import { resolveVerticalConfig } from "@/lib/verticals/registry";
 import type { VerticalId } from "@/lib/verticals/types";

--- a/src/lib/outreach-templates.ts
+++ b/src/lib/outreach-templates.ts
@@ -1,4 +1,4 @@
-import { emailReplyTo, emailSender } from "@/lib/resend";
+import { emailReplyTo, emailSender } from "@/lib/email-identity";
 import { resolveVerticalConfig } from "@/lib/verticals/registry";
 import type { VerticalId } from "@/lib/verticals/types";
 

--- a/src/lib/outreach-thread.test.ts
+++ b/src/lib/outreach-thread.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { Vertical } from "@/generated/prisma/enums";
 import {
   extractPlusTags,
   inboundThreadTokens,
@@ -21,15 +22,20 @@ describe("outreach thread identifiers", () => {
     );
   });
 
+  it("uses the factory sender domain for an SMB without a niche domain", () => {
+    expect(
+      outboundRfcMessageId("outreach_trade", Vertical.LOCAL_SERVICE, {
+        EMAIL_FROM: "Vincent from Cornershopdev <vincent@send.cornershop.dev>",
+      }),
+    ).toBe("<outreach_trade@send.cornershop.dev>");
+  });
+
   it("parses In-Reply-To and References tokens", () => {
     expect(
       parseRfcMessageIds(
         "<outreach_abc@send.restofront.com> <other@example.test>",
       ),
-    ).toEqual([
-      "outreach_abc@send.restofront.com",
-      "other@example.test",
-    ]);
+    ).toEqual(["outreach_abc@send.restofront.com", "other@example.test"]);
   });
 
   it("extracts plus-address tags from recipients", () => {

--- a/src/lib/outreach-thread.ts
+++ b/src/lib/outreach-thread.ts
@@ -1,9 +1,9 @@
 import { Vertical } from "@/generated/prisma/enums";
-import { resolveVerticalConfig } from "@/lib/verticals/registry";
+import { emailSender } from "@/lib/resend";
 import type { VerticalId } from "@/lib/verticals/types";
 
 export const OUTREACH_THREAD_PREFIX = "lead:";
-export const OUTBOUND_RFC_MESSAGE_DOMAIN = "send.restofront.com";
+export const OUTBOUND_RFC_MESSAGE_DOMAIN = "send.cornershop.dev";
 
 export type InboundAddressFields = {
   from: string;
@@ -21,9 +21,9 @@ export function outreachThreadKey(siteId: string): string {
 export function outboundRfcMessageId(
   messageId: string,
   vertical: VerticalId = Vertical.RESTAURANT,
+  environment: Record<string, string | undefined> = process.env,
 ): string {
-  const from = resolveVerticalConfig(vertical).marketing.email?.from;
-  const address = from ? extractEmailAddress(from) : null;
+  const address = extractEmailAddress(emailSender(vertical, environment));
   const domain = address?.slice(address.lastIndexOf("@") + 1);
   return `<${messageId}@${domain || OUTBOUND_RFC_MESSAGE_DOMAIN}>`;
 }
@@ -89,10 +89,7 @@ export function inboundThreadTokens(input: InboundAddressFields): string[] {
       ...parseRfcMessageIds(input.inReplyTo),
       ...parseRfcMessageIds(input.references),
       ...parseRfcMessageIds(input.rfcMessageId),
-      ...extractPlusTags([
-        ...input.to,
-        ...(input.receivedFor ?? []),
-      ]),
+      ...extractPlusTags([...input.to, ...(input.receivedFor ?? [])]),
     ]),
   ];
 }

--- a/src/lib/outreach-thread.ts
+++ b/src/lib/outreach-thread.ts
@@ -1,5 +1,5 @@
 import { Vertical } from "@/generated/prisma/enums";
-import { emailSender } from "@/lib/resend";
+import { emailSender } from "@/lib/email-identity";
 import type { VerticalId } from "@/lib/verticals/types";
 
 export const OUTREACH_THREAD_PREFIX = "lead:";

--- a/src/lib/resend.test.ts
+++ b/src/lib/resend.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { Vertical } from "@/generated/prisma/enums";
-import { emailReplyTo, emailSender } from "@/lib/resend";
+import { emailReplyTo, emailSender } from "@/lib/email-identity";
 import { restaurantMarketing } from "@/lib/verticals/restaurant/marketing";
 
 /**

--- a/src/lib/resend.ts
+++ b/src/lib/resend.ts
@@ -3,8 +3,8 @@ import {
   assertFirstCustomerTestModeSafety,
   firstCustomerTestModeEnabled,
 } from "@/lib/first-customer-test-mode";
-import { resolveVerticalConfig } from "@/lib/verticals/registry";
-import type { VerticalId } from "@/lib/verticals/types";
+
+export { emailReplyTo, emailSender } from "@/lib/email-identity";
 
 let resend: Resend | undefined;
 
@@ -92,58 +92,4 @@ export async function sendBoundedResendEmail(
   } finally {
     clearTimeout(timeout);
   }
-}
-
-/**
- * Reads EMAIL_FROM and EMAIL_REPLY_TO. Deliberately an index signature rather
- * than those two names: `process.env` is a weak type under bun-types, so a
- * type listing only optional keys it does not declare is not assignable to it.
- * Same shape `platform-readiness` uses for the same reason.
- */
-type EmailEnvironment = Record<string, string | undefined>;
-
-/**
- * The niche's declared sending identity, or null when it has not launched one.
- * An absent vertical — a caller with no site in hand — resolves the same way, so
- * the environment fallback below covers both without a second branch.
- */
-function nicheEmail(vertical: VerticalId | null | undefined) {
-  return vertical ? resolveVerticalConfig(vertical).marketing.email : null;
-}
-
-/**
- * The address a message goes out as, resolved from the niche that owns the site
- * it concerns rather than from one platform-wide identity. A restaurant bought
- * Restofrontapp, so Restofrontapp is who writes to it — the same rule the wordmark
- * already follows, applied to the envelope.
- *
- * EMAIL_FROM survives only as the floor for a niche with no verified sending
- * domain of its own. The resend.dev fallback beneath it reaches a developer
- * machine and nothing else; a blank value counts as unset, because Resend
- * rejects an empty `from` outright and a half-filled `.env` should not break
- * sign-in.
- */
-export function emailSender(
-  vertical?: VerticalId | null,
-  environment: EmailEnvironment = process.env,
-): string {
-  return (
-    nicheEmail(vertical)?.from ||
-    environment.EMAIL_FROM ||
-    "Cornershopdev <onboarding@resend.dev>"
-  );
-}
-
-/**
- * Where a reply lands. Senders are send-only subdomains nobody reads, so without
- * this a recipient who hits reply is talking to a black hole. Undefined leaves
- * the header off, which is the prior behaviour.
- */
-export function emailReplyTo(
-  vertical?: VerticalId | null,
-  environment: EmailEnvironment = process.env,
-): string | undefined {
-  return (
-    nicheEmail(vertical)?.replyTo || environment.EMAIL_REPLY_TO || undefined
-  );
 }

--- a/src/lib/resend.ts
+++ b/src/lib/resend.ts
@@ -4,8 +4,6 @@ import {
   firstCustomerTestModeEnabled,
 } from "@/lib/first-customer-test-mode";
 
-export { emailReplyTo, emailSender } from "@/lib/email-identity";
-
 let resend: Resend | undefined;
 
 export function getResend(): Resend {

--- a/src/lib/site-publication-capability.test.ts
+++ b/src/lib/site-publication-capability.test.ts
@@ -2,27 +2,12 @@ import { describe, expect, it } from "bun:test";
 import { Vertical } from "@/generated/prisma/enums";
 import {
   assertVerticalPublicationEnabled,
-  PUBLICATION_UNAVAILABLE_MESSAGE,
   publicationCapabilityFailureResponse,
 } from "@/lib/site-publication-capability";
 
 describe("site publication capability", () => {
-  it("returns the API conflict response and service error for private pilots", async () => {
-    for (const vertical of [Vertical.FOOD_RETAIL, Vertical.LOCAL_SERVICE]) {
-      const response = publicationCapabilityFailureResponse(vertical);
-
-      expect(response?.status).toBe(409);
-      expect(await response?.json()).toEqual({
-        error: PUBLICATION_UNAVAILABLE_MESSAGE,
-      });
-      expect(() => assertVerticalPublicationEnabled(vertical)).toThrow(
-        PUBLICATION_UNAVAILABLE_MESSAGE,
-      );
-    }
-  });
-
-  it("preserves restaurant and beauty publication behavior", () => {
-    for (const vertical of [Vertical.RESTAURANT, Vertical.BEAUTY]) {
+  it("allows reviewed publication for every registered SMB vertical", () => {
+    for (const vertical of Object.values(Vertical)) {
       expect(publicationCapabilityFailureResponse(vertical)).toBeNull();
       expect(() => assertVerticalPublicationEnabled(vertical)).not.toThrow();
     }

--- a/src/lib/site-publication.postgres.test.ts
+++ b/src/lib/site-publication.postgres.test.ts
@@ -1,12 +1,5 @@
 import { randomUUID } from "node:crypto";
-import {
-  afterAll,
-  beforeAll,
-  describe,
-  expect,
-  mock,
-  test,
-} from "bun:test";
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
 import type { Prisma } from "@/generated/prisma/client";
 
 mock.module("server-only", () => ({}));
@@ -31,11 +24,14 @@ const userId = `site-publication-user-${randomUUID()}`;
 const slug = `site-publication-${randomUUID()}`;
 const foodSiteId = `food-retail-publication-${randomUUID()}`;
 const foodSlug = `food-retail-publication-${randomUUID()}`;
+const localServiceSiteId = `local-service-publication-${randomUUID()}`;
+const localServiceSlug = `local-service-publication-${randomUUID()}`;
 const actor = { id: userId, email: `${userId}@example.test` };
 
 let db: ReturnType<typeof import("@/lib/db").getDb>;
 let sampleSiteDraft: typeof import("@/lib/restaurant").sampleSiteDraft;
 let sampleFoodRetailDraft: typeof import("@/lib/verticals/food-retail/fixtures").sampleFoodRetailDraft;
+let sampleLocalServiceDraft: typeof import("@/lib/verticals/local-service/fixtures").sampleLocalServiceSiteDraft;
 let publishSiteDraft: typeof import("@/lib/site-publication").publishSiteDraft;
 let rollbackPublishedSiteVersion: typeof import("@/lib/site-publication").rollbackPublishedSiteVersion;
 let updateSiteDraft: typeof import("@/lib/site-persistence").updateSiteDraft;
@@ -56,1032 +52,1060 @@ async function currentDraftRevision(): Promise<number> {
   ).draftRevision;
 }
 
-describe.skipIf(!enabled)("safe draft and publish PostgreSQL integration", () => {
-  beforeAll(async () => {
-    const database = await import("@/lib/db");
-    const restaurant = await import("@/lib/restaurant");
-    const foodRetail = await import("@/lib/verticals/food-retail/fixtures");
-    const publication = await import("@/lib/site-publication");
-    const persistence = await import("@/lib/site-persistence");
-    const sites = await import("@/lib/sites");
-    const siteDraft = await import("@/lib/site-draft");
-    const themeFixtures = await import(
-      "@/lib/site-themes/restaurant/fixtures"
-    );
-    const themeSelection = await import(
-      "@/lib/site-themes/restaurant/selection"
-    );
-    const enums = await import("@/generated/prisma/enums");
+describe.skipIf(!enabled)(
+  "safe draft and publish PostgreSQL integration",
+  () => {
+    beforeAll(async () => {
+      const database = await import("@/lib/db");
+      const restaurant = await import("@/lib/restaurant");
+      const foodRetail = await import("@/lib/verticals/food-retail/fixtures");
+      const localService =
+        await import("@/lib/verticals/local-service/fixtures");
+      const publication = await import("@/lib/site-publication");
+      const persistence = await import("@/lib/site-persistence");
+      const sites = await import("@/lib/sites");
+      const siteDraft = await import("@/lib/site-draft");
+      const themeFixtures =
+        await import("@/lib/site-themes/restaurant/fixtures");
+      const themeSelection =
+        await import("@/lib/site-themes/restaurant/selection");
+      const enums = await import("@/generated/prisma/enums");
 
-    db = database.getDb();
-    sampleSiteDraft = restaurant.sampleSiteDraft;
-    sampleFoodRetailDraft = foodRetail.sampleFoodRetailDraft;
-    publishSiteDraft = publication.publishSiteDraft;
-    rollbackPublishedSiteVersion =
-      publication.rollbackPublishedSiteVersion;
-    updateSiteDraft = persistence.updateSiteDraft;
-    findOwnerSiteDraft = sites.findOwnerSiteDraft;
-    findPublishedSiteView = sites.findPublishedSiteView;
-    findSiteView = sites.findSiteView;
-    localizeSiteDraft = siteDraft.localizeSiteDraft;
-    restaurantThemeFixtures = themeFixtures.restaurantThemeFixtures;
-    selectOwnerRestaurantTheme =
-      themeSelection.selectOwnerRestaurantTheme;
-    Vertical = enums.Vertical;
+      db = database.getDb();
+      sampleSiteDraft = restaurant.sampleSiteDraft;
+      sampleFoodRetailDraft = foodRetail.sampleFoodRetailDraft;
+      sampleLocalServiceDraft = localService.sampleLocalServiceSiteDraft;
+      publishSiteDraft = publication.publishSiteDraft;
+      rollbackPublishedSiteVersion = publication.rollbackPublishedSiteVersion;
+      updateSiteDraft = persistence.updateSiteDraft;
+      findOwnerSiteDraft = sites.findOwnerSiteDraft;
+      findPublishedSiteView = sites.findPublishedSiteView;
+      findSiteView = sites.findSiteView;
+      localizeSiteDraft = siteDraft.localizeSiteDraft;
+      restaurantThemeFixtures = themeFixtures.restaurantThemeFixtures;
+      selectOwnerRestaurantTheme = themeSelection.selectOwnerRestaurantTheme;
+      Vertical = enums.Vertical;
 
-    await db.user.create({
-      data: {
-        id: userId,
-        email: actor.email,
-        name: "Publication owner",
-        memberships: {
-          create: {
-            organization: {
-              create: {
-                id: organizationId,
-                name: "Publication integration",
+      await db.user.create({
+        data: {
+          id: userId,
+          email: actor.email,
+          name: "Publication owner",
+          memberships: {
+            create: {
+              organization: {
+                create: {
+                  id: organizationId,
+                  name: "Publication integration",
+                },
               },
             },
           },
         },
-      },
-    });
-    await db.site.create({
-      data: {
-        id: siteId,
-        slug,
-        name: sampleSiteDraft.name,
-        eyebrow: sampleSiteDraft.eyebrow,
-        description: sampleSiteDraft.description,
-        address: sampleSiteDraft.address,
-        phone: sampleSiteDraft.phone,
-        sourceUrl: sampleSiteDraft.sourceUrl,
-        heroImageUrl: sampleSiteDraft.heroImageUrl,
-        heroOriginalImageUrl: sampleSiteDraft.heroOriginalImageUrl,
-        heroImageProvenance: "OWNER",
-        draftTheme: { id: "warm" },
-        draftThemeVersion: "legacy-v1",
-        draftPalette: sampleSiteDraft.palette,
-        attributes: sampleSiteDraft.attributes,
-        autoEnhanceImages: sampleSiteDraft.autoEnhanceImages,
-        defaultLocale: sampleSiteDraft.defaultLocale,
-        translations: sampleSiteDraft.translations,
-        vertical: "RESTAURANT",
-        status: "CLAIMED",
-        organizationId,
-        integrations: {
-          create: sampleSiteDraft.integrations.map(
-            (integration, position) => ({
-              type: integration.type.toUpperCase() as
-                | "BOOKING"
-                | "ORDERING"
-                | "DELIVERY"
-                | "SOCIAL",
-              label: integration.label,
-              provider: integration.provider,
-              url: integration.url,
-              venueId: integration.venueId,
-              position,
-            }),
-          ),
-        },
-        catalogSections: {
-          create: sampleSiteDraft.catalogSections.map(
-            (section, sectionPosition) => ({
-              name: section.name,
-              description: section.description,
-              position: sectionPosition,
-              items: {
-                create: section.items.map((item, itemPosition) => ({
-                  name: item.name,
-                  description: item.description,
-                  price: item.price,
-                  currency: item.currency,
-                  imageUrl: item.imageUrl,
-                  originalImageUrl: item.originalImageUrl,
-                  imageProvenance: item.imageProvenance?.toUpperCase() as
-                    | "OFFICIAL"
-                    | "OWNER"
-                    | undefined,
-                  attributes: item.attributes,
-                  position: itemPosition,
-                })),
-              },
-            }),
-          ),
-        },
-      },
-    });
-    if (!sampleSiteDraft.heroImageUrl) {
-      throw new Error("Publication fixture requires its reviewed hero");
-    }
-    await db.photoAsset.create({
-      data: {
-        siteId,
-        sourceUrl: sampleSiteDraft.heroImageUrl,
-        provenance: "OWNER",
-        sourceKind: "OWNER_REFERENCE",
-        contentSha256: "e".repeat(64),
-        originalStorageKey: `test/${"e".repeat(64)}.jpg`,
-        originalUrl: sampleSiteDraft.heroImageUrl,
-        mediaType: "image/jpeg",
-        byteLength: 1_024,
-        candidateUsages: ["HERO"],
-        reviewStatus: "APPROVED",
-        selectedUsage: "HERO",
-        reviewedAt: new Date(),
-        reviewedBy: actor.id,
-      },
-    });
-    await db.domain.create({
-      data: {
-        hostname: `${randomUUID()}.example.test`,
-        siteId,
-        verificationToken: randomUUID(),
-        verified: true,
-        verifiedAt: new Date(),
-      },
-    });
-    await db.site.create({
-      data: {
-        id: foodSiteId,
-        slug: foodSlug,
-        name: sampleFoodRetailDraft.name,
-        vertical: Vertical.FOOD_RETAIL,
-        attributes: sampleFoodRetailDraft.attributes,
-        organizationId,
-      },
-    });
-  });
-
-  afterAll(async () => {
-    if (!db) return;
-    await db.site.deleteMany({ where: { id: { in: [siteId, foodSiteId] } } });
-    await db.organization.deleteMany({ where: { id: organizationId } });
-    await db.user.deleteMany({ where: { id: userId } });
-  });
-
-  test("does not let Publish bypass a paused lifecycle state", async () => {
-    await db.site.update({
-      where: { id: siteId },
-      data: { status: "PAUSED" },
-    });
-
-    await expect(
-      publishSiteDraft({
-        siteId,
-        slug,
-        vertical: Vertical.RESTAURANT,
-        actor,
-        changeSummary: "Attempt to bypass pause",
-        expectedRevision: await currentDraftRevision(),
-      }),
-    ).rejects.toThrow("Only claimed or live sites can be published");
-    expect(
-      await db.site.findUniqueOrThrow({
-        where: { id: siteId },
-        select: {
-          publishedSiteVersionId: true,
-          _count: { select: { siteVersions: true, auditEvents: true } },
-        },
-      }),
-    ).toEqual({
-      publishedSiteVersionId: null,
-      _count: { siteVersions: 0, auditEvents: 0 },
-    });
-
-    await db.site.update({
-      where: { id: siteId },
-      data: { status: "CLAIMED" },
-    });
-  });
-
-  test("publishes a validated immutable snapshot and promotes a verified custom-domain site to LIVE", async () => {
-    expect(
-      await db.domain.count({ where: { siteId, verified: true } }),
-    ).toBe(1);
-    const published = await publishSiteDraft({
-      siteId,
-      slug,
-      vertical: Vertical.RESTAURANT,
-      actor,
-      changeSummary: "Initial customer launch",
-      expectedRevision: await currentDraftRevision(),
-      now: new Date("2026-07-26T20:00:00.000Z"),
-    });
-
-    expect(published).toMatchObject({
-      version: 1,
-      theme: { id: "warm", version: "legacy-v1" },
-    });
-    const site = await db.site.findUnique({
-      where: { id: siteId },
-      select: {
-        status: true,
-        publishedSiteVersionId: true,
-        publishedSiteVersion: {
-          select: {
-            content: true,
-            translations: true,
-            integrations: true,
-            palette: true,
-            publishedBy: true,
-            changeSummary: true,
+      });
+      await db.site.create({
+        data: {
+          id: siteId,
+          slug,
+          name: sampleSiteDraft.name,
+          eyebrow: sampleSiteDraft.eyebrow,
+          description: sampleSiteDraft.description,
+          address: sampleSiteDraft.address,
+          phone: sampleSiteDraft.phone,
+          sourceUrl: sampleSiteDraft.sourceUrl,
+          heroImageUrl: sampleSiteDraft.heroImageUrl,
+          heroOriginalImageUrl: sampleSiteDraft.heroOriginalImageUrl,
+          heroImageProvenance: "OWNER",
+          draftTheme: { id: "warm" },
+          draftThemeVersion: "legacy-v1",
+          draftPalette: sampleSiteDraft.palette,
+          attributes: sampleSiteDraft.attributes,
+          autoEnhanceImages: sampleSiteDraft.autoEnhanceImages,
+          defaultLocale: sampleSiteDraft.defaultLocale,
+          translations: sampleSiteDraft.translations,
+          vertical: "RESTAURANT",
+          status: "CLAIMED",
+          organizationId,
+          integrations: {
+            create: sampleSiteDraft.integrations.map(
+              (integration, position) => ({
+                type: integration.type.toUpperCase() as
+                  "BOOKING" | "ORDERING" | "DELIVERY" | "SOCIAL",
+                label: integration.label,
+                provider: integration.provider,
+                url: integration.url,
+                venueId: integration.venueId,
+                position,
+              }),
+            ),
+          },
+          catalogSections: {
+            create: sampleSiteDraft.catalogSections.map(
+              (section, sectionPosition) => ({
+                name: section.name,
+                description: section.description,
+                position: sectionPosition,
+                items: {
+                  create: section.items.map((item, itemPosition) => ({
+                    name: item.name,
+                    description: item.description,
+                    price: item.price,
+                    currency: item.currency,
+                    imageUrl: item.imageUrl,
+                    originalImageUrl: item.originalImageUrl,
+                    imageProvenance: item.imageProvenance?.toUpperCase() as
+                      "OFFICIAL" | "OWNER" | undefined,
+                    attributes: item.attributes,
+                    position: itemPosition,
+                  })),
+                },
+              }),
+            ),
           },
         },
-        auditEvents: {
-          where: { type: "site.published" },
-          select: { actor: true, metadata: true },
+      });
+      if (!sampleSiteDraft.heroImageUrl) {
+        throw new Error("Publication fixture requires its reviewed hero");
+      }
+      await db.photoAsset.create({
+        data: {
+          siteId,
+          sourceUrl: sampleSiteDraft.heroImageUrl,
+          provenance: "OWNER",
+          sourceKind: "OWNER_REFERENCE",
+          contentSha256: "e".repeat(64),
+          originalStorageKey: `test/${"e".repeat(64)}.jpg`,
+          originalUrl: sampleSiteDraft.heroImageUrl,
+          mediaType: "image/jpeg",
+          byteLength: 1_024,
+          candidateUsages: ["HERO"],
+          reviewStatus: "APPROVED",
+          selectedUsage: "HERO",
+          reviewedAt: new Date(),
+          reviewedBy: actor.id,
         },
-      },
+      });
+      await db.domain.create({
+        data: {
+          hostname: `${randomUUID()}.example.test`,
+          siteId,
+          verificationToken: randomUUID(),
+          verified: true,
+          verifiedAt: new Date(),
+        },
+      });
+      await db.site.create({
+        data: {
+          id: foodSiteId,
+          slug: foodSlug,
+          name: sampleFoodRetailDraft.name,
+          vertical: Vertical.FOOD_RETAIL,
+          attributes: sampleFoodRetailDraft.attributes,
+          organizationId,
+        },
+      });
+      await db.site.create({
+        data: {
+          id: localServiceSiteId,
+          slug: localServiceSlug,
+          name: sampleLocalServiceDraft.name,
+          vertical: Vertical.LOCAL_SERVICE,
+          attributes: sampleLocalServiceDraft.attributes,
+          organizationId,
+        },
+      });
     });
 
-    expect(site?.status).toBe("LIVE");
-    expect(site?.publishedSiteVersionId).toBe(published.id);
-    expect(site?.publishedSiteVersion).toMatchObject({
-      publishedBy: actor.id,
-      changeSummary: "Initial customer launch",
-      palette: sampleSiteDraft.palette,
-      translations: sampleSiteDraft.translations,
-      integrations: sampleSiteDraft.integrations,
+    afterAll(async () => {
+      if (!db) return;
+      await db.site.deleteMany({
+        where: {
+          id: { in: [siteId, foodSiteId, localServiceSiteId] },
+        },
+      });
+      await db.organization.deleteMany({ where: { id: organizationId } });
+      await db.user.deleteMany({ where: { id: userId } });
     });
-    expect(site?.publishedSiteVersion?.content).toMatchObject({
-      slug,
-      name: sampleSiteDraft.name,
-      palette: sampleSiteDraft.palette,
-    });
-    expect(site?.auditEvents).toEqual([
-      {
-        actor: actor.id,
-        metadata: expect.objectContaining({
-          siteVersionId: published.id,
-          version: 1,
-          changeSummary: "Initial customer launch",
-          actorEmail: actor.email,
-          draftRevision: 0,
-          draftContentDigest: expect.stringMatching(/^[a-f0-9]{64}$/),
-          integrationUrlDigest: expect.stringMatching(/^[a-f0-9]{64}$/),
-          previousSiteVersionId: null,
-        }),
-      },
-    ]);
-  });
 
-  test("keeps Save private until a later atomic publish", async () => {
-    const firstPointer = (
-      await db.site.findUniqueOrThrow({
+    test("does not let Publish bypass a paused lifecycle state", async () => {
+      await db.site.update({
         where: { id: siteId },
-        select: { publishedSiteVersionId: true },
-      })
-    ).publishedSiteVersionId;
-    const changedDraft = {
-      ...sampleSiteDraft,
-      slug,
-      name: "Private draft name",
-      description:
-        "This description is visible in the owner preview but not on the public domain.",
-      palette: {
-        background: "#101010",
-        foreground: "#f5f5f5",
-        accent: "#dd5544",
-      },
-      attributes: {
-        ...sampleSiteDraft.attributes,
-        cuisine: "Japanese omakase",
-      },
-    };
+        data: { status: "PAUSED" },
+      });
 
-    await updateSiteDraft(slug, changedDraft, Vertical.RESTAURANT);
+      await expect(
+        publishSiteDraft({
+          siteId,
+          slug,
+          vertical: Vertical.RESTAURANT,
+          actor,
+          changeSummary: "Attempt to bypass pause",
+          expectedRevision: await currentDraftRevision(),
+        }),
+      ).rejects.toThrow("Only claimed or live sites can be published");
+      expect(
+        await db.site.findUniqueOrThrow({
+          where: { id: siteId },
+          select: {
+            publishedSiteVersionId: true,
+            _count: { select: { siteVersions: true, auditEvents: true } },
+          },
+        }),
+      ).toEqual({
+        publishedSiteVersionId: null,
+        _count: { siteVersions: 0, auditEvents: 0 },
+      });
 
-    const afterSave = await db.site.findUniqueOrThrow({
-      where: { id: siteId },
-      select: {
-        publishedSiteVersionId: true,
-        siteVersions: { select: { id: true } },
-      },
-    });
-    const [privateView, publicView] = await Promise.all([
-      findSiteView(slug),
-      findPublishedSiteView(slug),
-    ]);
-    expect(afterSave.publishedSiteVersionId).toBe(firstPointer);
-    expect(afterSave.siteVersions).toHaveLength(1);
-    expect(privateView?.draft.name).toBe("Private draft name");
-    expect(privateView?.theme.id).toBe("nocturne");
-    expect(publicView?.draft.name).toBe(sampleSiteDraft.name);
-    expect(publicView?.draft.palette).toEqual(sampleSiteDraft.palette);
-    expect(publicView?.theme).toMatchObject({
-      id: "warm",
-      version: "legacy-v1",
+      await db.site.update({
+        where: { id: siteId },
+        data: { status: "CLAIMED" },
+      });
     });
 
-    const second = await publishSiteDraft({
-      siteId,
-      slug,
-      vertical: Vertical.RESTAURANT,
-      actor,
-      changeSummary: "Publish private copy and palette",
-      expectedRevision: await currentDraftRevision(),
-    });
-    expect(second.version).toBe(2);
-    expect(second.theme).toEqual({ id: "nocturne", version: "legacy-v1" });
-    expect(second.id).not.toBe(firstPointer);
-    expect((await findPublishedSiteView(slug))?.draft).toMatchObject({
-      name: changedDraft.name,
-      palette: changedDraft.palette,
-    });
-  });
-
-  test("rejects a publish when another save advances the reviewed revision", async () => {
-    const loadedRevision = await currentDraftRevision();
-    const reviewedDraft = {
-      ...sampleSiteDraft,
-      slug,
-      name: "Reviewed owner draft",
-    };
-    const reviewed = await updateSiteDraft(
-      slug,
-      reviewedDraft,
-      Vertical.RESTAURANT,
-      { actor, expectedRevision: loadedRevision },
-    );
-    const concurrentlySaved = {
-      ...reviewedDraft,
-      name: "Concurrent unreviewed owner draft",
-    };
-    const concurrent = await updateSiteDraft(
-      slug,
-      concurrentlySaved,
-      Vertical.RESTAURANT,
-      { actor, expectedRevision: reviewed.revision },
-    );
-    const beforePublish = await db.site.findUniqueOrThrow({
-      where: { id: siteId },
-      select: {
-        publishedSiteVersionId: true,
-        _count: { select: { siteVersions: true, auditEvents: true } },
-      },
-    });
-
-    await expect(
-      publishSiteDraft({
+    test("publishes a validated immutable snapshot and promotes a verified custom-domain site to LIVE", async () => {
+      expect(await db.domain.count({ where: { siteId, verified: true } })).toBe(
+        1,
+      );
+      const published = await publishSiteDraft({
         siteId,
         slug,
         vertical: Vertical.RESTAURANT,
         actor,
-        changeSummary: "Publish the reviewed owner draft",
-        expectedRevision: reviewed.revision,
-      }),
-    ).rejects.toMatchObject({
-      name: "DraftRevisionConflictError",
-      currentRevision: concurrent.revision,
+        changeSummary: "Initial customer launch",
+        expectedRevision: await currentDraftRevision(),
+        now: new Date("2026-07-26T20:00:00.000Z"),
+      });
+
+      expect(published).toMatchObject({
+        version: 1,
+        theme: { id: "warm", version: "legacy-v1" },
+      });
+      const site = await db.site.findUnique({
+        where: { id: siteId },
+        select: {
+          status: true,
+          publishedSiteVersionId: true,
+          publishedSiteVersion: {
+            select: {
+              content: true,
+              translations: true,
+              integrations: true,
+              palette: true,
+              publishedBy: true,
+              changeSummary: true,
+            },
+          },
+          auditEvents: {
+            where: { type: "site.published" },
+            select: { actor: true, metadata: true },
+          },
+        },
+      });
+
+      expect(site?.status).toBe("LIVE");
+      expect(site?.publishedSiteVersionId).toBe(published.id);
+      expect(site?.publishedSiteVersion).toMatchObject({
+        publishedBy: actor.id,
+        changeSummary: "Initial customer launch",
+        palette: sampleSiteDraft.palette,
+        translations: sampleSiteDraft.translations,
+        integrations: sampleSiteDraft.integrations,
+      });
+      expect(site?.publishedSiteVersion?.content).toMatchObject({
+        slug,
+        name: sampleSiteDraft.name,
+        palette: sampleSiteDraft.palette,
+      });
+      expect(site?.auditEvents).toEqual([
+        {
+          actor: actor.id,
+          metadata: expect.objectContaining({
+            siteVersionId: published.id,
+            version: 1,
+            changeSummary: "Initial customer launch",
+            actorEmail: actor.email,
+            draftRevision: 0,
+            draftContentDigest: expect.stringMatching(/^[a-f0-9]{64}$/),
+            integrationUrlDigest: expect.stringMatching(/^[a-f0-9]{64}$/),
+            previousSiteVersionId: null,
+          }),
+        },
+      ]);
     });
 
-    expect(
-      await db.site.findUniqueOrThrow({
+    test("keeps Save private until a later atomic publish", async () => {
+      const firstPointer = (
+        await db.site.findUniqueOrThrow({
+          where: { id: siteId },
+          select: { publishedSiteVersionId: true },
+        })
+      ).publishedSiteVersionId;
+      const changedDraft = {
+        ...sampleSiteDraft,
+        slug,
+        name: "Private draft name",
+        description:
+          "This description is visible in the owner preview but not on the public domain.",
+        palette: {
+          background: "#101010",
+          foreground: "#f5f5f5",
+          accent: "#dd5544",
+        },
+        attributes: {
+          ...sampleSiteDraft.attributes,
+          cuisine: "Japanese omakase",
+        },
+      };
+
+      await updateSiteDraft(slug, changedDraft, Vertical.RESTAURANT);
+
+      const afterSave = await db.site.findUniqueOrThrow({
+        where: { id: siteId },
+        select: {
+          publishedSiteVersionId: true,
+          siteVersions: { select: { id: true } },
+        },
+      });
+      const [privateView, publicView] = await Promise.all([
+        findSiteView(slug),
+        findPublishedSiteView(slug),
+      ]);
+      expect(afterSave.publishedSiteVersionId).toBe(firstPointer);
+      expect(afterSave.siteVersions).toHaveLength(1);
+      expect(privateView?.draft.name).toBe("Private draft name");
+      expect(privateView?.theme.id).toBe("nocturne");
+      expect(publicView?.draft.name).toBe(sampleSiteDraft.name);
+      expect(publicView?.draft.palette).toEqual(sampleSiteDraft.palette);
+      expect(publicView?.theme).toMatchObject({
+        id: "warm",
+        version: "legacy-v1",
+      });
+
+      const second = await publishSiteDraft({
+        siteId,
+        slug,
+        vertical: Vertical.RESTAURANT,
+        actor,
+        changeSummary: "Publish private copy and palette",
+        expectedRevision: await currentDraftRevision(),
+      });
+      expect(second.version).toBe(2);
+      expect(second.theme).toEqual({ id: "nocturne", version: "legacy-v1" });
+      expect(second.id).not.toBe(firstPointer);
+      expect((await findPublishedSiteView(slug))?.draft).toMatchObject({
+        name: changedDraft.name,
+        palette: changedDraft.palette,
+      });
+    });
+
+    test("rejects a publish when another save advances the reviewed revision", async () => {
+      const loadedRevision = await currentDraftRevision();
+      const reviewedDraft = {
+        ...sampleSiteDraft,
+        slug,
+        name: "Reviewed owner draft",
+      };
+      const reviewed = await updateSiteDraft(
+        slug,
+        reviewedDraft,
+        Vertical.RESTAURANT,
+        { actor, expectedRevision: loadedRevision },
+      );
+      const concurrentlySaved = {
+        ...reviewedDraft,
+        name: "Concurrent unreviewed owner draft",
+      };
+      const concurrent = await updateSiteDraft(
+        slug,
+        concurrentlySaved,
+        Vertical.RESTAURANT,
+        { actor, expectedRevision: reviewed.revision },
+      );
+      const beforePublish = await db.site.findUniqueOrThrow({
         where: { id: siteId },
         select: {
           publishedSiteVersionId: true,
           _count: { select: { siteVersions: true, auditEvents: true } },
         },
-      }),
-    ).toEqual(beforePublish);
-    expect((await findSiteView(slug))?.draft.name).toBe(
-      concurrentlySaved.name,
-    );
-  });
+      });
 
-  test("persists menu order, availability, currency and approved imagery", async () => {
-    const firstSection = sampleSiteDraft.catalogSections[0];
-    const secondSection = sampleSiteDraft.catalogSections[1];
-    const editedDraft = {
-      ...sampleSiteDraft,
-      slug,
-      catalogSections: [
-        {
-          ...secondSection,
-          items: [...secondSection.items].reverse(),
+      await expect(
+        publishSiteDraft({
+          siteId,
+          slug,
+          vertical: Vertical.RESTAURANT,
+          actor,
+          changeSummary: "Publish the reviewed owner draft",
+          expectedRevision: reviewed.revision,
+        }),
+      ).rejects.toMatchObject({
+        name: "DraftRevisionConflictError",
+        currentRevision: concurrent.revision,
+      });
+
+      expect(
+        await db.site.findUniqueOrThrow({
+          where: { id: siteId },
+          select: {
+            publishedSiteVersionId: true,
+            _count: { select: { siteVersions: true, auditEvents: true } },
+          },
+        }),
+      ).toEqual(beforePublish);
+      expect((await findSiteView(slug))?.draft.name).toBe(
+        concurrentlySaved.name,
+      );
+    });
+
+    test("persists menu order, availability, currency and approved imagery", async () => {
+      const firstSection = sampleSiteDraft.catalogSections[0];
+      const secondSection = sampleSiteDraft.catalogSections[1];
+      const editedDraft = {
+        ...sampleSiteDraft,
+        slug,
+        catalogSections: [
+          {
+            ...secondSection,
+            items: [...secondSection.items].reverse(),
+          },
+          {
+            ...firstSection,
+            items: firstSection.items.map((item, index) =>
+              index === 0
+                ? {
+                    ...item,
+                    price: 8.5,
+                    currency: "GBP" as const,
+                    available: false,
+                    imageUrl: "/approved/menu-item.webp",
+                    originalImageUrl: "/approved/menu-item.webp",
+                    imageProvenance: "owner" as const,
+                  }
+                : item,
+            ),
+          },
+        ],
+      };
+
+      await updateSiteDraft(slug, editedDraft, Vertical.RESTAURANT);
+      const reloaded = await findSiteView(slug);
+      expect(
+        reloaded?.draft.catalogSections.map((section) => section.name),
+      ).toEqual([secondSection.name, firstSection.name]);
+      expect(
+        reloaded?.draft.catalogSections[0].items.map((item) => item.name),
+      ).toEqual([...secondSection.items].reverse().map((item) => item.name));
+      expect(reloaded?.draft.catalogSections[1].items[0]).toMatchObject({
+        price: 8.5,
+        currency: "GBP",
+        available: false,
+        imageUrl: "/approved/menu-item.webp",
+      });
+    });
+
+    test("round-trips nullable, evidence-backed food-retail stock separately from visibility", async () => {
+      const editedDraft = structuredClone(sampleFoodRetailDraft);
+      editedDraft.slug = foodSlug;
+      editedDraft.catalogSections[0].items[0].available = false;
+      editedDraft.catalogSections[0].items[0].attributes.visible = true;
+      editedDraft.catalogSections[0].items[0].attributes.stockSourceUrl =
+        "https://example.com/maison-levain/daily-breads";
+      editedDraft.catalogSections[1].items[0].available = null;
+      editedDraft.catalogSections[1].items[0].attributes.visible = true;
+      editedDraft.catalogSections[1].items[0].attributes.stockSourceUrl = null;
+
+      await updateSiteDraft(foodSlug, editedDraft, Vertical.FOOD_RETAIL);
+      const reloaded = await findSiteView(foodSlug);
+
+      expect(reloaded?.draft.catalogSections[0].items[0]).toMatchObject({
+        available: false,
+        attributes: {
+          visible: true,
+          stockSourceUrl: "https://example.com/maison-levain/daily-breads",
         },
-        {
-          ...firstSection,
-          items: firstSection.items.map((item, index) =>
-            index === 0
-              ? {
-                  ...item,
-                  price: 8.5,
-                  currency: "GBP" as const,
-                  available: false,
-                  imageUrl: "/approved/menu-item.webp",
-                  originalImageUrl: "/approved/menu-item.webp",
-                  imageProvenance: "owner" as const,
-                }
-              : item,
-          ),
+      });
+      expect(reloaded?.draft.catalogSections[1].items[0]).toMatchObject({
+        available: null,
+        attributes: {
+          visible: true,
+          stockSourceUrl: null,
         },
-      ],
-    };
-
-    await updateSiteDraft(slug, editedDraft, Vertical.RESTAURANT);
-    const reloaded = await findSiteView(slug);
-    expect(
-      reloaded?.draft.catalogSections.map((section) => section.name),
-    ).toEqual([
-      secondSection.name,
-      firstSection.name,
-    ]);
-    expect(reloaded?.draft.catalogSections[0].items.map((item) => item.name))
-      .toEqual([...secondSection.items].reverse().map((item) => item.name));
-    expect(reloaded?.draft.catalogSections[1].items[0]).toMatchObject({
-      price: 8.5,
-      currency: "GBP",
-      available: false,
-      imageUrl: "/approved/menu-item.webp",
-    });
-  });
-
-  test("round-trips nullable, evidence-backed food-retail stock separately from visibility", async () => {
-    const editedDraft = structuredClone(sampleFoodRetailDraft);
-    editedDraft.slug = foodSlug;
-    editedDraft.catalogSections[0].items[0].available = false;
-    editedDraft.catalogSections[0].items[0].attributes.visible = true;
-    editedDraft.catalogSections[0].items[0].attributes.stockSourceUrl =
-      "https://example.com/maison-levain/daily-breads";
-    editedDraft.catalogSections[1].items[0].available = null;
-    editedDraft.catalogSections[1].items[0].attributes.visible = true;
-    editedDraft.catalogSections[1].items[0].attributes.stockSourceUrl = null;
-
-    await updateSiteDraft(foodSlug, editedDraft, Vertical.FOOD_RETAIL);
-    const reloaded = await findSiteView(foodSlug);
-
-    expect(reloaded?.draft.catalogSections[0].items[0]).toMatchObject({
-      available: false,
-      attributes: {
-        visible: true,
-        stockSourceUrl:
-          "https://example.com/maison-levain/daily-breads",
-      },
-    });
-    expect(reloaded?.draft.catalogSections[1].items[0]).toMatchObject({
-      available: null,
-      attributes: {
-        visible: true,
-        stockSourceUrl: null,
-      },
-    });
-  });
-
-  test("keeps legacy food-retail snapshots private and rejects publish or rollback without mutation", async () => {
-    const canonicalDraft = structuredClone(sampleFoodRetailDraft);
-    canonicalDraft.slug = foodSlug;
-    await updateSiteDraft(foodSlug, canonicalDraft, Vertical.FOOD_RETAIL);
-    const loaded = await findOwnerSiteDraft(foodSlug);
-    if (!loaded) throw new Error("Expected the food editor draft");
-    const reviewed = await updateSiteDraft(
-      foodSlug,
-      {
-        ...(loaded.draft as typeof sampleFoodRetailDraft),
-        description: "Reviewed food-retail editor save.",
-      },
-      Vertical.FOOD_RETAIL,
-      { actor, expectedRevision: loaded.revision },
-    );
-    expect((await findOwnerSiteDraft(foodSlug))?.revision).toBe(
-      reviewed.revision,
-    );
-    expect((await findSiteView(foodSlug))?.draft.description).toBe(
-      "Reviewed food-retail editor save.",
-    );
-
-    const privateView = await findSiteView(foodSlug);
-    if (!privateView) throw new Error("Expected private food-retail preview");
-    // Each value was parsed by the registered draft/theme schemas immediately
-    // above; the casts bridge those JSON-safe domain types to Prisma's write type.
-    const legacyVersion = await db.siteVersion.create({
-      data: {
-        siteId: foodSiteId,
-        version: 1,
-        vertical: Vertical.FOOD_RETAIL,
-        theme: privateView.theme.selection as Prisma.InputJsonValue,
-        themeVersion: privateView.theme.version,
-        palette: privateView.draft.palette as Prisma.InputJsonValue,
-        content: privateView.draft as Prisma.InputJsonValue,
-        translations:
-          privateView.draft.translations as Prisma.InputJsonValue,
-        integrations:
-          privateView.draft.integrations as Prisma.InputJsonValue,
-        publishedAt: new Date(),
-        publishedBy: actor.id,
-        changeSummary: "Legacy snapshot created before the launch gate",
-      },
-    });
-    await db.site.update({
-      where: { id: foodSiteId },
-      data: {
-        status: "CLAIMED",
-        publishedSiteVersionId: legacyVersion.id,
-      },
-    });
-    const before = await db.site.findUniqueOrThrow({
-      where: { id: foodSiteId },
-      select: {
-        status: true,
-        draftRevision: true,
-        publishedSiteVersionId: true,
-        _count: { select: { siteVersions: true, auditEvents: true } },
-      },
+      });
     });
 
-    await expect(
-      publishSiteDraft({
+    test("publishes reviewed food retail and can roll back to a valid historical snapshot", async () => {
+      const canonicalDraft = structuredClone(sampleFoodRetailDraft);
+      canonicalDraft.slug = foodSlug;
+      canonicalDraft.heroImageUrl = null;
+      canonicalDraft.heroOriginalImageUrl = null;
+      canonicalDraft.heroImageProvenance = null;
+      await updateSiteDraft(foodSlug, canonicalDraft, Vertical.FOOD_RETAIL);
+      // Hero selection is owned by the photo library, not the general draft save.
+      // Clear the previous test's unreviewed source projection through the same
+      // persisted boundary before exercising publication without a selected hero.
+      await db.site.update({
+        where: { id: foodSiteId },
+        data: {
+          heroImageUrl: null,
+          heroOriginalImageUrl: null,
+          heroImageProvenance: null,
+        },
+      });
+      const loaded = await findOwnerSiteDraft(foodSlug);
+      if (!loaded) throw new Error("Expected the food editor draft");
+      const reviewed = await updateSiteDraft(
+        foodSlug,
+        {
+          ...(loaded.draft as typeof sampleFoodRetailDraft),
+          description: "Reviewed food-retail editor save.",
+        },
+        Vertical.FOOD_RETAIL,
+        { actor, expectedRevision: loaded.revision },
+      );
+      expect((await findOwnerSiteDraft(foodSlug))?.revision).toBe(
+        reviewed.revision,
+      );
+      expect((await findSiteView(foodSlug))?.draft.description).toBe(
+        "Reviewed food-retail editor save.",
+      );
+
+      const privateView = await findSiteView(foodSlug);
+      if (!privateView) throw new Error("Expected private food-retail preview");
+      const legacyContent = structuredClone(privateView.draft);
+      legacyContent.description = "Valid historical food-retail snapshot.";
+      // Each value was parsed by the registered draft/theme schemas immediately
+      // above; the casts bridge those JSON-safe domain types to Prisma's write type.
+      const legacyVersion = await db.siteVersion.create({
+        data: {
+          siteId: foodSiteId,
+          version: 1,
+          vertical: Vertical.FOOD_RETAIL,
+          theme: privateView.theme.selection as Prisma.InputJsonValue,
+          themeVersion: privateView.theme.version,
+          palette: privateView.draft.palette as Prisma.InputJsonValue,
+          content: legacyContent as Prisma.InputJsonValue,
+          translations: privateView.draft.translations as Prisma.InputJsonValue,
+          integrations: privateView.draft.integrations as Prisma.InputJsonValue,
+          publishedAt: new Date(),
+          publishedBy: actor.id,
+          changeSummary: "Valid historical food-retail snapshot",
+        },
+      });
+      await db.site.update({
+        where: { id: foodSiteId },
+        data: {
+          status: "CLAIMED",
+          publishedSiteVersionId: legacyVersion.id,
+        },
+      });
+      const published = await publishSiteDraft({
         siteId: foodSiteId,
         slug: foodSlug,
         vertical: Vertical.FOOD_RETAIL,
         actor,
-        changeSummary: "Food publishing must stay closed",
+        changeSummary: "Publish reviewed food storefront",
         expectedRevision: reviewed.revision,
-      }),
-    ).rejects.toMatchObject({
-      name: "SitePublicationCapabilityError",
-      message: "Publishing is not available for this vertical",
-    });
-    await expect(
-      rollbackPublishedSiteVersion({
+      });
+      expect(published.version).toBe(2);
+      expect((await findPublishedSiteView(foodSlug))?.draft.description).toBe(
+        "Reviewed food-retail editor save.",
+      );
+
+      const rolledBack = await rollbackPublishedSiteVersion({
         siteId: foodSiteId,
         slug: foodSlug,
         vertical: Vertical.FOOD_RETAIL,
         targetSiteVersionId: legacyVersion.id,
         actor,
-      }),
-    ).rejects.toMatchObject({
-      name: "SitePublicationCapabilityError",
-      message: "Publishing is not available for this vertical",
+      });
+      expect(rolledBack.version).toBe(3);
+      expect((await findPublishedSiteView(foodSlug))?.draft.description).toBe(
+        "Valid historical food-retail snapshot.",
+      );
+      expect((await findSiteView(foodSlug))?.draft.description).toBe(
+        "Reviewed food-retail editor save.",
+      );
     });
 
-    expect(
-      await db.site.findUniqueOrThrow({
-        where: { id: foodSiteId },
-        select: {
-          status: true,
-          draftRevision: true,
-          publishedSiteVersionId: true,
-          _count: { select: { siteVersions: true, auditEvents: true } },
-        },
-      }),
-    ).toEqual(before);
-    expect(await findPublishedSiteView(foodSlug)).toBeNull();
-    expect((await findSiteView(foodSlug))?.draft.description).toBe(
-      "Reviewed food-retail editor save.",
-    );
-  });
+    test("publishes a deterministic local-service owner draft", async () => {
+      const draft = structuredClone(sampleLocalServiceDraft);
+      draft.slug = localServiceSlug;
+      const saved = await updateSiteDraft(
+        localServiceSlug,
+        draft,
+        Vertical.LOCAL_SERVICE,
+        { actor, expectedRevision: 0 },
+      );
+      await db.site.update({
+        where: { id: localServiceSiteId },
+        data: { status: "CLAIMED" },
+      });
 
-  test("versions and audits authorized integration saves without publishing", async () => {
-    const before = await db.site.findUniqueOrThrow({
-      where: { id: siteId },
-      select: {
-        draftRevision: true,
-        publishedSiteVersionId: true,
-        _count: { select: { siteVersions: true } },
-      },
+      const published = await publishSiteDraft({
+        siteId: localServiceSiteId,
+        slug: localServiceSlug,
+        vertical: Vertical.LOCAL_SERVICE,
+        actor,
+        changeSummary: "Publish reviewed electrician website",
+        expectedRevision: saved.revision,
+      });
+
+      expect(published.version).toBe(1);
+      expect(
+        (await findPublishedSiteView(localServiceSlug))?.draft.description,
+      ).toBe(sampleLocalServiceDraft.description);
     });
-    const first = sampleSiteDraft.integrations[0];
-    const second = sampleSiteDraft.integrations[1];
-    const editedDraft = {
-      ...sampleSiteDraft,
-      slug,
-      integrations: [
-        { ...second, enabled: false },
-        {
-          ...first,
-          label: "Reserve securely",
-          enabled: true,
-        },
-      ],
-    };
 
-    const saved = await updateSiteDraft(
-      slug,
-      editedDraft,
-      Vertical.RESTAURANT,
-      { actor },
-    );
-    const [reloaded, after, audit] = await Promise.all([
-      findSiteView(slug),
-      db.site.findUniqueOrThrow({
+    test("versions and audits authorized integration saves without publishing", async () => {
+      const before = await db.site.findUniqueOrThrow({
         where: { id: siteId },
         select: {
           draftRevision: true,
           publishedSiteVersionId: true,
           _count: { select: { siteVersions: true } },
         },
-      }),
-      db.auditEvent.findFirst({
-        where: {
-          siteId,
-          type: "site.draft.saved",
-          actor: actor.id,
-        },
-        orderBy: { createdAt: "desc" },
-        select: { metadata: true },
-      }),
-    ]);
+      });
+      const first = sampleSiteDraft.integrations[0];
+      const second = sampleSiteDraft.integrations[1];
+      const editedDraft = {
+        ...sampleSiteDraft,
+        slug,
+        integrations: [
+          { ...second, enabled: false },
+          {
+            ...first,
+            label: "Reserve securely",
+            enabled: true,
+          },
+        ],
+      };
 
-    expect(saved.revision).toBe(before.draftRevision + 1);
-    expect(after).toEqual({
-      draftRevision: saved.revision,
-      publishedSiteVersionId: before.publishedSiteVersionId,
-      _count: before._count,
+      const saved = await updateSiteDraft(
+        slug,
+        editedDraft,
+        Vertical.RESTAURANT,
+        { actor },
+      );
+      const [reloaded, after, audit] = await Promise.all([
+        findSiteView(slug),
+        db.site.findUniqueOrThrow({
+          where: { id: siteId },
+          select: {
+            draftRevision: true,
+            publishedSiteVersionId: true,
+            _count: { select: { siteVersions: true } },
+          },
+        }),
+        db.auditEvent.findFirst({
+          where: {
+            siteId,
+            type: "site.draft.saved",
+            actor: actor.id,
+          },
+          orderBy: { createdAt: "desc" },
+          select: { metadata: true },
+        }),
+      ]);
+
+      expect(saved.revision).toBe(before.draftRevision + 1);
+      expect(after).toEqual({
+        draftRevision: saved.revision,
+        publishedSiteVersionId: before.publishedSiteVersionId,
+        _count: before._count,
+      });
+      expect(reloaded?.draft.integrations).toEqual([
+        expect.objectContaining({
+          label: second.label,
+          enabled: false,
+        }),
+        expect.objectContaining({
+          label: "Reserve securely",
+          provider: first.provider,
+          enabled: true,
+        }),
+      ]);
+      expect(audit?.metadata).toMatchObject({
+        revision: saved.revision,
+        actorEmail: actor.email,
+        integrationCount: 2,
+        enabledIntegrationCount: 1,
+        draftContentDigest: expect.stringMatching(/^[a-f0-9]{64}$/),
+        integrationUrlDigest: expect.stringMatching(/^[a-f0-9]{64}$/),
+        publishedSiteVersionIdAtSave: before.publishedSiteVersionId,
+      });
     });
-    expect(reloaded?.draft.integrations).toEqual([
-      expect.objectContaining({
-        label: second.label,
-        enabled: false,
-      }),
-      expect.objectContaining({
-        label: "Reserve securely",
-        provider: first.provider,
-        enabled: true,
-      }),
-    ]);
-    expect(audit?.metadata).toMatchObject({
-      revision: saved.revision,
-      actorEmail: actor.email,
-      integrationCount: 2,
-      enabledIntegrationCount: 1,
-      draftContentDigest: expect.stringMatching(/^[a-f0-9]{64}$/),
-      integrationUrlDigest: expect.stringMatching(/^[a-f0-9]{64}$/),
-      publishedSiteVersionIdAtSave: before.publishedSiteVersionId,
-    });
-  });
 
-  test("rejects the second first-save from two owner tabs loaded at the same revision", async () => {
-    const [firstTab, secondTab] = await Promise.all([
-      findOwnerSiteDraft(slug),
-      findOwnerSiteDraft(slug),
-    ]);
-    if (!firstTab || !secondTab) {
-      throw new Error("Expected both owner tabs to load the persisted draft");
-    }
-    expect(secondTab.revision).toBe(firstTab.revision);
-    expect(await findSiteView(slug)).not.toHaveProperty("draftRevision");
+    test("rejects the second first-save from two owner tabs loaded at the same revision", async () => {
+      const [firstTab, secondTab] = await Promise.all([
+        findOwnerSiteDraft(slug),
+        findOwnerSiteDraft(slug),
+      ]);
+      if (!firstTab || !secondTab) {
+        throw new Error("Expected both owner tabs to load the persisted draft");
+      }
+      expect(secondTab.revision).toBe(firstTab.revision);
+      expect(await findSiteView(slug)).not.toHaveProperty("draftRevision");
 
-    const firstSave = await updateSiteDraft(
-      slug,
-      {
-        ...(firstTab.draft as typeof sampleSiteDraft),
-        description: "Saved from the first independently loaded owner tab.",
-      },
-      Vertical.RESTAURANT,
-      { actor, expectedRevision: firstTab.revision },
-    );
-
-    await expect(
-      updateSiteDraft(
+      const firstSave = await updateSiteDraft(
         slug,
         {
-          ...(secondTab.draft as typeof sampleSiteDraft),
-          description: "This stale owner tab must not overwrite the first.",
+          ...(firstTab.draft as typeof sampleSiteDraft),
+          description: "Saved from the first independently loaded owner tab.",
         },
         Vertical.RESTAURANT,
-        { actor, expectedRevision: secondTab.revision },
-      ),
-    ).rejects.toMatchObject({
-      name: "DraftRevisionConflictError",
-      currentRevision: firstSave.revision,
-    });
+        { actor, expectedRevision: firstTab.revision },
+      );
 
-    expect((await findOwnerSiteDraft(slug))?.draft).toMatchObject({
-      description: "Saved from the first independently loaded owner tab.",
-    });
-  });
-
-  test("refuses to publish stale translated copy without moving the live pointer", async () => {
-    const current = await findSiteView(slug);
-    if (!current) throw new Error("Expected the persisted restaurant draft");
-    const staleDraft = {
-      ...current.draft,
-      autoEnhanceImages: sampleSiteDraft.autoEnhanceImages,
-      translations: [
-        {
-          locale: "fr" as const,
-          status: "stale" as const,
-          attributes: {
-            cuisine: current.draft.attributes.cuisine,
+      await expect(
+        updateSiteDraft(
+          slug,
+          {
+            ...(secondTab.draft as typeof sampleSiteDraft),
+            description: "This stale owner tab must not overwrite the first.",
           },
-          eyebrow: current.draft.eyebrow,
-          description: current.draft.description,
-          catalogSections: current.draft.catalogSections.map((section) => ({
-            name: section.name,
-            description: section.description,
-            items: section.items.map((item) => ({
-              name: item.name,
-              description: item.description,
-              attributes: {
-                dietaryLabels: item.attributes.dietaryLabels,
-              },
-            })),
-          })),
-          integrationLabels: current.draft.integrations.map(
-            (integration) => integration.label,
-          ),
-        },
-      ],
-    };
-    await updateSiteDraft(slug, staleDraft, Vertical.RESTAURANT);
-    const before = await db.site.findUniqueOrThrow({
-      where: { id: siteId },
-      select: {
-        publishedSiteVersionId: true,
-        _count: { select: { siteVersions: true, auditEvents: true } },
-      },
+          Vertical.RESTAURANT,
+          { actor, expectedRevision: secondTab.revision },
+        ),
+      ).rejects.toMatchObject({
+        name: "DraftRevisionConflictError",
+        currentRevision: firstSave.revision,
+      });
+
+      expect((await findOwnerSiteDraft(slug))?.draft).toMatchObject({
+        description: "Saved from the first independently loaded owner tab.",
+      });
     });
 
-    await expect(
-      publishSiteDraft({
-        siteId,
-        slug,
-        vertical: Vertical.RESTAURANT,
-        actor,
-        changeSummary: "Stale translation must not publish",
-        expectedRevision: await currentDraftRevision(),
-      }),
-    ).rejects.toThrow("Review every stale translation before publishing");
-
-    expect(
-      await db.site.findUniqueOrThrow({
+    test("refuses to publish stale translated copy without moving the live pointer", async () => {
+      const current = await findSiteView(slug);
+      if (!current) throw new Error("Expected the persisted restaurant draft");
+      const staleDraft = {
+        ...current.draft,
+        autoEnhanceImages: sampleSiteDraft.autoEnhanceImages,
+        translations: [
+          {
+            locale: "fr" as const,
+            status: "stale" as const,
+            attributes: {
+              cuisine: current.draft.attributes.cuisine,
+            },
+            eyebrow: current.draft.eyebrow,
+            description: current.draft.description,
+            catalogSections: current.draft.catalogSections.map((section) => ({
+              name: section.name,
+              description: section.description,
+              items: section.items.map((item) => ({
+                name: item.name,
+                description: item.description,
+                attributes: {
+                  dietaryLabels: item.attributes.dietaryLabels,
+                },
+              })),
+            })),
+            integrationLabels: current.draft.integrations.map(
+              (integration) => integration.label,
+            ),
+          },
+        ],
+      };
+      await updateSiteDraft(slug, staleDraft, Vertical.RESTAURANT);
+      const before = await db.site.findUniqueOrThrow({
         where: { id: siteId },
         select: {
           publishedSiteVersionId: true,
           _count: { select: { siteVersions: true, auditEvents: true } },
         },
-      }),
-    ).toEqual(before);
-    await updateSiteDraft(
-      slug,
-      { ...staleDraft, translations: [] },
-      Vertical.RESTAURANT,
-    );
-  });
+      });
 
-  test("leaves the live pointer untouched when persisted draft validation fails", async () => {
-    const before = await db.site.findUniqueOrThrow({
-      where: { id: siteId },
-      select: {
-        publishedSiteVersionId: true,
-        _count: { select: { siteVersions: true, auditEvents: true } },
-      },
+      await expect(
+        publishSiteDraft({
+          siteId,
+          slug,
+          vertical: Vertical.RESTAURANT,
+          actor,
+          changeSummary: "Stale translation must not publish",
+          expectedRevision: await currentDraftRevision(),
+        }),
+      ).rejects.toThrow("Review every stale translation before publishing");
+
+      expect(
+        await db.site.findUniqueOrThrow({
+          where: { id: siteId },
+          select: {
+            publishedSiteVersionId: true,
+            _count: { select: { siteVersions: true, auditEvents: true } },
+          },
+        }),
+      ).toEqual(before);
+      await updateSiteDraft(
+        slug,
+        { ...staleDraft, translations: [] },
+        Vertical.RESTAURANT,
+      );
     });
-    await db.site.update({
-      where: { id: siteId },
-      data: {
+
+    test("leaves the live pointer untouched when persisted draft validation fails", async () => {
+      const before = await db.site.findUniqueOrThrow({
+        where: { id: siteId },
+        select: {
+          publishedSiteVersionId: true,
+          _count: { select: { siteVersions: true, auditEvents: true } },
+        },
+      });
+      await db.site.update({
+        where: { id: siteId },
+        data: {
+          translations: [
+            {
+              locale: "fr",
+              catalogSections: [],
+              integrationLabels: [],
+            },
+          ],
+        },
+      });
+
+      await expect(
+        publishSiteDraft({
+          siteId,
+          slug,
+          vertical: Vertical.RESTAURANT,
+          actor,
+          changeSummary: "This publish must fail",
+          expectedRevision: await currentDraftRevision(),
+        }),
+      ).rejects.toThrow();
+
+      const after = await db.site.findUniqueOrThrow({
+        where: { id: siteId },
+        select: {
+          publishedSiteVersionId: true,
+          _count: { select: { siteVersions: true, auditEvents: true } },
+        },
+      });
+      expect(after).toEqual(before);
+      await db.site.update({
+        where: { id: siteId },
+        data: { translations: [] },
+      });
+    });
+
+    test("serializes concurrent publishes and never mutates published history", async () => {
+      const results = await Promise.all([
+        publishSiteDraft({
+          siteId,
+          slug,
+          vertical: Vertical.RESTAURANT,
+          actor,
+          changeSummary: "Concurrent publish A",
+          expectedRevision: await currentDraftRevision(),
+        }),
+        publishSiteDraft({
+          siteId,
+          slug,
+          vertical: Vertical.RESTAURANT,
+          actor,
+          changeSummary: "Concurrent publish B",
+          expectedRevision: await currentDraftRevision(),
+        }),
+      ]);
+      const versions = await db.siteVersion.findMany({
+        where: { siteId },
+        orderBy: { version: "asc" },
+        select: { id: true, version: true },
+      });
+      const pointer = await db.site.findUniqueOrThrow({
+        where: { id: siteId },
+        select: { publishedSiteVersionId: true },
+      });
+
+      expect(results.map((result) => result.version).sort()).toEqual([3, 4]);
+      expect(versions.map((version) => version.version)).toEqual([1, 2, 3, 4]);
+      expect(pointer.publishedSiteVersionId).toBe(versions.at(-1)?.id ?? null);
+
+      await expect(
+        Promise.resolve(
+          db.siteVersion.update({
+            where: { id: versions[0].id },
+            data: { changeSummary: "Tampered history" },
+          }),
+        ),
+      ).rejects.toThrow("Published site versions are immutable");
+    });
+
+    test("preserves an owner theme through save, reload, locale, publish and rollback", async () => {
+      await db.domain.deleteMany({ where: { siteId } });
+      const fixture = restaurantThemeFixtures["counter-service"];
+      const ownerSelection = selectOwnerRestaurantTheme(
+        fixture.profile,
+        "after-dark",
+      );
+      const ownerDraft = {
+        ...fixture,
+        slug,
+        attributes: {
+          ...fixture.attributes,
+          themeSelection: ownerSelection,
+        },
         translations: [
           {
             locale: "fr",
-            catalogSections: [],
-            integrationLabels: [],
+            attributes: { cuisine: "Comptoir italien" },
+            eyebrow: "Des parts, des pizzas entières, sans détour",
+            description:
+              "Un comptoir de quartier pour des pizzas au levain, des boissons fraîches et une collecte rapide.",
+            catalogSections: fixture.catalogSections.map((section) => ({
+              name: section.name,
+              description: section.description,
+              items: section.items.map((item) => ({
+                name: item.name,
+                description: item.description,
+                attributes: item.attributes,
+              })),
+            })),
+            integrationLabels: fixture.integrations.map(
+              (integration) => integration.label,
+            ),
           },
         ],
-      },
-    });
+      };
 
-    await expect(
-      publishSiteDraft({
+      await updateSiteDraft(slug, ownerDraft, Vertical.RESTAURANT);
+      await db.photoAsset.updateMany({
+        where: { siteId, selectedUsage: "HERO" },
+        data: {
+          sourceUrl: fixture.heroImageUrl!,
+          originalUrl: fixture.heroImageUrl!,
+          originalStorageKey: "test/reviewed-counter-service-hero.webp",
+        },
+      });
+      await db.site.update({
+        where: { id: siteId },
+        data: {
+          heroOriginalImageUrl: fixture.heroImageUrl,
+          heroImageProvenance: "OWNER",
+        },
+      });
+      const reloaded = await findSiteView(slug);
+      expect(reloaded?.theme).toEqual({
+        id: "after-dark",
+        version: "restaurant-renderer-v1",
+        selection: ownerSelection,
+      });
+      expect(reloaded?.draft.attributes.themeSelection).toEqual(ownerSelection);
+      expect(
+        localizeSiteDraft(reloaded!.draft, "fr").attributes.themeSelection,
+      ).toEqual(ownerSelection);
+
+      const ownerPublished = await publishSiteDraft({
         siteId,
         slug,
         vertical: Vertical.RESTAURANT,
         actor,
-        changeSummary: "This publish must fail",
+        changeSummary: "Publish owner-selected after-dark theme",
         expectedRevision: await currentDraftRevision(),
-      }),
-    ).rejects.toThrow();
+      });
+      expect(ownerPublished.theme).toEqual({
+        id: "after-dark",
+        version: "restaurant-renderer-v1",
+      });
+      const storedOwnerVersion = await db.siteVersion.findUniqueOrThrow({
+        where: { id: ownerPublished.id },
+        select: {
+          theme: true,
+          themeVersion: true,
+          translations: true,
+        },
+      });
+      expect(storedOwnerVersion).toMatchObject({
+        theme: ownerSelection,
+        themeVersion: "restaurant-renderer-v1",
+        translations: ownerDraft.translations,
+      });
 
-    const after = await db.site.findUniqueOrThrow({
-      where: { id: siteId },
-      select: {
-        publishedSiteVersionId: true,
-        _count: { select: { siteVersions: true, auditEvents: true } },
-      },
-    });
-    expect(after).toEqual(before);
-    await db.site.update({
-      where: { id: siteId },
-      data: { translations: [] },
-    });
-  });
-
-  test("serializes concurrent publishes and never mutates published history", async () => {
-    const results = await Promise.all([
-      publishSiteDraft({
-        siteId,
+      const nextSelection = selectOwnerRestaurantTheme(
+        fixture.profile,
+        "terroir-editorial",
+      );
+      await updateSiteDraft(
         slug,
-        vertical: Vertical.RESTAURANT,
-        actor,
-        changeSummary: "Concurrent publish A",
-        expectedRevision: await currentDraftRevision(),
-      }),
-      publishSiteDraft({
-        siteId,
-        slug,
-        vertical: Vertical.RESTAURANT,
-        actor,
-        changeSummary: "Concurrent publish B",
-        expectedRevision: await currentDraftRevision(),
-      }),
-    ]);
-    const versions = await db.siteVersion.findMany({
-      where: { siteId },
-      orderBy: { version: "asc" },
-      select: { id: true, version: true },
-    });
-    const pointer = await db.site.findUniqueOrThrow({
-      where: { id: siteId },
-      select: { publishedSiteVersionId: true },
-    });
-
-    expect(results.map((result) => result.version).sort()).toEqual([3, 4]);
-    expect(versions.map((version) => version.version)).toEqual([1, 2, 3, 4]);
-    expect(pointer.publishedSiteVersionId).toBe(versions.at(-1)?.id ?? null);
-
-    await expect(
-      Promise.resolve(
-        db.siteVersion.update({
-          where: { id: versions[0].id },
-          data: { changeSummary: "Tampered history" },
-        }),
-      ),
-    ).rejects.toThrow("Published site versions are immutable");
-  });
-
-  test("preserves an owner theme through save, reload, locale, publish and rollback", async () => {
-    await db.domain.deleteMany({ where: { siteId } });
-    const fixture = restaurantThemeFixtures["counter-service"];
-    const ownerSelection = selectOwnerRestaurantTheme(
-      fixture.profile,
-      "after-dark",
-    );
-    const ownerDraft = {
-      ...fixture,
-      slug,
-      attributes: {
-        ...fixture.attributes,
-        themeSelection: ownerSelection,
-      },
-      translations: [
         {
-          locale: "fr",
-          attributes: { cuisine: "Comptoir italien" },
-          eyebrow: "Des parts, des pizzas entières, sans détour",
-          description:
-            "Un comptoir de quartier pour des pizzas au levain, des boissons fraîches et une collecte rapide.",
-          catalogSections: fixture.catalogSections.map((section) => ({
-            name: section.name,
-            description: section.description,
-            items: section.items.map((item) => ({
-              name: item.name,
-              description: item.description,
-              attributes: item.attributes,
-            })),
-          })),
-          integrationLabels: fixture.integrations.map(
-            (integration) => integration.label,
-          ),
+          ...ownerDraft,
+          attributes: {
+            ...ownerDraft.attributes,
+            themeSelection: nextSelection,
+          },
         },
-      ],
-    };
-
-    await updateSiteDraft(slug, ownerDraft, Vertical.RESTAURANT);
-    await db.photoAsset.updateMany({
-      where: { siteId, selectedUsage: "HERO" },
-      data: {
-        sourceUrl: fixture.heroImageUrl!,
-        originalUrl: fixture.heroImageUrl!,
-        originalStorageKey: "test/reviewed-counter-service-hero.webp",
-      },
-    });
-    await db.site.update({
-      where: { id: siteId },
-      data: {
-        heroOriginalImageUrl: fixture.heroImageUrl,
-        heroImageProvenance: "OWNER",
-      },
-    });
-    const reloaded = await findSiteView(slug);
-    expect(reloaded?.theme).toEqual({
-      id: "after-dark",
-      version: "restaurant-renderer-v1",
-      selection: ownerSelection,
-    });
-    expect(reloaded?.draft.attributes.themeSelection).toEqual(ownerSelection);
-    expect(
-      localizeSiteDraft(reloaded!.draft, "fr").attributes.themeSelection,
-    ).toEqual(ownerSelection);
-
-    const ownerPublished = await publishSiteDraft({
-      siteId,
-      slug,
-      vertical: Vertical.RESTAURANT,
-      actor,
-      changeSummary: "Publish owner-selected after-dark theme",
-      expectedRevision: await currentDraftRevision(),
-    });
-    expect(ownerPublished.theme).toEqual({
-      id: "after-dark",
-      version: "restaurant-renderer-v1",
-    });
-    const storedOwnerVersion = await db.siteVersion.findUniqueOrThrow({
-      where: { id: ownerPublished.id },
-      select: {
-        theme: true,
-        themeVersion: true,
-        translations: true,
-      },
-    });
-    expect(storedOwnerVersion).toMatchObject({
-      theme: ownerSelection,
-      themeVersion: "restaurant-renderer-v1",
-      translations: ownerDraft.translations,
-    });
-
-    const nextSelection = selectOwnerRestaurantTheme(
-      fixture.profile,
-      "terroir-editorial",
-    );
-    await updateSiteDraft(
-      slug,
-      {
-        ...ownerDraft,
-        attributes: {
-          ...ownerDraft.attributes,
-          themeSelection: nextSelection,
-        },
-      },
-      Vertical.RESTAURANT,
-    );
-    await publishSiteDraft({
-      siteId,
-      slug,
-      vertical: Vertical.RESTAURANT,
-      actor,
-      changeSummary: "Publish a later owner theme",
-      expectedRevision: await currentDraftRevision(),
-    });
-
-    const rolledBack = await rollbackPublishedSiteVersion({
-      siteId,
-      slug,
-      vertical: Vertical.RESTAURANT,
-      targetSiteVersionId: ownerPublished.id,
-      actor,
-    });
-    expect(rolledBack.id).not.toBe(ownerPublished.id);
-    expect(rolledBack.theme).toEqual(ownerPublished.theme);
-    expect((await findPublishedSiteView(slug))?.draft.attributes.themeSelection)
-      .toEqual(ownerSelection);
-    expect(
-      localizeSiteDraft((await findPublishedSiteView(slug))!.draft, "fr")
-        .attributes.themeSelection,
-    ).toEqual(ownerSelection);
-    // Rollback moves only the public pointer; the owner's later private draft
-    // remains available for another edit or publish.
-    expect((await findSiteView(slug))?.draft.attributes.themeSelection).toEqual(
-      nextSelection,
-    );
-    expect(
-      await db.site.findUniqueOrThrow({
-        where: { id: siteId },
-        select: { status: true },
-      }),
-    ).toEqual({ status: "CLAIMED" });
-
-    await db.domain.create({
-      data: {
-        hostname: `${randomUUID()}.example.test`,
+        Vertical.RESTAURANT,
+      );
+      await publishSiteDraft({
         siteId,
-        verificationToken: randomUUID(),
-        verified: true,
-        verifiedAt: new Date(),
-      },
-    });
-    await rollbackPublishedSiteVersion({
-      siteId,
-      slug,
-      vertical: Vertical.RESTAURANT,
-      targetSiteVersionId: ownerPublished.id,
-      actor,
-    });
-    expect(
-      await db.site.findUniqueOrThrow({
-        where: { id: siteId },
-        select: { status: true },
-      }),
-    ).toEqual({ status: "LIVE" });
-    expect(
-      await db.auditEvent.count({
-        where: {
+        slug,
+        vertical: Vertical.RESTAURANT,
+        actor,
+        changeSummary: "Publish a later owner theme",
+        expectedRevision: await currentDraftRevision(),
+      });
+
+      const rolledBack = await rollbackPublishedSiteVersion({
+        siteId,
+        slug,
+        vertical: Vertical.RESTAURANT,
+        targetSiteVersionId: ownerPublished.id,
+        actor,
+      });
+      expect(rolledBack.id).not.toBe(ownerPublished.id);
+      expect(rolledBack.theme).toEqual(ownerPublished.theme);
+      expect(
+        (await findPublishedSiteView(slug))?.draft.attributes.themeSelection,
+      ).toEqual(ownerSelection);
+      expect(
+        localizeSiteDraft((await findPublishedSiteView(slug))!.draft, "fr")
+          .attributes.themeSelection,
+      ).toEqual(ownerSelection);
+      // Rollback moves only the public pointer; the owner's later private draft
+      // remains available for another edit or publish.
+      expect(
+        (await findSiteView(slug))?.draft.attributes.themeSelection,
+      ).toEqual(nextSelection);
+      expect(
+        await db.site.findUniqueOrThrow({
+          where: { id: siteId },
+          select: { status: true },
+        }),
+      ).toEqual({ status: "CLAIMED" });
+
+      await db.domain.create({
+        data: {
+          hostname: `${randomUUID()}.example.test`,
           siteId,
-          type: "site.rolled_back",
-          actor: actor.id,
+          verificationToken: randomUUID(),
+          verified: true,
+          verifiedAt: new Date(),
         },
-      }),
-    ).toBe(2);
-  });
-});
+      });
+      await rollbackPublishedSiteVersion({
+        siteId,
+        slug,
+        vertical: Vertical.RESTAURANT,
+        targetSiteVersionId: ownerPublished.id,
+        actor,
+      });
+      expect(
+        await db.site.findUniqueOrThrow({
+          where: { id: siteId },
+          select: { status: true },
+        }),
+      ).toEqual({ status: "LIVE" });
+      expect(
+        await db.auditEvent.count({
+          where: {
+            siteId,
+            type: "site.rolled_back",
+            actor: actor.id,
+          },
+        }),
+      ).toBe(2);
+    });
+  },
+);

--- a/src/lib/source-monitoring.ts
+++ b/src/lib/source-monitoring.ts
@@ -9,10 +9,9 @@ import { z } from "zod";
 import { configuredSuperadminEmails } from "@/lib/superadmin-config";
 import { getDb } from "@/lib/db";
 import { sameJsonValue } from "@/lib/evidence-digests";
-import {
-  inspectPublicLink,
-} from "@/lib/importer";
-import { emailReplyTo, emailSender, getResend } from "@/lib/resend";
+import { inspectPublicLink } from "@/lib/importer";
+import { emailReplyTo, emailSender } from "@/lib/email-identity";
+import { getResend } from "@/lib/resend";
 import {
   buildSourceMonitoringDiff,
   type MonitoringSuggestionInput,
@@ -27,14 +26,8 @@ import {
   DraftRevisionConflictError,
   type PersistableSiteDraft,
 } from "@/lib/site-persistence";
-import {
-  projectSiteDraft,
-  siteDraftRelations,
-} from "@/lib/sites";
-import {
-  crawlSiteSource,
-  generateDraftForVertical,
-} from "@/lib/site-pipeline";
+import { projectSiteDraft, siteDraftRelations } from "@/lib/sites";
+import { crawlSiteSource, generateDraftForVertical } from "@/lib/site-pipeline";
 import {
   businessHoursSchema,
   catalogSectionSchema,
@@ -315,10 +308,7 @@ export async function executeSourceMonitoringRun(context: {
   if (!site) throw new Error("Source monitoring site not found");
   const current = projectSiteDraft(site).draft as PersistableSiteDraft;
   const extracted = await crawlSiteSource(context.sourceUrl, context.vertical);
-  const proposed = await generateDraftForVertical(
-    extracted,
-    context.vertical,
-  );
+  const proposed = await generateDraftForVertical(extracted, context.vertical);
   const linkUrls = [
     ...new Set([
       ...current.integrations.map((link) => link.url),
@@ -573,10 +563,7 @@ export async function reviewSourceMonitoringSuggestion(input: {
       }
       const loaded = projectSiteDraft(site);
       const currentDraft = loaded.draft as PersistableSiteDraft;
-      const currentValue = monitoringFieldValue(
-        currentDraft,
-        suggestion.field,
-      );
+      const currentValue = monitoringFieldValue(currentDraft, suggestion.field);
       if (!sameJsonValue(currentValue, suggestion.currentValue)) {
         throw new SourceMonitoringConflictError();
       }
@@ -750,7 +737,9 @@ async function applySuggestionValue(
     const updated = await transaction.site.update({
       where: { id: siteId },
       data: {
-        businessHours: businessHoursSchema.parse(value) as Prisma.InputJsonValue,
+        businessHours: businessHoursSchema.parse(
+          value,
+        ) as Prisma.InputJsonValue,
         draftRevision: { increment: 1 },
       },
       select: { draftRevision: true },
@@ -830,14 +819,16 @@ function integrationType(value: string): IntegrationType {
 function imageProvenance(value: string | null | undefined) {
   if (!value) return null;
   return value.replaceAll("-", "_").toUpperCase() as
-    | "OFFICIAL"
-    | "OWNER"
-    | "PERMISSIONED_UGC";
+    "OFFICIAL" | "OWNER" | "PERMISSIONED_UGC";
 }
 
 async function createReviewAudit(
   transaction: Prisma.TransactionClient,
-  suggestion: { id: string; runId: string; field: SourceMonitorSuggestionField },
+  suggestion: {
+    id: string;
+    runId: string;
+    field: SourceMonitorSuggestionField;
+  },
   input: {
     siteId: string;
     actor: { id: string; email: string; role: "owner" | "operator" };

--- a/src/lib/stripe-billing-preflight.test.ts
+++ b/src/lib/stripe-billing-preflight.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type Stripe from "stripe";
-import { preflightRestofrontBilling } from "@/lib/stripe-billing-preflight";
+import { preflightFoundingBilling } from "@/lib/stripe-billing-preflight";
 
 const environment = {
   STRIPE_SECRET_KEY: "sk_live_example",
@@ -36,7 +36,7 @@ function stripePrice(
 
 describe("Stripe billing preflight", () => {
   it("returns redacted evidence for the exact live founding offer", async () => {
-    const result = await preflightRestofrontBilling({
+    const result = await preflightFoundingBilling({
       stripe: stripePrice(),
       environment,
       requiredMode: "live",
@@ -56,14 +56,14 @@ describe("Stripe billing preflight", () => {
 
   it("fails closed for mode and provider-resource drift", async () => {
     await expect(
-      preflightRestofrontBilling({
+      preflightFoundingBilling({
         stripe: stripePrice(),
         environment,
         requiredMode: "test",
       }),
     ).rejects.toThrow("mode");
     await expect(
-      preflightRestofrontBilling({
+      preflightFoundingBilling({
         stripe: stripePrice({ unit_amount: 2_500 }),
         environment,
         requiredMode: "live",

--- a/src/lib/stripe-billing-preflight.ts
+++ b/src/lib/stripe-billing-preflight.ts
@@ -2,17 +2,17 @@ import { createHash } from "node:crypto";
 import type Stripe from "stripe";
 import {
   configuredBillingPlan,
-  RESTOFRONT_FOUNDING_PLAN_ID,
-  RESTOFRONT_FOUNDING_PRICE,
+  FOUNDING_PLAN_ID,
+  FOUNDING_PRICE,
   stripeLivemodeForSecret,
-  validateRestofrontFoundingPrice,
+  validateFoundingPrice,
 } from "@/lib/billing-plans";
 
 type Environment = Record<string, string | undefined>;
 
 export type StripePriceReader = Pick<Stripe, "prices">;
 
-export async function preflightRestofrontBilling(input: {
+export async function preflightFoundingBilling(input: {
   stripe: StripePriceReader;
   environment?: Environment;
   requiredMode: "test" | "live";
@@ -22,7 +22,9 @@ export async function preflightRestofrontBilling(input: {
     environment.STRIPE_SECRET_KEY,
   );
   if (expectedLivemode !== (input.requiredMode === "live")) {
-    throw new Error("Stripe secret mode does not match the requested environment");
+    throw new Error(
+      "Stripe secret mode does not match the requested environment",
+    );
   }
   if (!environment.STRIPE_WEBHOOK_SECRET?.startsWith("whsec_")) {
     throw new Error("STRIPE_WEBHOOK_SECRET is not configured");
@@ -32,20 +34,20 @@ export async function preflightRestofrontBilling(input: {
   const price = await input.stripe.prices.retrieve(plan.priceId, {
     expand: ["product"],
   });
-  validateRestofrontFoundingPrice(price, {
+  validateFoundingPrice(price, {
     expectedPriceId: plan.priceId,
     expectedLivemode,
   });
 
   return {
-    check: "restofront-founding-billing",
+    check: "cornershop-founding-billing",
     ready: true as const,
     mode: input.requiredMode,
-    plan: RESTOFRONT_FOUNDING_PLAN_ID,
-    amount: RESTOFRONT_FOUNDING_PRICE.unitAmount,
-    currency: RESTOFRONT_FOUNDING_PRICE.currency,
-    interval: RESTOFRONT_FOUNDING_PRICE.interval,
-    taxBehavior: RESTOFRONT_FOUNDING_PRICE.taxBehavior,
+    plan: FOUNDING_PLAN_ID,
+    amount: FOUNDING_PRICE.unitAmount,
+    currency: FOUNDING_PRICE.currency,
+    interval: FOUNDING_PRICE.interval,
+    taxBehavior: FOUNDING_PRICE.taxBehavior,
     priceFingerprint: createHash("sha256").update(plan.priceId).digest("hex"),
     checkedAt: new Date().toISOString(),
   };

--- a/src/lib/stripe-webhook.ts
+++ b/src/lib/stripe-webhook.ts
@@ -1,10 +1,7 @@
 import type Stripe from "stripe";
 import type { Prisma, PrismaClient } from "@/generated/prisma/client";
 import { normalizeAccountEmail } from "@/lib/account-email";
-import {
-  configuredBillingPlan,
-  RESTOFRONT_FOUNDING_PRICE,
-} from "@/lib/billing-plans";
+import { configuredBillingPlan, FOUNDING_PRICE } from "@/lib/billing-plans";
 import {
   claimSite,
   hasValidClaimApprovalEvidence,
@@ -30,10 +27,7 @@ const subscriptionEventTypes = new Set<Stripe.Event.Type>([
 ]);
 
 export type StripeWebhookResult =
-  | "processed"
-  | "duplicate"
-  | "ignored"
-  | "rejected";
+  "processed" | "duplicate" | "ignored" | "rejected";
 
 type StripeWebhookDatabase = Pick<
   PrismaClient,
@@ -69,7 +63,12 @@ export async function processStripeWebhookEvent(
       : await retrieveSubscription(event, stripe);
   } catch (error) {
     if (!(error instanceof StripeWebhookValidationError)) throw error;
-    return persistRejectedEvent(db, event, error.message, eventInvitationId(event));
+    return persistRejectedEvent(
+      db,
+      event,
+      error.message,
+      eventInvitationId(event),
+    );
   }
 
   try {
@@ -218,7 +217,9 @@ async function provisionCheckout(
   }
   const invitationId = session.metadata?.claimInvitationId;
   if (!invitationId || session.client_reference_id !== invitationId) {
-    throw new StripeWebhookValidationError("Checkout claim metadata is invalid");
+    throw new StripeWebhookValidationError(
+      "Checkout claim metadata is invalid",
+    );
   }
 
   const invitation = await tx.claimInvitation.findUnique({
@@ -259,8 +260,8 @@ async function provisionCheckout(
     throw new StripeWebhookValidationError("Checkout price is not configured");
   }
   if (
-    session.currency?.toLowerCase() !== RESTOFRONT_FOUNDING_PRICE.currency ||
-    session.amount_subtotal !== RESTOFRONT_FOUNDING_PRICE.unitAmount ||
+    session.currency?.toLowerCase() !== FOUNDING_PRICE.currency ||
+    session.amount_subtotal !== FOUNDING_PRICE.unitAmount ||
     (session.total_details?.amount_discount ?? 0) !== 0
   ) {
     throw new StripeWebhookValidationError(

--- a/src/lib/verticals/beauty/config.ts
+++ b/src/lib/verticals/beauty/config.ts
@@ -77,6 +77,7 @@ export const beautyConfig = {
     item: "Service",
   },
   marketing: beautyMarketing,
+  claimMode: "disabled",
   publicationEnabled: true,
   integrationTypes: ["booking", "social"],
   attributesSchema: beautyAttributesSchema,
@@ -119,7 +120,11 @@ export const beautyConfig = {
         badges.push(`${attributes.durationMinutes} min`);
       }
       if (attributes.anyStylist) {
-        badges.push(locale.toLowerCase().startsWith("fr") ? "Tout praticien" : "With any stylist");
+        badges.push(
+          locale.toLowerCase().startsWith("fr")
+            ? "Tout praticien"
+            : "With any stylist",
+        );
       }
       return badges;
     },

--- a/src/lib/verticals/beauty/marketing.ts
+++ b/src/lib/verticals/beauty/marketing.ts
@@ -1,10 +1,9 @@
 import type { VerticalMarketing } from "@/lib/verticals/types";
 
 /**
- * Built and sellable, but not yet launched on its own domain — hence no
- * `hostnames` and a null `domain`. The factory homepage lists it as upcoming and
- * routes its leads through cornershop.dev's own studio; the day a domain exists
- * it is two strings here and a DNS record, with no route to add.
+ * Built for public preview, but owner claim stays disabled until its dedicated
+ * dashboard and evidence review are complete. It has no standalone domain —
+ * hence no `hostnames` and a null `domain`.
  *
  * `heroVisual: "none"` because the restaurant transformation mock is a menu PDF
  * turning into a menu — dressing it up as a salon would be a lie about what the

--- a/src/lib/verticals/food-retail/config.ts
+++ b/src/lib/verticals/food-retail/config.ts
@@ -134,7 +134,8 @@ export const foodRetailConfig = {
     item: "Product",
   },
   marketing: foodRetailMarketing,
-  publicationEnabled: false,
+  claimMode: "factory",
+  publicationEnabled: true,
   integrationTypes: ["ordering", "delivery", "social"],
   attributesSchema: foodRetailAttributesSchema,
   attributeDefaults: {

--- a/src/lib/verticals/food-retail/marketing.ts
+++ b/src/lib/verticals/food-retail/marketing.ts
@@ -1,9 +1,10 @@
 import type { VerticalMarketing } from "@/lib/verticals/types";
 
 /**
- * Built but deliberately private. A real domain, a verified sender and the
- * production checkout/configuration evidence must exist before these null launch
- * gates are replaced. Until then it is available only in the factory studio.
+ * Discovery stays operator-only, while approved previews can be claimed through
+ * Cornershopdev's factory identity and published on the platform subdomain.
+ * A future niche domain can replace that factory surface without changing the
+ * vertical's evidence and review rules.
  */
 export const foodRetailMarketing = {
   publiclyAccessible: false,
@@ -103,9 +104,9 @@ export const foodRetailMarketing = {
     ],
   },
   pricing: {
-    eyebrow: "Launch after evidence",
+    eyebrow: "One founding offer",
     headline: "A maintained local storefront.",
-    copy: "The one $49 founding offer becomes claimable after the domain, sender and production configuration are verified. Local currency is shown at checkout.",
+    copy: "Claim the reviewed preview for $49/month through Cornershopdev. Local currency is shown at checkout.",
     plans: [
       {
         name: "Founding",

--- a/src/lib/verticals/local-service/config.ts
+++ b/src/lib/verticals/local-service/config.ts
@@ -91,11 +91,13 @@ export const localServiceDictionaryExtensions = {
     language: "Language",
     reservationsVia: "Contact via",
     bookingPartner: "our scheduling partner",
-    seasonalNotice: "Service coverage and availability may change. Confirm before booking work.",
+    seasonalNotice:
+      "Service coverage and availability may change. Confirm before booking work.",
     heroImageAlt: "Image for",
     bookingHeading: "Contact",
     bookingRequestHeading: "Request the work",
-    bookingRequestIntro: "Use the listed phone, WhatsApp or quote tool to describe the job.",
+    bookingRequestIntro:
+      "Use the listed phone, WhatsApp or quote tool to describe the job.",
     serviceAreasHeading: "Service areas",
     credentialsHeading: "Credentials and cover",
     trustHeading: "Why customers call",
@@ -147,9 +149,14 @@ function tradeTypeFromSource(
 
 export const localServiceConfig = {
   id: Vertical.LOCAL_SERVICE,
-  vocabulary: { catalog: "Services", section: "Service group", item: "Service" },
+  vocabulary: {
+    catalog: "Services",
+    section: "Service group",
+    item: "Service",
+  },
   marketing: localServiceMarketing,
-  publicationEnabled: false,
+  claimMode: "factory",
+  publicationEnabled: true,
   draftGenerationStrategy: "deterministic-only",
   integrationTypes: ["quote", "contact", "booking", "social"],
   attributesSchema: localServiceAttributesSchema,
@@ -191,8 +198,10 @@ export const localServiceConfig = {
     contextLabel: "Trade business",
     forbiddenElements:
       "completed work, wiring, pipework, joinery, finish, defect, damage, safety equipment, credential, certification mark",
-    sceneClause: "make unfinished work look complete or make the job look like a different trade",
-    fidelityClause: "the condition, quality, safety or outcome of the work actually shown",
+    sceneClause:
+      "make unfinished work look complete or make the job look like a different trade",
+    fidelityClause:
+      "the condition, quality, safety or outcome of the work actually shown",
     gradeClause:
       "Use a neutral documentary colour grade. Avoid fake before-and-after contrast, removed defects, fabricated finishes, exaggerated sharpness, artificial dust or sparks, and stock-photo polish.",
   },

--- a/src/lib/verticals/local-service/local-service-renderer.test.tsx
+++ b/src/lib/verticals/local-service/local-service-renderer.test.tsx
@@ -12,10 +12,7 @@ import {
   type SiteDraftGenerationDependencies,
 } from "@/lib/ai/site-generation";
 import { FACTORY_BRAND } from "@/lib/brand";
-import {
-  extractSourceLinks,
-  type ExtractedSite,
-} from "@/lib/importer";
+import { extractSourceLinks, type ExtractedSite } from "@/lib/importer";
 import { reconstructSource } from "@/lib/source-reconstruction";
 import { Vertical } from "@/generated/prisma/enums";
 import { localServiceConfig } from "@/lib/verticals/local-service/config";
@@ -64,7 +61,7 @@ describe("local-service surfaces", () => {
     expect(html).toContain("trade website or business name");
   });
 
-  it("ships a revision-safe private owner editor without publication controls", () => {
+  it("ships a revision-safe owner editor with reviewed publication controls", () => {
     const html = renderToStaticMarkup(
       <LocalServiceDashboard
         initialDraft={sampleLocalServiceSiteDraft}
@@ -72,14 +69,16 @@ describe("local-service surfaces", () => {
         email="owner@harbourelectrical.example"
         brand={FACTORY_BRAND}
         canSwitchWorkspace={false}
+        initiallyPublished={false}
+        platformUrl="https://harbour-electrical.cornershop.dev"
       />,
     );
 
     expect(html).toContain("Draft revision 7");
-    expect(html).toContain("Private pilot · publishing disabled");
+    expect(html).toContain("Private draft");
     expect(html).toContain("Services, proof and contact.");
     expect(html).toContain("Show project gallery");
-    expect(html).not.toContain(">Publish<");
+    expect(html).toContain(">Publish<");
   });
 
   it("preserves post-dispatch edits and advances the revision after a deferred save", async () => {
@@ -127,7 +126,10 @@ describe("local-service surfaces", () => {
     });
     const sourceUrl = new URL("https://atelier-riviere.example/");
     const fixture = await Bun.file(
-      new URL("../../__fixtures__/importer/french-plumber.html", import.meta.url),
+      new URL(
+        "../../__fixtures__/importer/french-plumber.html",
+        import.meta.url,
+      ),
     ).text();
     const reconstructed = reconstructSource({
       homepage: { html: fixture, url: sourceUrl },
@@ -255,7 +257,10 @@ describe("local-service surfaces", () => {
     expect(draft.sourceData.evidence).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ field: "business.type", value: "plumber" }),
-        expect.objectContaining({ field: "catalog.item", value: "Recherche de fuite" }),
+        expect.objectContaining({
+          field: "catalog.item",
+          value: "Recherche de fuite",
+        }),
       ]),
     );
     expect(html).toContain('lang="fr"');

--- a/src/lib/verticals/local-service/marketing.ts
+++ b/src/lib/verticals/local-service/marketing.ts
@@ -1,8 +1,9 @@
 import type { VerticalMarketing } from "@/lib/verticals/types";
 
 /**
- * Product-complete does not mean launched. Tradefront owns no approved domain
- * or verified sender yet, so hostname, domain and email stay empty together.
+ * Tradefront has no standalone niche domain yet. Approved previews claim through
+ * Cornershopdev's verified factory sender and publish on the shared platform
+ * subdomain; the null niche identity prevents accidental standalone marketing.
  */
 export const localServiceMarketing = {
   publiclyAccessible: false,
@@ -18,7 +19,11 @@ export const localServiceMarketing = {
     headline: "A trade website that earns the call.",
     subheadline:
       "Turn an existing website or business profile into a clear mobile-first site with services, service areas, credentials, projects and the contact tools customers already use.",
-    proofPoints: ["Private preview first", "Existing tools preserved", "No invented claims"],
+    proofPoints: [
+      "Private preview first",
+      "Existing tools preserved",
+      "No invented claims",
+    ],
   },
   form: {
     placeholder: "Trade website or business name",
@@ -36,46 +41,91 @@ export const localServiceMarketing = {
     createHref: "/create?vertical=local_service",
   },
   steps: [
-    { number: "01", title: "Share the current source", copy: "Paste the existing website or business name. Tradefront recovers the services, areas, trust evidence, projects and contact links it can verify." },
-    { number: "02", title: "Review the private preview", copy: "Check every service, credential and availability claim before anything can be published." },
-    { number: "03", title: "Claim and keep it current", copy: "Connect a domain when ready, while the phone, WhatsApp and quote tools already used by the business stay in place." },
+    {
+      number: "01",
+      title: "Share the current source",
+      copy: "Paste the existing website or business name. Tradefront recovers the services, areas, trust evidence, projects and contact links it can verify.",
+    },
+    {
+      number: "02",
+      title: "Review the private preview",
+      copy: "Check every service, credential and availability claim before anything can be published.",
+    },
+    {
+      number: "03",
+      title: "Claim and keep it current",
+      copy: "Connect a domain when ready, while the phone, WhatsApp and quote tools already used by the business stay in place.",
+    },
   ],
   valueProps: {
     eyebrow: "Built around the job",
     headline: "Not every local business takes reservations.",
     copy: "Tradefront presents the evidence customers need before they call, then routes them into the business's real contact and quoting workflow.",
     items: [
-      { icon: "catalog", title: "Services in plain language", copy: "Structured services, pricing posture and callout eligibility instead of a vague paragraph about quality." },
-      { icon: "shield", title: "Trust without invention", copy: "Credentials, insurance and guarantees appear only when the source supports them." },
-      { icon: "imagery", title: "Real project evidence", copy: "Completed projects and workshop imagery stay tied to the work they actually show." },
-      { icon: "booking", title: "The shortest path to contact", copy: "Phone, WhatsApp, quote forms and existing job-management portals remain one tap away." },
+      {
+        icon: "catalog",
+        title: "Services in plain language",
+        copy: "Structured services, pricing posture and callout eligibility instead of a vague paragraph about quality.",
+      },
+      {
+        icon: "shield",
+        title: "Trust without invention",
+        copy: "Credentials, insurance and guarantees appear only when the source supports them.",
+      },
+      {
+        icon: "imagery",
+        title: "Real project evidence",
+        copy: "Completed projects and workshop imagery stay tied to the work they actually show.",
+      },
+      {
+        icon: "booking",
+        title: "The shortest path to contact",
+        copy: "Phone, WhatsApp, quote forms and existing job-management portals remain one tap away.",
+      },
     ],
   },
   imagery: {
-    imageUrl: "https://images.unsplash.com/photo-1504307651254-35680f356dfd?auto=format&fit=crop&w=1400&q=85",
+    imageUrl:
+      "https://images.unsplash.com/photo-1504307651254-35680f356dfd?auto=format&fit=crop&w=1400&q=85",
     imageAlt: "Tradesperson reviewing plans on an active building project",
     eyebrow: "Evidence over stock claims",
     headline: "Show the work without changing what happened.",
     copy: "Source photography is preserved as evidence. Enhancement can correct light and crop, but it cannot add completed work, remove defects or manufacture a before-and-after result.",
     assurances: [
-      { icon: "shield", copy: "No invented licences, insurance, guarantees or availability" },
-      { icon: "cursor", copy: "Every service, project and link remains owner-reviewable" },
+      {
+        icon: "shield",
+        copy: "No invented licences, insurance, guarantees or availability",
+      },
+      {
+        icon: "cursor",
+        copy: "Every service, project and link remains owner-reviewable",
+      },
     ],
   },
   pricing: {
     eyebrow: "Simple ongoing care",
     headline: "A current front door for the business.",
     copy: "Preview first. Publish only after the facts, owner and billing state are verified. Local currency is shown at checkout.",
-    plans: [{
-      name: "Founding",
-      price: "$49",
-      cadence: "/month",
-      copy: "The complete local-service website for one independent business.",
-      features: ["Mobile-first services and project gallery", "Phone, WhatsApp and quote actions", "Custom domain and SSL", "Owner editing and source monitoring"],
-      featured: true,
-      badge: "Founding offer",
-    }],
+    plans: [
+      {
+        name: "Founding",
+        price: "$49",
+        cadence: "/month",
+        copy: "The complete local-service website for one independent business.",
+        features: [
+          "Mobile-first services and project gallery",
+          "Phone, WhatsApp and quote actions",
+          "Custom domain and SSL",
+          "Owner editing and source monitoring",
+        ],
+        featured: true,
+        badge: "Founding offer",
+      },
+    ],
   },
-  closing: { headline: "Show the work before asking for the call.", copy: "Paste one source. Tradefront will build the private first draft." },
+  closing: {
+    headline: "Show the work before asking for the call.",
+    copy: "Paste one source. Tradefront will build the private first draft.",
+  },
   footerTagline: "Services, proof and a fast way to request the work.",
 } satisfies VerticalMarketing;

--- a/src/lib/verticals/registry.test.ts
+++ b/src/lib/verticals/registry.test.ts
@@ -51,9 +51,9 @@ describe("vertical registry", () => {
   });
 
   it("requires one vertical-specific lead discovery adapter per enum entry", () => {
-    expect(listLeadDiscoveryAdapters().map((adapter) => adapter.vertical)).toEqual(
-      listVerticalIds(),
-    );
+    expect(
+      listLeadDiscoveryAdapters().map((adapter) => adapter.vertical),
+    ).toEqual(listVerticalIds());
     expect(
       new Set(listLeadDiscoveryAdapters().map((adapter) => adapter.adapterId))
         .size,
@@ -312,18 +312,18 @@ describe("niche routing", () => {
     expect(isVerticalPubliclyAccessible(Vertical.FOOD_RETAIL)).toBe(false);
   });
 
-  it("enables claim checkout only for a fully launched vertical", () => {
+  it("enables niche or factory checkout only when the vertical opts in", () => {
     expect(isVerticalClaimEnabled(Vertical.RESTAURANT)).toBe(true);
     expect(isVerticalClaimEnabled(Vertical.BEAUTY)).toBe(false);
-    expect(isVerticalClaimEnabled(Vertical.LOCAL_SERVICE)).toBe(false);
-    expect(isVerticalClaimEnabled(Vertical.FOOD_RETAIL)).toBe(false);
+    expect(isVerticalClaimEnabled(Vertical.LOCAL_SERVICE)).toBe(true);
+    expect(isVerticalClaimEnabled(Vertical.FOOD_RETAIL)).toBe(true);
   });
 
-  it("keeps publication explicit while food retail remains private", () => {
+  it("enables reviewed publication for every registered SMB vertical", () => {
     expect(isVerticalPublicationEnabled(Vertical.RESTAURANT)).toBe(true);
     expect(isVerticalPublicationEnabled(Vertical.BEAUTY)).toBe(true);
-    expect(isVerticalPublicationEnabled(Vertical.LOCAL_SERVICE)).toBe(false);
-    expect(isVerticalPublicationEnabled(Vertical.FOOD_RETAIL)).toBe(false);
+    expect(isVerticalPublicationEnabled(Vertical.LOCAL_SERVICE)).toBe(true);
+    expect(isVerticalPublicationEnabled(Vertical.FOOD_RETAIL)).toBe(true);
   });
 
   it("keeps local service gated until public access, domain, routing and sender are real", () => {

--- a/src/lib/verticals/registry.ts
+++ b/src/lib/verticals/registry.ts
@@ -130,11 +130,7 @@ export function isVerticalPubliclyLaunched(id: VerticalId): boolean {
 export type VerticalLaunchReadiness = {
   ready: boolean;
   issues: Array<
-    | "public-access"
-    | "domain"
-    | "sender"
-    | "hostname"
-    | "sender-domain"
+    "public-access" | "domain" | "sender" | "hostname" | "sender-domain"
   >;
 };
 
@@ -164,12 +160,14 @@ export function verticalLaunchReadiness(
 }
 
 /**
- * Claim invitations and subscription checkout exist only for a fully launched
- * niche with its own domain, routing and sender. Public factory-route access is
- * deliberately insufficient: previewing Beauty must not sell Restofront's plan.
+ * Claim invitations and checkout are an explicit product capability. A niche
+ * claim still requires the niche's complete launch contract; a factory claim
+ * uses Cornershopdev's verified runtime sender and the platform subdomain.
  */
 export function isVerticalClaimEnabled(id: VerticalId): boolean {
-  return isVerticalPubliclyLaunched(id);
+  const mode = resolveVerticalConfig(id).claimMode;
+  if (mode === "disabled") return false;
+  return mode === "factory" || isVerticalPubliclyLaunched(id);
 }
 
 /**

--- a/src/lib/verticals/restaurant/config.ts
+++ b/src/lib/verticals/restaurant/config.ts
@@ -111,6 +111,7 @@ export const restaurantConfig = {
     item: "Dish",
   },
   marketing: restaurantMarketing,
+  claimMode: "niche",
   publicationEnabled: true,
   integrationTypes: ["booking", "ordering", "delivery", "social"],
   attributesSchema: restaurantAttributesSchema,

--- a/src/lib/verticals/types.ts
+++ b/src/lib/verticals/types.ts
@@ -11,12 +11,7 @@ export type CatalogVocabulary = {
 };
 
 export type IntegrationLinkType =
-  | "booking"
-  | "ordering"
-  | "delivery"
-  | "social"
-  | "quote"
-  | "contact";
+  "booking" | "ordering" | "delivery" | "social" | "quote" | "contact";
 
 export type VerticalProject = {
   title: string;
@@ -265,6 +260,12 @@ export type VerticalConfig<
   vocabulary: CatalogVocabulary;
   /** The niche's own marketing site. See `VerticalMarketing`. */
   marketing: VerticalMarketing;
+  /**
+   * How an approved owner reaches checkout. A niche launch uses its own domain
+   * and sender; a factory claim uses Cornershopdev's verified sender and the
+   * site's platform subdomain; disabled keeps a review-only vertical private.
+   */
+  claimMode: "disabled" | "factory" | "niche";
   /**
    * Whether owner-reviewed drafts may create or roll back public snapshots.
    * This is explicit and server-enforced: a registered vertical can support

--- a/src/workflows/lead-outreach.test.ts
+++ b/src/workflows/lead-outreach.test.ts
@@ -109,7 +109,7 @@ describe("isLeadEligibleForOutreach", () => {
   });
 });
 
-describe("reviewed niche delivery eligibility", () => {
+describe("reviewed claim-enabled delivery eligibility", () => {
   const reviewedAt = "2026-08-19T08:01:00.000Z";
   const site = {
     status: "PREVIEW_READY",
@@ -135,7 +135,7 @@ describe("reviewed niche delivery eligibility", () => {
     auditEvents: [{ createdAt: new Date("2026-08-19T08:01:00.000Z") }],
   };
 
-  it("binds delivery to the current reviewed restaurant and recipient", () => {
+  it("binds delivery to the current reviewed claim-enabled vertical and recipient", () => {
     expect(isReviewedLead(site, false, "owner@example.com", reviewedAt)).toBe(
       true,
     );
@@ -147,7 +147,17 @@ describe("reviewed niche delivery eligibility", () => {
         reviewedAt,
       ),
     ).toBe(false);
-    for (const vertical of ["BEAUTY", "FOOD_RETAIL", "LOCAL_SERVICE"]) {
+    for (const vertical of ["FOOD_RETAIL", "LOCAL_SERVICE"]) {
+      expect(
+        isReviewedLead(
+          { ...site, vertical },
+          false,
+          "owner@example.com",
+          reviewedAt,
+        ),
+      ).toBe(true);
+    }
+    for (const vertical of ["BEAUTY"]) {
       expect(
         isReviewedLead(
           { ...site, vertical },

--- a/tests/e2e/first-customer.pw.ts
+++ b/tests/e2e/first-customer.pw.ts
@@ -7,32 +7,46 @@ import {
 import { execFileSync } from "node:child_process";
 import { e2e } from "./support/fixtures";
 
-test("private food-retail preview exposes no claim page, invitation, or checkout", async ({
+test("food-retail factory preview issues ownership and starts the one-plan checkout", async ({
   page,
   request,
 }) => {
   const claimPage = await page.goto(`/claim/${e2e.foodSlug}`);
-  expect(claimPage?.status()).toBe(404);
-  await expect(page.getByText(e2e.foodName)).not.toBeVisible();
+  expect(claimPage?.status()).toBe(200);
+  await expect(page.getByText(e2e.foodName)).toBeVisible();
 
   const invitation = await request.post("/api/claim-invitations", {
     headers: { Origin: "http://127.0.0.1:3100" },
     data: { siteSlug: e2e.foodSlug, email: e2e.foodOwnerEmail },
   });
-  expect(invitation.status()).toBe(409);
+  expect(invitation.status()).toBe(200);
+  const claimLink = await latestMailboxLink(request, e2e.foodOwnerEmail);
+  const invitationToken = new URL(claimLink).hash.replace(/^#claim_token=/, "");
 
   const checkout = await request.post("/api/checkout", {
     headers: { Origin: "http://127.0.0.1:3100" },
     data: {
       plan: "founding",
       siteSlug: e2e.foodSlug,
-      invitationToken: e2e.foodInvitationToken,
+      invitationToken,
     },
   });
-  expect(checkout.status()).toBe(409);
+  expect(checkout.status()).toBe(200);
   expect(await checkout.json()).toMatchObject({
-    error: "This site already has an owner or is not available to claim.",
+    url: expect.stringMatching(
+      /^http:\/\/127\.0\.0\.1:4100\/checkout\/cs_test_/,
+    ),
   });
+
+  const replacedToken = await request.post("/api/checkout", {
+    headers: { Origin: "http://127.0.0.1:3100" },
+    data: {
+      plan: "founding",
+      siteSlug: e2e.foodSlug,
+      invitationToken: e2e.foodSupersededInvitationToken,
+    },
+  });
+  expect(replacedToken.status()).toBe(403);
 });
 
 test("claim, paid webhook, sign-in, workspace selection, private save, atomic publish, and live routing", async ({
@@ -56,7 +70,9 @@ test("claim, paid webhook, sign-in, workspace selection, private save, atomic pu
   ).toBeVisible();
   await page.getByRole("button", { name: "Claim and continue" }).click();
   await expect(page).toHaveURL(/127\.0\.0\.1:4100\/checkout\/cs_test_/);
-  await expect(page.getByText("€43.00 local presentment for the $49 monthly plan")).toBeVisible();
+  await expect(
+    page.getByText("€43.00 local presentment for the $49 monthly plan"),
+  ).toBeVisible();
   await page.getByRole("button", { name: "Pay €43 in test mode" }).click();
 
   await expect(page).toHaveURL(/\/workspace\/select$/);

--- a/tests/e2e/first-customer.pw.ts
+++ b/tests/e2e/first-customer.pw.ts
@@ -13,7 +13,9 @@ test("food-retail factory preview issues ownership and starts the one-plan check
 }) => {
   const claimPage = await page.goto(`/claim/${e2e.foodSlug}`);
   expect(claimPage?.status()).toBe(200);
-  await expect(page.getByText(e2e.foodName)).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: e2e.foodName, exact: true }),
+  ).toBeVisible();
 
   const invitation = await request.post("/api/claim-invitations", {
     headers: { Origin: "http://127.0.0.1:3100" },

--- a/tests/e2e/support/database.ts
+++ b/tests/e2e/support/database.ts
@@ -74,10 +74,7 @@ export async function seedFirstCustomerBrowserJourney() {
       integrations: {
         create: sampleSiteDraft.integrations.map((integration, position) => ({
           type: integration.type.toUpperCase() as
-            | "BOOKING"
-            | "ORDERING"
-            | "DELIVERY"
-            | "SOCIAL",
+            "BOOKING" | "ORDERING" | "DELIVERY" | "SOCIAL",
           label: integration.label,
           provider: integration.provider,
           url: integration.url,
@@ -144,8 +141,7 @@ export async function seedFirstCustomerBrowserJourney() {
     catalogSections: [
       {
         name: "Product ranges",
-        description:
-          "No sourced products in this private billing-gate fixture.",
+        description: "No sourced products in this factory claim fixture.",
         items: [],
       },
     ],
@@ -161,7 +157,9 @@ export async function seedFirstCustomerBrowserJourney() {
       claimInvitations: {
         create: {
           email: e2e.foodOwnerEmail,
-          tokenHash: hashClaimInvitationToken(e2e.foodInvitationToken),
+          tokenHash: hashClaimInvitationToken(
+            e2e.foodSupersededInvitationToken,
+          ),
           proofMethod: "DOMAIN_EMAIL",
           expiresAt: new Date(Date.now() + 24 * 60 * 60_000),
         },

--- a/tests/e2e/support/fixtures.ts
+++ b/tests/e2e/support/fixtures.ts
@@ -10,9 +10,9 @@ export const e2e = {
   unauthorizedName: "Unowned Browser Workspace",
   ownerEmail: "owner@restaurant.example.test",
   editedName: "First Customer Published Browser Edit",
-  foodId: "first-customer-browser-food-private",
-  foodSlug: "first-customer-browser-food-private",
-  foodName: "Private Food Retail Browser Preview",
+  foodId: "first-customer-browser-food-factory",
+  foodSlug: "first-customer-browser-food-factory",
+  foodName: "Factory Food Retail Browser Preview",
   foodOwnerEmail: "owner@example.com",
-  foodInvitationToken: "food_private_claim_token_1234567890abcdef",
+  foodSupersededInvitationToken: "food_superseded_claim_token_1234567890abcdef",
 };


### PR DESCRIPTION
## Outcome
- enable reviewed factory claim, checkout, and publication for LOCAL_SERVICE and FOOD_RETAIL
- keep BEAUTY claim-disabled until its owner workflow exists
- use the single Cornershopdev $49 USD monthly billing contract across verticals
- use verified Cornershopdev sender/reply identities for factory outreach
- add revision-safe owner publish controls and food translation review gating

## Safety
- operator-reviewed and evidence-eligible outreach remains mandatory
- private preview remains private before claim/publication
- checkout and publication remain server-authorized, billing-gated, and revision-safe
- local-service reconstruction remains deterministic-only
- no customer email or charge was sent during verification

## Verification
- bun test: 914 pass, 71 opt-in database skips, 0 fail
- focused changed-path tests: 80 pass, 0 fail
- ESLint: pass
- design lint: pass
- TypeScript: pass
- Next.js production build: pass with CI-equivalent configuration
- changed-file Prettier check: pass
- git diff --check and secret scan: pass

## Live configuration already aligned
- Stripe: exactly one active $49 USD monthly exclusive-tax price; generic Cornershopdev product identity
- Resend: send.cornershop.dev verified for sending; reply.cornershop.dev verified for receiving
- SSM EMAIL_FROM and EMAIL_REPLY_TO updated to those verified identities
