### PR TITLE
fix(dashboard): make restaurant overview truthful

### DIFF
--- a/src/app/dashboard/dashboard.tsx
+++ b/src/app/dashboard/dashboard.tsx
@@ -17,7 +17,6 @@ import {
   Link2,
   LoaderCircle,
   Mail,
-  MoreHorizontal,
   Newspaper,
   Palette,
   RefreshCcw,
@@ -69,6 +68,7 @@ import {
   restaurantDraftSchema,
   type RestaurantDraft,
 } from "@/lib/restaurant";
+import { buildRestaurantDashboardOverview } from "@/lib/restaurant-dashboard-overview";
 import {
   applyRestaurantIntegrationMutation,
   validateRestaurantIntegrations,
@@ -227,8 +227,17 @@ export function Dashboard({
       ? `https://${domainSetup.hostname}`
       : platformUrl;
   const siteHref = isPublished ? liveUrl : ownerPreviewHref(draft.slug);
-  // Ordering integrations are the portable hook for optional owner apps
-  // (e.g. Servizo Pulse). Keep them generic so demos can leave the factory.
+  const overview = buildRestaurantDashboardOverview(draft);
+  const launchChecklist = [
+    { label: "Menu has items", complete: overview.menuComplete },
+    { label: "Booking link enabled", complete: overview.bookingComplete },
+    { label: "Owner account claimed", complete: !demo },
+    { label: "Site published", complete: isPublished },
+    {
+      label: "Custom domain connected",
+      complete: Boolean(domainSetup?.verified),
+    },
+  ];
   const connectedApps = draft.integrations.filter(
     (integration) =>
       integration.enabled !== false &&
@@ -889,10 +898,9 @@ export function Dashboard({
         <div className="flex items-center gap-5">
           <Brand {...brand} />
           <span className="hidden h-5 w-px bg-border sm:block" />
-          <button className="hidden items-center gap-2 text-sm font-medium sm:flex">
+          <span className="hidden max-w-56 truncate text-sm font-medium sm:block">
             {draft.name}
-            <MoreHorizontal className="size-4 text-muted-foreground" />
-          </button>
+          </span>
         </div>
         <div className="flex items-center gap-2">
           <Badge
@@ -900,7 +908,7 @@ export function Dashboard({
             className="hidden rounded-full bg-emerald-500/10 text-emerald-700 sm:inline-flex"
           >
             <span className="size-1.5 rounded-full bg-emerald-500" />
-            Preview ready
+            Preview available
           </Badge>
           <Button
             render={
@@ -1038,20 +1046,15 @@ export function Dashboard({
             <TabsContent value="overview" className="mt-0">
               <PageHeading
                 eyebrow="Restaurant overview"
-                title={`Good afternoon, ${draft.name}.`}
-                copy={`Everything guests see, and everything ${brand.name} is watching.`}
+                title={`Welcome to ${draft.name}.`}
+                copy="Review your website content and publishing progress."
               />
               <div className="mt-8 grid gap-5 xl:grid-cols-[1.35fr_0.65fr]">
                 <Card className="overflow-hidden py-0">
                   <div className="grid md:grid-cols-[1fr_230px]">
                     <div className="p-6">
                       <div className="flex items-center gap-2">
-                        <Badge
-                          variant="secondary"
-                          className="bg-emerald-500/10 text-emerald-700"
-                        >
-                          <Check /> Preview healthy
-                        </Badge>
+                        <Badge variant="outline">Preview available</Badge>
                         <Badge variant="outline">Mobile-first</Badge>
                       </div>
                       <h2 className="font-display mt-6 text-4xl tracking-[-0.04em]">
@@ -1069,9 +1072,6 @@ export function Dashboard({
                         >
                           {isPublished ? "Open live site" : "Open preview"}{" "}
                           <ArrowUpRight />
-                        </Button>
-                        <Button variant="outline" size="sm">
-                          Edit homepage
                         </Button>
                         {connectedApps.map((app) => (
                           <Button
@@ -1115,26 +1115,28 @@ export function Dashboard({
                     <CardTitle className="text-sm">Launch checklist</CardTitle>
                   </CardHeader>
                   <CardContent className="space-y-4">
-                    {[
-                      ["Menu imported", true],
-                      ["Booking link preserved", true],
-                      ["Owner account claimed", !demo],
-                      ["Site published", isPublished],
-                      ["Custom domain connected", Boolean(domainSetup?.verified)],
-                    ].map(([label, done]) => (
+                    {launchChecklist.map(({ label, complete }) => (
                       <div
-                        key={label as string}
+                        key={label}
                         className="flex items-center justify-between text-sm"
                       >
-                        <span>{label as string}</span>
-                        <span
-                          className={`grid size-5 place-items-center rounded-full ${
-                            done
-                              ? "bg-emerald-500/12 text-emerald-700"
-                              : "border text-muted-foreground"
-                          }`}
-                        >
-                          {done ? <Check className="size-3" /> : null}
+                        <span>{label}</span>
+                        <span className="flex items-center gap-2">
+                          <span className="sr-only">
+                            {complete ? "Complete" : "Incomplete"}
+                          </span>
+                          <span
+                            aria-hidden="true"
+                            className={`grid size-5 place-items-center rounded-full ${
+                              complete
+                                ? "bg-emerald-500/12 text-emerald-700"
+                                : "border text-muted-foreground"
+                            }`}
+                          >
+                            {complete ? (
+                              <Check aria-hidden="true" className="size-3" />
+                            ) : null}
+                          </span>
                         </span>
                       </div>
                     ))}
@@ -1142,8 +1144,20 @@ export function Dashboard({
                 </Card>
               </div>
               <div className="mt-5 grid gap-5 md:grid-cols-3">
-                <Metric label="Menu items" value={`${draft.menuSections.reduce((sum, section) => sum + section.items.length, 0)}`} detail={`${draft.menuSections.length} sections`} />
-                <Metric label="Preserved systems" value={`${draft.integrations.length}`} detail="No migrations required" />
+                <Metric
+                  label="Menu items"
+                  value={`${overview.menuItemCount}`}
+                  detail={`${overview.menuSectionCount} ${
+                    overview.menuSectionCount === 1 ? "section" : "sections"
+                  }`}
+                />
+                <Metric
+                  label="Enabled links"
+                  value={`${overview.enabledLinkCount}`}
+                  detail={`${
+                    overview.enabledLinkCount === 1 ? "Link" : "Links"
+                  } currently enabled`}
+                />
                 <Metric
                   label="Last source check"
                   value={sourceMonitoring.lastSuccessAt ? "Completed" : "Pending"}
@@ -1514,7 +1528,7 @@ export function Dashboard({
               <PageHeading
                 eyebrow="Go live"
                 title="Use your own domain (optional)."
-                copy="Your site is already live on a Restofront address. Connect a custom domain when you want guests to type your own name. Email and booking systems remain untouched."
+                copy="Connect a custom domain when you want guests to use your own address."
               />
               <Card className="mt-8">
                 <CardHeader>

--- a/src/lib/restaurant-dashboard-overview.test.tsx
+++ b/src/lib/restaurant-dashboard-overview.test.tsx
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Dashboard } from "@/app/dashboard/dashboard";
+import { buildEmptyAnalyticsSummary } from "@/lib/analytics-contract";
+import { FACTORY_BRAND } from "@/lib/brand";
+import {
+  restaurantDraftSchema,
+  sampleRestaurant,
+} from "@/lib/restaurant";
+import { buildRestaurantDashboardOverview } from "@/lib/restaurant-dashboard-overview";
+
+const dashboardSource = await Bun.file(
+  new URL("../app/dashboard/dashboard.tsx", import.meta.url),
+).text();
+
+describe("Restaurant dashboard overview", () => {
+  it("marks an empty menu and missing booking link incomplete", () => {
+    const draft = restaurantDraftSchema.parse({
+      ...sampleRestaurant,
+      menuSections: sampleRestaurant.menuSections.map((section) => ({
+        ...section,
+        items: [],
+      })),
+      integrations: [],
+    });
+
+    expect(buildRestaurantDashboardOverview(draft)).toEqual({
+      menuItemCount: 0,
+      menuSectionCount: draft.menuSections.length,
+      enabledLinkCount: 0,
+      menuComplete: false,
+      bookingComplete: false,
+    });
+
+    const html = renderDashboard(draft);
+    expect(checklistStatus(html, "Menu has items")).toBe("Incomplete");
+    expect(checklistStatus(html, "Booking link enabled")).toBe("Incomplete");
+  });
+
+  it("reports only enabled links and honors the booking enabled default", () => {
+    const defaultEnabledBooking = restaurantDraftSchema.parse({
+      ...sampleRestaurant,
+      integrations: [
+        {
+          type: "booking",
+          label: "Reserve",
+          provider: null,
+          url: "https://www.opentable.com/r/osteria-luna",
+        },
+      ],
+    });
+    const disabledBooking = restaurantDraftSchema.parse({
+      ...sampleRestaurant,
+      integrations: sampleRestaurant.integrations.map(
+        (integration, index) => ({
+          ...integration,
+          enabled: index !== 0,
+        }),
+      ),
+    });
+
+    expect(defaultEnabledBooking.integrations[0].enabled).toBe(true);
+    expect(
+      buildRestaurantDashboardOverview(defaultEnabledBooking),
+    ).toMatchObject({
+      enabledLinkCount: 1,
+      menuComplete: true,
+      bookingComplete: true,
+    });
+    expect(buildRestaurantDashboardOverview(disabledBooking)).toMatchObject({
+      enabledLinkCount: 1,
+      bookingComplete: false,
+    });
+
+    const html = renderDashboard(defaultEnabledBooking);
+    expect(checklistStatus(html, "Menu has items")).toBe("Complete");
+    expect(checklistStatus(html, "Booking link enabled")).toBe("Complete");
+    expect(html).toMatch(
+      />Enabled links<\/p><p[^>]*>1<\/p><p[^>]*>Link currently enabled<\/p>/,
+    );
+  });
+
+  it("renders literal checklist statuses and no dead or unsupported overview copy", () => {
+    const html = renderDashboard(sampleRestaurant);
+    const checklistLabels = [
+      "Menu has items",
+      "Booking link enabled",
+      "Owner account claimed",
+      "Site published",
+      "Custom domain connected",
+    ];
+
+    for (const label of checklistLabels) {
+      const row = checklistRow(html, label);
+      const status = checklistStatus(html, label);
+      expect(["Complete", "Incomplete"]).toContain(status);
+      expect(row).toContain(
+        `<span class="sr-only">${status}</span>`,
+      );
+      expect(row).toContain(
+        '<span aria-hidden="true" class="grid size-5',
+      );
+      if (status === "Complete") {
+        expect(row).toMatch(/<svg[^>]*aria-hidden="true"/);
+      } else {
+        expect(row).not.toContain("<svg");
+      }
+    }
+
+    for (const unsupported of [
+      "MoreHorizontal",
+      "Edit homepage",
+      "Good afternoon",
+      "Preview healthy",
+      "Preview ready",
+      "Menu imported",
+      "Booking link preserved",
+      "Preserved systems",
+      "No migrations required",
+      "Email and booking systems remain untouched",
+    ]) {
+      expect(dashboardSource).not.toContain(unsupported);
+    }
+    expect(dashboardSource).not.toContain(
+      '<button className="hidden items-center',
+    );
+    expect(dashboardSource).toContain(
+      '<span className="hidden max-w-56 truncate text-sm font-medium sm:block">',
+    );
+  });
+});
+
+function renderDashboard(draft: typeof sampleRestaurant) {
+  return renderToStaticMarkup(
+    <Dashboard
+      initialDraft={draft}
+      initialDraftRevision={0}
+      email="owner@example.com"
+      checkoutComplete={false}
+      demo
+      brand={FACTORY_BRAND}
+      analyticsSummary={buildEmptyAnalyticsSummary(
+        new Date("2026-08-23T00:00:00.000Z"),
+      )}
+      bookingInbox={{
+        requests: [],
+        total: 0,
+        awaitingContact: 0,
+        truncated: false,
+      }}
+      billingAccess={null}
+      publicationHistory={[]}
+      canSwitchWorkspace={false}
+      sourceMonitoring={{
+        cadenceDays: null,
+        nextRunAt: null,
+        lastRunAt: null,
+        lastSuccessAt: null,
+        lastFailureAt: null,
+        lastFailureCode: null,
+        latestRun: null,
+        suggestions: [],
+      }}
+      platformUrl="https://osteria-luna.cornershop.dev"
+    />,
+  );
+}
+
+function checklistStatus(html: string, label: string) {
+  const row = checklistRow(html, label);
+  const status = row.match(
+    /<span class="sr-only">(Complete|Incomplete)<\/span>/,
+  )?.[1];
+  if (!status) throw new Error(`Missing checklist status for: ${label}`);
+  return status;
+}
+
+function checklistRow(html: string, label: string) {
+  const labelIndex = html.indexOf(`>${label}</span>`);
+  if (labelIndex < 0) throw new Error(`Missing checklist label: ${label}`);
+  const rowEnd = html.indexOf("</div>", labelIndex);
+  return html.slice(labelIndex, rowEnd);
+}

--- a/src/lib/restaurant-dashboard-overview.ts
+++ b/src/lib/restaurant-dashboard-overview.ts
@@ -1,0 +1,36 @@
+import type { RestaurantDraft } from "@/lib/restaurant";
+
+type RestaurantOverviewDraft = Pick<
+  RestaurantDraft,
+  "menuSections" | "integrations"
+>;
+
+export type RestaurantDashboardOverview = {
+  menuItemCount: number;
+  menuSectionCount: number;
+  enabledLinkCount: number;
+  menuComplete: boolean;
+  bookingComplete: boolean;
+};
+
+export function buildRestaurantDashboardOverview(
+  draft: RestaurantOverviewDraft,
+): RestaurantDashboardOverview {
+  const menuItemCount = draft.menuSections.reduce(
+    (sum, section) => sum + section.items.length,
+    0,
+  );
+  const enabledLinks = draft.integrations.filter(
+    (integration) => integration.enabled !== false,
+  );
+
+  return {
+    menuItemCount,
+    menuSectionCount: draft.menuSections.length,
+    enabledLinkCount: enabledLinks.length,
+    menuComplete: menuItemCount > 0,
+    bookingComplete: enabledLinks.some(
+      (integration) => integration.type === "booking",
+    ),
+  };
+}

--- a/tests/e2e/first-customer.pw.ts
+++ b/tests/e2e/first-customer.pw.ts
@@ -93,7 +93,7 @@ test("claim, paid webhook, sign-in, workspace selection, private save, atomic pu
     siteId: e2e.targetId,
   });
   await expect(
-    page.getByRole("heading", { name: `Good afternoon, ${e2e.targetName}.` }),
+    page.getByRole("heading", { name: `Welcome to ${e2e.targetName}.` }),
   ).toBeVisible();
 
   const replay = await request.post("/api/checkout", {


### PR DESCRIPTION
## Summary

- derive Restaurant menu, booking, and enabled-link status from the current draft
- remove inert overview controls and unsupported time, health, import, preservation, and migration claims
- expose literal Complete or Incomplete checklist status while keeping visual indicators decorative
- cover empty, populated, schema-default, disabled-link, rendering, accessibility, and structural cases
- align the first-customer browser journey with the required neutral dashboard greeting

## Verification

- `bun test src/lib/restaurant-dashboard-overview.test.tsx`: 3 passed, 0 failed, 41 assertions
- `bun run test`: 923 passed, 72 expected opt-in PostgreSQL skips, 0 failed
- `bun run lint`: passed
- `bun run design:lint`: passed
- `bunx next typegen`: passed
- `bunx tsc --noEmit`: passed
- local `bun run build`: Prisma generation passed; Next optimized compilation hit the known silent Mac Studio Turbopack stall and was boundedly terminated without source or configuration workarounds
- exact-head GitHub CI: verify, first-customer browser E2E, container runtime, and CodeQL passed; PR deploy skipped as expected
- staged secret scans, diff checks, and independent spec/accessibility reviews: passed

Closes #137
