### PR TITLE
chore: harden GitHub governance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/docs/operations/github-governance.md
+++ b/docs/operations/github-governance.md
@@ -1,0 +1,122 @@
+# GitHub delivery governance
+
+**Last audited:** 2026-08-23
+
+**Frozen audit base:** `cb3894977a5bd1c2ac6139e51f5f9d574d79eee4`
+
+This runbook defines the effective merge, security, and work-readiness contract
+for `cornershopdev/cornershop.dev`. Repository settings are live configuration;
+this document is the durable review record and must be updated when those
+settings change.
+
+## Effective default-branch gate
+
+Every pull request to `main` must be current with `main` and have successful
+exact-head results from the GitHub Actions app for all three contexts:
+
+- `verify`
+- `container-runtime`
+- `first-customer-browser-e2e`
+
+The classic `main` protection and the active `Passing CI on main`
+ruleset intentionally encode the same three strict checks. The ruleset also
+requires a pull request, linear history, and resolved review threads, and has no
+bypass actors. Classic protection enforces the same linear-history and
+conversation-resolution requirements for administrators. The separate
+`Protect default branch` ruleset prevents deletion and non-fast-forward updates.
+
+| Control | Frozen audit state | Effective contract |
+| --- | --- | --- |
+| Classic required checks | `verify`, `container-runtime`; strict | All three checks; strict |
+| Ruleset required checks | `verify`; non-strict | All three checks; strict |
+| Browser E2E | Green but optional | Required and app-bound |
+| Linear history | Ruleset only | Ruleset and classic protection |
+| Review threads | Ruleset only | Ruleset and classic protection |
+| Bypass | No ruleset bypass; classic admins exempt | No bypass, including administrators |
+| Merge methods | Merge, squash, and rebase exposed | Squash only |
+| Update branch | Disabled | Enabled |
+| Auto-merge | Disabled | Enabled; never bypasses required checks |
+| Merged head cleanup | Disabled | Automatic branch deletion |
+
+Squash commits use the pull-request title and body. Rebase and merge commits are
+disabled at repository level so the UI exposes one method that is compatible
+with the linear-history rule. Enabling auto-merge is permission to queue an
+eligible pull request, not permission for an agent to merge one.
+
+When auditing protection, read both sources. A green check that appears in only
+one source is not enough, and changing one source must not leave the other with
+a weaker or contradictory policy.
+
+## Native security controls
+
+The repository uses GitHub-native controls without a custom CodeQL workflow:
+
+- dependency graph and Dependabot alerts;
+- Dependabot security updates;
+- weekly Dependabot version checks for the Bun/npm, Docker, and GitHub Actions
+  ecosystems from `.github/dependabot.yml`;
+- secret scanning and push protection;
+- CodeQL default setup for Actions and JavaScript/TypeScript, using the default
+  query suite on GitHub-hosted runners with a weekly schedule.
+
+Default CodeQL setup owns its generated workflow. Do not add a competing CodeQL
+workflow unless default setup becomes unavailable and a separately reviewed
+advanced configuration is required. Never retrieve or paste security alerts as
+governance evidence; record only feature enablement and scan/run status.
+
+Dependabot version updates begin after `.github/dependabot.yml` reaches the
+default branch. Security alerts and security updates are repository settings and
+do not wait for that file.
+
+At this audit, GitHub accepted enable requests for non-provider secret patterns
+and validity checks both alongside base secret scanning and again after base
+scanning was active. Both target re-reads still reported `disabled`. They are
+therefore unavailable under the repository's current plan/configuration and
+must not be reported as enabled. Re-evaluate them only after the GitHub plan or
+security-product configuration changes. Private vulnerability reporting also
+remains disabled because it is a separate disclosure workflow outside issue
+#132's scanning and dependency-alert scope.
+
+## Readiness labels
+
+Each tracked issue receives at most one readiness label. The label classifies
+the next executable boundary; it never replaces the issue's acceptance criteria.
+
+| Label | Meaning | Initial issues |
+| --- | --- | --- |
+| `agent-ready` | Bounded repository work can proceed without new authority. | #124 |
+| `human-only` | Requires authorized human or real-customer action. | #20, #47, #52 |
+| `external-blocked` | Waits on external runtime, provider, or customer evidence. | #10, #98 |
+| `gated` | Must not start until its documented prerequisite gate passes. | #49-#51, #53 |
+
+Issue #20 is the human first-customer acceptance epic. Its unmet runtime and
+alerting readiness is tracked in #10. Issue #47 is downstream commercial
+validation that reuses evidence from #20; #47 does not block #20. Neither label
+nor automation may complete their real payment, owner action, customer-domain,
+support-cost, second-lead, or review-date acceptance rows.
+
+## Project placement
+
+The Restofront execution board owns work that contributes to the first paid
+restaurant or the self-serve beta:
+
+| Issue | Status | Priority | Area |
+| --- | --- | --- | --- |
+| #124 | In Progress | P1 — Self-serve beta | Lead operations |
+| #132 | In Progress | P1 — Self-serve beta | Quality |
+
+The private Cornershopdev Portfolio remains strategic-only. Issues #49-#53 stay
+there as `Todo`; adding #124 or #132 to that board would blur the written revenue
+gate. For user-owned Projects, verify membership from the project's item list:
+the issue-level `projectItems` connection can appear empty even when the item is
+present.
+
+## Change procedure
+
+Before every governance mutation, re-read classic protection, both active
+rulesets, repository merge/security settings, both project boards, open pull
+requests, and the issues whose readiness or dependency semantics are in scope.
+After the mutation, read the same target again and record the smallest
+non-sensitive before/after evidence. Never weaken a gate to land a governance
+change, and never treat a settings response or automated test as real-customer
+acceptance.


