### PR TITLE
fix(a11y): associate owner editor field labels

### DIFF
--- a/src/app/dashboard/food-retail-dashboard.tsx
+++ b/src/app/dashboard/food-retail-dashboard.tsx
@@ -17,6 +17,7 @@ import { Brand } from "@/components/brand";
 import { SiteRenderer } from "@/components/site-renderer";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Field } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
@@ -982,7 +983,6 @@ export function FoodRetailDashboard({
                 <div className="grid gap-3 sm:grid-cols-2">
                   <Field label="Eyebrow">
                     <Input
-                      aria-label={`${translation.locale} eyebrow`}
                       value={translation.eyebrow}
                       onChange={(event) =>
                         changeTranslation(translation.locale, (next) => {
@@ -993,7 +993,6 @@ export function FoodRetailDashboard({
                   </Field>
                   <Field label="Pickup details">
                     <Input
-                      aria-label={`${translation.locale} pickup details`}
                       value={translation.attributes.pickupDetails}
                       onChange={(event) =>
                         changeTranslation(translation.locale, (next) => {
@@ -1004,7 +1003,6 @@ export function FoodRetailDashboard({
                   </Field>
                   <Field label="Description" className="sm:col-span-2">
                     <Textarea
-                      aria-label={`${translation.locale} description`}
                       value={translation.description}
                       onChange={(event) =>
                         changeTranslation(translation.locale, (next) => {
@@ -1138,7 +1136,6 @@ export function FoodRetailDashboard({
                           label={`Link ${integrationIndex + 1} label`}
                         >
                           <Input
-                            aria-label={`${translation.locale} link ${integrationIndex + 1} label`}
                             value={label}
                             onChange={(event) =>
                               changeTranslation(translation.locale, (next) => {
@@ -1167,23 +1164,6 @@ export function FoodRetailDashboard({
           </div>
         </div>
       </main>
-    </div>
-  );
-}
-
-function Field({
-  label,
-  className,
-  children,
-}: {
-  label: string;
-  className?: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className={className}>
-      <Label className="mb-2">{label}</Label>
-      {children}
     </div>
   );
 }

--- a/src/app/dashboard/local-service-dashboard.tsx
+++ b/src/app/dashboard/local-service-dashboard.tsx
@@ -15,6 +15,7 @@ import { Brand } from "@/components/brand";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Field } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -421,8 +422,16 @@ export function LocalServiceDashboard({
                   }
                 />
               </Field>
-              <Field label="Insurance posture">
+              <div>
+                <Label
+                  id="insurance-posture-label"
+                  htmlFor="insurance-posture"
+                  className="mb-2 block"
+                >
+                  Insurance posture
+                </Label>
                 <select
+                  id="insurance-posture"
                   className="h-8 w-full rounded-lg border bg-background px-2.5 text-sm"
                   value={draft.attributes.insuranceStatus}
                   onChange={(event) =>
@@ -436,7 +445,12 @@ export function LocalServiceDashboard({
                   <option>insured</option>
                   <option>not-insured</option>
                 </select>
+                <span id="insurance-posture-detail" className="sr-only">
+                  detail
+                </span>
                 <Input
+                  id="insurance-posture-evidence"
+                  aria-labelledby="insurance-posture-label insurance-posture-detail"
                   className="mt-2"
                   value={draft.attributes.insuranceDetail}
                   placeholder="Evidence-backed detail"
@@ -446,7 +460,7 @@ export function LocalServiceDashboard({
                     })
                   }
                 />
-              </Field>
+              </div>
               <Field
                 label="Credentials — name | issuer | reference"
                 className="md:col-span-2"
@@ -601,9 +615,30 @@ export function LocalServiceDashboard({
                         <option>quote</option>
                       </select>
                     </Field>
-                    <Field label="Price / unit">
+                    <div>
+                      <Label
+                        id={`service-price-unit-${sectionIndex}-${itemIndex}-label`}
+                        htmlFor={`service-price-unit-${sectionIndex}-${itemIndex}-price`}
+                        className="mb-2 block"
+                      >
+                        Price / unit
+                      </Label>
                       <div className="grid grid-cols-2 gap-2">
+                        <span
+                          id={`service-price-unit-${sectionIndex}-${itemIndex}-price-label`}
+                          className="sr-only"
+                        >
+                          price
+                        </span>
+                        <span
+                          id={`service-price-unit-${sectionIndex}-${itemIndex}-unit-label`}
+                          className="sr-only"
+                        >
+                          unit
+                        </span>
                         <Input
+                          id={`service-price-unit-${sectionIndex}-${itemIndex}-price`}
+                          aria-labelledby={`service-price-unit-${sectionIndex}-${itemIndex}-label service-price-unit-${sectionIndex}-${itemIndex}-price-label`}
                           type="number"
                           min="0"
                           value={item.price ?? ""}
@@ -620,6 +655,8 @@ export function LocalServiceDashboard({
                           }
                         />
                         <Input
+                          id={`service-price-unit-${sectionIndex}-${itemIndex}-unit`}
+                          aria-labelledby={`service-price-unit-${sectionIndex}-${itemIndex}-label service-price-unit-${sectionIndex}-${itemIndex}-unit-label`}
                           value={item.attributes.priceUnit}
                           placeholder="per hour"
                           onChange={(event) =>
@@ -631,7 +668,7 @@ export function LocalServiceDashboard({
                           }
                         />
                       </div>
-                    </Field>
+                    </div>
                     <label className="flex items-center gap-2 text-sm">
                       <input
                         type="checkbox"
@@ -911,23 +948,6 @@ function EditorSection({
       </div>
       {children}
     </section>
-  );
-}
-
-function Field({
-  label,
-  className,
-  children,
-}: {
-  label: string;
-  className?: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className={className}>
-      <Label className="mb-2 block">{label}</Label>
-      {children}
-    </div>
   );
 }
 

--- a/src/components/restaurant-integration-editor.tsx
+++ b/src/components/restaurant-integration-editor.tsx
@@ -17,8 +17,8 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Field } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import type { RestaurantDraft } from "@/lib/restaurant";
 import {
@@ -237,10 +237,7 @@ export function RestaurantIntegrationEditor({
                 {canonical ? (
                   <>
                     <div className="grid gap-4 md:grid-cols-2">
-                      <Field
-                        label="Link type"
-                        htmlFor={`integration-type-${integrationIndex}`}
-                      >
+                      <Field label="Link type">
                         <select
                           id={`integration-type-${integrationIndex}`}
                           className="border-input bg-background h-9 w-full rounded-md border px-3 text-sm"
@@ -261,10 +258,7 @@ export function RestaurantIntegrationEditor({
                           ))}
                         </select>
                       </Field>
-                      <Field
-                        label="Customer-facing label"
-                        htmlFor={`integration-label-${integrationIndex}`}
-                      >
+                      <Field label="Customer-facing label">
                         <Input
                           id={`integration-label-${integrationIndex}`}
                           value={integration.label}
@@ -279,10 +273,7 @@ export function RestaurantIntegrationEditor({
                       </Field>
                     </div>
                     <div className="mt-4 grid gap-4 md:grid-cols-[1fr_180px]">
-                      <Field
-                        label="HTTPS destination"
-                        htmlFor={`integration-url-${integrationIndex}`}
-                      >
+                      <Field label="HTTPS destination">
                         <Input
                           id={`integration-url-${integrationIndex}`}
                           type="url"
@@ -298,11 +289,14 @@ export function RestaurantIntegrationEditor({
                           }
                         />
                       </Field>
-                      <Field label="Provider identity">
+                      <div className="grid gap-2">
+                        <p className="text-sm leading-none font-medium">
+                          Provider identity
+                        </p>
                         <div className="flex h-9 items-center rounded-md border bg-muted/40 px-3 text-sm">
                           {integration.provider ?? "Independent link"}
                         </div>
-                      </Field>
+                      </div>
                     </div>
                     <div className="mt-4 flex flex-wrap items-center gap-2">
                       <Button
@@ -369,10 +363,7 @@ export function RestaurantIntegrationEditor({
                     </div>
                   </>
                 ) : (
-                  <Field
-                    label="Localized customer-facing label"
-                    htmlFor={`translated-integration-${integrationIndex}`}
-                  >
+                  <Field label="Localized customer-facing label">
                     <Input
                       id={`translated-integration-${integrationIndex}`}
                       value={
@@ -465,23 +456,6 @@ export function RestaurantIntegrationEditor({
           </CardContent>
         </Card>
       </div>
-    </div>
-  );
-}
-
-function Field({
-  label,
-  htmlFor,
-  children,
-}: {
-  label: string;
-  htmlFor?: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="grid gap-2">
-      <Label htmlFor={htmlFor}>{label}</Label>
-      {children}
     </div>
   );
 }

--- a/src/components/restaurant-menu-editor.tsx
+++ b/src/components/restaurant-menu-editor.tsx
@@ -17,6 +17,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Field } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
@@ -577,21 +578,6 @@ export function RestaurantMenuEditor({
           ),
         )}
       </div>
-    </div>
-  );
-}
-
-function Field({
-  label,
-  children,
-}: {
-  label: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="grid gap-2">
-      <Label>{label}</Label>
-      {children}
     </div>
   );
 }

--- a/src/components/ui/field.tsx
+++ b/src/components/ui/field.tsx
@@ -1,0 +1,82 @@
+"use client"
+
+import * as React from "react"
+
+import { Label } from "@/components/ui/label"
+import { cn } from "@/lib/utils"
+
+type FieldControlProps = {
+  id?: string
+  "aria-describedby"?: string
+  "aria-invalid"?: React.AriaAttributes["aria-invalid"]
+}
+
+function Field({
+  label,
+  controlId,
+  description,
+  error,
+  className,
+  children,
+}: {
+  label: React.ReactNode
+  controlId?: string
+  description?: React.ReactNode
+  error?: React.ReactNode
+  className?: string
+  children: React.ReactElement<FieldControlProps>
+}) {
+  const generatedId = React.useId()
+  const resolvedControlId =
+    controlId ?? children.props.id ?? `field-${generatedId}`
+  const hasDescription = description !== undefined && description !== null
+  const hasError = error !== undefined && error !== null && error !== false
+  const descriptionId = hasDescription
+    ? `${resolvedControlId}-description`
+    : undefined
+  const errorId = hasError ? `${resolvedControlId}-error` : undefined
+  const describedBy = mergeIds(
+    children.props["aria-describedby"],
+    descriptionId,
+    errorId,
+  )
+
+  return (
+    <div data-slot="field" className={cn("grid gap-2", className)}>
+      <Label htmlFor={resolvedControlId}>{label}</Label>
+      {React.cloneElement(children, {
+        id: resolvedControlId,
+        "aria-describedby": describedBy,
+        "aria-invalid": hasError
+          ? true
+          : children.props["aria-invalid"],
+      })}
+      {hasDescription ? (
+        <p
+          id={descriptionId}
+          data-slot="field-description"
+          className="text-xs text-muted-foreground"
+        >
+          {description}
+        </p>
+      ) : null}
+      {hasError ? (
+        <p
+          id={errorId}
+          data-slot="field-error"
+          role="alert"
+          className="text-xs text-destructive"
+        >
+          {error}
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+function mergeIds(...values: Array<string | undefined>) {
+  const ids = values.flatMap((value) => value?.split(/\s+/).filter(Boolean) ?? [])
+  return ids.length > 0 ? [...new Set(ids)].join(" ") : undefined
+}
+
+export { Field }

--- a/src/lib/editor-field-accessibility.test.tsx
+++ b/src/lib/editor-field-accessibility.test.tsx
@@ -1,0 +1,334 @@
+import { describe, expect, it, mock } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+mock.module("next/navigation", () => ({
+  useRouter: () => ({
+    push: () => {},
+    replace: () => {},
+    refresh: () => {},
+    back: () => {},
+    prefetch: () => {},
+  }),
+  usePathname: () => "/dashboard",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+import { FoodRetailDashboard } from "@/app/dashboard/food-retail-dashboard";
+import { LocalServiceDashboard } from "@/app/dashboard/local-service-dashboard";
+import { RestaurantIntegrationEditor } from "@/components/restaurant-integration-editor";
+import { RestaurantMenuEditor } from "@/components/restaurant-menu-editor";
+import { Field } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { FACTORY_BRAND } from "@/lib/brand";
+import { sampleRestaurant } from "@/lib/restaurant";
+import { sampleFoodRetailDraft } from "@/lib/verticals/food-retail/fixtures";
+import { sampleLocalServiceSiteDraft } from "@/lib/verticals/local-service/fixtures";
+
+const restaurantIntegrationEditorSource = await Bun.file(
+  new URL("../components/restaurant-integration-editor.tsx", import.meta.url),
+).text();
+
+describe("shared editor field", () => {
+  it("generates unique, stable control IDs for repeated visible labels", () => {
+    const render = () =>
+      renderToStaticMarkup(
+        <>
+          <Field label="Description">
+            <Input defaultValue="Corner Shop" />
+          </Field>
+          <Field label="Description">
+            <Textarea defaultValue="Neighbourhood essentials" />
+          </Field>
+        </>,
+      );
+
+    const first = render();
+    const second = render();
+    const firstIds = associatedControlIds(first, "Description");
+    const secondIds = associatedControlIds(second, "Description");
+
+    expect(firstIds).toHaveLength(2);
+    expect(new Set(firstIds).size).toBe(2);
+    expect(firstIds).toEqual(secondIds);
+    controlById(first, firstIds[0], "input");
+    controlById(first, firstIds[1], "textarea");
+  });
+
+  it("preserves caller IDs and composes help and error associations", () => {
+    const html = renderToStaticMarkup(
+      <>
+        <Field label="Currency">
+          <select id="menu-currency" defaultValue="EUR">
+            <option>EUR</option>
+          </select>
+        </Field>
+        <Field
+          label="Contact email"
+          controlId="contact-email"
+          description="Used for order questions."
+          error="Enter a valid email."
+        >
+          <Input
+            type="email"
+            aria-describedby="account-help"
+            disabled
+          />
+        </Field>
+      </>,
+    );
+
+    expect(associatedControl(html, "Currency", "select").id).toBe(
+      "menu-currency",
+    );
+    const email = associatedControl(html, "Contact email", "input");
+    expect(email.id).toBe("contact-email");
+    expect(attribute(email.attributes, "aria-describedby")).toBe(
+      "account-help contact-email-description contact-email-error",
+    );
+    expect(attribute(email.attributes, "aria-invalid")).toBe("true");
+    expect(email.attributes).toContain(" disabled");
+    expect(html).toContain('id="contact-email-description"');
+    expect(html).toContain('id="contact-email-error"');
+    expect(html).toContain('role="alert"');
+  });
+});
+
+describe("owner editor field accessibility", () => {
+  it("names Food Retail inputs, selects, and textareas from visible labels", () => {
+    const html = renderToStaticMarkup(
+      <FoodRetailDashboard
+        email="owner@example.com"
+        brand={FACTORY_BRAND}
+        initialDraft={sampleFoodRetailDraft}
+        initialRevision={7}
+        initiallyPublished={false}
+        platformUrl="https://bakery.cornershop.dev"
+      />,
+    );
+
+    expectNamedEditorControls(html);
+    associatedControl(html, "Business name", "input");
+    associatedControl(html, "Shop type", "select");
+    associatedControl(html, "Pickup details", "textarea");
+    associatedControl(html, "Link 1 label", "input");
+    expect(html).not.toContain('aria-label="fr link 1 label"');
+  });
+
+  it("names Local Service controls, including both composite fields", () => {
+    const html = renderToStaticMarkup(
+      <LocalServiceDashboard
+        initialDraft={sampleLocalServiceSiteDraft}
+        initialRevision={7}
+        email="owner@harbourelectrical.example"
+        brand={FACTORY_BRAND}
+        canSwitchWorkspace={false}
+        initiallyPublished={false}
+        platformUrl="https://harbour-electrical.cornershop.dev"
+      />,
+    );
+
+    expectNamedEditorControls(html);
+    associatedControl(html, "Business name", "input");
+    associatedControl(html, "Trade type", "select");
+    associatedControl(html, "Description", "textarea");
+    const insurance = associatedControl(html, "Insurance posture", "select");
+    expect(insurance.id).toBe("insurance-posture");
+    expect(labelledByText(html, "insurance-posture-evidence")).toBe(
+      "Insurance posture detail",
+    );
+    expect(labelledByText(html, "service-price-unit-0-0-price")).toBe(
+      "Price / unit price",
+    );
+    expect(labelledByText(html, "service-price-unit-0-0-unit")).toBe(
+      "Price / unit unit",
+    );
+  });
+
+  it("names restaurant menu controls without changing existing switch labels", () => {
+    const html = renderToStaticMarkup(
+      <RestaurantMenuEditor
+        draft={sampleRestaurant}
+        dirty={false}
+        saving={false}
+        saveError={null}
+        validationIssues={[]}
+        canUndo={false}
+        regeneratingLocale={null}
+        onMutation={() => {}}
+        onTranslationChange={() => {}}
+        onReviewTranslation={() => {}}
+        onRegenerateTranslation={() => {}}
+        onUndo={() => {}}
+        onSave={() => {}}
+      />,
+    );
+
+    expectNamedEditorControls(html);
+    associatedControl(html, "Item name", "input");
+    associatedControl(html, "Description", "textarea");
+    associatedControl(html, "Currency", "select");
+    expect(html).toContain('for="available-0-0"');
+    expect(html).toContain('id="available-0-0"');
+  });
+
+  it("preserves explicit restaurant integration control IDs", () => {
+    const html = renderToStaticMarkup(
+      <RestaurantIntegrationEditor
+        draft={sampleRestaurant}
+        dirty={false}
+        saving={false}
+        saveError={null}
+        validationIssues={[]}
+        savedRevision={7}
+        canUndo={false}
+        onMutation={() => {}}
+        onTranslationLabelChange={() => {}}
+        onReviewTranslation={() => {}}
+        onUndo={() => {}}
+        onSave={() => {}}
+      />,
+    );
+
+    expectNamedEditorControls(html);
+    expect(associatedControl(html, "Link type", "select").id).toBe(
+      "integration-type-0",
+    );
+    expect(
+      associatedControl(html, "Customer-facing label", "input").id,
+    ).toBe("integration-label-0");
+    expect(associatedControl(html, "HTTPS destination", "input").id).toBe(
+      "integration-url-0",
+    );
+    expect(html).not.toContain("<label>Provider identity</label>");
+  });
+
+  it("keeps the client-selected localized integration on the shared field contract", () => {
+    expect(restaurantIntegrationEditorSource).toContain(
+      '<Field label="Localized customer-facing label">',
+    );
+    expect(restaurantIntegrationEditorSource).toContain(
+      'id={`translated-integration-${integrationIndex}`}',
+    );
+    expect(restaurantIntegrationEditorSource).not.toContain("function Field(");
+  });
+});
+
+function associatedControlIds(html: string, label: string) {
+  const labels = html.matchAll(
+    new RegExp(
+      `<label\\b[^>]*\\bfor="([^"]+)"[^>]*>${escapeRegex(label)}</label>`,
+      "g",
+    ),
+  );
+  return [...labels].map((match) => match[1]);
+}
+
+function associatedControl(
+  html: string,
+  label: string,
+  tag: "input" | "select" | "textarea",
+) {
+  const labelMatch = html.match(
+    new RegExp(
+      `<label\\b[^>]*\\bfor="([^"]+)"[^>]*>${escapeRegex(label)}</label>`,
+    ),
+  );
+  expect(labelMatch, `Expected a visible label named “${label}”`).not.toBeNull();
+  const id = labelMatch![1];
+  return {
+    id,
+    attributes: controlById(html, id, tag, label),
+  };
+}
+
+function expectNamedEditorControls(html: string) {
+  const controls = html.matchAll(/<(input|select|textarea)\b([^>]*)>/g);
+  const controlIds = new Set<string>();
+  for (const match of controls) {
+    const [element, tag, attributes] = match;
+    if (tag === "input" && !attributes.includes('data-slot="input"')) {
+      continue;
+    }
+
+    const directLabel = attribute(attributes, "aria-label")?.trim();
+    const labelledBy = attribute(attributes, "aria-labelledby");
+    const id = attribute(attributes, "id");
+    if (id !== undefined) {
+      expect(
+        controlIds.has(id),
+        `Expected a unique control ID, received ${id}`,
+      ).toBe(false);
+      controlIds.add(id);
+    }
+    const hasExplicitLabel =
+      id !== undefined &&
+      new RegExp(`<label\\b[^>]*\\bfor="${escapeRegex(id)}"`).test(html);
+    const hasLabelledBy =
+      labelledBy !== undefined &&
+      labelledBy
+        .split(/\s+/)
+        .filter(Boolean)
+        .every((labelId) => elementTextById(html, labelId).length > 0);
+
+    expect(
+      Boolean(directLabel || hasExplicitLabel || hasLabelledBy),
+      `Expected an accessible name for ${element}`,
+    ).toBe(true);
+  }
+}
+
+function controlById(
+  html: string,
+  id: string,
+  tag: "input" | "select" | "textarea",
+  label?: string,
+) {
+  const control = html.match(
+    new RegExp(`<${tag}\\b(?=[^>]*\\bid="${escapeRegex(id)}")[^>]*>`),
+  );
+  expect(
+    control,
+    label
+      ? `Expected ${tag}#${id} to be associated with “${label}”`
+      : `Expected ${tag}#${id}`,
+  ).not.toBeNull();
+  return control![0];
+}
+
+function labelledByText(html: string, controlId: string) {
+  const control = html.match(
+    new RegExp(
+      `<(?:input|select|textarea)\\b(?=[^>]*\\bid="${escapeRegex(controlId)}")[^>]*>`,
+    ),
+  );
+  expect(control, `Expected control #${controlId}`).not.toBeNull();
+  const labelledBy = attribute(control![0], "aria-labelledby");
+  expect(labelledBy, `Expected #${controlId} to use aria-labelledby`).toBeDefined();
+  return labelledBy!
+    .split(/\s+/)
+    .map((id) => elementTextById(html, id))
+    .join(" ");
+}
+
+function elementTextById(html: string, id: string) {
+  const element = html.match(
+    new RegExp(
+      `<[^>]+\\bid="${escapeRegex(id)}"[^>]*>([\\s\\S]*?)</[^>]+>`,
+    ),
+  );
+  return (element?.[1] ?? "")
+    .replace(/<[^>]*>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function attribute(attributes: string, name: string) {
+  return attributes.match(
+    new RegExp(`(?:^|\\s)${escapeRegex(name)}="([^"]*)"`),
+  )?.[1];
+}
+
+function escapeRegex(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/lib/food-retail-editor.test.tsx
+++ b/src/lib/food-retail-editor.test.tsx
@@ -109,7 +109,8 @@ describe("food-retail bilingual dashboard editing", () => {
     expect(html).toContain("temporarily reuse the canonical source wording");
     expect(html).toContain('aria-label="fr category 3 name"');
     expect(html).toContain('aria-label="fr product 1 name"');
-    expect(html).toContain('aria-label="fr link 2 label"');
+    expect(html).toContain(">Link 2 label</label>");
+    expect(html).not.toContain('aria-label="fr link 2 label"');
     expect(html).not.toContain('aria-label="fr product 1 allergen');
     expect(html).toContain("Sourced allergen terms remain unchanged: gluten");
     expect(html).toContain("Mark reviewed");


### PR DESCRIPTION
## Summary

- add one design-system field pattern with stable generated or caller-supplied control IDs
- migrate Food Retail, Local Service, restaurant menu, and restaurant integration editor fields without changing owner operations
- associate help and error text and add focused accessible-name coverage across all four surfaces

## Verification

- bun test: 920 passed, 72 PostgreSQL-gated skips, 0 failed
- bun run lint
- bun run design:lint
- bunx next typegen and bunx tsc --noEmit
- git diff --check
- local production build entered the optimized Turbopack phase, then hit the documented host-specific PostCSS stall; exact-head PR CI is authoritative

Closes #129