### PR DESCRIPTION
## Summary

- reconcile classic `main` protection and the active CI ruleset around the same strict, app-bound `verify`, `container-runtime`, and `first-customer-browser-e2e` gate
- make repository merge hygiene deterministic with squash-only history, update-branch, auto-merge eligibility, and merged-head cleanup
- enable supported GitHub-native vulnerability, dependency, secret, push-protection, and CodeQL controls without reading security alerts
- add the minimal readiness taxonomy, correct the #20/#47 dependency semantics without changing their human acceptance criteria, and verify Restofront/Portfolio metadata
- add weekly Dependabot version-update configuration and a durable governance runbook without changing `.github/workflows/ci.yml`

## Before / after evidence

| Control | Frozen audit base `cb389497` | Re-read effective state |
| --- | --- | --- |
| Classic required checks | strict `verify`, `container-runtime` | strict app-bound `verify`, `container-runtime`, `first-customer-browser-e2e` |
| Active CI ruleset | non-strict `verify`; merge/squash/rebase | strict app-bound three-check gate; squash only |
| Admin / review hygiene | admins exempt; classic linear history and thread resolution off | admin enforcement, linear history, and resolved conversations on; ruleset has no bypass actors |
| Merge settings | merge, squash, rebase; update/auto-merge/delete off | squash only; update/auto-merge/delete on; PR title/body squash metadata |
| Native security | vulnerability alerts, security updates, secret scanning, push protection, and CodeQL absent or disabled | vulnerability alerts and security updates enabled; secret scanning and push protection enabled; CodeQL default setup configured and setup run `32627422679` passed |
| Extended secret controls | disabled | enable requests were accepted but target re-reads remain disabled; recorded as unavailable under the current plan/configuration |
| Readiness | no machine-readable next boundary | `agent-ready`: #124; `human-only`: #20, #47, #52; `external-blocked`: #10, #98; `gated`: #49-#51, #53 |
| #20 / #47 | #20 depended on every P0 while #47 depended on #20 | #20 depends only on #10's matching runtime/alerting row; #47 is explicitly downstream and non-blocking |
| Restofront board | #124/#132 metadata missing from the audit contract | #124: In Progress / P1 / Lead operations; #132: In Progress / P1 / Quality |
| Portfolio | strategic gates retained | #49-#53 remain Todo; #124/#132 remain off the strategic board |

Every external settings, issue, label, and project mutation was followed by a target re-read. The final campaign snapshot re-read classic protection, both active rulesets, repository merge/security settings, all mandated issue bodies/comments, both project boards, and open-PR overlap. No security-alert list endpoint was queried.

Immediately before PR creation, fresh REST reads reconfirmed every mandated issue/comment, open-PR state, protection layer, merge/security setting, and CodeQL configuration. GitHub's GraphQL quota was then exhausted, so the controller directed this PR to use the last successful same-turn ProjectV2 snapshot taken immediately before the branch push; no project mutation occurred after that snapshot, and GraphQL was not retried before its reset.

## Repository changes

- `.github/dependabot.yml`: weekly npm/Bun, Docker, and GitHub Actions version checks
- `docs/operations/github-governance.md`: durable effective-gate, security, readiness, board, and change-procedure record

## Verification

- `bun install --frozen-lockfile` — pass; lockfile unchanged
- Dependabot YAML semantic assertion — pass
- `bun run lint` — pass
- `node node_modules/next/dist/bin/next typegen` — pass
- `bunx --bun tsc --noEmit` — pass
- `bun test` — 913 pass, 72 skip, 0 fail; 2,849 assertions across 985 tests / 145 files
- `bun run design:lint` — pass; 0 errors, 0 warnings
- `git diff --check origin/main...HEAD` — pass
- staged sensitive-filename and secret-shaped-line scans — no matches
- independent final QA — approve; no remaining critical, high, or medium findings

The local production build reached Next.js 16.3.1's optimized Turbopack phase and then hit the documented Mac Studio PostCSS worker stall. It was stopped without a source workaround; exact-head GitHub CI remains authoritative.

## Residual constraints

- Dependabot version updates begin only after `.github/dependabot.yml` reaches `main`.
- Non-provider secret patterns and secret validity checks remain unavailable under the repository's current plan/configuration.
- Private vulnerability reporting and Actions SHA-pinning are separate policy changes outside this issue.
- This PR does not merge, deploy, release, alter secrets, or change production data.

Closes #132
