### PR TITLE
fix(articles): harden batch generation guardrails

### DIFF
--- a/deploy/aws/bootstrap-host.sh
+++ b/deploy/aws/bootstrap-host.sh
@@ -8,16 +8,33 @@ if [[ ! -f "$host_launcher_source" || ! -f "$caddy_fragment_source" ]]; then
   exit 2
 fi
 
-install -m 755 "$host_launcher_source" /usr/local/bin/deploy-cornershopdev
-install -d -m 700 /etc/cornershopdev /var/lib/cornershopdev
+host_launcher_destination="${CORNERSHOPDEV_HOST_LAUNCHER_PATH:-/usr/local/bin/deploy-cornershopdev}"
+config_directory="${CORNERSHOPDEV_CONFIG_DIR:-/etc/cornershopdev}"
+state_directory="${CORNERSHOPDEV_STATE_DIR:-/var/lib/cornershopdev}"
+caddyfile="${CORNERSHOPDEV_CADDYFILE:-/etc/caddy/Caddyfile}"
 
-caddyfile="/etc/caddy/Caddyfile"
+install -m 755 "$host_launcher_source" "$host_launcher_destination"
+install -d -m 700 "$config_directory" "$state_directory"
+
 backup="/etc/caddy/Caddyfile.$(date -u +%Y%m%dT%H%M%SZ).bak"
+if [[ "$caddyfile" != "/etc/caddy/Caddyfile" ]]; then
+  backup="${caddyfile}.$(date -u +%Y%m%dT%H%M%SZ).bak"
+fi
 cp "$caddyfile" "$backup"
 
-temporary_body="$(mktemp /etc/caddy/Caddyfile.body.XXXXXX)"
-temporary_caddyfile="$(mktemp /etc/caddy/Caddyfile.XXXXXX)"
-trap 'rm -f "$temporary_body" "$temporary_caddyfile"' EXIT
+temporary_body="$(mktemp "${caddyfile}.body.XXXXXX")"
+temporary_retargeted_body="$(mktemp "${caddyfile}.retargeted.XXXXXX")"
+temporary_caddyfile="$(mktemp "${caddyfile}.candidate.XXXXXX")"
+temporary_gated_caddyfile="$(mktemp "${caddyfile}.gated.XXXXXX")"
+trap 'rm -f "$temporary_body" "$temporary_retargeted_body" "$temporary_caddyfile" "$temporary_gated_caddyfile"' EXIT
+
+# A failed article rollout intentionally leaves the edge gate embedded in the
+# managed block. Remember that state before replacing the block so a retry can
+# never reload an open route while it downloads or verifies the next image.
+article_gate_was_closed=0
+if grep -q '^[[:space:]]*# BEGIN ARTICLE MUTATION GATE$' "$caddyfile"; then
+  article_gate_was_closed=1
+fi
 
 # RESTOFRONT is the marker an earlier revision of this script wrote. A host
 # bootstrapped before the rename still carries that block, and the fragment we
@@ -35,10 +52,11 @@ awk '
 # Caddy denies every on-demand certificate when that endpoint stops resolving,
 # which would cost each customer domain its issuance and renewal. Retarget only
 # the exact line the old bootstrap wrote and leave operator edits untouched.
-sed -i \
+sed \
   -e 's#ask http://restofront:3000/api/domains/authorize#ask http://api-cornershop-dev:3000/api/domains/authorize#' \
   -e 's#ask http://cornershopdev:3000/api/domains/authorize#ask http://api-cornershop-dev:3000/api/domains/authorize#' \
-  "$temporary_body"
+  "$temporary_body" >"$temporary_retargeted_body"
+cat "$temporary_retargeted_body" >"$temporary_body"
 
 {
   if ! grep -q "on_demand_tls" "$temporary_body"; then
@@ -52,6 +70,27 @@ sed -i \
   printf '\n'
   cat "$caddy_fragment_source"
 } >"$temporary_caddyfile"
+
+if [[ "$article_gate_was_closed" == 1 ]]; then
+  article_gate_body="Article mutations are temporarily gated for a safe release."
+  awk -v body="$article_gate_body" '
+    /^# BEGIN CORNERSHOPDEV$/ { managed = 1 }
+    /^# END CORNERSHOPDEV$/ { managed = 0 }
+    {
+      print
+      if (managed && ($0 == "api.cornershop.dev {" || $0 == "https:// {")) {
+        print "\t# BEGIN ARTICLE MUTATION GATE"
+        print "\t@articleMutations {"
+        print "\t\tmethod POST"
+        print "\t\tpath /api/sites/*/articles /api/sites/*/articles/generate"
+        print "\t}"
+        print "\trespond @articleMutations \"" body "\" 503"
+        print "\t# END ARTICLE MUTATION GATE"
+      }
+    }
+  ' "$temporary_caddyfile" >"$temporary_gated_caddyfile"
+  cat "$temporary_gated_caddyfile" >"$temporary_caddyfile"
+fi
 
 # Validate the candidate in the exact context that will load it. A throwaway
 # caddy:2 container cannot resolve other tenants' managed imports — e.g.

--- a/deploy/aws/container-entrypoint.sh
+++ b/deploy/aws/container-entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -eu
 
-bun run db:migrate:deploy
-bun run workflow:migrate
+if [ "${CORNERSHOP_SKIP_STARTUP_MIGRATIONS:-false}" != "true" ]; then
+  bun run db:migrate:deploy
+  bun run workflow:migrate
+fi
 exec node server.js

--- a/deploy/aws/deploy.sh
+++ b/deploy/aws/deploy.sh
@@ -15,7 +15,7 @@ readonly container="api-cornershop-dev"
 readonly candidate="${container}-candidate"
 readonly previous="${container}-previous"
 readonly deployed_sha="${image_name#cornershopdev:}"
-readonly expected_bootstrap_sha256="257af17d1b20743948bb5d674d8dc12675bf45e47c697f987ed596bdcf802532"
+readonly expected_bootstrap_sha256="e9634ec4452851279a933eb0e423b1239bebdc84c87f0bf9ef9a9ac4bef375f5"
 readonly expected_caddy_fragment_sha256="9f0bb5f0c1d9cc0e4b341b2795c6c63563aff918c4e47a8570fcecc23ec72b70"
 readonly expected_host_launcher_sha256="75aa0e06cf621dd7c9c742b6a73e45a1d8c23dc7720feab08547253f1e934abc"
 readonly article_gate_body="Article mutations are temporarily gated for a safe release."
@@ -300,12 +300,27 @@ rollback_article_rollout() {
   local failure_status="${1:-1}"
   trap - ERR
   set +e
+  local edge_gate_verified=0
+  local database_gate_verified=0
   if [[ "$article_rollout_active" == 1 ]]; then
     echo "Article rollout failed; retaining both mutation gates" >&2
-    set_article_edge_gate closed
-    run_article_rollout close >/dev/null
+    if set_article_edge_gate closed && verify_article_edge_gate closed; then
+      edge_gate_verified=1
+    fi
+    if run_article_rollout close >/dev/null; then
+      database_gate_verified=1
+    fi
   fi
   docker rm -f "$candidate" >/dev/null 2>&1
+  if
+    [[ "$article_rollout_active" == 1 ]] &&
+    [[ "$edge_gate_verified" != 1 || "$database_gate_verified" != 1 ]]
+  then
+    echo "Article gates could not be verified; leaving application containers stopped" >&2
+    docker stop "$container" >/dev/null 2>&1
+    docker stop "$previous" >/dev/null 2>&1
+    return "$failure_status"
+  fi
   if docker inspect "$previous" >/dev/null 2>&1; then
     docker rm -f "$container" >/dev/null 2>&1
     docker rename "$previous" "$container"

--- a/deploy/aws/deploy.sh
+++ b/deploy/aws/deploy.sh
@@ -18,6 +18,7 @@ readonly deployed_sha="${image_name#cornershopdev:}"
 readonly expected_bootstrap_sha256="257af17d1b20743948bb5d674d8dc12675bf45e47c697f987ed596bdcf802532"
 readonly expected_caddy_fragment_sha256="9f0bb5f0c1d9cc0e4b341b2795c6c63563aff918c4e47a8570fcecc23ec72b70"
 readonly expected_host_launcher_sha256="75aa0e06cf621dd7c9c742b6a73e45a1d8c23dc7720feab08547253f1e934abc"
+readonly article_gate_body="Article mutations are temporarily gated for a safe release."
 
 install -d -m 700 /etc/cornershopdev /var/lib/cornershopdev
 environment_file="/etc/cornershopdev/production.env"
@@ -28,6 +29,88 @@ caddy_fragment_file="$(mktemp /var/lib/cornershopdev/Caddyfile.XXXXXX.fragment)"
 host_launcher_file="$(mktemp /var/lib/cornershopdev/launcher.XXXXXX.sh)"
 trap 'rm -f "$temporary_environment" "$artifact_file" "$bootstrap_file" "$caddy_fragment_file" "$host_launcher_file"' EXIT
 umask 077
+
+reload_caddy() {
+  docker exec shipshit-caddy caddy reload --config /etc/caddy/Caddyfile >/dev/null
+}
+
+set_article_edge_gate() {
+  local state="$1"
+  if [[ "$state" != "closed" && "$state" != "open" ]]; then
+    echo "Article edge gate state must be closed or open" >&2
+    return 2
+  fi
+  local caddyfile="/etc/caddy/Caddyfile"
+  local stripped
+  local candidate_config
+  stripped="$(mktemp /etc/caddy/Caddyfile.article-stripped.XXXXXX)"
+  candidate_config="$(mktemp /etc/caddy/Caddyfile.article-candidate.XXXXXX)"
+  awk '
+    /^[[:space:]]*# BEGIN ARTICLE MUTATION GATE$/ { gate = 1; next }
+    /^[[:space:]]*# END ARTICLE MUTATION GATE$/ { gate = 0; next }
+    !gate { print }
+  ' "$caddyfile" >"$stripped"
+  awk -v state="$state" -v body="$article_gate_body" '
+    /^# BEGIN CORNERSHOPDEV$/ { managed = 1 }
+    /^# END CORNERSHOPDEV$/ { managed = 0 }
+    {
+      print
+      if (
+        state == "closed" && managed &&
+        ($0 == "api.cornershop.dev {" || $0 == "https:// {")
+      ) {
+        print "\t# BEGIN ARTICLE MUTATION GATE"
+        print "\t@articleMutations {"
+        print "\t\tmethod POST"
+        print "\t\tpath /api/sites/*/articles /api/sites/*/articles/generate"
+        print "\t}"
+        print "\trespond @articleMutations \"" body "\" 503"
+        print "\t# END ARTICLE MUTATION GATE"
+      }
+    }
+  ' "$stripped" >"$candidate_config"
+  local container_candidate="/etc/caddy/.cornershopdev-article-gate.Caddyfile"
+  if ! docker cp "$candidate_config" "shipshit-caddy:$container_candidate"; then
+    rm -f "$stripped" "$candidate_config"
+    return 1
+  fi
+  if ! docker exec shipshit-caddy caddy validate --config "$container_candidate"; then
+    docker exec shipshit-caddy rm -f "$container_candidate" || true
+    rm -f "$stripped" "$candidate_config"
+    return 1
+  fi
+  docker exec shipshit-caddy rm -f "$container_candidate" || true
+  cat "$candidate_config" >"$caddyfile"
+  chmod 644 "$caddyfile"
+  rm -f "$stripped" "$candidate_config"
+  reload_caddy
+}
+
+verify_article_edge_gate() {
+  local expected_state="$1"
+  local response
+  for origin in "https://api.cornershop.dev" "https://cornershop.dev"; do
+    response="$(
+      curl --silent --show-error --max-time 10 \
+        --request POST \
+        --header 'Content-Type: application/json' \
+        --data '{"count":1}' \
+        --write-out $'\n%{http_code}' \
+        "${origin}/api/sites/__article-rollout__/articles/generate"
+    )"
+    local status="${response##*$'\n'}"
+    local body="${response%$'\n'*}"
+    if [[ "$expected_state" == "closed" ]]; then
+      if [[ "$status" != "503" || "$body" != "$article_gate_body" ]]; then
+        echo "Article edge gate did not close ${origin}" >&2
+        return 1
+      fi
+    elif [[ "$status" == "503" && "$body" == "$article_gate_body" ]]; then
+      echo "Article edge gate remained closed on ${origin}" >&2
+      return 1
+    fi
+  done
+}
 
 required_parameters=(
   AWS_REGION
@@ -176,30 +259,6 @@ aws s3 cp "$artifact_uri" "$artifact_file" --region us-west-1 --only-show-errors
 gzip -dc "$artifact_file" | docker load >/dev/null
 docker image inspect "$image_name" >/dev/null
 
-# Run from the reviewed image before its entrypoint can apply migrations. This
-# uses only predecessor-schema columns and blocks a chargeable legacy Checkout
-# from being stranded by the migration. Remediation is an explicit operator
-# procedure after the matching Stripe Session has been expired.
-docker run --rm \
-  --network shipshit \
-  --env-file "$environment_file" \
-  --entrypoint bun \
-  "$image_name" \
-  run operator:preflight-first-customer-migration \
-  --environment production \
-  --mode check \
-  --execute >/dev/null
-
-docker rm -f "$candidate" >/dev/null 2>&1 || true
-docker run -d \
-  --name "$candidate" \
-  --network shipshit \
-  --env-file "$environment_file" \
-  --restart no \
-  --memory 768m \
-  --cpus 1 \
-  "$image_name" >/dev/null
-
 wait_for_health() {
   # `container` is a script-wide readonly; a local of the same name would abort
   # the function under `set -u` on bash < 5 with "readonly variable".
@@ -217,6 +276,109 @@ wait_for_health() {
   return 1
 }
 
+run_article_rollout() {
+  local action="$1"
+  docker run --rm \
+    --network shipshit \
+    --env-file "$environment_file" \
+    --entrypoint bun \
+    "$image_name" \
+    run operator:article-rollout --action "$action"
+}
+
+wait_for_article_quiescence() {
+  for _ in $(seq 1 120); do
+    if run_article_rollout check >/dev/null 2>&1; then return 0; fi
+    sleep 5
+  done
+  run_article_rollout check
+  return 1
+}
+
+article_rollout_active=0
+rollback_article_rollout() {
+  local failure_status="${1:-1}"
+  trap - ERR
+  set +e
+  if [[ "$article_rollout_active" == 1 ]]; then
+    echo "Article rollout failed; retaining both mutation gates" >&2
+    set_article_edge_gate closed
+    run_article_rollout close >/dev/null
+  fi
+  docker rm -f "$candidate" >/dev/null 2>&1
+  if docker inspect "$previous" >/dev/null 2>&1; then
+    docker rm -f "$container" >/dev/null 2>&1
+    docker rename "$previous" "$container"
+    docker start "$container" >/dev/null
+    reload_caddy
+  fi
+  return "$failure_status"
+}
+
+# Close both public article mutation routes before any schema change. The
+# database setting exists on the predecessor schema and is also asserted by the
+# expand migration, so a candidate or rollback cannot reopen itself.
+set_article_edge_gate closed
+verify_article_edge_gate closed
+article_rollout_active=1
+trap 'rollback_article_rollout $?' ERR
+run_article_rollout close >/dev/null
+echo "release-state article-mutations-gated sha=${deployed_sha}"
+
+# Run from the reviewed image before its entrypoint can apply migrations. This
+# uses only predecessor-schema columns and blocks a chargeable legacy Checkout
+# from being stranded by the migration. Remediation is an explicit operator
+# procedure after the matching Stripe Session has been expired.
+docker run --rm \
+  --network shipshit \
+  --env-file "$environment_file" \
+  --entrypoint bun \
+  "$image_name" \
+  run operator:preflight-first-customer-migration \
+  --environment production \
+  --mode check \
+  --execute >/dev/null
+
+docker run --rm \
+  --network shipshit \
+  --env-file "$environment_file" \
+  --entrypoint bun \
+  "$image_name" \
+  run db:migrate:deploy
+echo "release-state migrations-applied sha=${deployed_sha}"
+
+# The predecessor remains alive behind the edge gate while its already-bound
+# work drains. Workflow run state is authoritative; passive timestamps never
+# participate. Graphile flow/step jobs must be absent too.
+wait_for_article_quiescence
+echo "release-state article-workflow-drained sha=${deployed_sha}"
+
+docker rm -f "$previous" >/dev/null 2>&1 || true
+if docker inspect "$container" >/dev/null 2>&1; then
+  docker stop "$container" >/dev/null
+  docker rename "$container" "$previous"
+fi
+run_article_rollout check >/dev/null
+echo "release-state predecessor-worker-stopped sha=${deployed_sha}"
+
+docker run --rm \
+  --network shipshit \
+  --env-file "$environment_file" \
+  --entrypoint bun \
+  "$image_name" \
+  run workflow:migrate
+
+docker rm -f "$candidate" >/dev/null 2>&1 || true
+docker run -d \
+  --name "$candidate" \
+  --network shipshit \
+  --env-file "$environment_file" \
+  --env CORNERSHOP_SKIP_STARTUP_MIGRATIONS=true \
+  --restart no \
+  --memory 768m \
+  --cpus 1 \
+  "$image_name" >/dev/null
+
 wait_for_health "$candidate"
 candidate_image="$(docker inspect --format '{{.Config.Image}}' "$candidate")"
 if [[ "$candidate_image" != "$image_name" ]]; then
@@ -224,7 +386,8 @@ if [[ "$candidate_image" != "$image_name" ]]; then
   exit 1
 fi
 docker exec "$candidate" bun run db:migrate:status
-echo "release-state migrations-applied sha=${deployed_sha}"
+docker exec "$candidate" bun run operator:article-rollout --action check >/dev/null
+echo "release-state article-candidate-verified sha=${deployed_sha}"
 docker exec "$candidate" \
   bun run operator:preflight-outreach --environment production
 echo "release-state outreach-configured sha=${deployed_sha}"
@@ -235,41 +398,29 @@ echo "release-state wildcard-dns-ready sha=${deployed_sha}"
 # matches the approved founding offer. It is intentionally separate from the
 # five-second health probe so normal readiness never hammers Stripe.
 docker exec "$candidate" bun run operator:preflight-stripe --mode live >/dev/null
-docker rm -f "$previous" >/dev/null 2>&1 || true
-if docker inspect "$container" >/dev/null 2>&1; then
-  docker stop "$container" >/dev/null
-  docker rename "$container" "$previous"
-fi
 docker rename "$candidate" "$container"
 docker update --restart unless-stopped "$container" >/dev/null
 
-reload_caddy() {
-  docker exec shipshit-caddy caddy reload --config /etc/caddy/Caddyfile >/dev/null
-}
-
 if ! reload_caddy || ! wait_for_health "$container"; then
   echo "Deployment failed after cutover; rolling back" >&2
-  docker rm -f "$container" >/dev/null 2>&1 || true
-  if docker inspect "$previous" >/dev/null 2>&1; then
-    docker rename "$previous" "$container"
-    docker start "$container" >/dev/null
-    reload_caddy
-  fi
-  exit 1
+  false
 fi
 
 if ! docker exec "$container" \
   bun run operator:preflight-platform-edge --phase tls; then
   echo "Platform TLS preflight failed after cutover; rolling back" >&2
-  docker rm -f "$container" >/dev/null 2>&1 || true
-  if docker inspect "$previous" >/dev/null 2>&1; then
-    docker rename "$previous" "$container"
-    docker start "$container" >/dev/null
-    reload_caddy
-  fi
-  exit 1
+  false
 fi
 echo "release-state platform-tls-ready sha=${deployed_sha}"
+
+# Open the application setting first, then the edge. If either operation fails,
+# the ERR handler recloses both and any predecessor rollback remains gated.
+docker exec "$container" bun run operator:article-rollout --action open >/dev/null
+set_article_edge_gate open
+verify_article_edge_gate open
+article_rollout_active=0
+trap - ERR
+echo "release-state article-mutations-open sha=${deployed_sha}"
 
 echo "release-state production-deployed sha=${deployed_sha}"
 

--- a/deploy/aws/test-article-rollout.sh
+++ b/deploy/aws/test-article-rollout.sh
@@ -114,7 +114,11 @@ run_rollback_case() {
       grep -Fxq "rename ${previous} ${container}" "$log"
       grep -Fxq "start ${container}" "$log"
     else
-      if grep -Fq "start ${previous}" "$log"; then
+      if
+        grep -Fxq "rename ${previous} ${container}" "$log" ||
+        grep -Fxq "start ${container}" "$log" ||
+        grep -Fxq "reload" "$log"
+      then
         echo "Rollback restarted the predecessor without verified gates" >&2
         exit 1
       fi

--- a/deploy/aws/test-article-rollout.sh
+++ b/deploy/aws/test-article-rollout.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # The rollback function is extracted and sourced dynamically so this harness
 # executes the production definition; ShellCheck cannot resolve those symbols.
-# shellcheck disable=SC1090,SC2034,SC2329
+# shellcheck disable=SC1090,SC2034,SC2317,SC2329
 set -Eeuo pipefail
 
 deploy_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/deploy/aws/test-article-rollout.sh
+++ b/deploy/aws/test-article-rollout.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# The rollback function is extracted and sourced dynamically so this harness
+# executes the production definition; ShellCheck cannot resolve those symbols.
+# shellcheck disable=SC1090,SC2034,SC2329
+set -Eeuo pipefail
+
+deploy_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(mktemp -d)"
+trap 'rm -rf "$root"' EXIT
+
+fake_bin="${root}/bin"
+mkdir -p "$fake_bin" "${root}/usr/local/bin" "${root}/etc/caddy"
+cat >"${fake_bin}/docker" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+exit 0
+EOF
+chmod +x "${fake_bin}/docker"
+
+cat >"${root}/launcher.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "${root}/launcher.sh"
+
+caddyfile="${root}/etc/caddy/Caddyfile"
+cat >"$caddyfile" <<'EOF'
+{
+	on_demand_tls {
+		ask http://api-cornershop-dev:3000/api/domains/authorize
+	}
+}
+
+# BEGIN CORNERSHOPDEV
+api.cornershop.dev {
+	# BEGIN ARTICLE MUTATION GATE
+	@articleMutations {
+		method POST
+		path /api/sites/*/articles /api/sites/*/articles/generate
+	}
+	respond @articleMutations "Article mutations are temporarily gated for a safe release." 503
+	# END ARTICLE MUTATION GATE
+	reverse_proxy api-cornershop-dev:3000
+}
+https:// {
+	# BEGIN ARTICLE MUTATION GATE
+	@articleMutations {
+		method POST
+		path /api/sites/*/articles /api/sites/*/articles/generate
+	}
+	respond @articleMutations "Article mutations are temporarily gated for a safe release." 503
+	# END ARTICLE MUTATION GATE
+	reverse_proxy api-cornershop-dev:3000
+}
+# END CORNERSHOPDEV
+EOF
+
+PATH="${fake_bin}:$PATH" \
+  CORNERSHOPDEV_HOST_LAUNCHER_PATH="${root}/usr/local/bin/deploy-cornershopdev" \
+  CORNERSHOPDEV_CONFIG_DIR="${root}/etc/cornershopdev" \
+  CORNERSHOPDEV_STATE_DIR="${root}/var/lib/cornershopdev" \
+  CORNERSHOPDEV_CADDYFILE="$caddyfile" \
+  "${deploy_directory}/bootstrap-host.sh" \
+  "${root}/launcher.sh" \
+  "${deploy_directory}/Caddyfile.fragment" >/dev/null
+
+if [[ "$(grep -c 'BEGIN ARTICLE MUTATION GATE' "$caddyfile")" != 2 ]]; then
+  echo "Bootstrap did not preserve both closed article edge gates" >&2
+  exit 1
+fi
+if [[ "$(grep -c 'respond @articleMutations .* 503' "$caddyfile")" != 2 ]]; then
+  echo "Bootstrap did not preserve fail-closed article responses" >&2
+  exit 1
+fi
+
+rollback_function="${root}/rollback-function.sh"
+sed -n '/^rollback_article_rollout() {$/,/^}$/p' \
+  "${deploy_directory}/deploy.sh" >"$rollback_function"
+if [[ ! -s "$rollback_function" ]]; then
+  echo "Could not extract rollback_article_rollout" >&2
+  exit 1
+fi
+
+run_rollback_case() {
+  local edge_set_result="$1"
+  local edge_verify_result="$2"
+  local database_result="$3"
+  local expect_restore="$4"
+  local log="${root}/rollback-${edge_set_result}-${edge_verify_result}-${database_result}.log"
+  (
+    source "$rollback_function"
+    container="api-cornershop-dev"
+    candidate="api-cornershop-dev-candidate"
+    previous="api-cornershop-dev-previous"
+    article_rollout_active=1
+    set_article_edge_gate() { return "$edge_set_result"; }
+    verify_article_edge_gate() { return "$edge_verify_result"; }
+    run_article_rollout() { return "$database_result"; }
+    reload_caddy() { printf '%s\n' "reload" >>"$log"; }
+    docker() {
+      printf '%s\n' "$*" >>"$log"
+      if [[ "$1" == "inspect" && "$2" == "$previous" ]]; then return 0; fi
+      return 0
+    }
+    set +e
+    rollback_article_rollout 17 2>>"$log"
+    status="$?"
+    set -e
+    if [[ "$status" != 17 ]]; then
+      echo "Rollback changed the original failure status" >&2
+      exit 1
+    fi
+    if [[ "$expect_restore" == 1 ]]; then
+      grep -Fxq "rename ${previous} ${container}" "$log"
+      grep -Fxq "start ${container}" "$log"
+    else
+      if grep -Fq "start ${previous}" "$log"; then
+        echo "Rollback restarted the predecessor without verified gates" >&2
+        exit 1
+      fi
+      grep -Fxq "stop ${container}" "$log"
+      grep -Fxq "stop ${previous}" "$log"
+    fi
+  )
+}
+
+run_rollback_case 1 0 0 0
+run_rollback_case 0 1 0 0
+run_rollback_case 0 0 1 0
+run_rollback_case 0 0 0 1
+
+echo "article rollout failure-path tests passed"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "operator:monitor-public-site": "bun scripts/monitor-public-site.ts",
     "operator:preflight-outreach": "bun scripts/preflight-outreach.ts",
     "operator:preflight-platform-edge": "bun scripts/preflight-platform-edge.ts",
+    "operator:article-rollout": "bun scripts/article-rollout.ts",
     "workflow:migrate": "bun node_modules/@workflow/world-postgres/bin/setup.js",
     "postinstall": "bunx --bun prisma generate",
     "operator:import:servizo": "bun scripts/import-servizo.ts",

--- a/prisma/migrations/20260823110000_article_batch_admission_outcomes/migration.sql
+++ b/prisma/migrations/20260823110000_article_batch_admission_outcomes/migration.sql
@@ -1,0 +1,57 @@
+-- Atomically reserve article generation before model work and preserve every
+-- terminal outcome in the batch ledger.
+CREATE TYPE "ArticleBatchStatus" AS ENUM (
+    'QUEUED',
+    'RUNNING',
+    'SUCCEEDED',
+    'ZERO_OUTPUT',
+    'REJECTED',
+    'SKIPPED',
+    'FAILED'
+);
+
+ALTER TABLE "ArticleBatch"
+    RENAME COLUMN "producedCount" TO "acceptedCount";
+
+ALTER TABLE "ArticleBatch"
+    ALTER COLUMN "acceptedCount" SET DEFAULT 0;
+
+ALTER TABLE "ArticleBatch"
+    ADD COLUMN "rejectedCount" INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN "status" "ArticleBatchStatus" NOT NULL DEFAULT 'QUEUED',
+    ADD COLUMN "statusReason" TEXT,
+    ADD COLUMN "workflowRunId" TEXT,
+    ADD COLUMN "startedAt" TIMESTAMP(3),
+    ADD COLUMN "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- The workflow persisted only non-empty provider output. The manual live-proof
+-- script could persist an empty array, which the old schema represented as a
+-- zero requested/accepted row; retain that distinction during backfill.
+UPDATE "ArticleBatch"
+SET
+    "rejectedCount" = GREATEST("requestedCount" - "acceptedCount", 0),
+    "status" = CASE
+        WHEN "requestedCount" = 0 THEN 'ZERO_OUTPUT'::"ArticleBatchStatus"
+        WHEN "acceptedCount" > 0 THEN 'SUCCEEDED'::"ArticleBatchStatus"
+        ELSE 'REJECTED'::"ArticleBatchStatus"
+    END,
+    "statusReason" = CASE
+        WHEN "requestedCount" = 0 THEN 'LEGACY_ZERO_OUTPUT'
+        WHEN "acceptedCount" > 0 THEN NULL
+        ELSE 'ALL_DRAFTS_REJECTED'
+    END,
+    "startedAt" = "createdAt",
+    "updatedAt" = COALESCE("completedAt", "createdAt");
+
+ALTER TABLE "ArticleBatch"
+    ALTER COLUMN "updatedAt" DROP DEFAULT;
+
+CREATE UNIQUE INDEX "ArticleBatch_workflowRunId_key"
+    ON "ArticleBatch"("workflowRunId");
+
+CREATE INDEX "ArticleBatch_siteId_status_createdAt_idx"
+    ON "ArticleBatch"("siteId", "status", "createdAt");
+
+CREATE UNIQUE INDEX "ArticleBatch_one_active_per_site_key"
+    ON "ArticleBatch"("siteId")
+    WHERE "status" IN ('QUEUED', 'RUNNING');

--- a/prisma/migrations/20260823110000_article_batch_admission_outcomes/migration.sql
+++ b/prisma/migrations/20260823110000_article_batch_admission_outcomes/migration.sql
@@ -1,5 +1,7 @@
 -- Atomically reserve article generation before model work and preserve every
 -- terminal outcome in the batch ledger.
+BEGIN;
+
 CREATE TYPE "ArticleBatchStatus" AS ENUM (
     'QUEUED',
     'RUNNING',
@@ -11,40 +13,104 @@ CREATE TYPE "ArticleBatchStatus" AS ENUM (
 );
 
 ALTER TABLE "ArticleBatch"
-    RENAME COLUMN "producedCount" TO "acceptedCount";
-
-ALTER TABLE "ArticleBatch"
-    ALTER COLUMN "acceptedCount" SET DEFAULT 0;
+    ALTER COLUMN "producedCount" SET DEFAULT 0;
 
 ALTER TABLE "ArticleBatch"
     ADD COLUMN "rejectedCount" INTEGER NOT NULL DEFAULT 0,
     ADD COLUMN "status" "ArticleBatchStatus" NOT NULL DEFAULT 'QUEUED',
     ADD COLUMN "statusReason" TEXT,
     ADD COLUMN "workflowRunId" TEXT,
+    ADD COLUMN "dispatchLeaseToken" TEXT,
+    ADD COLUMN "dispatchLeaseUntil" TIMESTAMP(3),
     ADD COLUMN "startedAt" TIMESTAMP(3),
     ADD COLUMN "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- The candidate deploy opens this only after the predecessor worker is
+-- stopped, Workflow/Graphile are quiescent, and the new runtime is verified.
+-- A rollback to the predecessor intentionally leaves the value closed.
+INSERT INTO "OperatorSetting" (
+    "key",
+    "value",
+    "updatedBy",
+    "createdAt",
+    "updatedAt"
+)
+VALUES (
+    'articles.mutations.gated',
+    'true'::jsonb,
+    'migration:20260823110000_article_batch_admission_outcomes',
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP
+)
+ON CONFLICT ("key") DO UPDATE
+SET
+    "value" = 'true'::jsonb,
+    "updatedBy" = EXCLUDED."updatedBy",
+    "updatedAt" = CURRENT_TIMESTAMP;
 
 -- The workflow persisted only non-empty provider output. The manual live-proof
 -- script could persist an empty array, which the old schema represented as a
 -- zero requested/accepted row; retain that distinction during backfill.
 UPDATE "ArticleBatch"
 SET
-    "rejectedCount" = GREATEST("requestedCount" - "acceptedCount", 0),
+    "rejectedCount" = GREATEST("requestedCount" - "producedCount", 0),
     "status" = CASE
         WHEN "requestedCount" = 0 THEN 'ZERO_OUTPUT'::"ArticleBatchStatus"
-        WHEN "acceptedCount" > 0 THEN 'SUCCEEDED'::"ArticleBatchStatus"
+        WHEN "producedCount" > 0 THEN 'SUCCEEDED'::"ArticleBatchStatus"
         ELSE 'REJECTED'::"ArticleBatchStatus"
     END,
     "statusReason" = CASE
         WHEN "requestedCount" = 0 THEN 'LEGACY_ZERO_OUTPUT'
-        WHEN "acceptedCount" > 0 THEN NULL
+        WHEN "producedCount" > 0 THEN NULL
         ELSE 'ALL_DRAFTS_REJECTED'
     END,
     "startedAt" = "createdAt",
     "updatedAt" = COALESCE("completedAt", "createdAt");
 
-ALTER TABLE "ArticleBatch"
-    ALTER COLUMN "updatedAt" DROP DEFAULT;
+-- Expand compatibility for an old application container that writes the
+-- predecessor row shape during a rolling deploy. Its non-null completedAt is
+-- the unambiguous terminal marker; new reservations leave completedAt null.
+CREATE FUNCTION article_batch_expand_legacy_terminal()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NEW."completedAt" IS NOT NULL
+       AND NEW."status" = 'QUEUED'
+       AND NEW."startedAt" IS NULL THEN
+        NEW."rejectedCount" := GREATEST(
+            NEW."requestedCount" - NEW."producedCount",
+            0
+        );
+        NEW."status" := CASE
+            WHEN NEW."requestedCount" = 0 THEN 'ZERO_OUTPUT'::"ArticleBatchStatus"
+            WHEN NEW."producedCount" > 0 THEN 'SUCCEEDED'::"ArticleBatchStatus"
+            ELSE 'REJECTED'::"ArticleBatchStatus"
+        END;
+        NEW."statusReason" := CASE
+            WHEN NEW."requestedCount" = 0 THEN 'LEGACY_ZERO_OUTPUT'
+            WHEN NEW."producedCount" > 0 THEN NULL
+            ELSE 'ALL_DRAFTS_REJECTED'
+        END;
+        NEW."startedAt" := COALESCE(
+            NEW."createdAt",
+            NEW."completedAt",
+            CURRENT_TIMESTAMP
+        );
+        NEW."updatedAt" := COALESCE(
+            NEW."completedAt",
+            NEW."createdAt",
+            CURRENT_TIMESTAMP
+        );
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER "ArticleBatch_expand_legacy_terminal"
+BEFORE INSERT ON "ArticleBatch"
+FOR EACH ROW
+EXECUTE FUNCTION article_batch_expand_legacy_terminal();
 
 CREATE UNIQUE INDEX "ArticleBatch_workflowRunId_key"
     ON "ArticleBatch"("workflowRunId");
@@ -52,6 +118,16 @@ CREATE UNIQUE INDEX "ArticleBatch_workflowRunId_key"
 CREATE INDEX "ArticleBatch_siteId_status_createdAt_idx"
     ON "ArticleBatch"("siteId", "status", "createdAt");
 
+CREATE INDEX "ArticleBatch_dispatch_queue_idx"
+    ON "ArticleBatch"(
+        "status",
+        "workflowRunId",
+        "dispatchLeaseUntil",
+        "createdAt"
+    );
+
 CREATE UNIQUE INDEX "ArticleBatch_one_active_per_site_key"
     ON "ArticleBatch"("siteId")
     WHERE "status" IN ('QUEUED', 'RUNNING');
+
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -363,21 +363,23 @@ model Article {
 /// produced an article set and so dedupe checks can read "what did the last
 /// batch cover" without scanning every article ever generated.
 model ArticleBatch {
-  id             String             @id @default(cuid())
-  siteId         String
-  site           Site               @relation(fields: [siteId], references: [id], onDelete: Cascade)
-  requestedCount Int
-  acceptedCount  Int                @default(0)
-  rejectedCount  Int                @default(0)
-  status         ArticleBatchStatus @default(QUEUED)
-  statusReason   String?
-  model          String?
-  workflowRunId  String?            @unique
-  requestedBy    String
-  startedAt      DateTime?
-  completedAt    DateTime?
-  createdAt      DateTime           @default(now())
-  updatedAt      DateTime           @updatedAt
+  id                 String             @id @default(cuid())
+  siteId             String
+  site               Site               @relation(fields: [siteId], references: [id], onDelete: Cascade)
+  requestedCount     Int
+  acceptedCount      Int                @default(0) @map("producedCount")
+  rejectedCount      Int                @default(0)
+  status             ArticleBatchStatus @default(QUEUED)
+  statusReason       String?
+  model              String?
+  workflowRunId      String?            @unique
+  dispatchLeaseToken String?
+  dispatchLeaseUntil DateTime?
+  requestedBy        String
+  startedAt          DateTime?
+  completedAt        DateTime?
+  createdAt          DateTime           @default(now())
+  updatedAt          DateTime           @default(now()) @updatedAt
 
   articles Article[]
   /// Backed by a partial unique index in
@@ -386,6 +388,7 @@ model ArticleBatch {
 
   @@index([siteId, createdAt])
   @@index([siteId, status, createdAt])
+  @@index([status, workflowRunId, dispatchLeaseUntil, createdAt], map: "ArticleBatch_dispatch_queue_idx")
 }
 
 model PhotoAsset {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,6 +49,16 @@ enum ArticleStatus {
   PUBLISHED
 }
 
+enum ArticleBatchStatus {
+  QUEUED
+  RUNNING
+  SUCCEEDED
+  ZERO_OUTPUT
+  REJECTED
+  SKIPPED
+  FAILED
+}
+
 enum IntegrationType {
   BOOKING
   ORDERING
@@ -321,28 +331,28 @@ model Site {
 /// so content stays specific; nothing here may assert a fact the site does
 /// not carry. Published articles render on the customer's live surfaces.
 model Article {
-  id                String        @id @default(cuid())
-  siteId            String
-  site              Site          @relation(fields: [siteId], references: [id], onDelete: Cascade)
-  batchId           String?
-  batch             ArticleBatch? @relation(fields: [batchId], references: [id], onDelete: SetNull)
-  slug              String
-  locale            String
-  title             String
-  excerpt           String
-  bodyMarkdown      String
-  status            ArticleStatus @default(DRAFT)
-  publishedAt       DateTime?
-  publishedBy       String?
+  id               String        @id @default(cuid())
+  siteId           String
+  site             Site          @relation(fields: [siteId], references: [id], onDelete: Cascade)
+  batchId          String?
+  batch            ArticleBatch? @relation(fields: [batchId], references: [id], onDelete: SetNull)
+  slug             String
+  locale           String
+  title            String
+  excerpt          String
+  bodyMarkdown     String
+  status           ArticleStatus @default(DRAFT)
+  publishedAt      DateTime?
+  publishedBy      String?
   /// Stable key naming which topic slot this fills (e.g. `seasonal-menu`),
   /// used to avoid repeating topics across consecutive batches per site.
-  topicKey          String
-  topicTitle        String
-  generatedByModel  String?
-  sourceBatchId     String?
-  unpublishReason   String?
-  createdAt         DateTime      @default(now())
-  updatedAt         DateTime      @updatedAt
+  topicKey         String
+  topicTitle       String
+  generatedByModel String?
+  sourceBatchId    String?
+  unpublishReason  String?
+  createdAt        DateTime      @default(now())
+  updatedAt        DateTime      @updatedAt
 
   @@unique([siteId, slug])
   @@index([siteId, status, publishedAt])
@@ -353,19 +363,29 @@ model Article {
 /// produced an article set and so dedupe checks can read "what did the last
 /// batch cover" without scanning every article ever generated.
 model ArticleBatch {
-  id             String   @id @default(cuid())
+  id             String             @id @default(cuid())
   siteId         String
-  site           Site     @relation(fields: [siteId], references: [id], onDelete: Cascade)
+  site           Site               @relation(fields: [siteId], references: [id], onDelete: Cascade)
   requestedCount Int
-  producedCount  Int
+  acceptedCount  Int                @default(0)
+  rejectedCount  Int                @default(0)
+  status         ArticleBatchStatus @default(QUEUED)
+  statusReason   String?
   model          String?
+  workflowRunId  String?            @unique
   requestedBy    String
+  startedAt      DateTime?
   completedAt    DateTime?
-  createdAt       DateTime @default(now())
+  createdAt      DateTime           @default(now())
+  updatedAt      DateTime           @updatedAt
 
   articles Article[]
+  /// Backed by a partial unique index in
+  /// 20260823110000_article_batch_admission_outcomes so every site has at most
+  /// one QUEUED or RUNNING batch.
 
   @@index([siteId, createdAt])
+  @@index([siteId, status, createdAt])
 }
 
 model PhotoAsset {

--- a/scripts/article-rollout.ts
+++ b/scripts/article-rollout.ts
@@ -1,0 +1,241 @@
+import { Client } from "pg";
+import { reconcileBoundArticleBatches } from "../src/lib/articles/start-batch";
+import {
+  ARTICLE_MUTATION_GATE_KEY,
+} from "../src/lib/articles/mutation-gate";
+import {
+  isArticleBatchQueueIdentifier,
+  isArticleBatchWorkflowName,
+} from "../src/lib/articles/workflow-state";
+import { getDb } from "../src/lib/db";
+
+type Action = "close" | "check" | "open";
+
+const action = parseAction(process.argv.slice(2));
+
+try {
+  if (action === "close" || action === "open") {
+    await setGate(action === "close");
+    console.log(
+      JSON.stringify({
+        command: "article-rollout",
+        action,
+        gateClosed: action === "close",
+      }),
+    );
+  } else {
+    const result = await checkQuiescence();
+    console.log(
+      JSON.stringify(
+        { command: "article-rollout", action, ...result },
+        null,
+        2,
+      ),
+    );
+    if (!result.ready) process.exitCode = 1;
+  }
+} catch (error) {
+  console.error(
+    JSON.stringify({
+      command: "article-rollout",
+      action,
+      ready: false,
+      error: error instanceof Error ? error.message : "unknown",
+    }),
+  );
+  process.exitCode = 1;
+}
+
+async function setGate(closed: boolean): Promise<void> {
+  const databaseUrl = requiredEnvironment("DATABASE_URL");
+  const client = new Client({
+    connectionString: databaseUrl,
+    application_name: "cornershopdev-article-rollout-gate",
+    connectionTimeoutMillis: 5_000,
+    statement_timeout: 10_000,
+  });
+  await client.connect();
+  try {
+    await client.query("BEGIN");
+    const result = await client.query(
+      `INSERT INTO "OperatorSetting" (
+         "key", "value", "updatedBy", "createdAt", "updatedAt"
+       ) VALUES ($1, $2::jsonb, $3, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+       ON CONFLICT ("key") DO UPDATE
+       SET "value" = EXCLUDED."value",
+           "updatedBy" = EXCLUDED."updatedBy",
+           "updatedAt" = CURRENT_TIMESTAMP
+       RETURNING "value"`,
+      [
+        ARTICLE_MUTATION_GATE_KEY,
+        JSON.stringify(closed),
+        `deploy:article-rollout:${closed ? "close" : "open"}`,
+      ],
+    );
+    if (result.rows[0]?.value !== closed) {
+      throw new Error("article mutation gate did not persist the requested state");
+    }
+    await client.query("COMMIT");
+  } catch (error) {
+    await client.query("ROLLBACK").catch(() => undefined);
+    throw error;
+  } finally {
+    await client.end().catch(() => undefined);
+  }
+}
+
+async function checkQuiescence(): Promise<{
+  ready: boolean;
+  gateClosed: boolean;
+  reconciliation: Awaited<ReturnType<typeof reconcileBoundArticleBatches>>;
+  activeWorkflowRuns: Array<{
+    runId: string;
+    status: "pending" | "running";
+    workflowName: string;
+  }>;
+  articleGraphileJobs: Array<{ id: string; identifier: string }>;
+  remainingBoundBatches: number;
+}> {
+  const workflowClient = new Client({
+    connectionString: requiredEnvironment("WORKFLOW_POSTGRES_URL"),
+    application_name: "cornershopdev-article-rollout-quiescence",
+    connectionTimeoutMillis: 5_000,
+    statement_timeout: 10_000,
+  });
+  await workflowClient.connect();
+  try {
+    // This operator is a read-only quiescence probe over Workflow's durable
+    // materialized state. Direct reads avoid starting a Workflow worker in the
+    // one-shot deploy container while preserving the runtime's exact identity
+    // and terminal-state reconciliation rules.
+    const reconciliation = await reconcileBoundArticleBatches(async (runId) => {
+      const result = await workflowClient.query<{
+        status: string;
+        workflowName: string;
+      }>(
+        `SELECT "status"::text, "name" AS "workflowName"
+         FROM "workflow"."workflow_runs"
+         WHERE "id" = $1`,
+        [runId],
+      );
+      const run = result.rows[0];
+      if (!run) throw new Error(`Workflow run not found: ${runId}`);
+      return {
+        status: workflowStatus(run.status),
+        workflowName: run.workflowName,
+      };
+    });
+    const activeWorkflowRuns = (
+      await workflowClient.query<{
+        runId: string;
+        status: "pending" | "running";
+        workflowName: string;
+      }>(`
+        SELECT "id" AS "runId", "status"::text, "name" AS "workflowName"
+        FROM "workflow"."workflow_runs"
+        WHERE "status" IN ('pending', 'running')
+      `)
+    ).rows
+      .filter((run) => isArticleBatchWorkflowName(run.workflowName))
+      .map((run) => ({
+        runId: run.runId,
+        status: run.status,
+        workflowName: run.workflowName,
+      }));
+    const [gate, remainingBoundBatches, articleGraphileJobs] =
+      await Promise.all([
+        getDb().operatorSetting.findUnique({
+          where: { key: ARTICLE_MUTATION_GATE_KEY },
+          select: { value: true },
+        }),
+        getDb().articleBatch.count({
+          where: {
+            status: { in: ["QUEUED", "RUNNING"] },
+            workflowRunId: { not: null },
+          },
+        }),
+        findArticleGraphileJobs(workflowClient),
+      ]);
+    const gateClosed = gate?.value === true;
+    return {
+      ready:
+        gateClosed &&
+        activeWorkflowRuns.length === 0 &&
+        articleGraphileJobs.length === 0 &&
+        remainingBoundBatches === 0,
+      gateClosed,
+      reconciliation,
+      activeWorkflowRuns,
+      articleGraphileJobs,
+      remainingBoundBatches,
+    };
+  } finally {
+    await workflowClient.end().catch(() => undefined);
+    await getDb().$disconnect();
+  }
+}
+
+async function findArticleGraphileJobs(client: Client): Promise<
+  Array<{ id: string; identifier: string }>
+> {
+  const jobPrefix = requiredEnvironment("WORKFLOW_POSTGRES_JOB_PREFIX");
+  if (!/^[a-z][a-z0-9_]{0,62}_$/.test(jobPrefix)) {
+    throw new Error("WORKFLOW_POSTGRES_JOB_PREFIX is not a bounded SQL-safe prefix");
+  }
+  const result = await client.query<{
+    id: string;
+    payload: unknown;
+  }>(
+    `SELECT jobs."id"::text, jobs."payload"
+     FROM "graphile_worker"."_private_jobs" AS jobs
+     INNER JOIN "graphile_worker"."_private_tasks" AS tasks
+       ON tasks."id" = jobs."task_id"
+     WHERE tasks."identifier" = ANY($1::text[])`,
+    [[`${jobPrefix}flows`, `${jobPrefix}steps`]],
+  );
+  return result.rows.flatMap((row) => {
+    const identifier = graphilePayloadIdentifier(row.payload);
+    return identifier && isArticleBatchQueueIdentifier(identifier)
+      ? [{ id: row.id, identifier }]
+      : [];
+  });
+}
+
+function graphilePayloadIdentifier(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object" || !("id" in payload)) {
+    return null;
+  }
+  return typeof payload.id === "string" ? payload.id : null;
+}
+
+function requiredEnvironment(key: string): string {
+  const value = process.env[key];
+  if (!value) throw new Error(`${key} is required`);
+  return value;
+}
+
+function workflowStatus(
+  value: string,
+): "pending" | "running" | "completed" | "failed" | "cancelled" {
+  if (
+    value === "pending" ||
+    value === "running" ||
+    value === "completed" ||
+    value === "failed" ||
+    value === "cancelled"
+  ) {
+    return value;
+  }
+  throw new Error(`Unsupported Workflow status: ${value}`);
+}
+
+function parseAction(args: string[]): Action {
+  if (
+    args.length !== 2 ||
+    args[0] !== "--action" ||
+    !["close", "check", "open"].includes(args[1] ?? "")
+  ) {
+    throw new Error("Use --action close, --action check, or --action open.");
+  }
+  return args[1] as Action;
+}

--- a/scripts/live-article-batch.ts
+++ b/scripts/live-article-batch.ts
@@ -11,7 +11,7 @@ async function main() {
   const { getDb } = await import("../src/lib/db");
   const {
     loadGenerationInputs,
-    generateBatchDrafts,
+    generateBatchPlans,
     persistArticleBatch,
     articleGenerationConfigured,
     beginArticleBatch,
@@ -20,7 +20,7 @@ async function main() {
   const { reserveArticleBatch } = await import(
     "../src/lib/articles/start-batch"
   );
-  const { checkArticleDraft } = await import(
+  const { checkArticlePlan, renderArticlePlan } = await import(
     "../src/lib/articles/composer"
   );
 
@@ -129,6 +129,7 @@ async function main() {
   });
   if (!admission.ok) throw new Error(admission.reason);
 
+  let knownRejectedCount = 0;
   try {
     const reservation = await beginArticleBatch(admission.batchId);
     if (!reservation) {
@@ -136,11 +137,12 @@ async function main() {
     }
     console.log("calling the model…");
     const started = Date.now();
-    const generated = await generateBatchDrafts({
+    const generated = await generateBatchPlans({
       facts: inputs.facts,
       recentTopicKeys: inputs.recentTopicKeys,
       count: reservation.requestedCount,
     });
+    knownRejectedCount = generated.rejectedCount;
     if (generated.status === "SKIPPED") {
       await closeArticleBatch({
         batchId: admission.batchId,
@@ -150,9 +152,9 @@ async function main() {
       throw new Error("No supportable article topics were available");
     }
     console.log(
-      `model returned ${generated.drafts.length} drafts in ${Date.now() - started}ms`,
+      `model returned ${generated.plans.length} plans in ${Date.now() - started}ms`,
     );
-    if (!generated.drafts.length) {
+    if (!generated.plans.length) {
       await closeArticleBatch({
         batchId: admission.batchId,
         status: generated.rejectedCount > 0 ? "REJECTED" : "ZERO_OUTPUT",
@@ -162,24 +164,24 @@ async function main() {
             : "MODEL_RETURNED_ZERO_DRAFTS",
         rejectedCount: generated.rejectedCount,
       });
-      throw new Error("The model returned no persistable article drafts");
+      throw new Error("The model returned no persistable article plans");
     }
 
-    for (const draft of generated.drafts) {
-      const problems = checkArticleDraft(draft, inputs.facts);
+    for (const plan of generated.plans) {
+      const problems = checkArticlePlan(plan, inputs.facts);
+      const rendered = renderArticlePlan(plan, inputs.facts);
       console.log(
-        `  [${draft.topicKey}] "${draft.title}" (${draft.bodyMarkdown.length} chars) → ${
+        `  [${plan.topicKey}] ${plan.templateKey} → ${
           problems.length ? `REJECTED: ${problems.join("; ")}` : "accepted"
-        }`,
+        }${rendered.ok ? `; preview title "${rendered.draft.title}"` : ""}`,
       );
     }
 
     const persisted = await persistArticleBatch({
       batchId: admission.batchId,
       siteId: site.id,
-      facts: inputs.facts,
       model: process.env.OPENROUTER_TEXT_MODEL ?? "openrouter/auto",
-      drafts: generated.drafts,
+      plans: generated.plans,
       rejectedCount: generated.rejectedCount,
     });
 
@@ -191,6 +193,7 @@ async function main() {
       batchId: admission.batchId,
       status: "FAILED",
       statusReason: "LIVE_SCRIPT_FAILED",
+      rejectedCount: knownRejectedCount,
     });
     throw error;
   }

--- a/scripts/live-article-batch.ts
+++ b/scripts/live-article-batch.ts
@@ -14,7 +14,12 @@ async function main() {
     generateBatchDrafts,
     persistArticleBatch,
     articleGenerationConfigured,
+    beginArticleBatch,
+    closeArticleBatch,
   } = await import("../src/lib/articles/generation");
+  const { reserveArticleBatch } = await import(
+    "../src/lib/articles/start-batch"
+  );
   const { checkArticleDraft } = await import(
     "../src/lib/articles/composer"
   );
@@ -114,38 +119,81 @@ async function main() {
   const inputs = await loadGenerationInputs(site.id);
   if (!inputs.ok) throw new Error(inputs.reason);
   console.log(
-    `facts: ${inputs.facts.catalogItemNames.length} items, locale ${inputs.facts.locale}, recent topics: [${inputs.recentTopicKeys}]`,
+    `facts: ${inputs.facts.catalogItems.length} items, locale ${inputs.facts.locale}, recent topics: [${inputs.recentTopicKeys}]`,
   );
 
-  console.log("calling the model…");
-  const started = Date.now();
-  const drafts = await generateBatchDrafts({
-    facts: inputs.facts,
-    recentTopicKeys: inputs.recentTopicKeys,
-    count: 4,
-  });
-  console.log(`model returned ${drafts.length} drafts in ${Date.now() - started}ms`);
-
-  for (const draft of drafts) {
-    const problems = checkArticleDraft(draft, inputs.facts);
-    console.log(
-      `  [${draft.topicKey}] "${draft.title}" (${draft.bodyMarkdown.length} chars) → ${
-        problems.length ? `REJECTED: ${problems.join("; ")}` : "accepted"
-      }`,
-    );
-  }
-
-  const persisted = await persistArticleBatch({
+  const admission = await reserveArticleBatch({
     siteId: site.id,
     requestedBy: "live-proof-script",
-    facts: inputs.facts,
-    model: process.env.OPENROUTER_TEXT_MODEL ?? "openrouter/auto",
-    drafts,
+    count: 4,
   });
+  if (!admission.ok) throw new Error(admission.reason);
 
-  console.log(
-    `\nbatch ${persisted.batchId}: requested ${drafts.length}, persisted ${persisted.producedCount}`,
-  );
+  try {
+    const reservation = await beginArticleBatch(admission.batchId);
+    if (!reservation) {
+      throw new Error("article batch reservation could not start");
+    }
+    console.log("calling the model…");
+    const started = Date.now();
+    const generated = await generateBatchDrafts({
+      facts: inputs.facts,
+      recentTopicKeys: inputs.recentTopicKeys,
+      count: reservation.requestedCount,
+    });
+    if (generated.status === "SKIPPED") {
+      await closeArticleBatch({
+        batchId: admission.batchId,
+        status: "SKIPPED",
+        statusReason: generated.statusReason,
+      });
+      throw new Error("No supportable article topics were available");
+    }
+    console.log(
+      `model returned ${generated.drafts.length} drafts in ${Date.now() - started}ms`,
+    );
+    if (!generated.drafts.length) {
+      await closeArticleBatch({
+        batchId: admission.batchId,
+        status: generated.rejectedCount > 0 ? "REJECTED" : "ZERO_OUTPUT",
+        statusReason:
+          generated.rejectedCount > 0
+            ? "INVALID_MODEL_OUTPUT"
+            : "MODEL_RETURNED_ZERO_DRAFTS",
+        rejectedCount: generated.rejectedCount,
+      });
+      throw new Error("The model returned no persistable article drafts");
+    }
+
+    for (const draft of generated.drafts) {
+      const problems = checkArticleDraft(draft, inputs.facts);
+      console.log(
+        `  [${draft.topicKey}] "${draft.title}" (${draft.bodyMarkdown.length} chars) → ${
+          problems.length ? `REJECTED: ${problems.join("; ")}` : "accepted"
+        }`,
+      );
+    }
+
+    const persisted = await persistArticleBatch({
+      batchId: admission.batchId,
+      siteId: site.id,
+      facts: inputs.facts,
+      model: process.env.OPENROUTER_TEXT_MODEL ?? "openrouter/auto",
+      drafts: generated.drafts,
+      rejectedCount: generated.rejectedCount,
+    });
+
+    console.log(
+      `\nbatch ${persisted.batchId}: requested ${reservation.requestedCount}, persisted ${persisted.producedCount}, rejected ${persisted.rejectedCount}`,
+    );
+  } catch (error) {
+    await closeArticleBatch({
+      batchId: admission.batchId,
+      status: "FAILED",
+      statusReason: "LIVE_SCRIPT_FAILED",
+    });
+    throw error;
+  }
   await db.$disconnect?.();
 }
 

--- a/src/app/api/sites/[slug]/articles/generate/route.ts
+++ b/src/app/api/sites/[slug]/articles/generate/route.ts
@@ -5,6 +5,10 @@ import {
 } from "@/lib/authorization";
 import { isSameOriginMutation } from "@/lib/request-origin";
 import { startArticleBatch } from "@/lib/articles/start-batch";
+import {
+  ARTICLE_MUTATION_GATE_REASON,
+  areArticleMutationsGated,
+} from "@/lib/articles/mutation-gate";
 
 const generateSchema = z.object({
   count: z.number().int().min(1).max(8).default(4),
@@ -20,6 +24,12 @@ export async function POST(
   const { slug } = await params;
   const access = await getSiteAccess(slug);
   if (!access.ok) return accessFailureResponse(access);
+  if (await areArticleMutationsGated()) {
+    return Response.json(
+      { error: ARTICLE_MUTATION_GATE_REASON },
+      { status: 503 },
+    );
+  }
 
   const parsed = generateSchema.safeParse(
     await request.json().catch(() => null),

--- a/src/app/api/sites/[slug]/articles/route.ts
+++ b/src/app/api/sites/[slug]/articles/route.ts
@@ -5,6 +5,10 @@ import {
   getSiteAccess,
 } from "@/lib/authorization";
 import { articleCacheTagFor } from "@/lib/articles/public-articles";
+import {
+  ARTICLE_MUTATION_GATE_REASON,
+  areArticleMutationsGated,
+} from "@/lib/articles/mutation-gate";
 import { getDb } from "@/lib/db";
 import { isSameOriginMutation } from "@/lib/request-origin";
 import { revalidateTag } from "next/cache";
@@ -53,6 +57,12 @@ export async function POST(
   const { slug } = await params;
   const access = await getSiteAccess(slug);
   if (!access.ok) return accessFailureResponse(access);
+  if (await areArticleMutationsGated()) {
+    return Response.json(
+      { error: ARTICLE_MUTATION_GATE_REASON },
+      { status: 503 },
+    );
+  }
 
   const parsed = actionSchema.safeParse(
     await request.json().catch(() => null),

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -25,6 +25,11 @@ export async function register() {
     process.env.DATABASE_URL &&
     process.env.WORKFLOW_ENABLED === "true"
   ) {
+    const { startArticleBatchDispatcher } = await import(
+      "@/lib/articles/article-batch-runtime"
+    );
+    startArticleBatchDispatcher();
+
     const { startSourceMonitoringScheduler } = await import(
       "@/lib/source-monitoring-runtime"
     );

--- a/src/lib/articles/article-batch-runtime.ts
+++ b/src/lib/articles/article-batch-runtime.ts
@@ -1,0 +1,57 @@
+import "server-only";
+import {
+  dispatchQueuedArticleBatches,
+  reconcileBoundArticleBatches,
+} from "@/lib/articles/start-batch";
+
+const ARTICLE_BATCH_DISPATCH_INTERVAL_MS = 60_000;
+const MAX_INITIAL_JITTER_MS = 30_000;
+
+type ArticleBatchSchedulerGlobal = typeof globalThis & {
+  __cornershopArticleBatchDispatcherStarted?: boolean;
+};
+
+/**
+ * Keeps durable QUEUED article batches moving independently of the request that
+ * admitted them. Database leases inside the dispatcher fence concurrent server
+ * instances; this process guard only prevents duplicate timers in one instance.
+ */
+export function startArticleBatchDispatcher(): void {
+  const schedulerGlobal = globalThis as ArticleBatchSchedulerGlobal;
+  if (schedulerGlobal.__cornershopArticleBatchDispatcherStarted) return;
+  schedulerGlobal.__cornershopArticleBatchDispatcherStarted = true;
+
+  let running = false;
+  const run = () => {
+    if (running) return;
+    running = true;
+    void reconcileBoundArticleBatches()
+      .then(async (reconciliation) => ({
+        reconciliation,
+        dispatch: await dispatchQueuedArticleBatches(),
+      }))
+      .then((result) => {
+        if (
+          result.reconciliation.inspected > 0 ||
+          result.dispatch.attempted > 0
+        ) {
+          console.log("[article-batches] runtime pass complete", result);
+        }
+      })
+      .catch((error) => {
+        console.error("[article-batches] dispatch failed", {
+          error: error instanceof Error ? error.message : "unknown",
+        });
+      })
+      .finally(() => {
+        running = false;
+      });
+  };
+
+  const initial = setTimeout(() => {
+    run();
+    const interval = setInterval(run, ARTICLE_BATCH_DISPATCH_INTERVAL_MS);
+    interval.unref();
+  }, Math.floor(Math.random() * MAX_INITIAL_JITTER_MS));
+  initial.unref();
+}

--- a/src/lib/articles/article-json-ld.test.tsx
+++ b/src/lib/articles/article-json-ld.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ArticleStructuredData } from "@/lib/articles/article-json-ld";
+
+describe("public article JSON-LD", () => {
+  it("renders untrusted fields without allowing a script breakout", () => {
+    const title = "</script><script>alert(1)</script>";
+    const excerpt = "before\u2028middle\u2029after";
+    const publishedAt = new Date("2026-08-23T12:34:56.000Z");
+
+    const markup = renderToStaticMarkup(
+      <ArticleStructuredData
+        article={{ title, excerpt, publishedAt, locale: "en" }}
+      />,
+    );
+    const script = markup.match(
+      /^<script type="application\/ld\+json">([\s\S]*)<\/script>$/,
+    );
+    const payload = script?.[1];
+
+    expect(payload).toBeDefined();
+    if (payload === undefined) throw new Error("Missing JSON-LD payload");
+    expect(markup.match(/<script/g)).toHaveLength(1);
+    expect(payload).not.toContain("<");
+    expect(payload).not.toContain("\u2028");
+    expect(payload).not.toContain("\u2029");
+    expect(JSON.parse(payload)).toEqual({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      headline: title,
+      description: excerpt,
+      datePublished: publishedAt.toISOString(),
+      dateModified: publishedAt.toISOString(),
+      inLanguage: "en",
+    });
+  });
+});

--- a/src/lib/articles/article-json-ld.tsx
+++ b/src/lib/articles/article-json-ld.tsx
@@ -1,0 +1,30 @@
+import type { PublishedArticle } from "@/lib/articles/public-articles";
+import { serializeJsonLd } from "@/lib/json-ld";
+
+type ArticleJsonLdSource = Pick<
+  PublishedArticle,
+  "title" | "excerpt" | "publishedAt" | "locale"
+>;
+
+export function ArticleStructuredData({
+  article,
+}: {
+  article: ArticleJsonLdSource;
+}) {
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: article.title,
+    description: article.excerpt,
+    datePublished: article.publishedAt.toISOString(),
+    dateModified: article.publishedAt.toISOString(),
+    inLanguage: article.locale,
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: serializeJsonLd(jsonLd) }}
+    />
+  );
+}

--- a/src/lib/articles/article-rollout-deployment.test.ts
+++ b/src/lib/articles/article-rollout-deployment.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+
+const repoRoot = new URL("../../..", import.meta.url);
+const [deployScript, entrypoint, migration, generateRoute, articleRoute] =
+  await Promise.all(
+    [
+      "deploy/aws/deploy.sh",
+      "deploy/aws/container-entrypoint.sh",
+      "prisma/migrations/20260823110000_article_batch_admission_outcomes/migration.sql",
+      "src/app/api/sites/[slug]/articles/generate/route.ts",
+      "src/app/api/sites/[slug]/articles/route.ts",
+    ].map((path) => Bun.file(new URL(path, repoRoot)).text()),
+  );
+
+function assertOrdered(markers: string[]) {
+  let cursor = -1;
+  for (const marker of markers) {
+    const next = deployScript.indexOf(marker, cursor + 1);
+    expect(next).toBeGreaterThan(cursor);
+    cursor = next;
+  }
+}
+
+describe("article blue-green rollout contract", () => {
+  it("gates both mutation routes on API and custom-domain ingress", () => {
+    expect(deployScript).toContain(
+      '$0 == "api.cornershop.dev {" || $0 == "https:// {"',
+    );
+    expect(deployScript).toContain(
+      "path /api/sites/*/articles /api/sites/*/articles/generate",
+    );
+    expect(deployScript).toContain(
+      'for origin in "https://api.cornershop.dev" "https://cornershop.dev"',
+    );
+    expect(generateRoute).toContain("areArticleMutationsGated");
+    expect(articleRoute).toContain("areArticleMutationsGated");
+  });
+
+  it("keeps the expand migration gated and transactionally compatible", () => {
+    const executable = migration.replace(/^--.*$/gm, "").trim();
+    expect(executable.startsWith("BEGIN;")).toBe(true);
+    expect(executable.endsWith("COMMIT;")).toBe(true);
+    expect(migration).toContain("'articles.mutations.gated'");
+    expect(migration).toContain("'true'::jsonb");
+    expect(migration).not.toContain('RENAME COLUMN "producedCount"');
+  });
+
+  it("drains before stopping the old worker and rechecks before candidate start", () => {
+    assertOrdered([
+      "set_article_edge_gate closed",
+      "run_article_rollout close",
+      "run db:migrate:deploy",
+      "wait_for_article_quiescence",
+      'docker stop "$container"',
+      "run_article_rollout check",
+      "run workflow:migrate",
+      '--env CORNERSHOP_SKIP_STARTUP_MIGRATIONS=true',
+      'wait_for_health "$candidate"',
+      "operator:article-rollout --action check",
+      'docker rename "$candidate" "$container"',
+      "operator:article-rollout --action open",
+      "set_article_edge_gate open",
+      "verify_article_edge_gate open",
+    ]);
+    expect(entrypoint).toContain("CORNERSHOP_SKIP_STARTUP_MIGRATIONS");
+  });
+
+  it("keeps an incompatible rollback closed at both layers", () => {
+    const rollback = deployScript.match(
+      /rollback_article_rollout\(\) \{([\s\S]*?)\n\}/,
+    )?.[1];
+    expect(rollback).toBeDefined();
+    expect(rollback).toContain("set_article_edge_gate closed");
+    expect(rollback).toContain("run_article_rollout close");
+    expect(rollback).toContain('docker rename "$previous" "$container"');
+    expect(rollback).not.toContain("set_article_edge_gate open");
+    expect(rollback).not.toContain("run_article_rollout open");
+  });
+});

--- a/src/lib/articles/article-rollout-deployment.test.ts
+++ b/src/lib/articles/article-rollout-deployment.test.ts
@@ -12,6 +12,13 @@ const [deployScript, entrypoint, migration, generateRoute, articleRoute] =
     ].map((path) => Bun.file(new URL(path, repoRoot)).text()),
   );
 
+const rolloutHarness = Bun.spawnSync({
+  cmd: ["bash", "deploy/aws/test-article-rollout.sh"],
+  cwd: repoRoot.pathname,
+  stdout: "pipe",
+  stderr: "pipe",
+});
+
 function assertOrdered(markers: string[]) {
   let cursor = -1;
   for (const marker of markers) {
@@ -22,6 +29,14 @@ function assertOrdered(markers: string[]) {
 }
 
 describe("article blue-green rollout contract", () => {
+  it("preserves a closed gate through bootstrap and proves rollback failures", () => {
+    expect(new TextDecoder().decode(rolloutHarness.stderr)).toBe("");
+    expect(rolloutHarness.exitCode).toBe(0);
+    expect(new TextDecoder().decode(rolloutHarness.stdout)).toContain(
+      "article rollout failure-path tests passed",
+    );
+  });
+
   it("gates both mutation routes on API and custom-domain ingress", () => {
     expect(deployScript).toContain(
       '$0 == "api.cornershop.dev {" || $0 == "https:// {"',
@@ -71,7 +86,9 @@ describe("article blue-green rollout contract", () => {
     )?.[1];
     expect(rollback).toBeDefined();
     expect(rollback).toContain("set_article_edge_gate closed");
+    expect(rollback).toContain("verify_article_edge_gate closed");
     expect(rollback).toContain("run_article_rollout close");
+    expect(rollback).toContain("leaving application containers stopped");
     expect(rollback).toContain('docker rename "$previous" "$container"');
     expect(rollback).not.toContain("set_article_edge_gate open");
     expect(rollback).not.toContain("run_article_rollout open");

--- a/src/lib/articles/composer.test.ts
+++ b/src/lib/articles/composer.test.ts
@@ -1,11 +1,22 @@
 import { describe, expect, it } from "bun:test";
 import {
+  ARTICLE_BODY_MAX_CHARS,
+  ARTICLE_BODY_MIN_CHARS,
+  ARTICLE_PLAN_CONTRACT_VERSION,
   articleFingerprint,
-  checkArticleDraft,
+  checkArticlePlan,
+  checkRenderedArticleDraft,
+  generatedArticlePlanSchema,
+  renderArticlePlan,
   selectBatchTopics,
+  type GeneratedArticlePlan,
 } from "@/lib/articles/composer";
 import type { SiteFacts } from "@/lib/articles/site-facts";
 import { availableFacts } from "@/lib/articles/site-facts";
+import { articleTopicPlansFor } from "@/lib/articles/topic-plans";
+import { formatPrice } from "@/lib/site-draft";
+import { supportedCurrencySchema } from "@/lib/verticals/schema";
+import type { VerticalId } from "@/lib/verticals/types";
 
 const facts: SiteFacts = {
   slug: "le-petit-meunier",
@@ -16,10 +27,23 @@ const facts: SiteFacts = {
   phone: "+33 1 42 00 00 00",
   businessHours: [{ days: "Tue–Sat", hours: "12:00–22:00" }],
   catalogItems: [
-    { name: "Croissant", price: 4.5, currency: "EUR" },
-    { name: "Pain au chocolat", price: null, currency: "EUR" },
+    { id: "catalog-croissant", name: "Croissant", price: 4.5, currency: "EUR" },
+    {
+      id: "catalog-pain-chocolat",
+      name: "Pain au chocolat",
+      price: null,
+      currency: "EUR",
+    },
   ],
-  integrationLabels: ["Book a table"],
+  integrationCapabilities: ["BOOKING"],
+};
+
+const catalogPlan: GeneratedArticlePlan = {
+  contractVersion: ARTICLE_PLAN_CONTRACT_VERSION,
+  topicKey: "seasonal-menu",
+  templateKey: "restaurant-current-menu",
+  catalogItemId: "catalog-croissant",
+  priceMode: "exact",
 };
 
 describe("availableFacts", () => {
@@ -29,7 +53,7 @@ describe("availableFacts", () => {
     expect(available.has("address")).toBe(true);
     expect(available.has("businessHours")).toBe(true);
     expect(available.has("phone")).toBe(true);
-    expect(available.has("integrations")).toBe(true);
+    expect(facts.integrationCapabilities).toEqual(["BOOKING"]);
   });
 
   it("withholds facts that are blank strings or empty arrays", () => {
@@ -38,7 +62,7 @@ describe("availableFacts", () => {
       address: "   ",
       businessHours: [],
       catalogItems: [],
-      integrationLabels: [],
+      integrationCapabilities: [],
       phone: null,
     });
     expect([...sparse]).toEqual([]);
@@ -46,32 +70,32 @@ describe("availableFacts", () => {
 });
 
 describe("selectBatchTopics", () => {
-  const plans = [
+  const plans: Parameters<typeof selectBatchTopics>[0]["plans"] = [
     { key: "seasonal-menu", requiredFacts: ["catalogItems"] },
     { key: "neighbourhood-guide", requiredFacts: ["address"] },
-    { key: "private-events", requiredFacts: ["phone", "integrations"] },
+    {
+      key: "private-events",
+      requiredFacts: ["phone"],
+      requiredAnyIntegrationCapabilities: ["BOOKING", "CONTACT"],
+    },
     { key: "first-visit", requiredFacts: ["businessHours", "address"] },
   ];
 
   it("never selects a topic whose required facts are missing", () => {
     const selected = selectBatchTopics({
-      facts: { ...facts, phone: null, integrationLabels: [] },
+      facts: { ...facts, phone: null, integrationCapabilities: [] },
       plans,
       count: 4,
       recentTopicKeys: [],
     });
-
     expect(selected.map((topic) => topic.key)).not.toContain("private-events");
   });
 
-  it("caps the batch size", () => {
-    const selected = selectBatchTopics({
-      facts,
-      plans,
-      count: 99,
-      recentTopicKeys: [],
-    });
-    expect(selected.length).toBeLessThanOrEqual(8);
+  it("caps the batch size and remains deterministic", () => {
+    const run = () =>
+      selectBatchTopics({ facts, plans, count: 99, recentTopicKeys: [] });
+    expect(run()).toEqual(run());
+    expect(run().length).toBeLessThanOrEqual(8);
   });
 
   it("avoids topics covered by recent batches when alternatives exist", () => {
@@ -87,14 +111,12 @@ describe("selectBatchTopics", () => {
       count: 2,
       recentTopicKeys: first.map((topic) => topic.key),
     });
-
-    const overlap = second.filter((topic) =>
-      first.some((entry) => entry.key === topic.key),
-    );
-    expect(overlap.length).toBe(0);
+    expect(
+      second.filter((topic) => first.some((entry) => entry.key === topic.key)),
+    ).toEqual([]);
   });
 
-  it("returns an empty selection when no topic is supportable", () => {
+  it("returns no topics when no required fact is present", () => {
     expect(
       selectBatchTopics({
         facts: {
@@ -103,7 +125,7 @@ describe("selectBatchTopics", () => {
           address: null,
           businessHours: [],
           phone: null,
-          integrationLabels: [],
+          integrationCapabilities: [],
         },
         plans,
         count: 4,
@@ -111,460 +133,664 @@ describe("selectBatchTopics", () => {
       }),
     ).toEqual([]);
   });
+});
 
-  it("is deterministic for the same site and inputs", () => {
-    const run = () =>
-      selectBatchTopics({ facts, plans, count: 3, recentTopicKeys: [] }).map(
-        (topic) => topic.key,
-      );
-    expect(run()).toEqual(run());
+describe("generatedArticlePlanSchema", () => {
+  it("exposes only the closed non-prose model contract", () => {
+    const parsed = generatedArticlePlanSchema.parse(catalogPlan);
+    expect(Object.keys(parsed).sort()).toEqual(
+      [
+        "catalogItemId",
+        "contractVersion",
+        "priceMode",
+        "templateKey",
+        "topicKey",
+      ].sort(),
+    );
+  });
+
+  it("strictly rejects every renderable or monetary extra field", () => {
+    const extras: Record<string, unknown> = {
+      title: "Moonbeam",
+      excerpt: "Tart is baked every morning",
+      bodyMarkdown: "Moonbeam **Tart** costs €**95**.",
+      text: "Try our moonbeam tart today.",
+      name: "Moonbeam Tart",
+      price: 95,
+      amount: "９５",
+      currency: "EUR",
+      range: { from: 4.5, to: 9.5 },
+      qualifier: "starts at",
+      unit: "per person",
+    };
+
+    for (const [field, value] of Object.entries(extras)) {
+      expect(
+        generatedArticlePlanSchema.safeParse({
+          ...catalogPlan,
+          [field]: value,
+        }).success,
+      ).toBe(false);
+    }
+  });
+
+  it("cannot launder assertions across public fields or markup/entities", () => {
+    for (const fields of [
+      { title: "Moonbeam", excerpt: "Tart is baked every morning" },
+      { title: "A Croissant costs €", excerpt: "95" },
+      { bodyMarkdown: "[Moonbeam **Tart**](javascript:x) is baked." },
+      { bodyMarkdown: "Croissant costs &amp;euro;95 or EUR&amp;nbsp;95." },
+    ]) {
+      expect(
+        generatedArticlePlanSchema.safeParse({ ...catalogPlan, ...fields })
+          .success,
+      ).toBe(false);
+    }
+  });
+
+  it("structurally rejects every previously reported prose bypass", () => {
+    const forbiddenProse = [
+      "Try our moonbeam tart today.",
+      "Moonbeam **Tart** is baked each morning.",
+      "[Moonbeam Tart](javascript:x) is baked each morning.",
+      "Moonbeam [Tart](javascript:x) is baked each morning.",
+      "A Croissant costs €**95**.",
+      "A Croissant costs &amp;euro;95.",
+      "A Croissant costs EUR&amp;nbsp;95.",
+      "A Croissant costs €\n95.",
+      "Try our\nmoonbeam tart today.",
+      "Moonbeam tart\nis delicious today.",
+      "A Croissant costs €９５.",
+      "A Croissant costs ＥＵＲ ９５.",
+      "A Croissant costs €\u206095.",
+      "A Croissant costs €\u200b95.",
+      "A Croissant costs €\u200e95.",
+      "A Croissant costs from €4.50.",
+      "A Croissant starts at €4.50.",
+      "A Croissant costs €4.50+.",
+      "A Croissant costs up to €4.50.",
+      "A Croissant costs between €4.50 and more.",
+      "Un croissant coûte à partir de 4,50 €.",
+      "Un croissant coûte entre 4,50 € et 9,50 €.",
+      "Le fromage coûte 4,50 €/kg.",
+      "Ein Croissant kostet ab €4,50.",
+      "Cena wynosi 4,50 zł/kg.",
+      "価格は1000円/個です。",
+    ];
+
+    for (const bodyMarkdown of forbiddenProse) {
+      expect(
+        generatedArticlePlanSchema.safeParse({
+          ...catalogPlan,
+          bodyMarkdown,
+        }).success,
+      ).toBe(false);
+      expect(
+        generatedArticlePlanSchema.safeParse({
+          ...catalogPlan,
+          text: bodyMarkdown,
+        }).success,
+      ).toBe(false);
+    }
+  });
+
+  it("uniformly rejects free prose that heuristic detectors used to misclassify", () => {
+    const validButNonRenderableProse = [
+      "Our dough for each Croissant is prepared every morning.",
+      "The butter inside our Croissant is folded carefully.",
+      "The kitchen is available for private events.",
+      "Morning service is prepared with care.",
+      "Our approach makes Every Visit feel easy.",
+    ];
+
+    for (const text of validButNonRenderableProse) {
+      expect(
+        generatedArticlePlanSchema.safeParse({ ...catalogPlan, text }).success,
+      ).toBe(false);
+    }
+  });
+
+  it("rejects unknown enum members and contract versions", () => {
+    for (const patch of [
+      { contractVersion: 2 },
+      { topicKey: "invented-topic" },
+      { templateKey: "free-prose" },
+      { priceMode: "from" },
+    ]) {
+      expect(
+        generatedArticlePlanSchema.safeParse({ ...catalogPlan, ...patch })
+          .success,
+      ).toBe(false);
+    }
   });
 });
 
-describe("checkArticleDraft", () => {
-  const base = {
-    topicKey: "seasonal-menu",
-    slug: "what-s-in-season",
-    title: "What's in season on our menu right now",
-    excerpt: "A look at this month's bakes.",
-    bodyMarkdown:
-      "Our croissant lamination uses butter from the same two dairies all year. ".repeat(
-        10,
-      ),
-    catalogClaims: [{ name: "Croissant", price: null, currency: null }],
-  };
-
-  it("accepts a factual draft", () => {
-    expect(checkArticleDraft(base, facts)).toEqual([]);
-  });
-
-  it("rejects award claims", () => {
+describe("article plan validation", () => {
+  it("requires the topic/template pair registered for the site vertical", () => {
     expect(
-      checkArticleDraft(
-        { ...base, bodyMarkdown: `${base.bodyMarkdown} We are award-winning.` },
-        facts,
-      ).some((problem) => problem.startsWith("forbidden claim")),
-    ).toBe(true);
-  });
-
-  it("rejects fabricated rankings and certifications", () => {
-    for (const claim of [
-      "Voted the best bakery in Paris.",
-      "We are certified organic.",
-      "Rated #1 by locals.",
-    ]) {
-      expect(
-        checkArticleDraft(
-          { ...base, bodyMarkdown: `${base.bodyMarkdown} ${claim}` },
-          facts,
-        ).some((problem) => problem.startsWith("forbidden claim")),
-      ).toBe(true);
-    }
-  });
-
-  it("accepts a structured catalog name and supported price claim", () => {
-    expect(
-      checkArticleDraft(
-        {
-          ...base,
-          bodyMarkdown: `${base.bodyMarkdown} A Croissant costs €4.50.`,
-          catalogClaims: [
-            { name: "Croissant", price: 4.5, currency: "EUR" },
-          ],
-        },
+      checkArticlePlan(
+        { ...catalogPlan, templateKey: "restaurant-menu-facts" },
         facts,
       ),
-    ).toEqual([]);
+    ).toContain('template is not allowed for topic: "restaurant-menu-facts"');
     expect(
-      checkArticleDraft(
+      checkArticlePlan(
         {
-          ...base,
-          bodyMarkdown: `${base.bodyMarkdown} A Croissant costs 4,50\u00a0€.`,
-          catalogClaims: [
-            { name: "Croissant", price: 4.5, currency: "EUR" },
-          ],
+          ...catalogPlan,
+          topicKey: "seasonal-stock",
+          templateKey: "retail-current-stock",
         },
         facts,
-      ),
-    ).toEqual([]);
+      )[0],
+    ).toContain("topic is not available for vertical");
   });
 
-  it("rejects an unknown structured catalog item claim", () => {
-    expect(
-      checkArticleDraft(
-        {
-          ...base,
-          bodyMarkdown: `${base.bodyMarkdown} The Moonbeam Tart is folded by hand.`,
-          catalogClaims: [
-            ...base.catalogClaims,
-            { name: "Moonbeam Tart", price: null, currency: null },
-          ],
-        },
-        facts,
-      ).some((problem) => problem.includes("unknown catalog item")),
-    ).toBe(true);
-  });
-
-  it("rejects high-confidence unknown prose even beside a valid claim", () => {
-    for (const unknownAssertion of [
-      "Moonbeam Tart is folded by hand.",
-      "Croissant Supreme is baked each morning.",
-      "Éclair Doré is prepared each afternoon.",
-      "Éclair is prepared each afternoon.",
-      "Moonbeam tart is folded by hand.",
-      "We prepare Moonbeam Tart each morning.",
-      "Croissant supreme is baked each morning.",
-      "Croissant-Supreme is baked each morning.",
-    ]) {
-      expect(
-        checkArticleDraft(
-          {
-            ...base,
-            topicKey: "first-visit",
-            bodyMarkdown: `${base.bodyMarkdown} ${unknownAssertion}`,
-          },
-          facts,
-        ).some((problem) => problem.includes("unknown catalog item mention")),
-      ).toBe(true);
-    }
-  });
-
-  it("does not mistake the verified business name for a catalog item", () => {
-    expect(
-      checkArticleDraft(
-        {
-          ...base,
-          bodyMarkdown: `${base.bodyMarkdown} Le Petit Meunier is available for private bookings.`,
-        },
-        facts,
-      ),
-    ).toEqual([]);
-  });
-
-  it("accepts only fully declared coordinated catalog mentions", () => {
-    expect(
-      checkArticleDraft(
-        {
-          ...base,
-          bodyMarkdown: `${base.bodyMarkdown} Croissant and Pain au chocolat are served each morning.`,
-          catalogClaims: [
-            ...base.catalogClaims,
-            { name: "Pain au chocolat", price: null, currency: null },
-          ],
-        },
-        facts,
-      ),
-    ).toEqual([]);
-    expect(
-      checkArticleDraft(
-        {
-          ...base,
-          bodyMarkdown: `${base.bodyMarkdown} Croissant and Moonbeam tart are served each morning.`,
-        },
-        facts,
-      ).some((problem) => problem.includes("unknown catalog item mention")),
-    ).toBe(true);
-  });
-
-  it("rejects catalog-dependent prose that omits its structured claims", () => {
-    expect(
-      checkArticleDraft(
-        {
-          ...base,
-          bodyMarkdown: "The invented Moonbeam Tart is folded by hand. ".repeat(15),
-          catalogClaims: [],
-        },
-        facts,
-      ).some((problem) => problem.includes("catalog-dependent topic")),
-    ).toBe(true);
-  });
-
-  it("rejects a canonical catalog mention omitted from structured claims", () => {
-    expect(
-      checkArticleDraft({ ...base, catalogClaims: [] }, facts).some((problem) =>
-        problem.includes("lacks a structured claim"),
-      ),
-    ).toBe(true);
-  });
-
-  it("rejects claims whose declared catalog item is absent from prose", () => {
-    expect(
-      checkArticleDraft(
-        {
-          ...base,
-          catalogClaims: [
-            ...base.catalogClaims,
-            { name: "Pain au chocolat", price: null, currency: null },
-          ],
-        },
-        facts,
-      ).some((problem) => problem.includes("absent from article")),
-    ).toBe(true);
-  });
-
-  it("rejects unsupported, wrong-currency, and unpriced catalog claims", () => {
-    const adversarialClaims = [
-      { name: "Croissant", price: 95, currency: "EUR" },
-      { name: "Croissant", price: 4.5, currency: "USD" },
-      { name: "Pain au chocolat", price: 4.5, currency: "EUR" },
+  it("requires exact, unique catalog-id membership without normalization", () => {
+    const insertedControls = ["\u200b", "\u200e", "\u2060", "\u202e", "\ufeff"];
+    const canonical = "catalog-croissant";
+    const variants = [
+      canonical.toUpperCase(),
+      "ｃａｔａｌｏｇ－ｃｒｏｉｓｓａｎｔ",
+      "catalοg-croissant",
+      ...insertedControls.flatMap((control) => [
+        `${control}${canonical}`,
+        `${canonical.slice(0, 7)}${control}${canonical.slice(7)}`,
+        `${canonical}${control}`,
+      ]),
     ];
-    const prose = [
-      "A Croissant costs €95.",
-      "A Croissant costs USD 4.50.",
-      "A Pain au chocolat costs €4.50.",
-    ];
-    for (const [index, claim] of adversarialClaims.entries()) {
+
+    for (const catalogItemId of variants) {
       expect(
-        checkArticleDraft(
-          {
-            ...base,
-            bodyMarkdown: `${base.bodyMarkdown} ${prose[index]}`,
-            catalogClaims: [claim],
-          },
-          facts,
-        ).some((problem) => problem.includes("catalog price")),
-      ).toBe(true);
-    }
-  });
-
-  it("rejects raw price assertions without matching structured backing", () => {
-    expect(
-      checkArticleDraft(
-        {
-          ...base,
-          bodyMarkdown: `${base.bodyMarkdown} A Croissant costs 4.50 euros.`,
-          catalogClaims: base.catalogClaims,
-        },
-        facts,
-      ).some((problem) => problem.includes("price")),
-    ).toBe(true);
-  });
-
-  it("does not let a valid price claim back a different item", () => {
-    expect(
-      checkArticleDraft(
-        {
-          ...base,
-          bodyMarkdown: `${base.bodyMarkdown} A Pain au chocolat costs €4.50.`,
-          catalogClaims: [
-            { name: "Croissant", price: 4.5, currency: "EUR" },
-            { name: "Pain au chocolat", price: null, currency: null },
-          ],
-        },
-        facts,
-      ).some((problem) => problem.includes("price assertion")),
-    ).toBe(true);
-  });
-
-  it("does not let same-sentence co-occurrence launder another item's price", () => {
-    expect(
-      checkArticleDraft(
-        {
-          ...base,
-          bodyMarkdown: `${base.bodyMarkdown} Croissant remains available while Pain au chocolat costs €4.50.`,
-          catalogClaims: [
-            { name: "Croissant", price: 4.5, currency: "EUR" },
-            { name: "Pain au chocolat", price: null, currency: null },
-          ],
-        },
-        facts,
-      ).some((problem) => problem.includes("price assertion")),
-    ).toBe(true);
-  });
-
-  it("does not let undeclared unknown items launder a known item's price", () => {
-    for (const prose of [
-      "Croissant remains available while Éclair costs €4.50.",
-      "Croissant remains available while Moonbeam tart costs €4.50.",
-      "Croissant remains available while Croissant-Supreme costs €4.50.",
-    ]) {
-      expect(
-        checkArticleDraft(
-          {
-            ...base,
-            bodyMarkdown: `${base.bodyMarkdown} ${prose}`,
-            catalogClaims: [
-              { name: "Croissant", price: 4.5, currency: "EUR" },
-            ],
-          },
-          facts,
-        ).length,
-      ).toBeGreaterThan(0);
-    }
-  });
-
-  it("recognizes every supported catalog currency in raw prose", () => {
-    for (const currency of ["JPY", "SEK", "NOK", "DKK", "PLN"]) {
-      const pricedFacts: SiteFacts = {
-        ...facts,
-        catalogItems: [{ name: "Matcha", price: 1_000, currency }],
-      };
-      expect(
-        checkArticleDraft(
-          {
-            ...base,
-            bodyMarkdown:
-              "Our Matcha is prepared consistently each morning. ".repeat(10) +
-              `Matcha costs ${currency} 1200.`,
-            catalogClaims: [
-              { name: "Matcha", price: 1_000, currency },
-            ],
-          },
-          pricedFacts,
-        ).some((problem) => problem.includes("price assertion")),
-      ).toBe(true);
-    }
-  });
-
-  it("recognizes supported native currency symbols in raw prose", () => {
-    const nativePrices = [
-      ["JPY", "¥1200", "¥1000"],
-      ["SEK", "1200 kr", "1000 kr"],
-      ["NOK", "1200 kr", "1000 kr"],
-      ["DKK", "1200 kr", "1000 kr"],
-      ["PLN", "1200 zł", "1000 zł"],
-    ] as const;
-    for (const [currency, wrongPrice, factualPrice] of nativePrices) {
-      const pricedFacts: SiteFacts = {
-        ...facts,
-        catalogItems: [{ name: "Matcha", price: 1_000, currency }],
-      };
-      const draft = {
-        ...base,
-        catalogClaims: [{ name: "Matcha", price: 1_000, currency }],
-      };
-      expect(
-        checkArticleDraft(
-          {
-            ...draft,
-            bodyMarkdown:
-              "Our Matcha is prepared consistently each morning. ".repeat(10) +
-              `Matcha costs ${wrongPrice}.`,
-          },
-          pricedFacts,
-        ).some((problem) => problem.includes("price assertion")),
-      ).toBe(true);
-      expect(
-        checkArticleDraft(
-          {
-            ...draft,
-            bodyMarkdown:
-              "Our Matcha is prepared consistently each morning. ".repeat(10) +
-              `Matcha costs ${factualPrice}.`,
-          },
-          pricedFacts,
+        checkArticlePlan({ ...catalogPlan, catalogItemId }, facts).some(
+          (problem) => problem.includes("unknown catalog item id"),
         ),
-      ).toEqual([]);
+      ).toBe(true);
     }
   });
 
-  it("rejects an ambiguous kr symbol", () => {
-    const ambiguousFacts: SiteFacts = {
+  it("treats canonically equivalent Unicode IDs as distinct identifiers", () => {
+    const composedId = "café";
+    const unicodeFacts: SiteFacts = {
       ...facts,
-      catalogItems: [
-        { name: "Matcha", price: 1_000, currency: "SEK" },
-        { name: "Cardamom Bun", price: 1_000, currency: "NOK" },
-      ],
+      catalogItems: [{ ...facts.catalogItems[0]!, id: composedId }],
     };
     expect(
-      checkArticleDraft(
-        {
-          ...base,
-          bodyMarkdown:
-            "Our Matcha is prepared consistently each morning. ".repeat(10) +
-            "Matcha costs 1000 kr.",
-          catalogClaims: [
-            { name: "Matcha", price: 1_000, currency: "SEK" },
-          ],
-        },
-        ambiguousFacts,
-      ).some((problem) => problem.includes("price assertion")),
+      checkArticlePlan(
+        { ...catalogPlan, catalogItemId: composedId.normalize("NFD") },
+        unicodeFacts,
+      ).some((problem) => problem.includes("unknown catalog item id")),
     ).toBe(true);
+    expect(
+      checkArticlePlan({ ...catalogPlan, catalogItemId: composedId }, unicodeFacts),
+    ).toEqual([]);
   });
 
-  it("rejects partially parsed monetary ranges across dash forms", () => {
-    for (const separator of ["-", "‐", "‑", "‒", "–", "—", "−", "/", "~"]) {
+  it("rejects duplicate factual IDs instead of picking one price", () => {
+    const duplicateFacts: SiteFacts = {
+      ...facts,
+      catalogItems: [
+        facts.catalogItems[0]!,
+        { ...facts.catalogItems[0]!, price: 95 },
+      ],
+    };
+    expect(checkArticlePlan(catalogPlan, duplicateFacts)).toContain(
+      'catalog item id is ambiguous: "catalog-croissant"',
+    );
+  });
+
+  it("binds exact price mode to a finite same-item canonical price", () => {
+    expect(
+      checkArticlePlan(
+        {
+          ...catalogPlan,
+          catalogItemId: "catalog-pain-chocolat",
+          priceMode: "exact",
+        },
+        facts,
+      ),
+    ).toContain("exact price mode requires a canonical catalog price");
+
+    for (const price of [Number.NaN, Number.POSITIVE_INFINITY, -1]) {
       expect(
-        checkArticleDraft(
-          {
-            ...base,
-            bodyMarkdown: `${base.bodyMarkdown} A Croissant costs €4.50${separator}95.`,
-            catalogClaims: [
-              { name: "Croissant", price: 4.5, currency: "EUR" },
-            ],
-          },
-          facts,
-        ).some((problem) => problem.includes("price assertion")),
-      ).toBe(true);
+        checkArticlePlan(catalogPlan, {
+          ...facts,
+          catalogItems: [{ ...facts.catalogItems[0]!, price }],
+        }),
+      ).toContain("selected catalog item has an invalid canonical price");
     }
   });
 
-  it("accepts a supported price before its same-sentence item name", () => {
+  it("keeps every public draft field independent of arbitrary catalog names", () => {
+    const directRepros = [
+      "",
+      "   \t  ",
+      "Croissant €95",
+      "Croissant ninety-five euros",
+      "Croissant E.U.R. 95",
+      "Croissant E U R 95",
+      "Croissant USD 95-125",
+      "Croissant €**95**",
+      "Croissant &amp;euro;95",
+      "Croissant &amp;amp;amp;euro;95",
+      "Croissant EUR&amp;nbsp;95",
+      "Croissant €９５",
+      "Croissant ＥＵＲ ９５",
+      "Croissant €\u206095",
+      "Croissant €\u200b95",
+      "Croissant €\u200e95",
+      "Croissant €\n95",
+      "Croissant from €4.50",
+      "Croissant starts at €4.50",
+      "Croissant €4.50+",
+      "Croissant up to €4.50",
+      "Croissant between €4.50 and more",
+      "Croissant EUR from 95",
+      "Croissant € up to 95",
+      "Croissant 95 per person EUR",
+      "Croissant à partir de 4,50 €",
+      "Croissant entre 4,50 € et 9,50 €",
+      "Fromage 4,50 €/kg",
+      "Croissant ab €4,50",
+      "Ser 4,50 zł/kg",
+      "商品1000円/個",
+      "Croissant €٩٥",
+      "Croissant EUR ۹۵",
+      "Croissant ₹95",
+      "Croissant ₽95",
+      "Croissant ₩95",
+      "Croissant RUB 95",
+      "Croissant INR 95",
+      "Croissant CNY 95",
+      "Croissant €\u00ad95",
+      "Croissant €\u034f95",
+      "</script><script>alert(1)</script>",
+      "Moonbeam\nTart €95",
+      "A".repeat(500),
+    ];
+    const arbitraryNames = [...directRepros, ...deterministicCatalogNameFuzz()];
+    const baselines = {
+      exact: renderArticlePlan(catalogPlan, facts),
+      omit: renderArticlePlan({ ...catalogPlan, priceMode: "omit" }, facts),
+    };
+    expect(baselines.exact.ok).toBe(true);
+    expect(baselines.omit.ok).toBe(true);
+
+    for (const name of arbitraryNames) {
+      const renamedFacts: SiteFacts = {
+        ...facts,
+        catalogItems: [{ ...facts.catalogItems[0]!, name }],
+      };
+      for (const priceMode of ["omit", "exact"] as const) {
+        const baseline = baselines[priceMode];
+        const result = renderArticlePlan(
+          { ...catalogPlan, priceMode },
+          renamedFacts,
+        );
+        expect(result.ok).toBe(true);
+        if (!result.ok || !baseline.ok) continue;
+        expect(result.draft).toEqual(baseline.draft);
+        if (directRepros.includes(name) && name.trim().length > 4) {
+          expect(Object.values(result.draft).join("\n")).not.toContain(name);
+        }
+      }
+    }
+  });
+
+  it("retains legitimate canonical names with non-price numerals", () => {
+    for (const name of [
+      "Studio 54",
+      "Treatment 2.0",
+      "Room 101",
+      "商品９５号",
+      "7-Eleven",
+      "Version ٢",
+      "B12 Serum",
+      "Route 66",
+      "Kraft 54",
+      "No. 7",
+      "BMW 3",
+    ]) {
+      const numberedFacts: SiteFacts = {
+        ...facts,
+        catalogItems: [{ ...facts.catalogItems[0]!, name }],
+      };
+      const omitted = renderArticlePlan(
+        { ...catalogPlan, priceMode: "omit" },
+        numberedFacts,
+      );
+      const exact = renderArticlePlan(catalogPlan, numberedFacts);
+      expect(omitted.ok).toBe(true);
+      expect(exact.ok).toBe(true);
+      if (!omitted.ok || !exact.ok) continue;
+      expect(Object.values(omitted.draft).join("\n")).not.toContain(name);
+      expect(Object.values(exact.draft).join("\n")).not.toContain(name);
+    }
+  });
+
+  it("forbids catalog IDs and price modes on non-catalog topics", () => {
+    const locationPlan = {
+      contractVersion: ARTICLE_PLAN_CONTRACT_VERSION,
+      topicKey: "neighbourhood-guide",
+      templateKey: "restaurant-location",
+      catalogItemId: "catalog-croissant",
+      priceMode: "exact",
+    };
+    const problems = checkArticlePlan(locationPlan, facts);
+    expect(problems).toContain("non-catalog topic must not select a catalog item");
+    expect(problems).toContain("non-catalog topic must omit catalog prices");
+  });
+
+  it("rejects a topic when its required structured fact is absent", () => {
     expect(
-      checkArticleDraft(
+      checkArticlePlan(
         {
-          ...base,
-          bodyMarkdown: `${base.bodyMarkdown} For €4.50, choose a Croissant.`,
-          catalogClaims: [
-            { name: "Croissant", price: 4.5, currency: "EUR" },
+          contractVersion: ARTICLE_PLAN_CONTRACT_VERSION,
+          topicKey: "neighbourhood-guide",
+          templateKey: "restaurant-location",
+          catalogItemId: null,
+          priceMode: "omit",
+        },
+        { ...facts, address: null },
+      ),
+    ).toContain('required fact is unavailable: "address"');
+  });
+});
+
+describe("deterministic article rendering", () => {
+  it("takes only the canonical same-item price and derives the slug", () => {
+    const sameNameFacts: SiteFacts = {
+      ...facts,
+      locale: "en",
+      catalogItems: [
+        { id: "first", name: "House Special", price: 4.5, currency: "EUR" },
+        { id: "second", name: "House Special", price: 8.25, currency: "EUR" },
+      ],
+    };
+    const result = renderArticlePlan(
+      { ...catalogPlan, catalogItemId: "second" },
+      sameNameFacts,
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const expectedPrice = formatPrice(8.25, "EUR", "en");
+    const otherPrice = formatPrice(4.5, "EUR", "en");
+    const publicText = Object.values(result.draft).join("\n");
+    expect(result.draft.slug).toBe("seasonal-menu");
+    expect(publicText).not.toContain("House Special");
+    expect(result.draft.bodyMarkdown).toContain(expectedPrice);
+    expect(publicText.split(expectedPrice).length - 1).toBe(1);
+    expect(publicText).not.toContain(otherPrice);
+  });
+
+  it("keeps catalog topic guidance distinct with the same selected fact", () => {
+    const catalogTopics = articleTopicPlansFor("RESTAURANT").filter(
+      (topic) => topic.catalogItem === "required",
+    );
+
+    for (const priceMode of ["omit", "exact"] as const) {
+      const topicCopy = catalogTopics.map((topic) => {
+        const result = renderArticlePlan(
+          {
+            contractVersion: ARTICLE_PLAN_CONTRACT_VERSION,
+            topicKey: topic.key,
+            templateKey: topic.templateKey,
+            catalogItemId: "catalog-croissant",
+            priceMode,
+          },
+          facts,
+        );
+        expect(result.ok).toBe(true);
+        if (!result.ok) return "";
+        return `${result.draft.title}\n${result.draft.excerpt}`;
+      });
+
+      expect(new Set(topicCopy).size).toBe(catalogTopics.length);
+    }
+  });
+
+  it("keeps canonical Unicode and Markdown-shaped names out of every public field", () => {
+    const names = [
+      "Moonbeam **Tart**",
+      "[Croissant](/menu/€95)",
+      "Crème brûlée",
+      "寿司",
+      "كعكة 🍰",
+      "ＥＵＲ ９５",
+      "Pain &amp; beurre",
+    ];
+
+    for (const name of names) {
+      const unicodeFacts: SiteFacts = {
+        ...facts,
+        locale: "en",
+        catalogItems: [
+          {
+            id: "unicode-item",
+            name,
+            price: null,
+            currency: "EUR",
+          },
+        ],
+      };
+      const before = JSON.stringify(unicodeFacts);
+      const result = renderArticlePlan(
+        {
+          ...catalogPlan,
+          catalogItemId: "unicode-item",
+          priceMode: "omit",
+        },
+        unicodeFacts,
+      );
+      expect(result.ok).toBe(true);
+      if (!result.ok) continue;
+      expect(Object.values(result.draft).join("\n")).not.toContain(name);
+      expect(JSON.stringify(unicodeFacts)).toBe(before);
+    }
+  });
+
+  it("omits prices unless the closed plan requests the canonical exact value", () => {
+    const exact = renderArticlePlan(catalogPlan, facts);
+    const omitted = renderArticlePlan({ ...catalogPlan, priceMode: "omit" }, facts);
+    expect(exact.ok).toBe(true);
+    expect(omitted.ok).toBe(true);
+    if (!exact.ok || !omitted.ok) return;
+    const price = formatPrice(4.5, "EUR", facts.locale);
+    expect(exact.draft.bodyMarkdown).toContain(price);
+    expect(Object.values(exact.draft).join("\n").split(price).length - 1).toBe(1);
+    expect(omitted.draft.excerpt).not.toContain(price);
+    expect(omitted.draft.bodyMarkdown).not.toContain(price);
+  });
+
+  it("keeps omit-price drafts independent of canonical price and currency", () => {
+    const base = renderArticlePlan({ ...catalogPlan, priceMode: "omit" }, facts);
+    expect(base.ok).toBe(true);
+    if (!base.ok) return;
+    expect(Object.values(base.draft).join("\n")).not.toContain("Croissant");
+
+    for (const [price, currency] of [
+      [null, "EUR"],
+      [0, "USD"],
+      [95, "JPY"],
+      [Number.NaN, "unsupported"],
+      [-1, "EUR"],
+      [Number.POSITIVE_INFINITY, "RUB"],
+    ] as const) {
+      const changed = renderArticlePlan(
+        { ...catalogPlan, priceMode: "omit" },
+        {
+          ...facts,
+          catalogItems: [
+            { ...facts.catalogItems[0]!, price, currency },
           ],
         },
-        facts,
-      ),
-    ).toEqual([]);
+      );
+      expect(changed.ok).toBe(true);
+      if (!changed.ok) continue;
+      expect(changed.draft).toEqual(base.draft);
+    }
   });
 
-  it("rejects an ambiguous or unsupported dollar symbol", () => {
-    expect(
-      checkArticleDraft(
+  it("renders every supported currency from the canonical fact", () => {
+    for (const currency of supportedCurrencySchema.options) {
+      const currencyFacts: SiteFacts = {
+        ...facts,
+        vertical: "FOOD_RETAIL",
+        locale: "en",
+        catalogItems: [
+          { id: `item-${currency}`, name: "Matcha", price: 1_000.25, currency },
+        ],
+      };
+      const result = renderArticlePlan(
         {
-          ...base,
-          bodyMarkdown: `${base.bodyMarkdown} A Croissant costs $4.50.`,
-          catalogClaims: [
-            { name: "Croissant", price: 4.5, currency: "EUR" },
+          contractVersion: ARTICLE_PLAN_CONTRACT_VERSION,
+          topicKey: "seasonal-stock",
+          templateKey: "retail-current-stock",
+          catalogItemId: `item-${currency}`,
+          priceMode: "exact",
+        },
+        currencyFacts,
+      );
+      expect(result.ok).toBe(true);
+      if (!result.ok) continue;
+      const formatted = formatPrice(1_000.25, currency, "en");
+      expect(result.draft.bodyMarkdown).toContain(formatted);
+      expect(
+        Object.values(result.draft).join("\n").split(formatted).length - 1,
+      ).toBe(1);
+      expect(Object.values(result.draft).join("\n")).not.toContain("Matcha");
+    }
+  });
+
+  it("renders every registered topic/template in English and French", () => {
+    const verticals: VerticalId[] = [
+      "RESTAURANT",
+      "BEAUTY",
+      "LOCAL_SERVICE",
+      "FOOD_RETAIL",
+    ];
+
+    for (const vertical of verticals) {
+      for (const locale of ["en", "fr"] as const) {
+        const templateFacts: SiteFacts = {
+          ...facts,
+          vertical,
+          locale,
+          integrationCapabilities: [
+            "BOOKING",
+            "ORDERING",
+            "DELIVERY",
+            "QUOTE",
+            "CONTACT",
           ],
-        },
-        facts,
-      ).some((problem) => problem.includes("price assertion")),
-    ).toBe(true);
+          catalogItems: [
+            {
+              id: "template-catalog-item",
+              name: "Unique ⟦Canonical⟧ Name",
+              price: 12.5,
+              currency: "EUR",
+            },
+          ],
+        };
+
+        for (const topic of articleTopicPlansFor(vertical)) {
+          const priceModes =
+            topic.catalogItem === "required"
+              ? (["omit", "exact"] as const)
+              : (["omit"] as const);
+          for (const priceMode of priceModes) {
+            const plan: GeneratedArticlePlan = {
+              contractVersion: ARTICLE_PLAN_CONTRACT_VERSION,
+              topicKey: topic.key,
+              templateKey: topic.templateKey,
+              catalogItemId:
+                topic.catalogItem === "required"
+                  ? "template-catalog-item"
+                  : null,
+              priceMode,
+            };
+            const result = renderArticlePlan(plan, templateFacts);
+            expect(result.ok).toBe(true);
+            if (!result.ok) continue;
+            expect(result.draft.topicKey).toBe(topic.key);
+            expect(result.draft.slug).toBe(topic.key);
+            expect(result.draft.title.trim().length).toBeGreaterThan(0);
+            expect(result.draft.excerpt.trim().length).toBeGreaterThan(0);
+            expect(result.draft.bodyMarkdown.length).toBeGreaterThanOrEqual(
+              ARTICLE_BODY_MIN_CHARS,
+            );
+            expect(result.draft.bodyMarkdown.length).toBeLessThanOrEqual(
+              ARTICLE_BODY_MAX_CHARS,
+            );
+            expect(
+              result.draft.bodyMarkdown.match(/^#{1,3}\s/gm)?.length ?? 0,
+            ).toBeLessThanOrEqual(2);
+            expect(result.draft.bodyMarkdown).not.toContain(
+              "template-catalog-item",
+            );
+            if (topic.catalogItem === "required") {
+              const publicText = Object.values(result.draft).join("\n");
+              const canonicalName = "Unique ⟦Canonical⟧ Name";
+              const formattedPrice = formatPrice(12.5, "EUR", locale);
+              if (priceMode === "exact") {
+                expect(publicText).not.toContain(canonicalName);
+                expect(publicText.split(formattedPrice).length - 1).toBe(1);
+                expect(result.draft.bodyMarkdown).toContain(formattedPrice);
+              } else {
+                expect(publicText).not.toContain(canonicalName);
+                expect(publicText).not.toContain(formattedPrice);
+              }
+            }
+            expect(checkRenderedArticleDraft(result.draft)).toEqual([]);
+          }
+        }
+      }
+    }
+  });
+});
+
+describe("rendered article compatibility", () => {
+  it("retains the existing bounded string shape", () => {
+    const rendered = {
+      topicKey: "seasonal-menu",
+      slug: "seasonal-menu",
+      title: "A factual title",
+      excerpt: "A factual excerpt",
+      bodyMarkdown: "A".repeat(ARTICLE_BODY_MIN_CHARS),
+    };
+    expect(checkRenderedArticleDraft(rendered)).toEqual([]);
+    expect(
+      checkRenderedArticleDraft({ ...rendered, slug: "Not A Slug" }),
+    ).toContain('slug is not a URL-safe kebab-case label: "Not A Slug"');
   });
 
-  it("does not treat ordinary non-currency numbers as price claims", () => {
-    expect(
-      checkArticleDraft(
-        {
-          ...base,
-          bodyMarkdown: `${base.bodyMarkdown} The method has stayed consistent since 2018.`,
-        },
-        facts,
-      ),
-    ).toEqual([]);
-  });
+  it("fails closed when any final rendered field contains unsafe characters", () => {
+    const rendered = {
+      topicKey: "seasonal-menu",
+      slug: "seasonal-menu",
+      title: "A factual title",
+      excerpt: "A factual excerpt",
+      bodyMarkdown: "A".repeat(ARTICLE_BODY_MIN_CHARS),
+    };
 
-  it("enforces the kebab-case slug contract", () => {
-    expect(
-      checkArticleDraft({ ...base, slug: "Not A Slug" }, facts).some((problem) =>
-        problem.includes("slug"),
-      ),
-    ).toBe(true);
-  });
-
-  it("rejects implausibly short bodies", () => {
-    expect(
-      checkArticleDraft({ ...base, bodyMarkdown: "Come visit us." }, facts).some(
-        (problem) => problem.includes("short"),
-      ),
-    ).toBe(true);
+    for (const patch of [
+      { title: "</script><script>alert(1)</script>" },
+      { excerpt: "A\nsecond line" },
+      { excerpt: "Ambiguous\u202e text" },
+      {
+        bodyMarkdown: `${"A".repeat(ARTICLE_BODY_MIN_CHARS)}<script>`,
+      },
+      {
+        bodyMarkdown: `${"A".repeat(ARTICLE_BODY_MIN_CHARS)}\u0000`,
+      },
+    ]) {
+      expect(checkRenderedArticleDraft({ ...rendered, ...patch }).length).toBeGreaterThan(0);
+    }
   });
 });
 
 describe("articleFingerprint", () => {
   it("is stable and input-sensitive", () => {
-    const one = articleFingerprint({
-      siteId: "a",
-      batchId: "b",
-      topicKey: "t",
-    });
+    const one = articleFingerprint({ siteId: "a", batchId: "b", topicKey: "t" });
     expect(one).toBe(
       articleFingerprint({ siteId: "a", batchId: "b", topicKey: "t" }),
     );
@@ -573,3 +799,45 @@ describe("articleFingerprint", () => {
     );
   });
 });
+
+function deterministicCatalogNameFuzz(): string[] {
+  let state = 0x130c0de;
+  const codeUnits = [
+    0x0000,
+    0x000a,
+    0x001f,
+    0x0020,
+    0x0026,
+    0x003c,
+    0x003e,
+    0x005b,
+    0x005d,
+    0x007f,
+    0x00a0,
+    0x034f,
+    0x061c,
+    0x200b,
+    0x200e,
+    0x202e,
+    0x2060,
+    0x20ac,
+    0x30af,
+    0x4e2d,
+    0xd800,
+    0xdfff,
+    0xff10,
+    0xff25,
+  ];
+  const next = () => {
+    state = (Math.imul(state, 1_664_525) + 1_013_904_223) >>> 0;
+    return state;
+  };
+
+  return Array.from({ length: 64 }, () => {
+    const length = next() % 33;
+    return Array.from(
+      { length },
+      () => String.fromCharCode(codeUnits[next() % codeUnits.length]!),
+    ).join("");
+  });
+}

--- a/src/lib/articles/composer.test.ts
+++ b/src/lib/articles/composer.test.ts
@@ -15,7 +15,10 @@ const facts: SiteFacts = {
   address: "12 Rue du Four, 75005 Paris",
   phone: "+33 1 42 00 00 00",
   businessHours: [{ days: "Tue–Sat", hours: "12:00–22:00" }],
-  catalogItemNames: ["Croissant", "Pain au chocolat"],
+  catalogItems: [
+    { name: "Croissant", price: 4.5, currency: "EUR" },
+    { name: "Pain au chocolat", price: null, currency: "EUR" },
+  ],
   integrationLabels: ["Book a table"],
 };
 
@@ -34,7 +37,7 @@ describe("availableFacts", () => {
       ...facts,
       address: "   ",
       businessHours: [],
-      catalogItemNames: [],
+      catalogItems: [],
       integrationLabels: [],
       phone: null,
     });
@@ -96,7 +99,7 @@ describe("selectBatchTopics", () => {
       selectBatchTopics({
         facts: {
           ...facts,
-          catalogItemNames: [],
+          catalogItems: [],
           address: null,
           businessHours: [],
           phone: null,
@@ -128,6 +131,7 @@ describe("checkArticleDraft", () => {
       "Our croissant lamination uses butter from the same two dairies all year. ".repeat(
         10,
       ),
+    catalogClaims: [{ name: "Croissant", price: null, currency: null }],
   };
 
   it("accepts a factual draft", () => {
@@ -158,16 +162,383 @@ describe("checkArticleDraft", () => {
     }
   });
 
-  it("rejects price assertions without catalog backing", () => {
+  it("accepts a structured catalog name and supported price claim", () => {
     expect(
       checkArticleDraft(
         {
           ...base,
-          bodyMarkdown: `${base.bodyMarkdown} The tasting menu is €95 per person.`,
+          bodyMarkdown: `${base.bodyMarkdown} A Croissant costs €4.50.`,
+          catalogClaims: [
+            { name: "Croissant", price: 4.5, currency: "EUR" },
+          ],
+        },
+        facts,
+      ),
+    ).toEqual([]);
+    expect(
+      checkArticleDraft(
+        {
+          ...base,
+          bodyMarkdown: `${base.bodyMarkdown} A Croissant costs 4,50\u00a0€.`,
+          catalogClaims: [
+            { name: "Croissant", price: 4.5, currency: "EUR" },
+          ],
+        },
+        facts,
+      ),
+    ).toEqual([]);
+  });
+
+  it("rejects an unknown structured catalog item claim", () => {
+    expect(
+      checkArticleDraft(
+        {
+          ...base,
+          bodyMarkdown: `${base.bodyMarkdown} The Moonbeam Tart is folded by hand.`,
+          catalogClaims: [
+            ...base.catalogClaims,
+            { name: "Moonbeam Tart", price: null, currency: null },
+          ],
+        },
+        facts,
+      ).some((problem) => problem.includes("unknown catalog item")),
+    ).toBe(true);
+  });
+
+  it("rejects high-confidence unknown prose even beside a valid claim", () => {
+    for (const unknownAssertion of [
+      "Moonbeam Tart is folded by hand.",
+      "Croissant Supreme is baked each morning.",
+      "Éclair Doré is prepared each afternoon.",
+      "Éclair is prepared each afternoon.",
+      "Moonbeam tart is folded by hand.",
+      "We prepare Moonbeam Tart each morning.",
+      "Croissant supreme is baked each morning.",
+      "Croissant-Supreme is baked each morning.",
+    ]) {
+      expect(
+        checkArticleDraft(
+          {
+            ...base,
+            topicKey: "first-visit",
+            bodyMarkdown: `${base.bodyMarkdown} ${unknownAssertion}`,
+          },
+          facts,
+        ).some((problem) => problem.includes("unknown catalog item mention")),
+      ).toBe(true);
+    }
+  });
+
+  it("does not mistake the verified business name for a catalog item", () => {
+    expect(
+      checkArticleDraft(
+        {
+          ...base,
+          bodyMarkdown: `${base.bodyMarkdown} Le Petit Meunier is available for private bookings.`,
+        },
+        facts,
+      ),
+    ).toEqual([]);
+  });
+
+  it("accepts only fully declared coordinated catalog mentions", () => {
+    expect(
+      checkArticleDraft(
+        {
+          ...base,
+          bodyMarkdown: `${base.bodyMarkdown} Croissant and Pain au chocolat are served each morning.`,
+          catalogClaims: [
+            ...base.catalogClaims,
+            { name: "Pain au chocolat", price: null, currency: null },
+          ],
+        },
+        facts,
+      ),
+    ).toEqual([]);
+    expect(
+      checkArticleDraft(
+        {
+          ...base,
+          bodyMarkdown: `${base.bodyMarkdown} Croissant and Moonbeam tart are served each morning.`,
+        },
+        facts,
+      ).some((problem) => problem.includes("unknown catalog item mention")),
+    ).toBe(true);
+  });
+
+  it("rejects catalog-dependent prose that omits its structured claims", () => {
+    expect(
+      checkArticleDraft(
+        {
+          ...base,
+          bodyMarkdown: "The invented Moonbeam Tart is folded by hand. ".repeat(15),
+          catalogClaims: [],
+        },
+        facts,
+      ).some((problem) => problem.includes("catalog-dependent topic")),
+    ).toBe(true);
+  });
+
+  it("rejects a canonical catalog mention omitted from structured claims", () => {
+    expect(
+      checkArticleDraft({ ...base, catalogClaims: [] }, facts).some((problem) =>
+        problem.includes("lacks a structured claim"),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects claims whose declared catalog item is absent from prose", () => {
+    expect(
+      checkArticleDraft(
+        {
+          ...base,
+          catalogClaims: [
+            ...base.catalogClaims,
+            { name: "Pain au chocolat", price: null, currency: null },
+          ],
+        },
+        facts,
+      ).some((problem) => problem.includes("absent from article")),
+    ).toBe(true);
+  });
+
+  it("rejects unsupported, wrong-currency, and unpriced catalog claims", () => {
+    const adversarialClaims = [
+      { name: "Croissant", price: 95, currency: "EUR" },
+      { name: "Croissant", price: 4.5, currency: "USD" },
+      { name: "Pain au chocolat", price: 4.5, currency: "EUR" },
+    ];
+    const prose = [
+      "A Croissant costs €95.",
+      "A Croissant costs USD 4.50.",
+      "A Pain au chocolat costs €4.50.",
+    ];
+    for (const [index, claim] of adversarialClaims.entries()) {
+      expect(
+        checkArticleDraft(
+          {
+            ...base,
+            bodyMarkdown: `${base.bodyMarkdown} ${prose[index]}`,
+            catalogClaims: [claim],
+          },
+          facts,
+        ).some((problem) => problem.includes("catalog price")),
+      ).toBe(true);
+    }
+  });
+
+  it("rejects raw price assertions without matching structured backing", () => {
+    expect(
+      checkArticleDraft(
+        {
+          ...base,
+          bodyMarkdown: `${base.bodyMarkdown} A Croissant costs 4.50 euros.`,
+          catalogClaims: base.catalogClaims,
         },
         facts,
       ).some((problem) => problem.includes("price")),
     ).toBe(true);
+  });
+
+  it("does not let a valid price claim back a different item", () => {
+    expect(
+      checkArticleDraft(
+        {
+          ...base,
+          bodyMarkdown: `${base.bodyMarkdown} A Pain au chocolat costs €4.50.`,
+          catalogClaims: [
+            { name: "Croissant", price: 4.5, currency: "EUR" },
+            { name: "Pain au chocolat", price: null, currency: null },
+          ],
+        },
+        facts,
+      ).some((problem) => problem.includes("price assertion")),
+    ).toBe(true);
+  });
+
+  it("does not let same-sentence co-occurrence launder another item's price", () => {
+    expect(
+      checkArticleDraft(
+        {
+          ...base,
+          bodyMarkdown: `${base.bodyMarkdown} Croissant remains available while Pain au chocolat costs €4.50.`,
+          catalogClaims: [
+            { name: "Croissant", price: 4.5, currency: "EUR" },
+            { name: "Pain au chocolat", price: null, currency: null },
+          ],
+        },
+        facts,
+      ).some((problem) => problem.includes("price assertion")),
+    ).toBe(true);
+  });
+
+  it("does not let undeclared unknown items launder a known item's price", () => {
+    for (const prose of [
+      "Croissant remains available while Éclair costs €4.50.",
+      "Croissant remains available while Moonbeam tart costs €4.50.",
+      "Croissant remains available while Croissant-Supreme costs €4.50.",
+    ]) {
+      expect(
+        checkArticleDraft(
+          {
+            ...base,
+            bodyMarkdown: `${base.bodyMarkdown} ${prose}`,
+            catalogClaims: [
+              { name: "Croissant", price: 4.5, currency: "EUR" },
+            ],
+          },
+          facts,
+        ).length,
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it("recognizes every supported catalog currency in raw prose", () => {
+    for (const currency of ["JPY", "SEK", "NOK", "DKK", "PLN"]) {
+      const pricedFacts: SiteFacts = {
+        ...facts,
+        catalogItems: [{ name: "Matcha", price: 1_000, currency }],
+      };
+      expect(
+        checkArticleDraft(
+          {
+            ...base,
+            bodyMarkdown:
+              "Our Matcha is prepared consistently each morning. ".repeat(10) +
+              `Matcha costs ${currency} 1200.`,
+            catalogClaims: [
+              { name: "Matcha", price: 1_000, currency },
+            ],
+          },
+          pricedFacts,
+        ).some((problem) => problem.includes("price assertion")),
+      ).toBe(true);
+    }
+  });
+
+  it("recognizes supported native currency symbols in raw prose", () => {
+    const nativePrices = [
+      ["JPY", "¥1200", "¥1000"],
+      ["SEK", "1200 kr", "1000 kr"],
+      ["NOK", "1200 kr", "1000 kr"],
+      ["DKK", "1200 kr", "1000 kr"],
+      ["PLN", "1200 zł", "1000 zł"],
+    ] as const;
+    for (const [currency, wrongPrice, factualPrice] of nativePrices) {
+      const pricedFacts: SiteFacts = {
+        ...facts,
+        catalogItems: [{ name: "Matcha", price: 1_000, currency }],
+      };
+      const draft = {
+        ...base,
+        catalogClaims: [{ name: "Matcha", price: 1_000, currency }],
+      };
+      expect(
+        checkArticleDraft(
+          {
+            ...draft,
+            bodyMarkdown:
+              "Our Matcha is prepared consistently each morning. ".repeat(10) +
+              `Matcha costs ${wrongPrice}.`,
+          },
+          pricedFacts,
+        ).some((problem) => problem.includes("price assertion")),
+      ).toBe(true);
+      expect(
+        checkArticleDraft(
+          {
+            ...draft,
+            bodyMarkdown:
+              "Our Matcha is prepared consistently each morning. ".repeat(10) +
+              `Matcha costs ${factualPrice}.`,
+          },
+          pricedFacts,
+        ),
+      ).toEqual([]);
+    }
+  });
+
+  it("rejects an ambiguous kr symbol", () => {
+    const ambiguousFacts: SiteFacts = {
+      ...facts,
+      catalogItems: [
+        { name: "Matcha", price: 1_000, currency: "SEK" },
+        { name: "Cardamom Bun", price: 1_000, currency: "NOK" },
+      ],
+    };
+    expect(
+      checkArticleDraft(
+        {
+          ...base,
+          bodyMarkdown:
+            "Our Matcha is prepared consistently each morning. ".repeat(10) +
+            "Matcha costs 1000 kr.",
+          catalogClaims: [
+            { name: "Matcha", price: 1_000, currency: "SEK" },
+          ],
+        },
+        ambiguousFacts,
+      ).some((problem) => problem.includes("price assertion")),
+    ).toBe(true);
+  });
+
+  it("rejects partially parsed monetary ranges across dash forms", () => {
+    for (const separator of ["-", "‐", "‑", "‒", "–", "—", "−", "/", "~"]) {
+      expect(
+        checkArticleDraft(
+          {
+            ...base,
+            bodyMarkdown: `${base.bodyMarkdown} A Croissant costs €4.50${separator}95.`,
+            catalogClaims: [
+              { name: "Croissant", price: 4.5, currency: "EUR" },
+            ],
+          },
+          facts,
+        ).some((problem) => problem.includes("price assertion")),
+      ).toBe(true);
+    }
+  });
+
+  it("accepts a supported price before its same-sentence item name", () => {
+    expect(
+      checkArticleDraft(
+        {
+          ...base,
+          bodyMarkdown: `${base.bodyMarkdown} For €4.50, choose a Croissant.`,
+          catalogClaims: [
+            { name: "Croissant", price: 4.5, currency: "EUR" },
+          ],
+        },
+        facts,
+      ),
+    ).toEqual([]);
+  });
+
+  it("rejects an ambiguous or unsupported dollar symbol", () => {
+    expect(
+      checkArticleDraft(
+        {
+          ...base,
+          bodyMarkdown: `${base.bodyMarkdown} A Croissant costs $4.50.`,
+          catalogClaims: [
+            { name: "Croissant", price: 4.5, currency: "EUR" },
+          ],
+        },
+        facts,
+      ).some((problem) => problem.includes("price assertion")),
+    ).toBe(true);
+  });
+
+  it("does not treat ordinary non-currency numbers as price claims", () => {
+    expect(
+      checkArticleDraft(
+        {
+          ...base,
+          bodyMarkdown: `${base.bodyMarkdown} The method has stayed consistent since 2018.`,
+        },
+        facts,
+      ),
+    ).toEqual([]);
   });
 
   it("enforces the kebab-case slug contract", () => {

--- a/src/lib/articles/composer.ts
+++ b/src/lib/articles/composer.ts
@@ -1,13 +1,43 @@
 import { createHash } from "node:crypto";
-import type { SiteFacts } from "@/lib/articles/site-facts";
-import { availableFacts } from "@/lib/articles/site-facts";
-import { articleTopicPlanByKey } from "@/lib/articles/topic-plans";
+import { z } from "zod";
+import { availableFacts, type SiteFacts } from "@/lib/articles/site-facts";
+import {
+  ARTICLE_TEMPLATE_KEYS,
+  ARTICLE_TOPIC_KEYS,
+  articleTopicPlanByKey,
+  type ArticleTemplateKey,
+  type ArticleTopicPlan,
+} from "@/lib/articles/topic-plans";
+import { formatPrice } from "@/lib/site-draft";
 import { supportedCurrencySchema } from "@/lib/verticals/schema";
 
+export const ARTICLE_PLAN_CONTRACT_VERSION = 1 as const;
+export const MAX_ARTICLES_PER_BATCH = 8;
+export const ARTICLE_BODY_MIN_CHARS = 400;
+export const ARTICLE_BODY_MAX_CHARS = 12_000;
+
 /**
- * The bounded shape the model must return per article. Anything outside this
- * shape is rejected wholesale — the composer never repairs prose, it re-runs
- * or produces fewer articles.
+ * The complete model-visible article contract. It deliberately has no text,
+ * catalog name, amount, currency, slug, title, excerpt, or markdown field.
+ * Every value that can reach publication is resolved by the server after this
+ * object has passed exact topic/template/catalog-id validation.
+ */
+export const generatedArticlePlanSchema = z
+  .object({
+    contractVersion: z.literal(ARTICLE_PLAN_CONTRACT_VERSION),
+    topicKey: z.enum(ARTICLE_TOPIC_KEYS),
+    templateKey: z.enum(ARTICLE_TEMPLATE_KEYS),
+    catalogItemId: z.string().min(1).max(128).nullable(),
+    priceMode: z.enum(["omit", "exact"]),
+  })
+  .strict();
+
+export type GeneratedArticlePlan = z.infer<typeof generatedArticlePlanSchema>;
+
+/**
+ * The persistence-compatible article snapshot produced only by
+ * `renderArticlePlan`. Existing Article rows and publication readers continue
+ * to consume these same scalar fields.
  */
 export type GeneratedArticleDraft = {
   topicKey: string;
@@ -15,33 +45,208 @@ export type GeneratedArticleDraft = {
   title: string;
   excerpt: string;
   bodyMarkdown: string;
-  catalogClaims: Array<{
-    name: string;
-    price: number | null;
-    currency: string | null;
-  }>;
 };
 
-export const MAX_ARTICLES_PER_BATCH = 8;
-const MAX_BODY_CHARS = 12_000;
-const MIN_BODY_CHARS = 400;
-const MAX_CATALOG_CLAIMS = 32;
+export type ArticlePlanRenderResult =
+  | { ok: true; draft: GeneratedArticleDraft }
+  | { ok: false; problems: string[] };
+
+type CatalogItemFact = SiteFacts["catalogItems"][number];
+type TemplateLanguage = "en" | "fr";
+type TemplateKind = "catalog" | "location" | "contact" | "visit" | "ordering";
+
+type LocalizedTemplateCopy = {
+  title: string;
+  excerpt: string;
+  listing?: string;
+};
+
+type TemplateDefinition = {
+  kind: TemplateKind;
+  en: LocalizedTemplateCopy;
+  fr: LocalizedTemplateCopy;
+};
+
+// Final public fields must remain safe even though every current value is
+// repository-owned. This gate prevents future template slots from bypassing
+// the plain/script boundary.
+const UNSAFE_PLAIN_ARTICLE_FIELD =
+  /[<\u0000-\u001f\u007f-\u009f\u061c\u200e\u200f\u2028\u2029\u202a-\u202e\u2066-\u2069]/u;
+const UNSAFE_ARTICLE_MARKDOWN =
+  /[<\u0000-\u0009\u000b-\u001f\u007f-\u009f\u061c\u200e\u200f\u2028\u2029\u202a-\u202e\u2066-\u2069]/u;
 
 /**
- * Strings a customer site may never publish about itself. A generated article
- * asserting an award, a "best of" ranking, a certification, or a price that
- * is not in the catalog is fabricated trust — the exact failure mode this
- * engine exists to avoid. Checked case-insensitively against title + body.
+ * Repository-owned copy is the only prose source. A catalog item's exact ID
+ * selects the factual row, but its name never enters any public article field.
+ * Exact mode may insert only the validated canonical price in its fixed slot.
  */
-const FORBIDDEN_CLAIM_PATTERNS: RegExp[] = [
-  /\baward[- ]?winning\b/i,
-  /\bbest (?:restaurant|salon|shop|barber|cafe|bakery)\b/i,
-  /\b(?:voted|rated) (?:the )?(?:best|#1|number one|no\.? ?1)\b/i,
-  /\b(?:michelin|gault.?millau|aa rosette)\b/i,
-  /\bcertified\b/i,
-  /\bgovernment[- ]?(?:licensed|registered)\b/i,
-  /\bguarantee[d]?\b/i,
-];
+const ARTICLE_TEMPLATES = {
+  "restaurant-current-menu": {
+    kind: "catalog",
+    en: {
+      title: "A current menu listing",
+      excerpt:
+        "This page covers one selected entry in the verified current menu",
+      listing: "menu listing",
+    },
+    fr: {
+      title: "Une référence actuelle de la carte",
+      excerpt:
+        "Cette page présente une référence sélectionnée de la carte actuelle vérifiée",
+      listing: "carte",
+    },
+  },
+  "restaurant-location": {
+    kind: "location",
+    en: { title: "How to find us", excerpt: "The currently published address" },
+    fr: { title: "Comment nous trouver", excerpt: "L’adresse actuellement publiée" },
+  },
+  "restaurant-group-enquiry": {
+    kind: "contact",
+    en: { title: "Making a group enquiry", excerpt: "The published ways to get in touch" },
+    fr: { title: "Faire une demande de groupe", excerpt: "Les moyens de contact publiés" },
+  },
+  "restaurant-dietary-enquiry": {
+    kind: "catalog",
+    en: {
+      title: "Checking dietary details before ordering",
+      excerpt:
+        "A selected verified menu entry is the basis for this dietary enquiry guide",
+      listing: "menu listing",
+    },
+    fr: {
+      title: "Vérifier les informations alimentaires avant de commander",
+      excerpt:
+        "Une référence vérifiée de la carte sert de base à ce guide de demande alimentaire",
+      listing: "carte",
+    },
+  },
+  "restaurant-menu-facts": {
+    kind: "catalog",
+    en: {
+      title: "What the current menu confirms",
+      excerpt:
+        "This page is limited to one selected entry in the verified current menu",
+      listing: "menu listing",
+    },
+    fr: {
+      title: "Ce que confirme la carte actuelle",
+      excerpt:
+        "Cette page se limite à une référence sélectionnée de la carte actuelle vérifiée",
+      listing: "carte",
+    },
+  },
+  "beauty-treatment-listing": {
+    kind: "catalog",
+    en: {
+      title: "A current treatment listing",
+      excerpt:
+        "This page covers one selected entry in the verified current treatment list",
+      listing: "treatment listing",
+    },
+    fr: {
+      title: "Une prestation actuellement référencée",
+      excerpt:
+        "Cette page présente une prestation sélectionnée dans la liste actuelle vérifiée",
+      listing: "liste des prestations",
+    },
+  },
+  "beauty-aftercare-enquiry": {
+    kind: "catalog",
+    en: {
+      title: "How to ask about aftercare",
+      excerpt:
+        "A selected verified treatment entry is the basis for this aftercare enquiry guide",
+      listing: "treatment listing",
+    },
+    fr: {
+      title: "Comment demander des conseils de suivi",
+      excerpt:
+        "Une prestation vérifiée sélectionnée sert de base à ce guide de demande de suivi",
+      listing: "liste des prestations",
+    },
+  },
+  "beauty-current-listing": {
+    kind: "catalog",
+    en: {
+      title: "What the current service list confirms",
+      excerpt:
+        "This page is limited to one selected entry in the verified current service list",
+      listing: "service listing",
+    },
+    fr: {
+      title: "Ce que confirme la liste actuelle des prestations",
+      excerpt:
+        "Cette page se limite à une prestation sélectionnée dans la liste actuelle vérifiée",
+      listing: "liste des prestations",
+    },
+  },
+  "beauty-visit-planning": {
+    kind: "visit",
+    en: { title: "Planning your first visit", excerpt: "Published location and opening details" },
+    fr: { title: "Préparer votre première visite", excerpt: "Adresse et horaires publiés" },
+  },
+  "service-current-listing": {
+    kind: "catalog",
+    en: {
+      title: "A current service listing",
+      excerpt:
+        "This page covers one selected entry in the verified current service list",
+      listing: "service listing",
+    },
+    fr: {
+      title: "Une prestation actuellement référencée",
+      excerpt:
+        "Cette page présente une prestation sélectionnée dans la liste actuelle vérifiée",
+      listing: "liste des prestations",
+    },
+  },
+  "service-location": {
+    kind: "location",
+    en: { title: "Where the business is based", excerpt: "The currently published business address" },
+    fr: { title: "Où se trouve l’entreprise", excerpt: "L’adresse professionnelle actuellement publiée" },
+  },
+  "service-quote-enquiry": {
+    kind: "contact",
+    en: { title: "How to make a quote enquiry", excerpt: "The published ways to contact the business" },
+    fr: { title: "Comment demander un devis", excerpt: "Les moyens publiés pour contacter l’entreprise" },
+  },
+  "retail-listing-facts": {
+    kind: "catalog",
+    en: {
+      title: "What the current listing confirms",
+      excerpt:
+        "This page is limited to one selected entry in the verified current shop catalog",
+      listing: "shop listing",
+    },
+    fr: {
+      title: "Ce que confirme la référence actuelle",
+      excerpt:
+        "Cette page se limite à une référence sélectionnée du catalogue actuel vérifié de la boutique",
+      listing: "catalogue de la boutique",
+    },
+  },
+  "retail-current-stock": {
+    kind: "catalog",
+    en: {
+      title: "A current shop listing",
+      excerpt:
+        "This page covers one selected entry in the verified current shop catalog",
+      listing: "shop listing",
+    },
+    fr: {
+      title: "Une référence actuelle de la boutique",
+      excerpt:
+        "Cette page présente une référence sélectionnée du catalogue actuel vérifié de la boutique",
+      listing: "catalogue de la boutique",
+    },
+  },
+  "retail-ordering-options": {
+    kind: "ordering",
+    en: { title: "Ways to shop with us", excerpt: "The ordering options currently published on the site" },
+    fr: { title: "Les moyens d’acheter chez nous", excerpt: "Les options de commande actuellement publiées sur le site" },
+  },
+} satisfies Record<ArticleTemplateKey, TemplateDefinition>;
 
 /**
  * Deterministically picks which topics a batch may fill.
@@ -50,24 +255,31 @@ const FORBIDDEN_CLAIM_PATTERNS: RegExp[] = [
  * whose required facts the site actually carries, seeded by the site id so
  * two sites with identical data do not get identical topic orders. Topics
  * covered by either of the site's last two batches are pushed to the back of
- * the queue instead of removed outright: with small plan sizes, dropping them
- * would strand a four-topic plan after two batches.
+ * the queue instead of removed outright.
  */
 export function selectBatchTopics(input: {
   facts: SiteFacts;
-  plans: Array<{ key: string; requiredFacts: string[] }>;
+  plans: Array<{
+    key: string;
+    requiredFacts: string[];
+    requiredAnyIntegrationCapabilities?: SiteFacts["integrationCapabilities"];
+  }>;
   count: number;
   recentTopicKeys: string[];
 }): Array<{ key: string }> {
   const available = availableFacts(input.facts);
-  const eligible = input.plans.filter((plan) =>
-    plan.requiredFacts.every((fact) => available.has(fact as never)),
+  const capabilities = new Set(input.facts.integrationCapabilities);
+  const eligible = input.plans.filter(
+    (plan) =>
+      plan.requiredFacts.every((fact) => available.has(fact as never)) &&
+      (!plan.requiredAnyIntegrationCapabilities?.length ||
+        plan.requiredAnyIntegrationCapabilities.some((capability) =>
+          capabilities.has(capability),
+        )),
   );
   if (!eligible.length) return [];
 
-  const recent = new Set(
-    input.recentTopicKeys.slice(0, Math.max(0, input.recentTopicKeys.length)),
-  );
+  const recent = new Set(input.recentTopicKeys);
   const seed = hashSeed(input.facts.slug);
   const rotated = rotate(eligible, seed % eligible.length);
   const fresh = rotated.filter((plan) => !recent.has(plan.key));
@@ -78,484 +290,372 @@ export function selectBatchTopics(input: {
     .map((plan) => ({ key: plan.key }));
 }
 
-/**
- * Guardrails every generated article must pass before it can be persisted.
- * Returns human-readable violations; an empty array means the draft is
- * acceptable. Deliberately strict: a rejected article shrinks the batch
- * rather than shipping unverified claims to a customer's live site.
- */
-export function checkArticleDraft(
-  draft: GeneratedArticleDraft,
-  facts: SiteFacts,
-): string[] {
-  const problems: string[] = [];
-  const haystack = `${draft.title}\n${draft.excerpt}\n${draft.bodyMarkdown}`;
+/** Returns deterministic, human-readable reasons an untrusted plan cannot render. */
+export function checkArticlePlan(plan: unknown, facts: SiteFacts): string[] {
+  const validated = validateArticlePlan(plan, facts);
+  return validated.ok ? [] : validated.problems;
+}
 
-  for (const pattern of FORBIDDEN_CLAIM_PATTERNS) {
-    if (pattern.test(haystack)) {
-      problems.push(`forbidden claim matched ${pattern.source}`);
+/**
+ * Validates an untrusted model plan completely before rendering any public
+ * text. The function is pure: it never repairs IDs, normalizes identifiers, or
+ * mutates the supplied factual snapshot.
+ */
+export function renderArticlePlan(
+  plan: unknown,
+  facts: SiteFacts,
+): ArticlePlanRenderResult {
+  const validated = validateArticlePlan(plan, facts);
+  if (!validated.ok) return validated;
+
+  const language = articleLanguage(facts.locale);
+  const definition = ARTICLE_TEMPLATES[validated.plan.templateKey];
+  const copy = definition[language];
+  const draft = renderTemplate({
+    plan: validated.plan,
+    topic: validated.topic,
+    item: validated.item,
+    facts,
+    language,
+    definition,
+    copy,
+  });
+  const problems = checkRenderedArticleDraft(draft);
+  return problems.length ? { ok: false, problems } : { ok: true, draft };
+}
+
+type ValidatedPlan = {
+  ok: true;
+  plan: GeneratedArticlePlan;
+  topic: ArticleTopicPlan;
+  item: CatalogItemFact | null;
+};
+
+type InvalidPlan = { ok: false; problems: string[] };
+
+function validateArticlePlan(plan: unknown, facts: SiteFacts): ValidatedPlan | InvalidPlan {
+  const parsed = generatedArticlePlanSchema.safeParse(plan);
+  if (!parsed.success) {
+    return { ok: false, problems: ["article plan does not match the strict schema"] };
+  }
+
+  const value = parsed.data;
+  const problems: string[] = [];
+  const topic = articleTopicPlanByKey(facts.vertical, value.topicKey);
+  if (!topic) {
+    return {
+      ok: false,
+      problems: [`topic is not available for vertical: "${value.topicKey}"`],
+    };
+  }
+  if (topic.templateKey !== value.templateKey) {
+    problems.push(`template is not allowed for topic: "${value.templateKey}"`);
+  }
+
+  const available = availableFacts(facts);
+  for (const required of topic.requiredFacts) {
+    if (!available.has(required)) problems.push(`required fact is unavailable: "${required}"`);
+  }
+  if (
+    topic.requiredAnyIntegrationCapabilities?.length &&
+    !topic.requiredAnyIntegrationCapabilities.some((capability) =>
+      facts.integrationCapabilities.includes(capability),
+    )
+  ) {
+    problems.push("required enabled integration capability is unavailable");
+  }
+
+  let item: CatalogItemFact | null = null;
+  if (topic.catalogItem === "required") {
+    if (value.catalogItemId === null) {
+      problems.push("catalog-dependent topic requires a catalog item id");
+    } else {
+      const matches = facts.catalogItems.filter(
+        (candidate) => candidate.id === value.catalogItemId,
+      );
+      if (matches.length === 0) {
+        problems.push(`unknown catalog item id: "${value.catalogItemId}"`);
+      } else if (matches.length > 1) {
+        problems.push(`catalog item id is ambiguous: "${value.catalogItemId}"`);
+      } else {
+        item = matches[0] ?? null;
+      }
+    }
+  } else {
+    if (value.catalogItemId !== null) {
+      problems.push("non-catalog topic must not select a catalog item");
+    }
+    if (value.priceMode !== "omit") {
+      problems.push("non-catalog topic must omit catalog prices");
     }
   }
 
-  checkCatalogClaims(draft, facts, haystack, problems);
+  if (item) {
+    if (value.priceMode === "exact") {
+      if (item.price === null) {
+        problems.push("exact price mode requires a canonical catalog price");
+      } else if (
+        !Number.isFinite(item.price) ||
+        item.price < 0 ||
+        item.price > 99_999_999.99
+      ) {
+        problems.push("selected catalog item has an invalid canonical price");
+      }
+      if (!supportedCurrencySchema.safeParse(item.currency).success) {
+        problems.push("exact price mode requires a supported canonical currency");
+      }
+    }
+  }
 
-  if (draft.bodyMarkdown.length > MAX_BODY_CHARS) {
+  if (problems.length) return { ok: false, problems: [...new Set(problems)] };
+  return { ok: true, plan: value, topic, item };
+}
+
+function renderTemplate(input: {
+  plan: GeneratedArticlePlan;
+  topic: ArticleTopicPlan;
+  item: CatalogItemFact | null;
+  facts: SiteFacts;
+  language: TemplateLanguage;
+  definition: TemplateDefinition;
+  copy: LocalizedTemplateCopy;
+}): GeneratedArticleDraft {
+  const { definition } = input;
+  if (definition.kind === "catalog") return renderCatalogTemplate(input);
+  if (definition.kind === "location") return renderLocationTemplate(input);
+  if (definition.kind === "contact") return renderContactTemplate(input);
+  if (definition.kind === "visit") return renderVisitTemplate(input);
+  return renderOrderingTemplate(input);
+}
+
+function renderCatalogTemplate(input: {
+  plan: GeneratedArticlePlan;
+  item: CatalogItemFact | null;
+  facts: SiteFacts;
+  language: TemplateLanguage;
+  copy: LocalizedTemplateCopy;
+}): GeneratedArticleDraft {
+  const item = input.item;
+  if (!item) throw new Error("validated catalog plan has no selected item");
+  const listing = input.copy.listing ?? "catalog listing";
+
+  if (input.plan.priceMode === "exact") {
+    if (item.price === null) {
+      throw new Error("validated exact-price plan has no canonical price");
+    }
+    const formattedPrice = formatPrice(
+      item.price,
+      item.currency,
+      input.language,
+    );
+    return {
+      topicKey: input.plan.topicKey,
+      slug: input.plan.topicKey,
+      title:
+        input.language === "fr"
+          ? `${input.copy.title} : prix vérifié`
+          : `${input.copy.title}: verified price`,
+      excerpt:
+        input.language === "fr"
+          ? `${input.copy.excerpt}. Le prix exact vérifié figure dans l’article.`
+          : `${input.copy.excerpt}. The exact verified price appears in the article.`,
+      bodyMarkdown: catalogBody({
+        language: input.language,
+        listing,
+        formattedPrice,
+      }),
+    };
+  }
+
+  return {
+    topicKey: input.plan.topicKey,
+    slug: input.plan.topicKey,
+    title: input.copy.title,
+    excerpt: `${input.copy.excerpt}.`,
+    bodyMarkdown: catalogBody({
+      language: input.language,
+      listing,
+      formattedPrice: null,
+    }),
+  };
+}
+
+function catalogBody(input: {
+  language: TemplateLanguage;
+  listing: string;
+  formattedPrice: string | null;
+}): string {
+  if (input.language === "fr") {
+    const price = input.formattedPrice
+      ? ` Le prix exact vérifié pour cette référence est ${input.formattedPrice}.`
+      : "";
+    return `## Ce que confirme cette page
+
+Cette page s’appuie sur la ${input.listing} vérifiée de l’établissement. La référence sélectionnée appartient à cette liste.${price} Aucun ingrédient, disponibilité, origine, résultat, niveau de popularité, compatibilité, distinction ou autre détail n’est supposé au-delà des informations publiées.
+
+## Vérifier les informations actuelles
+
+Les informations du catalogue peuvent évoluer après la création d’un brouillon. Avant de commander, de réserver, de vous déplacer ou de compter sur une option précise, utilisez les moyens de contact ou de commande publiés ailleurs sur le site pour confirmer sa disponibilité et tout détail important pour votre visite ou votre achat. Cette page reste volontairement limitée aux informations publiées pour la référence sélectionnée.`;
+  }
+
+  const price = input.formattedPrice
+    ? ` The exact verified price for this listing is ${input.formattedPrice}.`
+    : "";
+  return `## What this page confirms
+
+This page uses the business's verified ${input.listing}. The selected entry belongs to that listing.${price} No ingredients, availability, origin, results, popularity, suitability, awards, or other details are assumed beyond what the published listing states.
+
+## Checking current details
+
+Catalog information can change after a draft is created. Before ordering, booking, travelling, or relying on a particular option, use the contact or ordering routes published elsewhere on the site to confirm current availability and any detail that matters to your visit or purchase. This page deliberately stays within the published details for the selected listing.`;
+}
+
+function renderLocationTemplate(input: {
+  plan: GeneratedArticlePlan;
+  language: TemplateLanguage;
+  copy: LocalizedTemplateCopy;
+}): GeneratedArticleDraft {
+  const body =
+    input.language === "fr"
+      ? `## Utiliser les informations de localisation publiées
+
+Le site présente déjà l’adresse de l’établissement dans ses informations vérifiées. Consultez ce champ publié pour préparer votre déplacement. Cette page ne transforme pas une adresse en affirmation sur une zone desservie, un point de repère voisin, une durée de trajet, le stationnement, l’accessibilité ou un autre détail géographique absent des données structurées.
+
+## Préparer le déplacement
+
+Consultez les informations publiées juste avant votre départ et utilisez un service d’itinéraire adapté à votre point de départ. Si un détail de l’accès est important pour votre visite, confirmez-le directement par les moyens de contact présents ailleurs sur le site. Cette page reste volontairement générale et n’ajoute aucun nom, prix, lieu ou service non publié.`
+      : `## Using the published location details
+
+The site already presents the business address in its verified details. Use that published field when planning a journey. This page does not turn an address into a claim about a service area, nearby landmark, journey time, parking, accessibility, or any other location detail that has not been published.
+
+## Planning the journey
+
+Check the published information shortly before travelling and use a route service appropriate to your starting point. If a particular access detail matters to your visit, confirm it directly through the contact routes elsewhere on the site. This page stays deliberately general and adds no unpublished business name, product, price, place, or service claim.`;
+  return {
+    topicKey: input.plan.topicKey,
+    slug: input.plan.topicKey,
+    title: input.copy.title,
+    excerpt: `${input.copy.excerpt}.`,
+    bodyMarkdown: body,
+  };
+}
+
+function renderContactTemplate(input: {
+  plan: GeneratedArticlePlan;
+  language: TemplateLanguage;
+  copy: LocalizedTemplateCopy;
+}): GeneratedArticleDraft {
+  const body =
+    input.language === "fr"
+      ? `## Moyens de contact publiés
+
+Le site présente déjà ses moyens de contact et de demande dans les informations vérifiées de l’établissement. Utilisez ces champs publiés pour transmettre votre question. Leur présence ne promet ni disponibilité, ni capacité, ni délai, ni devis, ni réservation confirmée, et cette page n’ajoute aucun nom ou tarif absent des informations publiées.
+
+## Formuler votre demande
+
+Indiquez directement à l’établissement ce que vous souhaitez organiser ou vérifier, puis attendez sa confirmation avant de prendre un engagement. Les modalités peuvent dépendre de la date et du besoin précis. Consultez les coordonnées affichées ailleurs sur le site : seules les informations publiées doivent guider votre demande, sans supposer de condition de service supplémentaire.`
+      : `## Published contact routes
+
+The site already presents its contact and enquiry routes in the business's verified details. Use those published fields when sending a question. Their presence does not promise availability, capacity, timing, a quote, or a confirmed booking, and this page adds no name or price absent from the published information.
+
+## Making the enquiry
+
+Tell the business directly what you want to arrange or verify, then wait for its confirmation before making a commitment. Details may depend on the date and the specific request. Consult the contact values shown elsewhere on the site and rely only on the details the business publishes for your enquiry.`;
+  return {
+    topicKey: input.plan.topicKey,
+    slug: input.plan.topicKey,
+    title: input.copy.title,
+    excerpt: `${input.copy.excerpt}.`,
+    bodyMarkdown: body,
+  };
+}
+
+function renderVisitTemplate(input: {
+  plan: GeneratedArticlePlan;
+  language: TemplateLanguage;
+  copy: LocalizedTemplateCopy;
+}): GeneratedArticleDraft {
+  const body =
+    input.language === "fr"
+      ? `## Informations publiées pour la visite
+
+Le site présente déjà l’adresse et les horaires dans les informations vérifiées de l’établissement. Consultez ces champs pour préparer votre visite. Leur présence ne décrit pas le déroulement d’un rendez-vous, le temps d’attente, la disponibilité d’une prestation, un résultat attendu ou les besoins individuels.
+
+## Confirmer avant de venir
+
+Les horaires et modalités peuvent évoluer. Consultez les informations publiées ailleurs sur le site juste avant votre déplacement et contactez directement l’établissement si une contrainte est importante. Cette page s’en tient aux indications générales et n’ajoute ni coordonnées, ni prestation, ni tarif, ni supposition non publiés.`
+      : `## Published visit details
+
+The site already presents the address and opening details in the business's verified information. Consult those fields when planning a visit. Their presence does not describe how an appointment runs, waiting time, service availability, an expected result, or individual requirements.
+
+## Confirming before arrival
+
+Hours and arrangements can change. Check the information published elsewhere on the site shortly before travelling and contact the business directly if a particular constraint matters. This page stays with general guidance and adds no unpublished address, service, price, or assumption.`;
+  return {
+    topicKey: input.plan.topicKey,
+    slug: input.plan.topicKey,
+    title: input.copy.title,
+    excerpt: `${input.copy.excerpt}.`,
+    bodyMarkdown: body,
+  };
+}
+
+function renderOrderingTemplate(input: {
+  plan: GeneratedArticlePlan;
+  language: TemplateLanguage;
+  copy: LocalizedTemplateCopy;
+}): GeneratedArticleDraft {
+  const body =
+    input.language === "fr"
+      ? `## Options publiées
+
+Le site affiche déjà ses options de commande dans les informations vérifiées de l’établissement. Consultez ces champs publiés pour choisir la voie adaptée. Cette page ne copie pas leurs libellés et ne déduit ni stock disponible, ni prix, ni délai, ni zone de livraison, ni condition de retrait, ni confirmation de commande.
+
+## Avant de commander
+
+Ouvrez l’option publiée ailleurs sur le site qui correspond à votre besoin et vérifiez les informations qu’elle présente au moment de votre demande. Les disponibilités et modalités peuvent changer. Si un détail est essentiel, confirmez-le directement auprès de l’établissement. Cette page n’ajoute aucun produit, tarif ou fonctionnement non publié.`
+      : `## Published options
+
+The site already shows its ordering options in the business's verified information. Consult those published fields to choose the appropriate route. This page does not copy their labels or infer available stock, prices, timing, delivery areas, collection conditions, or a confirmed order.
+
+## Before ordering
+
+Open the option published elsewhere on the site that fits your need and check the information it presents when making the request. Availability and arrangements can change. If a detail is essential, confirm it directly with the business. This page adds no unpublished product, price, label, or operating detail.`;
+  return {
+    topicKey: input.plan.topicKey,
+    slug: input.plan.topicKey,
+    title: input.copy.title,
+    excerpt: `${input.copy.excerpt}.`,
+    bodyMarkdown: body,
+  };
+}
+
+/** Checks only deterministic rendered-shape invariants, never prose meaning. */
+export function checkRenderedArticleDraft(draft: GeneratedArticleDraft): string[] {
+  const problems: string[] = [];
+  if (draft.bodyMarkdown.length > ARTICLE_BODY_MAX_CHARS) {
     problems.push("body exceeds length budget");
   }
-  if (draft.bodyMarkdown.length < MIN_BODY_CHARS) {
+  if (draft.bodyMarkdown.length < ARTICLE_BODY_MIN_CHARS) {
     problems.push("body implausibly short");
   }
-
   const slug = draft.slug.trim();
   if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug)) {
     problems.push(`slug is not a URL-safe kebab-case label: "${slug}"`);
   }
-
   if (!draft.title.trim() || !draft.excerpt.trim()) {
     problems.push("title and excerpt are required");
   }
-
-  return [...new Set(problems)];
-}
-
-type ValidatedPriceClaim = {
-  normalizedName: string;
-  currency: string;
-  minorUnits: number;
-};
-
-type PriceAssertion = {
-  index: number;
-  end: number;
-  currencyToken: string;
-  amount: string;
-  hasUnsupportedTail: boolean;
-};
-
-const SUPPORTED_CURRENCY_CODE_PATTERN =
-  supportedCurrencySchema.options.join("|");
-const CURRENCY_TOKEN_PATTERN = `(?:€|£|\\$|¥|zł|\\bkr\\b|\\b(?:${SUPPORTED_CURRENCY_CODE_PATTERN})\\b)`;
-const CURRENCY_WORD_PATTERN = "(?:euros?|dollars?|pounds?)";
-const AMOUNT_PATTERN = "\\d+(?:[.,]\\d{1,2})?";
-
-/**
- * The model must enumerate every catalog fact it uses in structured output.
- * That declaration is checked against the same item's canonical name, price,
- * and currency before prose can reach persistence. Raw money tokens are also
- * scanned so omitting price metadata cannot bypass the structured boundary.
- */
-function checkCatalogClaims(
-  draft: GeneratedArticleDraft,
-  facts: SiteFacts,
-  haystack: string,
-  problems: string[],
-): void {
-  if (!Array.isArray(draft.catalogClaims)) {
-    problems.push("structured catalog claims are required");
-    return;
-  }
-  if (draft.catalogClaims.length > MAX_CATALOG_CLAIMS) {
-    problems.push("too many structured catalog claims");
-  }
-  const topicPlan = articleTopicPlanByKey(facts.vertical, draft.topicKey);
   if (
-    topicPlan?.requiredFacts.includes("catalogItems") &&
-    draft.catalogClaims.length === 0
+    UNSAFE_PLAIN_ARTICLE_FIELD.test(draft.title) ||
+    UNSAFE_PLAIN_ARTICLE_FIELD.test(draft.excerpt)
   ) {
-    problems.push("catalog-dependent topic requires a structured catalog claim");
+    problems.push("title or excerpt contains unsafe plain-text characters");
   }
-
-  const normalizedHaystack = normalizeCatalogText(haystack);
-  const factsByName = new Map<
-    string,
-    Array<{ name: string; price: number | null; currency: string }>
-  >();
-  for (const fact of facts.catalogItems) {
-    const normalizedName = normalizeCatalogText(fact.name);
-    const existing = factsByName.get(normalizedName) ?? [];
-    existing.push(fact);
-    factsByName.set(normalizedName, existing);
+  if (UNSAFE_ARTICLE_MARKDOWN.test(draft.bodyMarkdown)) {
+    problems.push("body contains unsafe markdown characters");
   }
-
-  const declaredNames = new Set<string>();
-  const validatedPrices: ValidatedPriceClaim[] = [];
-  for (const claim of draft.catalogClaims.slice(0, MAX_CATALOG_CLAIMS)) {
-    const normalizedName = normalizeCatalogText(claim.name);
-    if (!normalizedName) {
-      problems.push("catalog claim name is required");
-      continue;
-    }
-    declaredNames.add(normalizedName);
-
-    if (!containsCatalogName(normalizedHaystack, normalizedName)) {
-      problems.push(`catalog claim is absent from article: "${claim.name}"`);
-    }
-
-    const matchingFacts = factsByName.get(normalizedName) ?? [];
-    if (!matchingFacts.length) {
-      problems.push(`unknown catalog item claim: "${claim.name}"`);
-      continue;
-    }
-
-    const hasPrice = claim.price !== null;
-    const hasCurrency = Boolean(claim.currency?.trim());
-    if (hasPrice !== hasCurrency) {
-      problems.push(`catalog price claim is incomplete: "${claim.name}"`);
-      continue;
-    }
-    if (!hasPrice || !claim.currency) continue;
-
-    const claimedMinorUnits = toMinorUnits(claim.price);
-    const claimedCurrency = normalizeCurrency(claim.currency);
-    if (claimedMinorUnits === null || !claimedCurrency) {
-      problems.push(`catalog price claim is invalid: "${claim.name}"`);
-      continue;
-    }
-
-    const supported = matchingFacts.some((fact) => {
-      const factMinorUnits = toMinorUnits(fact.price);
-      return (
-        factMinorUnits === claimedMinorUnits &&
-        normalizeCurrency(fact.currency) === claimedCurrency
-      );
-    });
-    if (!supported) {
-      problems.push(`unsupported catalog price claim: "${claim.name}"`);
-      continue;
-    }
-    validatedPrices.push({
-      normalizedName,
-      currency: claimedCurrency,
-      minorUnits: claimedMinorUnits,
-    });
-  }
-
-  // Known catalog names in prose cannot be omitted from the structured claim
-  // list. This closes the metadata-omission path for every canonical item the
-  // deterministic matcher can identify without treating arbitrary nouns as
-  // products.
-  for (const normalizedName of factsByName.keys()) {
-    if (
-      containsCatalogName(normalizedHaystack, normalizedName) &&
-      !declaredNames.has(normalizedName)
-    ) {
-      problems.push(`catalog item mention lacks a structured claim: "${normalizedName}"`);
-    }
-  }
-
-  // The structured contract is the primary boundary, but deterministic prose
-  // still fails closed for high-confidence product assertions that omit it.
-  // Restricting this supplemental detector to title-cased names next to
-  // product verbs avoids classifying every arbitrary noun phrase as a product.
-  const knownNonCatalogNames = new Set(
-    [facts.name, facts.address, ...facts.integrationLabels].flatMap((value) => {
-      if (!value?.trim()) return [];
-      return [
-        normalizeCatalogText(value),
-        normalizeCatalogText(stripLikelyMentionDeterminer(value)),
-      ];
-    }),
-  );
-  for (const mention of extractLikelyCatalogMentions(haystack)) {
-    const normalizedMention = normalizeCatalogText(
-      stripLikelyMentionDeterminer(mention),
-    );
-    if (
-      knownNonCatalogNames.has(normalizeCatalogText(mention)) ||
-      knownNonCatalogNames.has(normalizedMention)
-    ) {
-      continue;
-    }
-    if (
-      isDeclaredCatalogComposition(
-        normalizedMention,
-        factsByName,
-        declaredNames,
-      )
-    ) {
-      continue;
-    }
-    if (!factsByName.has(normalizedMention)) {
-      problems.push(`unknown catalog item mention: "${mention}"`);
-    } else if (!declaredNames.has(normalizedMention)) {
-      problems.push(
-        `catalog item mention lacks a structured claim: "${normalizedMention}"`,
-      );
-    }
-  }
-
-  for (const assertion of extractPriceAssertions(haystack)) {
-    const assertionMinorUnits = toMinorUnits(
-      Number(assertion.amount.replace(",", ".")),
-    );
-    const assertionCurrency = currencyForToken(assertion.currencyToken, facts);
-    const sentenceBounds = catalogAssertionContextBounds(
-      haystack,
-      assertion.index,
-      assertion.end,
-      false,
-    );
-    const clauseBounds = catalogAssertionContextBounds(
-      haystack,
-      assertion.index,
-      assertion.end,
-      true,
-    );
-    const sentenceContext = normalizeCatalogText(
-      haystack.slice(sentenceBounds.start, sentenceBounds.end),
-    );
-    const clauseContext = normalizeCatalogText(
-      haystack.slice(clauseBounds.start, clauseBounds.end),
-    );
-    const afterAssertionContext = normalizeCatalogText(
-      haystack.slice(assertion.end, sentenceBounds.end),
-    );
-    const sentenceNames = catalogNamesInContext(sentenceContext, factsByName);
-    const clauseNames = catalogNamesInContext(clauseContext, factsByName);
-    const afterAssertionNames = catalogNamesInContext(
-      afterAssertionContext,
-      factsByName,
-    );
-    const boundNames =
-      clauseNames.size === 1
-        ? clauseNames
-        : clauseNames.size === 0 &&
-            sentenceNames.size === 1 &&
-            afterAssertionNames.size === 1
-          ? sentenceNames
-          : new Set<string>();
-    const backed =
-      !assertion.hasUnsupportedTail &&
-      assertionMinorUnits !== null &&
-      assertionCurrency !== null &&
-      boundNames.size === 1 &&
-      validatedPrices.some(
-        (claim) =>
-          claim.minorUnits === assertionMinorUnits &&
-          claim.currency === assertionCurrency &&
-          boundNames.has(claim.normalizedName),
-      );
-    if (!backed) problems.push("price assertion without catalog backing");
-  }
-}
-
-function isDeclaredCatalogComposition(
-  mention: string,
-  factsByName: Map<
-    string,
-    Array<{ name: string; price: number | null; currency: string }>
-  >,
-  declaredNames: Set<string>,
-): boolean {
-  const names = [...factsByName.keys()]
-    .filter((name) => declaredNames.has(name))
-    .sort((left, right) => right.length - left.length);
-
-  function consume(remaining: string): boolean {
-    for (const name of names) {
-      if (remaining !== name && !remaining.startsWith(`${name} `)) continue;
-      const tail = remaining.slice(name.length);
-      if (!tail) return true;
-      const separator = tail.match(
-        /^\s*(?:,\s*(?:(?:and|or|et|ou|&)\s+)?|(?:and|or|et|ou|&)\s+)/u,
-      );
-      if (separator && consume(tail.slice(separator[0].length))) return true;
-    }
-    return false;
-  }
-
-  return consume(mention);
-}
-
-function catalogNamesInContext(
-  context: string,
-  factsByName: Map<
-    string,
-    Array<{ name: string; price: number | null; currency: string }>
-  >,
-): Set<string> {
-  return new Set(
-    [...factsByName.keys()].filter((name) => containsCatalogName(context, name)),
-  );
-}
-
-function extractLikelyCatalogMentions(haystack: string): string[] {
-  const titleWord = String.raw`\p{Lu}[\p{L}\p{M}'’\-]*`;
-  const followingWord = String.raw`[\p{L}\p{M}'’\-]+`;
-  const candidate = `${titleWord}(?:\\s+${followingWord}){0,5}`;
-  const productPredicate =
-    String.raw`(?:costs?|(?:is|are|remains?)\s+(?:baked|folded|served|priced|prepared|made|available))`;
-  const predicatePattern = new RegExp(
-    String.raw`(?<![\p{L}\p{N}])(${candidate})\s+${productPredicate}\b`,
-    "gu",
-  );
-  const activePattern = new RegExp(
-    String.raw`\b(?:prepare|bake|serve|offer|sell|make)s?\s+(${titleWord}(?:\s+${titleWord}){0,4})\b`,
-    "gu",
-  );
-  return [...haystack.matchAll(predicatePattern), ...haystack.matchAll(activePattern)]
-    .flatMap((match) => (match[1] ? [match[1]] : []));
-}
-
-function stripLikelyMentionDeterminer(value: string): string {
-  return value.replace(/^(?:A|An|The|Our|Le|La|Les|Un|Une)\s+/u, "");
-}
-
-function normalizeCatalogText(value: string): string {
-  return value
-    .normalize("NFKC")
-    .toLocaleLowerCase("en")
-    .replace(/[’‘`]/g, "'")
-    .replace(/[‐‑‒–—]/g, "-")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-function containsCatalogName(haystack: string, name: string): boolean {
-  if (!name) return false;
-  let index = haystack.indexOf(name);
-  while (index >= 0) {
-    const before = haystack[index - 1];
-    const after = haystack[index + name.length];
-    if (!isWordCharacter(before) && !isWordCharacter(after)) return true;
-    index = haystack.indexOf(name, index + name.length);
-  }
-  return false;
-}
-
-function isWordCharacter(value: string | undefined): boolean {
-  return Boolean(value && /[\p{L}\p{N}]/u.test(value));
-}
-
-function toMinorUnits(value: number | null): number | null {
-  if (value === null || !Number.isFinite(value) || value < 0) return null;
-  const minorUnits = Math.round(value * 100);
-  return Math.abs(value * 100 - minorUnits) < 1e-6 ? minorUnits : null;
-}
-
-function normalizeCurrency(value: string): string | null {
-  const normalized = value.trim().toUpperCase();
-  return /^[A-Z]{3}$/.test(normalized) ? normalized : null;
-}
-
-function extractPriceAssertions(haystack: string): PriceAssertion[] {
-  const assertions: PriceAssertion[] = [];
-  const prefix = new RegExp(
-    `(${CURRENCY_TOKEN_PATTERN})[\\s\\u00a0]*(${AMOUNT_PATTERN})`,
-    "giu",
-  );
-  const suffix = new RegExp(
-    `(${AMOUNT_PATTERN})[\\s\\u00a0]*(${CURRENCY_TOKEN_PATTERN}|\\b${CURRENCY_WORD_PATTERN}\\b)`,
-    "giu",
-  );
-
-  for (const match of haystack.matchAll(prefix)) {
-    if (match[1] && match[2] && match.index !== undefined) {
-      const end = match.index + match[0].length;
-      assertions.push({
-        index: match.index,
-        end,
-        currencyToken: match[1],
-        amount: match[2],
-        hasUnsupportedTail: hasUnsupportedPriceTail(haystack, end),
-      });
-    }
-  }
-  for (const match of haystack.matchAll(suffix)) {
-    if (match[1] && match[2] && match.index !== undefined) {
-      const end = match.index + match[0].length;
-      assertions.push({
-        index: match.index,
-        end,
-        currencyToken: match[2],
-        amount: match[1],
-        hasUnsupportedTail: hasUnsupportedPriceTail(haystack, end),
-      });
-    }
-  }
-  return assertions.sort((left, right) => left.index - right.index);
-}
-
-function hasUnsupportedPriceTail(haystack: string, end: number): boolean {
-  return new RegExp(
-    `^(?:\\d|[\\s\\u00a0]*(?:[-‐‑‒–—−/~]|to\\b|à\\b)[\\s\\u00a0]*(?:${CURRENCY_TOKEN_PATTERN}[\\s\\u00a0]*)?\\d)`,
-    "iu",
-  ).test(haystack.slice(end));
-}
-
-function currencyForToken(token: string, facts: SiteFacts): string | null {
-  const normalized = token.trim().toUpperCase();
-  if (normalized === "€" || normalized.startsWith("EURO")) return "EUR";
-  if (normalized === "£" || normalized.startsWith("POUND")) return "GBP";
-  if (normalized === "¥") return "JPY";
-  if (normalized === "ZŁ") return "PLN";
-  if (normalized === "KR") {
-    const krCurrencies = new Set(
-      facts.catalogItems.flatMap((item) => {
-        if (item.price === null) return [];
-        const currency = normalizeCurrency(item.currency);
-        return currency && ["SEK", "NOK", "DKK"].includes(currency)
-          ? [currency]
-          : [];
-      }),
-    );
-    return krCurrencies.size === 1 ? [...krCurrencies][0] : null;
-  }
-  if (normalized !== "$" && !normalized.startsWith("DOLLAR")) {
-    return normalizeCurrency(normalized);
-  }
-
-  const dollarCurrencies = new Set(
-    facts.catalogItems.flatMap((item) => {
-      if (item.price === null) return [];
-      const currency = normalizeCurrency(item.currency);
-      return currency && ["USD", "CAD", "AUD", "NZD"].includes(currency)
-        ? [currency]
-        : [];
-    }),
-  );
-  return dollarCurrencies.size === 1 ? [...dollarCurrencies][0] : null;
-}
-
-function catalogAssertionContextBounds(
-  haystack: string,
-  index: number,
-  assertionEnd: number,
-  clause: boolean,
-): { start: number; end: number } {
-  let start = -1;
-  for (let cursor = index - 1; cursor >= 0; cursor -= 1) {
-    if (isCatalogContextBoundary(haystack, cursor, clause)) {
-      start = cursor;
-      break;
-    }
-  }
-  let end = haystack.length;
-  for (let cursor = assertionEnd; cursor < haystack.length; cursor += 1) {
-    if (isCatalogContextBoundary(haystack, cursor, clause)) {
-      end = cursor;
-      break;
-    }
-  }
-  return { start: start + 1, end };
-}
-
-function isCatalogContextBoundary(
-  haystack: string,
-  index: number,
-  clause: boolean,
-): boolean {
-  const character = haystack[index];
-  if (character === ".") {
-    return !(
-      /\d/.test(haystack[index - 1] ?? "") &&
-      /\d/.test(haystack[index + 1] ?? "")
-    );
-  }
-  if (character === "!" || character === "?" || character === "\n") {
-    return true;
-  }
-  return clause && (character === "," || character === ";");
+  return [...new Set(problems)];
 }
 
 /** Stable content fingerprint used as the generation idempotency key. */
@@ -568,6 +668,10 @@ export function articleFingerprint(input: {
     .update(`${input.siteId}:${input.batchId}:${input.topicKey}`, "utf8")
     .digest("hex")
     .slice(0, 32);
+}
+
+function articleLanguage(locale: string): TemplateLanguage {
+  return locale.toLowerCase().split("-")[0] === "fr" ? "fr" : "en";
 }
 
 function hashSeed(value: string): number {

--- a/src/lib/articles/composer.ts
+++ b/src/lib/articles/composer.ts
@@ -1,6 +1,8 @@
 import { createHash } from "node:crypto";
 import type { SiteFacts } from "@/lib/articles/site-facts";
 import { availableFacts } from "@/lib/articles/site-facts";
+import { articleTopicPlanByKey } from "@/lib/articles/topic-plans";
+import { supportedCurrencySchema } from "@/lib/verticals/schema";
 
 /**
  * The bounded shape the model must return per article. Anything outside this
@@ -13,11 +15,17 @@ export type GeneratedArticleDraft = {
   title: string;
   excerpt: string;
   bodyMarkdown: string;
+  catalogClaims: Array<{
+    name: string;
+    price: number | null;
+    currency: string | null;
+  }>;
 };
 
 export const MAX_ARTICLES_PER_BATCH = 8;
 const MAX_BODY_CHARS = 12_000;
 const MIN_BODY_CHARS = 400;
+const MAX_CATALOG_CLAIMS = 32;
 
 /**
  * Strings a customer site may never publish about itself. A generated article
@@ -89,11 +97,7 @@ export function checkArticleDraft(
     }
   }
 
-  // Every catalog item named in prose must exist on the site. This is the
-  // hallucinated-dish check: inventing a menu item is the most damaging fact
-  // fabrication a food article can make.
-  const mentioned = haystack.match(/\b[\p{L}][\p{L}'’ -]{2,60}\b/gu) ?? [];
-  void mentioned;
+  checkCatalogClaims(draft, facts, haystack, problems);
 
   if (draft.bodyMarkdown.length > MAX_BODY_CHARS) {
     problems.push("body exceeds length budget");
@@ -111,20 +115,447 @@ export function checkArticleDraft(
     problems.push("title and excerpt are required");
   }
 
-  // Price-like assertions ("€12", "$4.50") are only allowed when every named
-  // amount appears in the site's catalog item names — a weak but cheap signal
-  // that catches invented set-menu prices.
-  const prices = haystack.match(/[$€£]\s?\d+(?:[.,]\d{2})?/g) ?? [];
+  return [...new Set(problems)];
+}
+
+type ValidatedPriceClaim = {
+  normalizedName: string;
+  currency: string;
+  minorUnits: number;
+};
+
+type PriceAssertion = {
+  index: number;
+  end: number;
+  currencyToken: string;
+  amount: string;
+  hasUnsupportedTail: boolean;
+};
+
+const SUPPORTED_CURRENCY_CODE_PATTERN =
+  supportedCurrencySchema.options.join("|");
+const CURRENCY_TOKEN_PATTERN = `(?:€|£|\\$|¥|zł|\\bkr\\b|\\b(?:${SUPPORTED_CURRENCY_CODE_PATTERN})\\b)`;
+const CURRENCY_WORD_PATTERN = "(?:euros?|dollars?|pounds?)";
+const AMOUNT_PATTERN = "\\d+(?:[.,]\\d{1,2})?";
+
+/**
+ * The model must enumerate every catalog fact it uses in structured output.
+ * That declaration is checked against the same item's canonical name, price,
+ * and currency before prose can reach persistence. Raw money tokens are also
+ * scanned so omitting price metadata cannot bypass the structured boundary.
+ */
+function checkCatalogClaims(
+  draft: GeneratedArticleDraft,
+  facts: SiteFacts,
+  haystack: string,
+  problems: string[],
+): void {
+  if (!Array.isArray(draft.catalogClaims)) {
+    problems.push("structured catalog claims are required");
+    return;
+  }
+  if (draft.catalogClaims.length > MAX_CATALOG_CLAIMS) {
+    problems.push("too many structured catalog claims");
+  }
+  const topicPlan = articleTopicPlanByKey(facts.vertical, draft.topicKey);
   if (
-    prices.length &&
-    !facts.catalogItemNames.some((name) =>
-      prices.every((price) => name.includes(price.replace(/\s/g, ""))),
-    )
+    topicPlan?.requiredFacts.includes("catalogItems") &&
+    draft.catalogClaims.length === 0
   ) {
-    problems.push("price assertion without catalog backing");
+    problems.push("catalog-dependent topic requires a structured catalog claim");
   }
 
-  return [...new Set(problems)];
+  const normalizedHaystack = normalizeCatalogText(haystack);
+  const factsByName = new Map<
+    string,
+    Array<{ name: string; price: number | null; currency: string }>
+  >();
+  for (const fact of facts.catalogItems) {
+    const normalizedName = normalizeCatalogText(fact.name);
+    const existing = factsByName.get(normalizedName) ?? [];
+    existing.push(fact);
+    factsByName.set(normalizedName, existing);
+  }
+
+  const declaredNames = new Set<string>();
+  const validatedPrices: ValidatedPriceClaim[] = [];
+  for (const claim of draft.catalogClaims.slice(0, MAX_CATALOG_CLAIMS)) {
+    const normalizedName = normalizeCatalogText(claim.name);
+    if (!normalizedName) {
+      problems.push("catalog claim name is required");
+      continue;
+    }
+    declaredNames.add(normalizedName);
+
+    if (!containsCatalogName(normalizedHaystack, normalizedName)) {
+      problems.push(`catalog claim is absent from article: "${claim.name}"`);
+    }
+
+    const matchingFacts = factsByName.get(normalizedName) ?? [];
+    if (!matchingFacts.length) {
+      problems.push(`unknown catalog item claim: "${claim.name}"`);
+      continue;
+    }
+
+    const hasPrice = claim.price !== null;
+    const hasCurrency = Boolean(claim.currency?.trim());
+    if (hasPrice !== hasCurrency) {
+      problems.push(`catalog price claim is incomplete: "${claim.name}"`);
+      continue;
+    }
+    if (!hasPrice || !claim.currency) continue;
+
+    const claimedMinorUnits = toMinorUnits(claim.price);
+    const claimedCurrency = normalizeCurrency(claim.currency);
+    if (claimedMinorUnits === null || !claimedCurrency) {
+      problems.push(`catalog price claim is invalid: "${claim.name}"`);
+      continue;
+    }
+
+    const supported = matchingFacts.some((fact) => {
+      const factMinorUnits = toMinorUnits(fact.price);
+      return (
+        factMinorUnits === claimedMinorUnits &&
+        normalizeCurrency(fact.currency) === claimedCurrency
+      );
+    });
+    if (!supported) {
+      problems.push(`unsupported catalog price claim: "${claim.name}"`);
+      continue;
+    }
+    validatedPrices.push({
+      normalizedName,
+      currency: claimedCurrency,
+      minorUnits: claimedMinorUnits,
+    });
+  }
+
+  // Known catalog names in prose cannot be omitted from the structured claim
+  // list. This closes the metadata-omission path for every canonical item the
+  // deterministic matcher can identify without treating arbitrary nouns as
+  // products.
+  for (const normalizedName of factsByName.keys()) {
+    if (
+      containsCatalogName(normalizedHaystack, normalizedName) &&
+      !declaredNames.has(normalizedName)
+    ) {
+      problems.push(`catalog item mention lacks a structured claim: "${normalizedName}"`);
+    }
+  }
+
+  // The structured contract is the primary boundary, but deterministic prose
+  // still fails closed for high-confidence product assertions that omit it.
+  // Restricting this supplemental detector to title-cased names next to
+  // product verbs avoids classifying every arbitrary noun phrase as a product.
+  const knownNonCatalogNames = new Set(
+    [facts.name, facts.address, ...facts.integrationLabels].flatMap((value) => {
+      if (!value?.trim()) return [];
+      return [
+        normalizeCatalogText(value),
+        normalizeCatalogText(stripLikelyMentionDeterminer(value)),
+      ];
+    }),
+  );
+  for (const mention of extractLikelyCatalogMentions(haystack)) {
+    const normalizedMention = normalizeCatalogText(
+      stripLikelyMentionDeterminer(mention),
+    );
+    if (
+      knownNonCatalogNames.has(normalizeCatalogText(mention)) ||
+      knownNonCatalogNames.has(normalizedMention)
+    ) {
+      continue;
+    }
+    if (
+      isDeclaredCatalogComposition(
+        normalizedMention,
+        factsByName,
+        declaredNames,
+      )
+    ) {
+      continue;
+    }
+    if (!factsByName.has(normalizedMention)) {
+      problems.push(`unknown catalog item mention: "${mention}"`);
+    } else if (!declaredNames.has(normalizedMention)) {
+      problems.push(
+        `catalog item mention lacks a structured claim: "${normalizedMention}"`,
+      );
+    }
+  }
+
+  for (const assertion of extractPriceAssertions(haystack)) {
+    const assertionMinorUnits = toMinorUnits(
+      Number(assertion.amount.replace(",", ".")),
+    );
+    const assertionCurrency = currencyForToken(assertion.currencyToken, facts);
+    const sentenceBounds = catalogAssertionContextBounds(
+      haystack,
+      assertion.index,
+      assertion.end,
+      false,
+    );
+    const clauseBounds = catalogAssertionContextBounds(
+      haystack,
+      assertion.index,
+      assertion.end,
+      true,
+    );
+    const sentenceContext = normalizeCatalogText(
+      haystack.slice(sentenceBounds.start, sentenceBounds.end),
+    );
+    const clauseContext = normalizeCatalogText(
+      haystack.slice(clauseBounds.start, clauseBounds.end),
+    );
+    const afterAssertionContext = normalizeCatalogText(
+      haystack.slice(assertion.end, sentenceBounds.end),
+    );
+    const sentenceNames = catalogNamesInContext(sentenceContext, factsByName);
+    const clauseNames = catalogNamesInContext(clauseContext, factsByName);
+    const afterAssertionNames = catalogNamesInContext(
+      afterAssertionContext,
+      factsByName,
+    );
+    const boundNames =
+      clauseNames.size === 1
+        ? clauseNames
+        : clauseNames.size === 0 &&
+            sentenceNames.size === 1 &&
+            afterAssertionNames.size === 1
+          ? sentenceNames
+          : new Set<string>();
+    const backed =
+      !assertion.hasUnsupportedTail &&
+      assertionMinorUnits !== null &&
+      assertionCurrency !== null &&
+      boundNames.size === 1 &&
+      validatedPrices.some(
+        (claim) =>
+          claim.minorUnits === assertionMinorUnits &&
+          claim.currency === assertionCurrency &&
+          boundNames.has(claim.normalizedName),
+      );
+    if (!backed) problems.push("price assertion without catalog backing");
+  }
+}
+
+function isDeclaredCatalogComposition(
+  mention: string,
+  factsByName: Map<
+    string,
+    Array<{ name: string; price: number | null; currency: string }>
+  >,
+  declaredNames: Set<string>,
+): boolean {
+  const names = [...factsByName.keys()]
+    .filter((name) => declaredNames.has(name))
+    .sort((left, right) => right.length - left.length);
+
+  function consume(remaining: string): boolean {
+    for (const name of names) {
+      if (remaining !== name && !remaining.startsWith(`${name} `)) continue;
+      const tail = remaining.slice(name.length);
+      if (!tail) return true;
+      const separator = tail.match(
+        /^\s*(?:,\s*(?:(?:and|or|et|ou|&)\s+)?|(?:and|or|et|ou|&)\s+)/u,
+      );
+      if (separator && consume(tail.slice(separator[0].length))) return true;
+    }
+    return false;
+  }
+
+  return consume(mention);
+}
+
+function catalogNamesInContext(
+  context: string,
+  factsByName: Map<
+    string,
+    Array<{ name: string; price: number | null; currency: string }>
+  >,
+): Set<string> {
+  return new Set(
+    [...factsByName.keys()].filter((name) => containsCatalogName(context, name)),
+  );
+}
+
+function extractLikelyCatalogMentions(haystack: string): string[] {
+  const titleWord = String.raw`\p{Lu}[\p{L}\p{M}'’\-]*`;
+  const followingWord = String.raw`[\p{L}\p{M}'’\-]+`;
+  const candidate = `${titleWord}(?:\\s+${followingWord}){0,5}`;
+  const productPredicate =
+    String.raw`(?:costs?|(?:is|are|remains?)\s+(?:baked|folded|served|priced|prepared|made|available))`;
+  const predicatePattern = new RegExp(
+    String.raw`(?<![\p{L}\p{N}])(${candidate})\s+${productPredicate}\b`,
+    "gu",
+  );
+  const activePattern = new RegExp(
+    String.raw`\b(?:prepare|bake|serve|offer|sell|make)s?\s+(${titleWord}(?:\s+${titleWord}){0,4})\b`,
+    "gu",
+  );
+  return [...haystack.matchAll(predicatePattern), ...haystack.matchAll(activePattern)]
+    .flatMap((match) => (match[1] ? [match[1]] : []));
+}
+
+function stripLikelyMentionDeterminer(value: string): string {
+  return value.replace(/^(?:A|An|The|Our|Le|La|Les|Un|Une)\s+/u, "");
+}
+
+function normalizeCatalogText(value: string): string {
+  return value
+    .normalize("NFKC")
+    .toLocaleLowerCase("en")
+    .replace(/[’‘`]/g, "'")
+    .replace(/[‐‑‒–—]/g, "-")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function containsCatalogName(haystack: string, name: string): boolean {
+  if (!name) return false;
+  let index = haystack.indexOf(name);
+  while (index >= 0) {
+    const before = haystack[index - 1];
+    const after = haystack[index + name.length];
+    if (!isWordCharacter(before) && !isWordCharacter(after)) return true;
+    index = haystack.indexOf(name, index + name.length);
+  }
+  return false;
+}
+
+function isWordCharacter(value: string | undefined): boolean {
+  return Boolean(value && /[\p{L}\p{N}]/u.test(value));
+}
+
+function toMinorUnits(value: number | null): number | null {
+  if (value === null || !Number.isFinite(value) || value < 0) return null;
+  const minorUnits = Math.round(value * 100);
+  return Math.abs(value * 100 - minorUnits) < 1e-6 ? minorUnits : null;
+}
+
+function normalizeCurrency(value: string): string | null {
+  const normalized = value.trim().toUpperCase();
+  return /^[A-Z]{3}$/.test(normalized) ? normalized : null;
+}
+
+function extractPriceAssertions(haystack: string): PriceAssertion[] {
+  const assertions: PriceAssertion[] = [];
+  const prefix = new RegExp(
+    `(${CURRENCY_TOKEN_PATTERN})[\\s\\u00a0]*(${AMOUNT_PATTERN})`,
+    "giu",
+  );
+  const suffix = new RegExp(
+    `(${AMOUNT_PATTERN})[\\s\\u00a0]*(${CURRENCY_TOKEN_PATTERN}|\\b${CURRENCY_WORD_PATTERN}\\b)`,
+    "giu",
+  );
+
+  for (const match of haystack.matchAll(prefix)) {
+    if (match[1] && match[2] && match.index !== undefined) {
+      const end = match.index + match[0].length;
+      assertions.push({
+        index: match.index,
+        end,
+        currencyToken: match[1],
+        amount: match[2],
+        hasUnsupportedTail: hasUnsupportedPriceTail(haystack, end),
+      });
+    }
+  }
+  for (const match of haystack.matchAll(suffix)) {
+    if (match[1] && match[2] && match.index !== undefined) {
+      const end = match.index + match[0].length;
+      assertions.push({
+        index: match.index,
+        end,
+        currencyToken: match[2],
+        amount: match[1],
+        hasUnsupportedTail: hasUnsupportedPriceTail(haystack, end),
+      });
+    }
+  }
+  return assertions.sort((left, right) => left.index - right.index);
+}
+
+function hasUnsupportedPriceTail(haystack: string, end: number): boolean {
+  return new RegExp(
+    `^(?:\\d|[\\s\\u00a0]*(?:[-‐‑‒–—−/~]|to\\b|à\\b)[\\s\\u00a0]*(?:${CURRENCY_TOKEN_PATTERN}[\\s\\u00a0]*)?\\d)`,
+    "iu",
+  ).test(haystack.slice(end));
+}
+
+function currencyForToken(token: string, facts: SiteFacts): string | null {
+  const normalized = token.trim().toUpperCase();
+  if (normalized === "€" || normalized.startsWith("EURO")) return "EUR";
+  if (normalized === "£" || normalized.startsWith("POUND")) return "GBP";
+  if (normalized === "¥") return "JPY";
+  if (normalized === "ZŁ") return "PLN";
+  if (normalized === "KR") {
+    const krCurrencies = new Set(
+      facts.catalogItems.flatMap((item) => {
+        if (item.price === null) return [];
+        const currency = normalizeCurrency(item.currency);
+        return currency && ["SEK", "NOK", "DKK"].includes(currency)
+          ? [currency]
+          : [];
+      }),
+    );
+    return krCurrencies.size === 1 ? [...krCurrencies][0] : null;
+  }
+  if (normalized !== "$" && !normalized.startsWith("DOLLAR")) {
+    return normalizeCurrency(normalized);
+  }
+
+  const dollarCurrencies = new Set(
+    facts.catalogItems.flatMap((item) => {
+      if (item.price === null) return [];
+      const currency = normalizeCurrency(item.currency);
+      return currency && ["USD", "CAD", "AUD", "NZD"].includes(currency)
+        ? [currency]
+        : [];
+    }),
+  );
+  return dollarCurrencies.size === 1 ? [...dollarCurrencies][0] : null;
+}
+
+function catalogAssertionContextBounds(
+  haystack: string,
+  index: number,
+  assertionEnd: number,
+  clause: boolean,
+): { start: number; end: number } {
+  let start = -1;
+  for (let cursor = index - 1; cursor >= 0; cursor -= 1) {
+    if (isCatalogContextBoundary(haystack, cursor, clause)) {
+      start = cursor;
+      break;
+    }
+  }
+  let end = haystack.length;
+  for (let cursor = assertionEnd; cursor < haystack.length; cursor += 1) {
+    if (isCatalogContextBoundary(haystack, cursor, clause)) {
+      end = cursor;
+      break;
+    }
+  }
+  return { start: start + 1, end };
+}
+
+function isCatalogContextBoundary(
+  haystack: string,
+  index: number,
+  clause: boolean,
+): boolean {
+  const character = haystack[index];
+  if (character === ".") {
+    return !(
+      /\d/.test(haystack[index - 1] ?? "") &&
+      /\d/.test(haystack[index + 1] ?? "")
+    );
+  }
+  if (character === "!" || character === "?" || character === "\n") {
+    return true;
+  }
+  return clause && (character === "," || character === ";");
 }
 
 /** Stable content fingerprint used as the generation idempotency key. */

--- a/src/lib/articles/generation.postgres.test.ts
+++ b/src/lib/articles/generation.postgres.test.ts
@@ -1,4 +1,6 @@
 import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 import {
   afterAll,
   beforeAll,
@@ -7,14 +9,27 @@ import {
   mock,
   test,
 } from "bun:test";
-
-mock.module("server-only", () => ({}));
+import { Client } from "pg";
 
 const enabled = process.env.ARTICLES_POSTGRES_TEST === "1";
+if (enabled) mock.module("server-only", () => ({}));
+
 const siteId = `articles-test-${randomUUID()}`;
+const outcomeMigrationPath = fileURLToPath(
+  new URL(
+    "../../../prisma/migrations/20260823110000_article_batch_admission_outcomes/migration.sql",
+    import.meta.url,
+  ),
+);
+const createdSiteIds = new Set([siteId]);
+const createdOrganizationIds = new Set<string>();
 let db: ReturnType<typeof import("@/lib/db").getDb>;
 let loadGenerationInputs: typeof import("@/lib/articles/generation").loadGenerationInputs;
 let persistArticleBatch: typeof import("@/lib/articles/generation").persistArticleBatch;
+let beginArticleBatch: typeof import("@/lib/articles/generation").beginArticleBatch;
+let closeArticleBatch: typeof import("@/lib/articles/generation").closeArticleBatch;
+let reserveArticleBatch: typeof import("@/lib/articles/start-batch").reserveArticleBatch;
+let startArticleBatch: typeof import("@/lib/articles/start-batch").startArticleBatch;
 
 /**
  * PostgreSQL-gated integration coverage for the article engine's persistence
@@ -30,6 +45,11 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
     db = database.getDb();
     loadGenerationInputs = generation.loadGenerationInputs;
     persistArticleBatch = generation.persistArticleBatch;
+    beginArticleBatch = generation.beginArticleBatch;
+    closeArticleBatch = generation.closeArticleBatch;
+    ({ reserveArticleBatch, startArticleBatch } = await import(
+      "@/lib/articles/start-batch"
+    ));
 
     await db.site.create({
       data: {
@@ -47,8 +67,8 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
               position: 0,
               items: {
                 create: [
-                  { name: "Croissant", position: 0 },
-                  { name: "Pain au chocolat", position: 1 },
+                  { name: "Croissant", price: 4.5, currency: "EUR", position: 0 },
+                  { name: "Pain au chocolat", price: 3.5, currency: "EUR", position: 1 },
                 ],
               },
             },
@@ -64,16 +84,116 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
 
   afterAll(async () => {
     if (!enabled) return;
-    await db.site.delete({ where: { id: siteId } }).catch(() => undefined);
+    await db.site
+      .deleteMany({ where: { id: { in: [...createdSiteIds] } } })
+      .catch(() => undefined);
+    await db.organization
+      .deleteMany({ where: { id: { in: [...createdOrganizationIds] } } })
+      .catch(() => undefined);
   });
 
   test("loads facts from the live draft relations", async () => {
     const inputs = await loadGenerationInputs(siteId);
     if (!inputs.ok) throw new Error(inputs.reason);
-    expect(inputs.facts.catalogItemNames).toContain("Croissant");
+    expect(inputs.facts.catalogItems).toContainEqual({
+      name: "Croissant",
+      price: 4.5,
+      currency: "EUR",
+    });
     expect(inputs.facts.integrationLabels).toEqual(["Book a table"]);
     expect(inputs.facts.address).toBe("12 Rue du Four, Paris");
     expect(inputs.recentTopicKeys).toEqual([]);
+  });
+
+  test("backfills predecessor outcomes and installs the active-batch fence", async () => {
+    const databaseUrl = process.env.DATABASE_URL;
+    if (!databaseUrl) throw new Error("DATABASE_URL is required");
+    const schema = `article_batch_upgrade_${randomUUID().replaceAll("-", "")}`;
+    const client = new Client({ connectionString: databaseUrl });
+    await client.connect();
+    try {
+      await client.query(`CREATE SCHEMA "${schema}"`);
+      await client.query(`SET search_path TO "${schema}", public`);
+      await client.query(`
+        CREATE TABLE "ArticleBatch" (
+          "id" TEXT PRIMARY KEY,
+          "siteId" TEXT NOT NULL,
+          "requestedCount" INTEGER NOT NULL,
+          "producedCount" INTEGER NOT NULL,
+          "model" TEXT,
+          "requestedBy" TEXT NOT NULL,
+          "completedAt" TIMESTAMP(3),
+          "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )
+      `);
+      await client.query(`
+        INSERT INTO "ArticleBatch" (
+          "id", "siteId", "requestedCount", "producedCount", "requestedBy", "completedAt"
+        ) VALUES
+          ('legacy-zero', 'legacy-site-zero', 0, 0, 'legacy-script', NOW()),
+          ('legacy-rejected', 'legacy-site-rejected', 2, 0, 'legacy-workflow', NOW()),
+          ('legacy-succeeded', 'legacy-site-succeeded', 4, 2, 'legacy-workflow', NOW())
+      `);
+      await client.query(await readFile(outcomeMigrationPath, "utf8"));
+
+      const outcomes = await client.query<{
+        id: string;
+        requestedCount: number;
+        acceptedCount: number;
+        rejectedCount: number;
+        status: string;
+        statusReason: string | null;
+      }>(`
+        SELECT "id", "requestedCount", "acceptedCount", "rejectedCount",
+               "status"::text, "statusReason"
+        FROM "ArticleBatch"
+        ORDER BY "id"
+      `);
+      expect(outcomes.rows).toEqual([
+        {
+          id: "legacy-rejected",
+          requestedCount: 2,
+          acceptedCount: 0,
+          rejectedCount: 2,
+          status: "REJECTED",
+          statusReason: "ALL_DRAFTS_REJECTED",
+        },
+        {
+          id: "legacy-succeeded",
+          requestedCount: 4,
+          acceptedCount: 2,
+          rejectedCount: 2,
+          status: "SUCCEEDED",
+          statusReason: null,
+        },
+        {
+          id: "legacy-zero",
+          requestedCount: 0,
+          acceptedCount: 0,
+          rejectedCount: 0,
+          status: "ZERO_OUTPUT",
+          statusReason: "LEGACY_ZERO_OUTPUT",
+        },
+      ]);
+
+      const activeInsert = (id: string) =>
+        client.query(
+          `INSERT INTO "ArticleBatch" (
+             "id", "siteId", "requestedCount", "requestedBy", "updatedAt"
+           ) VALUES ($1, 'one-active-site', 4, 'migration-test', NOW())`,
+          [id],
+        );
+      await activeInsert("active-one");
+      await expect(activeInsert("active-two")).rejects.toMatchObject({
+        code: "23505",
+      });
+    } finally {
+      await client.query("SET search_path TO public").catch(() => undefined);
+      await client
+        .query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+        .catch(() => undefined);
+      await client.end().catch(() => undefined);
+    }
   });
 
   test("refuses unclaimed sites", async () => {
@@ -90,9 +210,10 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
     const inputs = await loadGenerationInputs(siteId);
     if (!inputs.ok) throw new Error(inputs.reason);
 
+    const batchId = await createRunningBatch(siteId, 4);
     const persisted = await persistArticleBatch({
+      batchId,
       siteId,
-      requestedBy: "test-operator",
       facts: inputs.facts,
       model: "test-model",
       drafts: [
@@ -103,6 +224,9 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
           excerpt: "What the ovens are doing this month.",
           bodyMarkdown:
             "Our croissant lamination stays the same all year. ".repeat(20),
+          catalogClaims: [
+            { name: "Croissant", price: null, currency: null },
+          ],
         },
         {
           topicKey: "neighbourhood-guide",
@@ -113,11 +237,22 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
             "We are on Rue du Four between the bakery and the bookshop. ".repeat(
               15,
             ),
+          catalogClaims: [],
         },
       ],
     });
 
     expect(persisted.producedCount).toBe(2);
+    expect(
+      await db.articleBatch.findUniqueOrThrow({ where: { id: batchId } }),
+    ).toMatchObject({
+      requestedCount: 4,
+      acceptedCount: 2,
+      rejectedCount: 0,
+      status: "SUCCEEDED",
+      statusReason: null,
+      model: "test-model",
+    });
     const rows = await db.article.findMany({ where: { siteId } });
     expect(rows.length).toBe(2);
     for (const row of rows) {
@@ -132,8 +267,8 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
     if (!inputs.ok) throw new Error(inputs.reason);
 
     const persisted = await persistArticleBatch({
+      batchId: await createRunningBatch(siteId, 1),
       siteId,
-      requestedBy: "test-operator",
       facts: inputs.facts,
       drafts: [
         {
@@ -141,7 +276,11 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
           slug: "seasonal-menu-update",
           title: "Same slug, different article",
           excerpt: "Slug collision test.",
-          bodyMarkdown: "Gluten-free options exist for every item. ".repeat(15),
+          bodyMarkdown:
+            "Ask us about the Croissant ingredients before choosing. ".repeat(15),
+          catalogClaims: [
+            { name: "Croissant", price: null, currency: null },
+          ],
         },
       ],
     });
@@ -162,8 +301,8 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
     const inputs = await loadGenerationInputs(siteId);
     if (!inputs.ok) throw new Error(inputs.reason);
     await persistArticleBatch({
+      batchId: await createRunningBatch(siteId, 1),
       siteId,
-      requestedBy: "test-operator",
       facts: inputs.facts,
       drafts: [
         {
@@ -171,7 +310,11 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
           slug: "our-kitchen",
           title: "Our kitchen",
           excerpt: "Suppliers and method.",
-          bodyMarkdown: "Butter arrives twice weekly from two dairies. ".repeat(12),
+          bodyMarkdown:
+            "Our Croissant is folded in the kitchen in small batches. ".repeat(12),
+          catalogClaims: [
+            { name: "Croissant", price: null, currency: null },
+          ],
         },
       ],
     });
@@ -188,8 +331,8 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
     const inputs = await loadGenerationInputs(siteId);
     if (!inputs.ok) throw new Error(inputs.reason);
     const persisted = await persistArticleBatch({
+      batchId: await createRunningBatch(siteId, 1),
       siteId,
-      requestedBy: "test-operator",
       facts: inputs.facts,
       drafts: [
         {
@@ -198,11 +341,302 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
           title: "Award winning bakes",
           excerpt: "This should never persist.",
           bodyMarkdown: "We are award winning and certified organic. ".repeat(10),
+          catalogClaims: [],
         },
       ],
     });
     expect(persisted.producedCount).toBe(0);
+    expect(
+      await db.articleBatch.findUniqueOrThrow({
+        where: { id: persisted.batchId },
+      }),
+    ).toMatchObject({
+      requestedCount: 1,
+      acceptedCount: 0,
+      rejectedCount: 1,
+      status: "REJECTED",
+      statusReason: "ALL_DRAFTS_REJECTED",
+    });
     expect(await db.article.count({ where: { siteId, topicKey: "trends" } })).toBe(0);
+
+    const afterRejected = await loadGenerationInputs(siteId);
+    if (!afterRejected.ok) throw new Error(afterRejected.reason);
+    expect([...afterRejected.recentTopicKeys].sort()).toEqual(
+      ["chef-story", "dietary-faqs"].sort(),
+    );
+  });
+
+  test("atomically admits one of two concurrent starts", async () => {
+    const concurrentSiteId = await createClaimedSite();
+    const results = await Promise.all([
+      reserveArticleBatch({
+        siteId: concurrentSiteId,
+        requestedBy: "concurrent-one",
+        count: 4,
+      }),
+      reserveArticleBatch({
+        siteId: concurrentSiteId,
+        requestedBy: "concurrent-two",
+        count: 4,
+      }),
+    ]);
+
+    const admitted = results.filter((result) => result.ok);
+    expect(admitted).toHaveLength(1);
+    expect(results.filter((result) => !result.ok)).toHaveLength(1);
+    expect(
+      await db.articleBatch.count({ where: { siteId: concurrentSiteId } }),
+    ).toBe(1);
+    const winner = admitted[0];
+    if (!winner?.ok) throw new Error("concurrent admission had no winner");
+    await closeArticleBatch({
+      batchId: winner.batchId,
+      status: "ZERO_OUTPUT",
+      statusReason: "TEST_CLEANUP",
+    });
+  });
+
+  test("allows paid cadence bypass only after the active batch is terminal", async () => {
+    const paidSiteId = await createClaimedSite({ paid: true });
+    const starts = await Promise.all([
+      reserveArticleBatch({
+        siteId: paidSiteId,
+        requestedBy: "paid-one",
+        count: 4,
+      }),
+      reserveArticleBatch({
+        siteId: paidSiteId,
+        requestedBy: "paid-two",
+        count: 4,
+      }),
+    ]);
+    const admitted = starts.filter((result) => result.ok);
+    expect(admitted).toHaveLength(1);
+    const first = admitted[0];
+    if (!first?.ok) throw new Error("paid admission had no winner");
+    await closeArticleBatch({
+      batchId: first.batchId,
+      status: "ZERO_OUTPUT",
+      statusReason: "MODEL_RETURNED_ZERO_DRAFTS",
+    });
+
+    const next = await reserveArticleBatch({
+      siteId: paidSiteId,
+      requestedBy: "paid-next",
+      count: 4,
+    });
+    expect(next.ok).toBe(true);
+    if (!next.ok) throw new Error(next.reason);
+    await closeArticleBatch({
+      batchId: next.batchId,
+      status: "ZERO_OUTPUT",
+      statusReason: "TEST_CLEANUP",
+    });
+  });
+
+  test("keeps requested, accepted, and rejected counts independent and replay-safe", async () => {
+    const accountingSiteId = await createClaimedSite();
+    const inputs = await loadGenerationInputs(accountingSiteId);
+    if (!inputs.ok) throw new Error(inputs.reason);
+    const admission = await reserveArticleBatch({
+      siteId: accountingSiteId,
+      requestedBy: "accounting-test",
+      count: 4,
+    });
+    if (!admission.ok) throw new Error(admission.reason);
+    expect(await beginArticleBatch(admission.batchId)).toMatchObject({
+      siteId: accountingSiteId,
+      requestedCount: 4,
+    });
+    const persistInput = {
+      batchId: admission.batchId,
+      siteId: accountingSiteId,
+      facts: inputs.facts,
+      drafts: [
+        factualDraft("accounting-factual", "seasonal-menu"),
+        {
+          ...factualDraft("accounting-invented", "first-visit"),
+          bodyMarkdown: "The invented Moonbeam Tart is ready today. ".repeat(15),
+          catalogClaims: [
+            { name: "Moonbeam Tart", price: 12, currency: "EUR" },
+          ],
+        },
+      ],
+    };
+    const first = await persistArticleBatch(persistInput);
+    const replay = await persistArticleBatch(persistInput);
+
+    expect(first).toEqual(replay);
+    expect(first).toMatchObject({ producedCount: 1, rejectedCount: 1 });
+    expect(
+      await db.articleBatch.findUniqueOrThrow({
+        where: { id: admission.batchId },
+      }),
+    ).toMatchObject({
+      requestedCount: 4,
+      acceptedCount: 1,
+      rejectedCount: 1,
+      status: "SUCCEEDED",
+    });
+    expect(
+      await db.article.count({ where: { batchId: admission.batchId } }),
+    ).toBe(1);
+    expect(
+      await closeArticleBatch({
+        batchId: admission.batchId,
+        status: "FAILED",
+        statusReason: "LATE_FAILURE",
+      }),
+    ).toBe(false);
+    expect(
+      await db.articleBatch.findUniqueOrThrow({
+        where: { id: admission.batchId },
+        select: { status: true },
+      }),
+    ).toEqual({ status: "SUCCEEDED" });
+  });
+
+  test("terminal zero, skipped, rejected, and failed outcomes close and consume cadence", async () => {
+    const outcomes = [
+      ["ZERO_OUTPUT", "MODEL_RETURNED_ZERO_DRAFTS", 0],
+      ["SKIPPED", "SITE_INELIGIBLE", 0],
+      ["REJECTED", "ALL_DRAFTS_REJECTED", 2],
+      ["FAILED", "GENERATION_FAILED", 0],
+    ] as const;
+
+    for (const [status, statusReason, rejectedCount] of outcomes) {
+      const outcomeSiteId = await createClaimedSite();
+      const admission = await reserveArticleBatch({
+        siteId: outcomeSiteId,
+        requestedBy: `outcome-${status.toLowerCase()}`,
+        count: 4,
+      });
+      if (!admission.ok) throw new Error(admission.reason);
+      await beginArticleBatch(admission.batchId);
+      expect(
+        await closeArticleBatch({
+          batchId: admission.batchId,
+          status,
+          statusReason,
+          rejectedCount,
+        }),
+      ).toBe(true);
+      const terminal = await db.articleBatch.findUniqueOrThrow({
+        where: { id: admission.batchId },
+      });
+      expect(terminal).toMatchObject({
+        requestedCount: 4,
+        acceptedCount: 0,
+        rejectedCount,
+        status,
+        statusReason,
+      });
+      expect(terminal.completedAt).toBeInstanceOf(Date);
+      const completedAt = terminal.completedAt;
+      expect(
+        await closeArticleBatch({
+          batchId: admission.batchId,
+          status,
+          statusReason: "MUST_NOT_REWRITE",
+          rejectedCount: 99,
+        }),
+      ).toBe(true);
+      expect(
+        await db.articleBatch.findUniqueOrThrow({
+          where: { id: admission.batchId },
+          select: {
+            completedAt: true,
+            rejectedCount: true,
+            statusReason: true,
+          },
+        }),
+      ).toEqual({ completedAt, rejectedCount, statusReason });
+
+      const retry = await reserveArticleBatch({
+        siteId: outcomeSiteId,
+        requestedBy: "cadence-retry",
+        count: 4,
+      });
+      expect(retry).toMatchObject({ ok: false, status: 409 });
+    }
+  });
+
+  test("workflow start failures close the reservation without provider work", async () => {
+    const failureSiteId = await createClaimedSite();
+    const previousApiKey = process.env.OPENROUTER_API_KEY;
+    process.env.OPENROUTER_API_KEY = "test-only-never-sent";
+    let startAttempts = 0;
+    try {
+      await expect(
+        startArticleBatch(
+          {
+            siteId: failureSiteId,
+            slug: "unused-test-slug",
+            requestedBy: "start-failure-test",
+            count: 4,
+          },
+          async () => {
+            startAttempts += 1;
+            throw new Error("synthetic workflow start failure");
+          },
+        ),
+      ).rejects.toThrow("synthetic workflow start failure");
+    } finally {
+      restoreEnvironment("OPENROUTER_API_KEY", previousApiKey);
+    }
+
+    expect(startAttempts).toBe(1);
+    expect(
+      await db.articleBatch.findFirstOrThrow({
+        where: { siteId: failureSiteId },
+      }),
+    ).toMatchObject({
+      requestedCount: 4,
+      acceptedCount: 0,
+      rejectedCount: 0,
+      status: "FAILED",
+      statusReason: "WORKFLOW_START_FAILED",
+    });
+    const retry = await reserveArticleBatch({
+      siteId: failureSiteId,
+      requestedBy: "failed-start-retry",
+      count: 4,
+    });
+    expect(retry).toMatchObject({ ok: false, status: 409 });
+  });
+
+  test("binds the workflow run id after a fast terminal outcome", async () => {
+    const fastSiteId = await createClaimedSite();
+    const previousApiKey = process.env.OPENROUTER_API_KEY;
+    process.env.OPENROUTER_API_KEY = "test-only-never-sent";
+    try {
+      const result = await startArticleBatch(
+        {
+          siteId: fastSiteId,
+          slug: "unused-fast-terminal-slug",
+          requestedBy: "fast-terminal-test",
+          count: 4,
+        },
+        async (batchId) => {
+          await beginArticleBatch(batchId);
+          await closeArticleBatch({
+            batchId,
+            status: "ZERO_OUTPUT",
+            statusReason: "MODEL_RETURNED_ZERO_DRAFTS",
+          });
+          return `run_fast_${randomUUID()}`;
+        },
+      );
+      if (!result.ok) throw new Error(result.reason);
+      expect(
+        await db.articleBatch.findFirstOrThrow({
+          where: { siteId: fastSiteId },
+          select: { status: true, workflowRunId: true },
+        }),
+      ).toEqual({ status: "ZERO_OUTPUT", workflowRunId: result.runId });
+    } finally {
+      restoreEnvironment("OPENROUTER_API_KEY", previousApiKey);
+    }
   });
 
   test("publishing an article makes it visible to the public reader", async () => {
@@ -249,3 +683,94 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
     expect(one?.title).toBeTruthy();
   });
 });
+
+async function createRunningBatch(
+  targetSiteId: string,
+  requestedCount: number,
+): Promise<string> {
+  const batch = await db.articleBatch.create({
+    data: {
+      siteId: targetSiteId,
+      requestedCount,
+      requestedBy: "test-operator",
+    },
+    select: { id: true },
+  });
+  const started = await beginArticleBatch(batch.id);
+  if (!started) throw new Error("test article batch did not start");
+  return batch.id;
+}
+
+async function createClaimedSite(options: { paid?: boolean } = {}): Promise<string> {
+  const targetSiteId = `articles-outcome-${randomUUID()}`;
+  createdSiteIds.add(targetSiteId);
+  let organizationId: string | undefined;
+  if (options.paid) {
+    organizationId = `articles-org-${randomUUID()}`;
+    createdOrganizationIds.add(organizationId);
+    await db.organization.create({
+      data: { id: organizationId, name: "Article batch test organization" },
+    });
+  }
+
+  await db.site.create({
+    data: {
+      id: targetSiteId,
+      slug: `articles-outcome-${randomUUID()}`,
+      name: "Article Batch Test Bakery",
+      status: "CLAIMED",
+      defaultLocale: "en",
+      organizationId,
+      catalogSections: {
+        create: {
+          name: "Bakes",
+          position: 0,
+          items: {
+            create: {
+              name: "Croissant",
+              price: 4.5,
+              currency: "EUR",
+              position: 0,
+            },
+          },
+        },
+      },
+      ...(organizationId
+        ? {
+            subscription: {
+              create: {
+                stripeCustomerId: `cus_${randomUUID()}`,
+                stripeSubscriptionId: `sub_${randomUUID()}`,
+                stripePriceId: "price_article_batch_test",
+                status: "ACTIVE" as const,
+                organizationId,
+              },
+            },
+          }
+        : {}),
+    },
+    select: { id: true },
+  });
+  return targetSiteId;
+}
+
+function factualDraft(slug: string, topicKey: string) {
+  return {
+    topicKey,
+    slug,
+    title: "A factual bakery article",
+    excerpt: "A source-backed look at one familiar bake.",
+    bodyMarkdown:
+      "Our Croissant is folded carefully and baked in small batches each morning. ".repeat(
+        10,
+      ),
+    catalogClaims: [
+      { name: "Croissant", price: null, currency: null },
+    ],
+  };
+}
+
+function restoreEnvironment(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}

--- a/src/lib/articles/generation.postgres.test.ts
+++ b/src/lib/articles/generation.postgres.test.ts
@@ -21,6 +21,9 @@ const outcomeMigrationPath = fileURLToPath(
     import.meta.url,
   ),
 );
+const prismaSchemaPath = fileURLToPath(
+  new URL("../../../prisma/schema.prisma", import.meta.url),
+);
 const createdSiteIds = new Set([siteId]);
 const createdOrganizationIds = new Set<string>();
 let db: ReturnType<typeof import("@/lib/db").getDb>;
@@ -30,6 +33,10 @@ let beginArticleBatch: typeof import("@/lib/articles/generation").beginArticleBa
 let closeArticleBatch: typeof import("@/lib/articles/generation").closeArticleBatch;
 let reserveArticleBatch: typeof import("@/lib/articles/start-batch").reserveArticleBatch;
 let startArticleBatch: typeof import("@/lib/articles/start-batch").startArticleBatch;
+let dispatchArticleBatch: typeof import("@/lib/articles/start-batch").dispatchArticleBatch;
+let dispatchQueuedArticleBatches: typeof import("@/lib/articles/start-batch").dispatchQueuedArticleBatches;
+let reconcileBoundArticleBatches: typeof import("@/lib/articles/start-batch").reconcileBoundArticleBatches;
+let articleBatchDispatchLeaseMs: number;
 
 /**
  * PostgreSQL-gated integration coverage for the article engine's persistence
@@ -47,9 +54,23 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
     persistArticleBatch = generation.persistArticleBatch;
     beginArticleBatch = generation.beginArticleBatch;
     closeArticleBatch = generation.closeArticleBatch;
-    ({ reserveArticleBatch, startArticleBatch } = await import(
-      "@/lib/articles/start-batch"
-    ));
+    const startBatch = await import("@/lib/articles/start-batch");
+    reserveArticleBatch = startBatch.reserveArticleBatch;
+    startArticleBatch = startBatch.startArticleBatch;
+    dispatchArticleBatch = startBatch.dispatchArticleBatch;
+    dispatchQueuedArticleBatches = startBatch.dispatchQueuedArticleBatches;
+    reconcileBoundArticleBatches = startBatch.reconcileBoundArticleBatches;
+    articleBatchDispatchLeaseMs = startBatch.ARTICLE_BATCH_DISPATCH_LEASE_MS;
+
+    await db.operatorSetting.upsert({
+      where: { key: "articles.mutations.gated" },
+      update: { value: false, updatedBy: "articles-postgres-test" },
+      create: {
+        key: "articles.mutations.gated",
+        value: false,
+        updatedBy: "articles-postgres-test",
+      },
+    });
 
     await db.site.create({
       data: {
@@ -96,13 +117,121 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
     const inputs = await loadGenerationInputs(siteId);
     if (!inputs.ok) throw new Error(inputs.reason);
     expect(inputs.facts.catalogItems).toContainEqual({
+      id: expect.any(String),
       name: "Croissant",
       price: 4.5,
       currency: "EUR",
     });
-    expect(inputs.facts.integrationLabels).toEqual(["Book a table"]);
+    expect(inputs.facts.integrationCapabilities).toEqual(["BOOKING"]);
     expect(inputs.facts.address).toBe("12 Rue du Four, Paris");
     expect(inputs.recentTopicKeys).toEqual([]);
+  });
+
+  test("retains the predecessor count column through fresh migration deploys", async () => {
+    const [schemaContract, migrationContract] = await Promise.all([
+      readFile(prismaSchemaPath, "utf8"),
+      readFile(outcomeMigrationPath, "utf8"),
+    ]);
+    expect(schemaContract).toMatch(
+      /acceptedCount\s+Int\s+@default\(0\)\s+@map\("producedCount"\)/,
+    );
+    expect(schemaContract).toMatch(
+      /updatedAt\s+DateTime\s+@default\(now\(\)\)\s+@updatedAt/,
+    );
+    const executableMigration = migrationContract
+      .replace(/^--.*$/gm, "")
+      .trim();
+    expect(executableMigration.startsWith("BEGIN;")).toBe(true);
+    expect(executableMigration.endsWith("COMMIT;")).toBe(true);
+    expect(migrationContract).not.toContain(
+      'RENAME COLUMN "producedCount"',
+    );
+    expect(migrationContract).not.toContain('"acceptedCount"');
+
+    const databaseUrl = process.env.DATABASE_URL;
+    if (!databaseUrl) throw new Error("DATABASE_URL is required");
+    const client = new Client({ connectionString: databaseUrl });
+    await client.connect();
+    try {
+      const columns = await client.query<{ column_name: string }>(`
+        SELECT "column_name"
+        FROM "information_schema"."columns"
+        WHERE "table_schema" = current_schema()
+          AND "table_name" = 'ArticleBatch'
+      `);
+      const physicalNames = columns.rows.map((column) => column.column_name);
+      expect(physicalNames).toContain("producedCount");
+      expect(physicalNames).not.toContain("acceptedCount");
+
+      const triggers = await client.query<{ trigger_name: string }>(`
+        SELECT "trigger_name"
+        FROM "information_schema"."triggers"
+        WHERE "event_object_schema" = current_schema()
+          AND "event_object_table" = 'ArticleBatch'
+      `);
+      expect(triggers.rows.map((trigger) => trigger.trigger_name)).toContain(
+        "ArticleBatch_expand_legacy_terminal",
+      );
+    } finally {
+      await client.end().catch(() => undefined);
+    }
+  });
+
+  test("expands a predecessor writer row to terminal during rolling deploys", async () => {
+    const legacySiteId = await createClaimedSite({ paid: true });
+    const legacyBatchId = `legacy-writer-${randomUUID()}`;
+    const completedAt = new Date();
+    await db.$executeRaw`
+      INSERT INTO "ArticleBatch" (
+        "id", "siteId", "requestedCount", "producedCount", "model",
+        "requestedBy", "completedAt"
+      ) VALUES (
+        ${legacyBatchId}, ${legacySiteId}, ${3}, ${1}, ${"legacy-model"},
+        ${"legacy-container"}, ${completedAt}
+      )
+    `;
+    await db.$executeRaw`
+      UPDATE "ArticleBatch"
+      SET "producedCount" = ${1}
+      WHERE "id" = ${legacyBatchId}
+    `;
+
+    const expanded = await db.articleBatch.findUniqueOrThrow({
+      where: { id: legacyBatchId },
+      select: {
+        requestedCount: true,
+        acceptedCount: true,
+        rejectedCount: true,
+        status: true,
+        statusReason: true,
+        startedAt: true,
+        completedAt: true,
+        updatedAt: true,
+      },
+    });
+    expect(expanded).toMatchObject({
+      requestedCount: 3,
+      acceptedCount: 1,
+      rejectedCount: 2,
+      status: "SUCCEEDED",
+      statusReason: null,
+      startedAt: expect.any(Date),
+      completedAt,
+      updatedAt: expect.any(Date),
+    });
+
+    const next = await reserveArticleBatch({
+      siteId: legacySiteId,
+      requestedBy: "post-rollout-admission",
+      count: 4,
+    });
+    expect(next.ok).toBe(true);
+    if (!next.ok) throw new Error(next.reason);
+    await closeArticleBatch({
+      batchId: next.batchId,
+      status: "ZERO_OUTPUT",
+      statusReason: "TEST_CLEANUP",
+    });
   });
 
   test("backfills predecessor outcomes and installs the active-batch fence", async () => {
@@ -127,6 +256,15 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
         )
       `);
       await client.query(`
+        CREATE TABLE "OperatorSetting" (
+          "key" TEXT PRIMARY KEY,
+          "value" JSONB NOT NULL,
+          "updatedBy" TEXT,
+          "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          "updatedAt" TIMESTAMP(3) NOT NULL
+        )
+      `);
+      await client.query(`
         INSERT INTO "ArticleBatch" (
           "id", "siteId", "requestedCount", "producedCount", "requestedBy", "completedAt"
         ) VALUES
@@ -136,6 +274,26 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
       `);
       await client.query(await readFile(outcomeMigrationPath, "utf8"));
 
+      expect(
+        (
+          await client.query<{ value: boolean }>(`
+            SELECT "value" FROM "OperatorSetting"
+            WHERE "key" = 'articles.mutations.gated'
+          `)
+        ).rows,
+      ).toEqual([{ value: true }]);
+
+      const columns = await client.query<{ column_name: string }>(
+        `SELECT "column_name"
+         FROM "information_schema"."columns"
+         WHERE "table_schema" = $1
+           AND "table_name" = 'ArticleBatch'`,
+        [schema],
+      );
+      const physicalNames = columns.rows.map((column) => column.column_name);
+      expect(physicalNames).toContain("producedCount");
+      expect(physicalNames).not.toContain("acceptedCount");
+
       const outcomes = await client.query<{
         id: string;
         requestedCount: number;
@@ -144,7 +302,7 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
         status: string;
         statusReason: string | null;
       }>(`
-        SELECT "id", "requestedCount", "acceptedCount", "rejectedCount",
+        SELECT "id", "requestedCount", "producedCount" AS "acceptedCount", "rejectedCount",
                "status"::text, "statusReason"
         FROM "ArticleBatch"
         ORDER BY "id"
@@ -176,14 +334,61 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
         },
       ]);
 
+      await client.query(`
+        INSERT INTO "ArticleBatch" (
+          "id", "siteId", "requestedCount", "producedCount", "model",
+          "requestedBy", "completedAt"
+        ) VALUES (
+          'legacy-client-after-upgrade', 'legacy-client-site', 3, 1,
+          'legacy-model', 'legacy-container', NOW()
+        )
+      `);
+      expect(
+        (
+          await client.query<{
+            acceptedCount: number;
+            rejectedCount: number;
+            status: string;
+            statusReason: string | null;
+            startedAt: Date;
+            updatedAt: Date;
+          }>(`
+            SELECT "producedCount" AS "acceptedCount", "rejectedCount",
+                   "status"::text, "statusReason", "startedAt", "updatedAt"
+            FROM "ArticleBatch"
+            WHERE "id" = 'legacy-client-after-upgrade'
+          `)
+        ).rows[0],
+      ).toEqual({
+        acceptedCount: 1,
+        rejectedCount: 2,
+        status: "SUCCEEDED",
+        statusReason: null,
+        startedAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+      });
+
       const activeInsert = (id: string) =>
         client.query(
           `INSERT INTO "ArticleBatch" (
-             "id", "siteId", "requestedCount", "requestedBy", "updatedAt"
-           ) VALUES ($1, 'one-active-site', 4, 'migration-test', NOW())`,
+             "id", "siteId", "requestedCount", "requestedBy"
+           ) VALUES ($1, 'one-active-site', 4, 'migration-test')`,
           [id],
         );
       await activeInsert("active-one");
+      expect(
+        (
+          await client.query<{
+            acceptedCount: number;
+            rejectedCount: number;
+            status: string;
+          }>(`
+            SELECT "producedCount" AS "acceptedCount", "rejectedCount", "status"::text
+            FROM "ArticleBatch"
+            WHERE "id" = 'active-one'
+          `)
+        ).rows[0],
+      ).toEqual({ acceptedCount: 0, rejectedCount: 0, status: "QUEUED" });
       await expect(activeInsert("active-two")).rejects.toMatchObject({
         code: "23505",
       });
@@ -209,35 +414,21 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
   test("persists a batch as drafts with a completed batch row", async () => {
     const inputs = await loadGenerationInputs(siteId);
     if (!inputs.ok) throw new Error(inputs.reason);
+    const croissantId = catalogItemIdByName(inputs.facts.catalogItems, "Croissant");
 
     const batchId = await createRunningBatch(siteId, 4);
     const persisted = await persistArticleBatch({
       batchId,
       siteId,
-      facts: inputs.facts,
       model: "test-model",
-      drafts: [
+      plans: [
+        factualPlan(croissantId, "seasonal-menu"),
         {
-          topicKey: "seasonal-menu",
-          slug: "seasonal-menu-update",
-          title: "In season now",
-          excerpt: "What the ovens are doing this month.",
-          bodyMarkdown:
-            "Our croissant lamination stays the same all year. ".repeat(20),
-          catalogClaims: [
-            { name: "Croissant", price: null, currency: null },
-          ],
-        },
-        {
+          contractVersion: 1,
           topicKey: "neighbourhood-guide",
-          slug: "where-to-find-us",
-          title: "Find us in the fifth",
-          excerpt: "Directions and what is nearby.",
-          bodyMarkdown:
-            "We are on Rue du Four between the bakery and the bookshop. ".repeat(
-              15,
-            ),
-          catalogClaims: [],
+          templateKey: "restaurant-location",
+          catalogItemId: null,
+          priceMode: "omit",
         },
       ],
     });
@@ -265,24 +456,12 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
   test("dedupes slugs across batches", async () => {
     const inputs = await loadGenerationInputs(siteId);
     if (!inputs.ok) throw new Error(inputs.reason);
+    const croissantId = catalogItemIdByName(inputs.facts.catalogItems, "Croissant");
 
     const persisted = await persistArticleBatch({
       batchId: await createRunningBatch(siteId, 1),
       siteId,
-      facts: inputs.facts,
-      drafts: [
-        {
-          topicKey: "dietary-faqs",
-          slug: "seasonal-menu-update",
-          title: "Same slug, different article",
-          excerpt: "Slug collision test.",
-          bodyMarkdown:
-            "Ask us about the Croissant ingredients before choosing. ".repeat(15),
-          catalogClaims: [
-            { name: "Croissant", price: null, currency: null },
-          ],
-        },
-      ],
+      plans: [factualPlan(croissantId, "seasonal-menu")],
     });
     expect(persisted.producedCount).toBe(1);
 
@@ -293,37 +472,25 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
       })
     ).map((row) => row.slug);
     expect(new Set(slugs).size).toBe(slugs.length);
-    expect(slugs).toContain("seasonal-menu-update-2");
+    expect(slugs).toContain("seasonal-menu-2");
   });
 
   test("extracts exactly the last two batches' topics for dedupe", async () => {
     // Third batch; only batch two's and batch three's topics may appear.
     const inputs = await loadGenerationInputs(siteId);
     if (!inputs.ok) throw new Error(inputs.reason);
+    const croissantId = catalogItemIdByName(inputs.facts.catalogItems, "Croissant");
     await persistArticleBatch({
       batchId: await createRunningBatch(siteId, 1),
       siteId,
-      facts: inputs.facts,
-      drafts: [
-        {
-          topicKey: "chef-story",
-          slug: "our-kitchen",
-          title: "Our kitchen",
-          excerpt: "Suppliers and method.",
-          bodyMarkdown:
-            "Our Croissant is folded in the kitchen in small batches. ".repeat(12),
-          catalogClaims: [
-            { name: "Croissant", price: null, currency: null },
-          ],
-        },
-      ],
+      plans: [factualPlan(croissantId, "chef-story")],
     });
 
     const afterThird = await loadGenerationInputs(siteId);
     if (!afterThird.ok) throw new Error(afterThird.reason);
-    // Batch 2 (dietary-faqs) + batch 3 (chef-story); batch 1 must be excluded.
+    // Batch 2 (seasonal-menu) + batch 3 (chef-story); batch 1 must be excluded.
     expect([...afterThird.recentTopicKeys].sort()).toEqual(
-      ["chef-story", "dietary-faqs"].sort(),
+      ["chef-story", "seasonal-menu"].sort(),
     );
   });
 
@@ -333,15 +500,13 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
     const persisted = await persistArticleBatch({
       batchId: await createRunningBatch(siteId, 1),
       siteId,
-      facts: inputs.facts,
-      drafts: [
+      plans: [
         {
-          topicKey: "trends",
-          slug: "award-winning-bakes",
-          title: "Award winning bakes",
-          excerpt: "This should never persist.",
-          bodyMarkdown: "We are award winning and certified organic. ".repeat(10),
-          catalogClaims: [],
+          contractVersion: 1,
+          topicKey: "dietary-faqs",
+          templateKey: "restaurant-dietary-enquiry",
+          catalogItemId: `unknown-${randomUUID()}`,
+          priceMode: "omit",
         },
       ],
     });
@@ -357,16 +522,415 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
       status: "REJECTED",
       statusReason: "ALL_DRAFTS_REJECTED",
     });
-    expect(await db.article.count({ where: { siteId, topicKey: "trends" } })).toBe(0);
+    expect(
+      await db.article.count({ where: { siteId, topicKey: "dietary-faqs" } }),
+    ).toBe(0);
 
     const afterRejected = await loadGenerationInputs(siteId);
     if (!afterRejected.ok) throw new Error(afterRejected.reason);
     expect([...afterRejected.recentTopicKeys].sort()).toEqual(
-      ["chef-story", "dietary-faqs"].sort(),
+      ["chef-story", "seasonal-menu"].sort(),
     );
   });
 
-  test("atomically admits one of two concurrent starts", async () => {
+  test("re-resolves selected catalog facts at persistence and snapshots them", async () => {
+    const snapshotSiteId = await createClaimedSite();
+    const inputs = await loadGenerationInputs(snapshotSiteId);
+    if (!inputs.ok) throw new Error(inputs.reason);
+    const catalogItemId = inputs.facts.catalogItems[0]!.id;
+    const selectedPlans = [
+      { ...factualPlan(catalogItemId, "seasonal-menu"), priceMode: "exact" as const },
+      factualPlan(catalogItemId, "dietary-faqs"),
+    ];
+
+    await db.catalogItem.update({
+      where: { id: catalogItemId },
+      data: {
+        name: "Current Snapshot Croissant",
+        price: 8.25,
+        currency: "GBP",
+      },
+    });
+    const persisted = await persistArticleBatch({
+      batchId: await createRunningBatch(snapshotSiteId, selectedPlans.length),
+      siteId: snapshotSiteId,
+      plans: selectedPlans,
+    });
+    expect(persisted).toMatchObject({ producedCount: 2, rejectedCount: 0 });
+
+    const beforeLaterEdit = await db.article.findMany({
+      where: { batchId: persisted.batchId },
+      orderBy: { topicKey: "asc" },
+      select: {
+        id: true,
+        topicKey: true,
+        title: true,
+        excerpt: true,
+        bodyMarkdown: true,
+      },
+    });
+    const exact = beforeLaterEdit.find(
+      (article) => article.topicKey === "seasonal-menu",
+    );
+    const omitted = beforeLaterEdit.find(
+      (article) => article.topicKey === "dietary-faqs",
+    );
+    const currentPrice = testPrice(8.25, "GBP", "en");
+    expect(exact).toBeDefined();
+    expect(omitted).toBeDefined();
+    expect(Object.values(exact ?? {}).join("\n")).toContain(currentPrice);
+    expect(Object.values(exact ?? {}).join("\n")).not.toContain(
+      "Current Snapshot Croissant",
+    );
+    expect(Object.values(omitted ?? {}).join("\n")).not.toContain(
+      "Current Snapshot Croissant",
+    );
+
+    await db.catalogItem.update({
+      where: { id: catalogItemId },
+      data: { name: "Later Catalog Name", price: 99, currency: "USD" },
+    });
+    expect(
+      await db.article.findMany({
+        where: { batchId: persisted.batchId },
+        orderBy: { topicKey: "asc" },
+        select: {
+          id: true,
+          topicKey: true,
+          title: true,
+          excerpt: true,
+          bodyMarkdown: true,
+        },
+      }),
+    ).toEqual(beforeLaterEdit);
+  });
+
+  test("binds an exact price to the selected ID when names collide", async () => {
+    const bindingSiteId = await createClaimedSite();
+    const first = await loadGenerationInputs(bindingSiteId);
+    if (!first.ok) throw new Error(first.reason);
+    const firstItem = first.facts.catalogItems[0]!;
+    const section = await db.catalogSection.findFirstOrThrow({
+      where: { siteId: bindingSiteId },
+      select: { id: true },
+    });
+    const secondItem = await db.catalogItem.create({
+      data: {
+        sectionId: section.id,
+        name: firstItem.name,
+        price: 9.75,
+        currency: "GBP",
+        position: 1,
+      },
+      select: { id: true },
+    });
+
+    const persisted = await persistArticleBatch({
+      batchId: await createRunningBatch(bindingSiteId, 1),
+      siteId: bindingSiteId,
+      plans: [
+        {
+          ...factualPlan(secondItem.id, "seasonal-menu"),
+          priceMode: "exact",
+        },
+      ],
+    });
+    const article = await db.article.findFirstOrThrow({
+      where: { batchId: persisted.batchId },
+      select: { title: true, excerpt: true, bodyMarkdown: true },
+    });
+    const publicText = Object.values(article).join("\n");
+    expect(publicText).toContain(testPrice(9.75, "GBP", "en"));
+    expect(publicText).not.toContain(testPrice(4.5, "EUR", "en"));
+    expect(publicText).not.toContain(firstItem.name);
+  });
+
+  test("rejects deleted, reparented, and cross-site catalog IDs", async () => {
+    const deletedSiteId = await createClaimedSite();
+    const deletedInputs = await loadGenerationInputs(deletedSiteId);
+    if (!deletedInputs.ok) throw new Error(deletedInputs.reason);
+    const deletedItemId = deletedInputs.facts.catalogItems[0]!.id;
+    await db.catalogItem.delete({ where: { id: deletedItemId } });
+
+    const otherSiteId = await createClaimedSite();
+    const otherInputs = await loadGenerationInputs(otherSiteId);
+    if (!otherInputs.ok) throw new Error(otherInputs.reason);
+    const crossSiteItemId = otherInputs.facts.catalogItems[0]!.id;
+
+    const reparentedSiteId = await createClaimedSite();
+    const reparentedInputs = await loadGenerationInputs(reparentedSiteId);
+    if (!reparentedInputs.ok) throw new Error(reparentedInputs.reason);
+    const reparentedItemId = reparentedInputs.facts.catalogItems[0]!.id;
+    const otherSection = await db.catalogSection.findFirstOrThrow({
+      where: { siteId: otherSiteId },
+      select: { id: true },
+    });
+    await db.catalogItem.update({
+      where: { id: reparentedItemId },
+      data: { sectionId: otherSection.id },
+    });
+
+    for (const [targetSiteId, catalogItemId] of [
+      [deletedSiteId, deletedItemId],
+      [deletedSiteId, crossSiteItemId],
+      [reparentedSiteId, reparentedItemId],
+    ] as const) {
+      const persisted = await persistArticleBatch({
+        batchId: await createRunningBatch(targetSiteId, 1),
+        siteId: targetSiteId,
+        plans: [factualPlan(catalogItemId, "seasonal-menu")],
+      });
+      expect(persisted).toMatchObject({ producedCount: 0, rejectedCount: 1 });
+      expect(
+        await db.article.count({ where: { batchId: persisted.batchId } }),
+      ).toBe(0);
+      expect(
+        await db.articleBatch.findUniqueOrThrow({
+          where: { id: persisted.batchId },
+          select: { status: true },
+        }),
+      ).toEqual({ status: "REJECTED" });
+    }
+  });
+
+  test("rejects an unsupported current currency for exact price mode", async () => {
+    const currencySiteId = await createClaimedSite();
+    const inputs = await loadGenerationInputs(currencySiteId);
+    if (!inputs.ok) throw new Error(inputs.reason);
+    const catalogItemId = inputs.facts.catalogItems[0]!.id;
+    await db.catalogItem.update({
+      where: { id: catalogItemId },
+      data: { currency: "RUB" },
+    });
+
+    const persisted = await persistArticleBatch({
+      batchId: await createRunningBatch(currencySiteId, 1),
+      siteId: currencySiteId,
+      plans: [
+        {
+          ...factualPlan(catalogItemId, "seasonal-menu"),
+          priceMode: "exact",
+        },
+      ],
+    });
+    expect(persisted).toMatchObject({ producedCount: 0, rejectedCount: 1 });
+    expect(await db.article.count({ where: { batchId: persisted.batchId } })).toBe(
+      0,
+    );
+  });
+
+  test("rejects a contact plan when its integration is disabled before persistence", async () => {
+    const integrationSiteId = await createClaimedSite();
+    await db.site.update({
+      where: { id: integrationSiteId },
+      data: { phone: "+356 2000 0000" },
+    });
+    const integration = await db.integration.create({
+      data: {
+        siteId: integrationSiteId,
+        type: "BOOKING",
+        label: "Book a table",
+        url: "https://book.example.test",
+        enabled: true,
+      },
+      select: { id: true },
+    });
+    const selectedInputs = await loadGenerationInputs(integrationSiteId);
+    if (!selectedInputs.ok) throw new Error(selectedInputs.reason);
+    expect(selectedInputs.facts.integrationCapabilities).toEqual(["BOOKING"]);
+    const selectedPlan = {
+      contractVersion: 1 as const,
+      topicKey: "private-events" as const,
+      templateKey: "restaurant-group-enquiry" as const,
+      catalogItemId: null,
+      priceMode: "omit" as const,
+    };
+
+    await db.integration.update({
+      where: { id: integration.id },
+      data: { enabled: false },
+    });
+    const afterDisable = await loadGenerationInputs(integrationSiteId);
+    if (!afterDisable.ok) throw new Error(afterDisable.reason);
+    expect(afterDisable.facts.integrationCapabilities).toEqual([]);
+
+    const persisted = await persistArticleBatch({
+      batchId: await createRunningBatch(integrationSiteId, 1),
+      siteId: integrationSiteId,
+      plans: [selectedPlan],
+    });
+    expect(persisted).toMatchObject({ producedCount: 0, rejectedCount: 1 });
+    expect(await db.article.count({ where: { batchId: persisted.batchId } })).toBe(
+      0,
+    );
+    expect(
+      await db.articleBatch.findUniqueOrThrow({
+        where: { id: persisted.batchId },
+        select: { status: true, statusReason: true },
+      }),
+    ).toEqual({ status: "REJECTED", statusReason: "ALL_DRAFTS_REJECTED" });
+  });
+
+  test("qualifies ordering only from enabled ordering or delivery capabilities", async () => {
+    const orderingSiteId = await createClaimedSite();
+    await db.site.update({
+      where: { id: orderingSiteId },
+      data: { vertical: "FOOD_RETAIL" },
+    });
+    await db.integration.createMany({
+      data: [
+        {
+          siteId: orderingSiteId,
+          type: "ORDERING",
+          label: "Disabled order link",
+          url: "https://disabled-order.example.test",
+          enabled: false,
+        },
+        {
+          siteId: orderingSiteId,
+          type: "BOOKING",
+          label: "Wrong capability",
+          url: "https://booking.example.test",
+          enabled: true,
+        },
+        {
+          siteId: orderingSiteId,
+          type: "SOCIAL",
+          label: "Social only",
+          url: "https://social.example.test",
+          enabled: true,
+        },
+        {
+          siteId: orderingSiteId,
+          type: "ANALYTICS",
+          label: "Analytics only",
+          url: "https://analytics.example.test",
+          enabled: true,
+        },
+      ],
+    });
+    const plan = {
+      contractVersion: 1 as const,
+      topicKey: "ordering-options" as const,
+      templateKey: "retail-ordering-options" as const,
+      catalogItemId: null,
+      priceMode: "omit" as const,
+    };
+    const withoutOrdering = await loadGenerationInputs(orderingSiteId);
+    if (!withoutOrdering.ok) throw new Error(withoutOrdering.reason);
+    expect(withoutOrdering.facts.integrationCapabilities).toEqual(["BOOKING"]);
+    const rejected = await persistArticleBatch({
+      batchId: await createRunningBatch(orderingSiteId, 1),
+      siteId: orderingSiteId,
+      plans: [plan],
+    });
+    expect(rejected).toMatchObject({ producedCount: 0, rejectedCount: 1 });
+
+    const delivery = await db.integration.create({
+      data: {
+        siteId: orderingSiteId,
+        type: "DELIVERY",
+        label: "Published delivery link",
+        url: "https://delivery.example.test",
+        enabled: true,
+      },
+      select: { id: true },
+    });
+    const withDelivery = await loadGenerationInputs(orderingSiteId);
+    if (!withDelivery.ok) throw new Error(withDelivery.reason);
+    expect(withDelivery.facts.integrationCapabilities).toEqual([
+      "BOOKING",
+      "DELIVERY",
+    ]);
+
+    await db.integration.update({
+      where: { id: delivery.id },
+      data: { type: "SOCIAL" },
+    });
+    const rejectedAfterCapabilityChange = await persistArticleBatch({
+      batchId: await createRunningBatch(orderingSiteId, 1),
+      siteId: orderingSiteId,
+      plans: [plan],
+    });
+    expect(rejectedAfterCapabilityChange).toMatchObject({
+      producedCount: 0,
+      rejectedCount: 1,
+    });
+
+    await db.integration.update({
+      where: { id: delivery.id },
+      data: { type: "DELIVERY" },
+    });
+    const accepted = await persistArticleBatch({
+      batchId: await createRunningBatch(orderingSiteId, 1),
+      siteId: orderingSiteId,
+      plans: [plan],
+    });
+    expect(accepted).toMatchObject({ producedCount: 1, rejectedCount: 0 });
+  });
+
+  test("rejects catalog plans hidden from the storefront before persistence", async () => {
+    for (const vertical of ["RESTAURANT", "FOOD_RETAIL"] as const) {
+      const visibilitySiteId = await createClaimedSite();
+      if (vertical === "FOOD_RETAIL") {
+        await db.site.update({
+          where: { id: visibilitySiteId },
+          data: { vertical },
+        });
+        await db.catalogItem.updateMany({
+          where: { section: { siteId: visibilitySiteId } },
+          data: { attributes: { visible: true } },
+        });
+      }
+      const selectedInputs = await loadGenerationInputs(visibilitySiteId);
+      if (!selectedInputs.ok) throw new Error(selectedInputs.reason);
+      expect(selectedInputs.facts.catalogItems).toHaveLength(1);
+      const catalogItemId = selectedInputs.facts.catalogItems[0]!.id;
+      const selectedPlan =
+        vertical === "RESTAURANT"
+          ? factualPlan(catalogItemId, "seasonal-menu")
+          : {
+              contractVersion: 1 as const,
+              topicKey: "seasonal-stock" as const,
+              templateKey: "retail-current-stock" as const,
+              catalogItemId,
+              priceMode: "omit" as const,
+            };
+
+      if (vertical === "RESTAURANT") {
+        await db.catalogItem.update({
+          where: { id: catalogItemId },
+          data: { available: false },
+        });
+      } else {
+        await db.catalogItem.update({
+          where: { id: catalogItemId },
+          data: { attributes: { visible: false } },
+        });
+      }
+      const hiddenInputs = await loadGenerationInputs(visibilitySiteId);
+      if (!hiddenInputs.ok) throw new Error(hiddenInputs.reason);
+      expect(hiddenInputs.facts.catalogItems).toEqual([]);
+
+      const persisted = await persistArticleBatch({
+        batchId: await createRunningBatch(visibilitySiteId, 1),
+        siteId: visibilitySiteId,
+        plans: [selectedPlan],
+      });
+      expect(persisted).toMatchObject({ producedCount: 0, rejectedCount: 1 });
+      expect(
+        await db.article.count({ where: { batchId: persisted.batchId } }),
+      ).toBe(0);
+      expect(
+        await db.articleBatch.findUniqueOrThrow({
+          where: { id: persisted.batchId },
+          select: { status: true },
+        }),
+      ).toEqual({ status: "REJECTED" });
+    }
+  });
+
+  test("atomically creates one reservation across concurrent admissions", async () => {
     const concurrentSiteId = await createClaimedSite();
     const results = await Promise.all([
       reserveArticleBatch({
@@ -381,16 +945,854 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
       }),
     ]);
 
-    const admitted = results.filter((result) => result.ok);
-    expect(admitted).toHaveLength(1);
-    expect(results.filter((result) => !result.ok)).toHaveLength(1);
+    expect(
+      results.filter((result) => result.ok && result.acquired),
+    ).toHaveLength(1);
     expect(
       await db.articleBatch.count({ where: { siteId: concurrentSiteId } }),
     ).toBe(1);
-    const winner = admitted[0];
+    const winner = results.find((result) => result.ok && result.acquired);
     if (!winner?.ok) throw new Error("concurrent admission had no winner");
+    for (const result of results) {
+      if (result.ok) expect(result.batchId).toBe(winner.batchId);
+      else expect(result.status).toBe(409);
+    }
     await closeArticleBatch({
       batchId: winner.batchId,
+      status: "ZERO_OUTPUT",
+      statusReason: "TEST_CLEANUP",
+    });
+  });
+
+  test("the durable release gate blocks admission and queued dispatch", async () => {
+    const gatedSiteId = await createClaimedSite({ paid: true });
+    const previousApiKey = process.env.OPENROUTER_API_KEY;
+    process.env.OPENROUTER_API_KEY = "test-only-never-sent";
+    let startCalls = 0;
+    try {
+      await db.operatorSetting.update({
+        where: { key: "articles.mutations.gated" },
+        data: { value: true, updatedBy: "article-gate-test" },
+      });
+      expect(
+        await startArticleBatch(
+          {
+            siteId: gatedSiteId,
+            slug: "unused-gated-slug",
+            requestedBy: "gated-start",
+            count: 4,
+          },
+          async () => {
+            startCalls += 1;
+            return `run_unexpected_${randomUUID()}`;
+          },
+        ),
+      ).toMatchObject({ ok: false, status: 503 });
+      expect(
+        await db.articleBatch.count({ where: { siteId: gatedSiteId } }),
+      ).toBe(0);
+
+      const reservation = await reserveArticleBatch({
+        siteId: gatedSiteId,
+        requestedBy: "reserve-before-gate-dispatch",
+        count: 4,
+      });
+      if (!reservation.ok) throw new Error(reservation.reason);
+      expect(
+        await dispatchArticleBatch(reservation.batchId, async () => {
+          startCalls += 1;
+          return `run_unexpected_${randomUUID()}`;
+        }),
+      ).toMatchObject({ ok: false, status: 503 });
+      expect(startCalls).toBe(0);
+      await db.operatorSetting.update({
+        where: { key: "articles.mutations.gated" },
+        data: { value: false, updatedBy: "article-gate-test-cleanup" },
+      });
+      await closeArticleBatch({
+        batchId: reservation.batchId,
+        status: "ZERO_OUTPUT",
+        statusReason: "TEST_CLEANUP",
+      });
+    } finally {
+      await db.operatorSetting.update({
+        where: { key: "articles.mutations.gated" },
+        data: { value: false, updatedBy: "articles-postgres-test" },
+      });
+      restoreEnvironment("OPENROUTER_API_KEY", previousApiKey);
+    }
+  });
+
+  test("redispatches the same queued row after a reserve-only crash", async () => {
+    const crashSiteId = await createClaimedSite();
+    const first = await reserveArticleBatch({
+      siteId: crashSiteId,
+      requestedBy: "reserve-before-crash",
+      count: 4,
+    });
+    if (!first.ok) throw new Error(first.reason);
+    expect(first.acquired).toBe(true);
+    const workflowRunId = `run_redispatch_${randomUUID()}`;
+    const previousApiKey = process.env.OPENROUTER_API_KEY;
+    process.env.OPENROUTER_API_KEY = "test-only-never-sent";
+    try {
+      const replay = await startArticleBatch(
+        {
+          siteId: crashSiteId,
+          slug: "unused-redispatch-slug",
+          requestedBy: "request-after-crash",
+          count: 2,
+        },
+        async (batchId, dispatchLeaseToken) => {
+          expect(batchId).toBe(first.batchId);
+          expect(dispatchLeaseToken).toBeTruthy();
+          return workflowRunId;
+        },
+      );
+      expect(replay).toEqual({ ok: true, runId: workflowRunId });
+      expect(
+        await db.articleBatch.findUniqueOrThrow({
+          where: { id: first.batchId },
+          select: {
+            requestedBy: true,
+            requestedCount: true,
+            status: true,
+            workflowRunId: true,
+            dispatchLeaseToken: true,
+            dispatchLeaseUntil: true,
+          },
+        }),
+      ).toEqual({
+        requestedBy: "reserve-before-crash",
+        requestedCount: 4,
+        status: "QUEUED",
+        workflowRunId,
+        dispatchLeaseToken: null,
+        dispatchLeaseUntil: null,
+      });
+      expect(
+        await db.articleBatch.count({ where: { siteId: crashSiteId } }),
+      ).toBe(1);
+      await closeArticleBatch({
+        batchId: first.batchId,
+        workflowRunId,
+        status: "ZERO_OUTPUT",
+        statusReason: "TEST_CLEANUP",
+      });
+    } finally {
+      restoreEnvironment("OPENROUTER_API_KEY", previousApiKey);
+    }
+  });
+
+  test("the dispatcher recovers an unbound queued reservation", async () => {
+    const queuedSiteId = await createClaimedSite({ paid: true });
+    const admission = await reserveArticleBatch({
+      siteId: queuedSiteId,
+      requestedBy: "dispatcher-crash-recovery",
+      count: 4,
+    });
+    if (!admission.ok) throw new Error(admission.reason);
+    const workflowRunId = `run_dispatcher_recovery_${randomUUID()}`;
+    const previousApiKey = process.env.OPENROUTER_API_KEY;
+    process.env.OPENROUTER_API_KEY = "test-only-never-sent";
+    try {
+      expect(
+        await dispatchQueuedArticleBatches(new Date(), async (batchId, token) => {
+          expect(batchId).toBe(admission.batchId);
+          expect(token).toBeTruthy();
+          return workflowRunId;
+        }),
+      ).toEqual({
+        attempted: 1,
+        started: 1,
+        deferred: 0,
+        failedToStart: 0,
+      });
+      expect(
+        await db.articleBatch.findUniqueOrThrow({
+          where: { id: admission.batchId },
+          select: {
+            status: true,
+            workflowRunId: true,
+            dispatchLeaseToken: true,
+            dispatchLeaseUntil: true,
+          },
+        }),
+      ).toEqual({
+        status: "QUEUED",
+        workflowRunId,
+        dispatchLeaseToken: null,
+        dispatchLeaseUntil: null,
+      });
+      await closeArticleBatch({
+        batchId: admission.batchId,
+        workflowRunId,
+        status: "ZERO_OUTPUT",
+        statusReason: "TEST_CLEANUP",
+      });
+    } finally {
+      restoreEnvironment("OPENROUTER_API_KEY", previousApiKey);
+    }
+  });
+
+  test("lets one concurrent dispatcher own a fresh lease", async () => {
+    const dispatchSiteId = await createClaimedSite({ paid: true });
+    const admission = await reserveArticleBatch({
+      siteId: dispatchSiteId,
+      requestedBy: "concurrent-dispatch",
+      count: 4,
+    });
+    if (!admission.ok) throw new Error(admission.reason);
+    const workflowRunId = `run_dispatch_winner_${randomUUID()}`;
+    let startCalls = 0;
+    let releaseStart!: () => void;
+    const startGate = new Promise<void>((resolve) => {
+      releaseStart = resolve;
+    });
+    let observeStart!: () => void;
+    const startObserved = new Promise<void>((resolve) => {
+      observeStart = resolve;
+    });
+    const winner = dispatchArticleBatch(
+      admission.batchId,
+      async () => {
+        startCalls += 1;
+        observeStart();
+        await startGate;
+        return workflowRunId;
+      },
+    );
+    await startObserved;
+    const contender = await dispatchArticleBatch(
+      admission.batchId,
+      async () => {
+        startCalls += 1;
+        return `run_unexpected_${randomUUID()}`;
+      },
+    );
+    expect(contender).toMatchObject({ ok: false, status: 409 });
+    releaseStart();
+    expect(await winner).toEqual({ ok: true, runId: workflowRunId });
+    expect(startCalls).toBe(1);
+    await closeArticleBatch({
+      batchId: admission.batchId,
+      workflowRunId,
+      status: "ZERO_OUTPUT",
+      statusReason: "TEST_CLEANUP",
+    });
+  });
+
+  test("defers a fresh dispatch lease and reclaims it after expiry", async () => {
+    const leaseSiteId = await createClaimedSite({ paid: true });
+    const admission = await reserveArticleBatch({
+      siteId: leaseSiteId,
+      requestedBy: "dispatch-lease-expiry",
+      count: 4,
+    });
+    if (!admission.ok) throw new Error(admission.reason);
+    const now = new Date();
+    await db.articleBatch.update({
+      where: { id: admission.batchId },
+      data: {
+        dispatchLeaseToken: `lease_fresh_${randomUUID()}`,
+        dispatchLeaseUntil: new Date(
+          now.getTime() + articleBatchDispatchLeaseMs,
+        ),
+      },
+    });
+    let startCalls = 0;
+    expect(
+      await dispatchArticleBatch(
+        admission.batchId,
+        async () => {
+          startCalls += 1;
+          return `run_unexpected_${randomUUID()}`;
+        },
+        now,
+      ),
+    ).toMatchObject({ ok: false, status: 409 });
+    expect(startCalls).toBe(0);
+
+    await db.articleBatch.update({
+      where: { id: admission.batchId },
+      data: { dispatchLeaseUntil: new Date(now.getTime() - 1) },
+    });
+    const workflowRunId = `run_reclaimed_${randomUUID()}`;
+    expect(
+      await dispatchArticleBatch(
+        admission.batchId,
+        async () => {
+          startCalls += 1;
+          return workflowRunId;
+        },
+        now,
+      ),
+    ).toEqual({ ok: true, runId: workflowRunId });
+    expect(startCalls).toBe(1);
+    await closeArticleBatch({
+      batchId: admission.batchId,
+      workflowRunId,
+      status: "ZERO_OUTPUT",
+      statusReason: "TEST_CLEANUP",
+    });
+  });
+
+  test("fences a leased queued row from ownerless and wrong-owner writes", async () => {
+    const leasedSiteId = await createClaimedSite({ paid: true });
+    const inputs = await loadGenerationInputs(leasedSiteId);
+    if (!inputs.ok) throw new Error(inputs.reason);
+    const catalogItemId = inputs.facts.catalogItems[0]!.id;
+    const admission = await reserveArticleBatch({
+      siteId: leasedSiteId,
+      requestedBy: "leased-owner-fence",
+      count: 1,
+    });
+    if (!admission.ok) throw new Error(admission.reason);
+    const dispatchLeaseToken = `lease_owner_fence_${randomUUID()}`;
+    await db.articleBatch.update({
+      where: { id: admission.batchId },
+      data: {
+        dispatchLeaseToken,
+        dispatchLeaseUntil: new Date(
+          Date.now() + articleBatchDispatchLeaseMs,
+        ),
+      },
+    });
+    const persistInput = {
+      batchId: admission.batchId,
+      siteId: leasedSiteId,
+      plans: [factualPlan(catalogItemId, "seasonal-menu")],
+    };
+    await expect(persistArticleBatch(persistInput)).rejects.toThrow(
+      "Article batch reservation is not running",
+    );
+    await expect(
+      persistArticleBatch({
+        ...persistInput,
+        workflowRunId: `run_wrong_leased_${randomUUID()}`,
+      }),
+    ).rejects.toThrow("Article batch workflow owner does not match");
+    expect(
+      await closeArticleBatch({
+        batchId: admission.batchId,
+        status: "FAILED",
+        statusReason: "OWNERLESS_CLOSE",
+      }),
+    ).toBe(false);
+    expect(
+      await closeArticleBatch({
+        batchId: admission.batchId,
+        workflowRunId: `run_wrong_leased_${randomUUID()}`,
+        status: "FAILED",
+        statusReason: "WRONG_OWNER_CLOSE",
+      }),
+    ).toBe(false);
+    expect(
+      await db.articleBatch.findUniqueOrThrow({
+        where: { id: admission.batchId },
+        select: {
+          status: true,
+          workflowRunId: true,
+          dispatchLeaseToken: true,
+          acceptedCount: true,
+          rejectedCount: true,
+        },
+      }),
+    ).toEqual({
+      status: "QUEUED",
+      workflowRunId: null,
+      dispatchLeaseToken,
+      acceptedCount: 0,
+      rejectedCount: 0,
+    });
+    expect(
+      await db.article.count({ where: { batchId: admission.batchId } }),
+    ).toBe(0);
+
+    await db.articleBatch.update({
+      where: { id: admission.batchId },
+      data: { dispatchLeaseToken: null, dispatchLeaseUntil: null },
+    });
+    await closeArticleBatch({
+      batchId: admission.batchId,
+      status: "ZERO_OUTPUT",
+      statusReason: "TEST_CLEANUP",
+    });
+  });
+
+  test("fences a delayed workflow after its dispatch lease is replaced", async () => {
+    const fencedSiteId = await createClaimedSite({ paid: true });
+    const admission = await reserveArticleBatch({
+      siteId: fencedSiteId,
+      requestedBy: "dispatch-fence",
+      count: 4,
+    });
+    if (!admission.ok) throw new Error(admission.reason);
+    const now = new Date();
+    const oldLeaseToken = `lease_old_${randomUUID()}`;
+    await db.articleBatch.update({
+      where: { id: admission.batchId },
+      data: {
+        dispatchLeaseToken: oldLeaseToken,
+        dispatchLeaseUntil: new Date(now.getTime() - 1),
+      },
+    });
+    const oldWorkflowRunId = `run_old_${randomUUID()}`;
+    const winningWorkflowRunId = `run_new_${randomUUID()}`;
+    const result = await dispatchArticleBatch(
+      admission.batchId,
+      async (batchId, winningLeaseToken) => {
+        expect(winningLeaseToken).not.toBe(oldLeaseToken);
+        expect(
+          await beginArticleBatch(
+            batchId,
+            oldWorkflowRunId,
+            oldLeaseToken,
+          ),
+        ).toBeNull();
+        expect(
+          await beginArticleBatch(
+            batchId,
+            winningWorkflowRunId,
+            winningLeaseToken,
+          ),
+        ).toEqual({ siteId: fencedSiteId, requestedCount: 4 });
+        return winningWorkflowRunId;
+      },
+      now,
+    );
+    expect(result).toEqual({ ok: true, runId: winningWorkflowRunId });
+    expect(
+      await db.articleBatch.findUniqueOrThrow({
+        where: { id: admission.batchId },
+        select: {
+          status: true,
+          workflowRunId: true,
+          dispatchLeaseToken: true,
+          dispatchLeaseUntil: true,
+        },
+      }),
+    ).toEqual({
+      status: "RUNNING",
+      workflowRunId: winningWorkflowRunId,
+      dispatchLeaseToken: null,
+      dispatchLeaseUntil: null,
+    });
+    await closeArticleBatch({
+      batchId: admission.batchId,
+      workflowRunId: winningWorkflowRunId,
+      status: "ZERO_OUTPUT",
+      statusReason: "TEST_CLEANUP",
+    });
+  });
+
+  test("never reclaims a healthy running workflow from updatedAt", async () => {
+    const runningSiteId = await createClaimedSite({ paid: true });
+    const admission = await reserveArticleBatch({
+      siteId: runningSiteId,
+      requestedBy: "healthy-long-running",
+      count: 4,
+    });
+    if (!admission.ok) throw new Error(admission.reason);
+    const workflowRunId = `run_healthy_long_${randomUUID()}`;
+    const dispatchLeaseToken = `lease_healthy_long_${randomUUID()}`;
+    await db.articleBatch.update({
+      where: { id: admission.batchId },
+      data: {
+        dispatchLeaseToken,
+        dispatchLeaseUntil: new Date(
+          Date.now() + articleBatchDispatchLeaseMs,
+        ),
+      },
+    });
+    await beginArticleBatch(
+      admission.batchId,
+      workflowRunId,
+      dispatchLeaseToken,
+    );
+    const started = await db.articleBatch.findUniqueOrThrow({
+      where: { id: admission.batchId },
+      select: { startedAt: true },
+    });
+    const yearsOld = new Date("2000-01-01T00:00:00.000Z");
+    await db.articleBatch.update({
+      where: { id: admission.batchId },
+      data: { updatedAt: yearsOld },
+    });
+    const previousApiKey = process.env.OPENROUTER_API_KEY;
+    process.env.OPENROUTER_API_KEY = "test-only-never-sent";
+    let startCalls = 0;
+    try {
+      const blocked = await startArticleBatch(
+        {
+          siteId: runningSiteId,
+          slug: "unused-running-slug",
+          requestedBy: "healthy-long-running-retry",
+          count: 2,
+        },
+        async () => {
+          startCalls += 1;
+          return `run_unexpected_${randomUUID()}`;
+        },
+      );
+      expect(blocked).toMatchObject({ ok: false, status: 409 });
+    } finally {
+      restoreEnvironment("OPENROUTER_API_KEY", previousApiKey);
+    }
+    expect(startCalls).toBe(0);
+    expect(
+      await db.articleBatch.findUniqueOrThrow({
+        where: { id: admission.batchId },
+        select: {
+          status: true,
+          workflowRunId: true,
+          startedAt: true,
+          updatedAt: true,
+        },
+      }),
+    ).toEqual({
+      status: "RUNNING",
+      workflowRunId,
+      startedAt: started.startedAt,
+      updatedAt: yearsOld,
+    });
+    expect(
+      await db.articleBatch.count({ where: { siteId: runningSiteId } }),
+    ).toBe(1);
+    await closeArticleBatch({
+      batchId: admission.batchId,
+      workflowRunId,
+      status: "ZERO_OUTPUT",
+      statusReason: "TEST_CLEANUP",
+    });
+  });
+
+  test("reconciles bound batches only from durable terminal Workflow state", async () => {
+    const workflowName =
+      "workflow//./src/workflows/article-batch//articleBatchWorkflow";
+    const cases = [
+      { engine: "pending", batch: "QUEUED", expected: "QUEUED" },
+      { engine: "running", batch: "RUNNING", expected: "RUNNING" },
+      { engine: "completed", batch: "QUEUED", expected: "FAILED" },
+      { engine: "failed", batch: "RUNNING", expected: "FAILED" },
+      { engine: "cancelled", batch: "RUNNING", expected: "FAILED" },
+      { engine: "wrong-workflow", batch: "RUNNING", expected: "RUNNING" },
+      { engine: "lookup-error", batch: "QUEUED", expected: "QUEUED" },
+    ] as const;
+    const rows: Array<{
+      engine: (typeof cases)[number]["engine"];
+      batch: (typeof cases)[number]["batch"];
+      expected: (typeof cases)[number]["expected"];
+      batchId: string;
+      workflowRunId: string;
+      index: number;
+    }> = [];
+    for (const [index, testCase] of cases.entries()) {
+      const targetSiteId = await createClaimedSite({ paid: true });
+      const admission = await reserveArticleBatch({
+        siteId: targetSiteId,
+        requestedBy: `workflow-reconcile-${testCase.engine}`,
+        count: 4,
+      });
+      if (!admission.ok) throw new Error(admission.reason);
+      const workflowRunId = `run_reconcile_${testCase.engine}_${randomUUID()}`;
+      await db.articleBatch.update({
+        where: { id: admission.batchId },
+        data: {
+          status: testCase.batch,
+          workflowRunId,
+          rejectedCount: index,
+          ...(testCase.batch === "RUNNING" ? { startedAt: new Date() } : {}),
+          // A passive timestamp must not affect any case.
+          updatedAt: new Date("2000-01-01T00:00:00.000Z"),
+        },
+      });
+      rows.push({ ...testCase, batchId: admission.batchId, workflowRunId, index });
+    }
+
+    expect(
+      await reconcileBoundArticleBatches(async (workflowRunId) => {
+        const row = rows.find((candidate) => candidate.workflowRunId === workflowRunId);
+        if (!row) throw new Error("unexpected workflow run");
+        if (row.engine === "lookup-error") {
+          throw new Error("synthetic Workflow lookup failure");
+        }
+        return {
+          status:
+            row.engine === "wrong-workflow" ? "completed" : row.engine,
+          workflowName:
+            row.engine === "wrong-workflow"
+              ? "workflow//./src/workflows/source-monitoring//sourceMonitoringWorkflow"
+              : workflowName,
+        };
+      }),
+    ).toEqual({ inspected: 7, active: 2, closed: 3, deferred: 2 });
+
+    for (const row of rows) {
+      const actual = await db.articleBatch.findUniqueOrThrow({
+        where: { id: row.batchId },
+        select: {
+          status: true,
+          statusReason: true,
+          rejectedCount: true,
+          workflowRunId: true,
+        },
+      });
+      expect(actual.status).toBe(row.expected);
+      expect(actual.rejectedCount).toBe(row.index);
+      expect(actual.workflowRunId).toBe(row.workflowRunId);
+      if (row.engine === "completed") {
+        expect(actual.statusReason).toBe(
+          "WORKFLOW_COMPLETED_WITHOUT_BATCH_OUTCOME",
+        );
+      } else if (row.engine === "failed") {
+        expect(actual.statusReason).toBe("WORKFLOW_ENGINE_FAILED");
+      } else if (row.engine === "cancelled") {
+        expect(actual.statusReason).toBe("WORKFLOW_ENGINE_CANCELLED");
+      } else {
+        expect(actual.statusReason).toBeNull();
+      }
+    }
+
+    const completed = rows.find((row) => row.engine === "completed");
+    if (!completed) throw new Error("missing completed Workflow case");
+    const completedBatch = await db.articleBatch.findUniqueOrThrow({
+      where: { id: completed.batchId },
+      select: { siteId: true },
+    });
+    const next = await reserveArticleBatch({
+      siteId: completedBatch.siteId,
+      requestedBy: "after-terminal-reconciliation",
+      count: 1,
+    });
+    expect(next.ok).toBe(true);
+    if (next.ok) {
+      await closeArticleBatch({
+        batchId: next.batchId,
+        status: "ZERO_OUTPUT",
+        statusReason: "TEST_CLEANUP",
+      });
+    }
+
+    for (const row of rows.filter((candidate) => candidate.expected !== "FAILED")) {
+      await closeArticleBatch({
+        batchId: row.batchId,
+        workflowRunId: row.workflowRunId,
+        status: "ZERO_OUTPUT",
+        statusReason: "TEST_CLEANUP",
+      });
+    }
+  });
+
+  test("fences persistence and terminal closes by workflow owner", async () => {
+    const ownerSiteId = await createClaimedSite({ paid: true });
+    const inputs = await loadGenerationInputs(ownerSiteId);
+    if (!inputs.ok) throw new Error(inputs.reason);
+    const catalogItemId = inputs.facts.catalogItems[0]!.id;
+    const admission = await reserveArticleBatch({
+      siteId: ownerSiteId,
+      requestedBy: "terminal-owner-fence",
+      count: 1,
+    });
+    if (!admission.ok) throw new Error(admission.reason);
+    const workflowRunId = `run_terminal_owner_${randomUUID()}`;
+    const dispatchLeaseToken = `lease_terminal_owner_${randomUUID()}`;
+    await db.articleBatch.update({
+      where: { id: admission.batchId },
+      data: {
+        dispatchLeaseToken,
+        dispatchLeaseUntil: new Date(
+          Date.now() + articleBatchDispatchLeaseMs,
+        ),
+      },
+    });
+    await beginArticleBatch(
+      admission.batchId,
+      workflowRunId,
+      dispatchLeaseToken,
+    );
+    const wrongWorkflowRunId = `run_terminal_loser_${randomUUID()}`;
+    await expect(
+      persistArticleBatch({
+        batchId: admission.batchId,
+        workflowRunId: wrongWorkflowRunId,
+        siteId: ownerSiteId,
+        plans: [factualPlan(catalogItemId, "seasonal-menu")],
+      }),
+    ).rejects.toThrow("Article batch workflow owner does not match");
+    expect(
+      await closeArticleBatch({
+        batchId: admission.batchId,
+        workflowRunId: wrongWorkflowRunId,
+        status: "FAILED",
+        statusReason: "WRONG_OWNER",
+      }),
+    ).toBe(false);
+
+    const persisted = await persistArticleBatch({
+      batchId: admission.batchId,
+      workflowRunId,
+      siteId: ownerSiteId,
+      plans: [factualPlan(catalogItemId, "seasonal-menu")],
+    });
+    expect(persisted).toMatchObject({ producedCount: 1, rejectedCount: 0 });
+    expect(
+      await persistArticleBatch({
+        batchId: admission.batchId,
+        workflowRunId,
+        siteId: ownerSiteId,
+        plans: [factualPlan(catalogItemId, "seasonal-menu")],
+      }),
+    ).toEqual(persisted);
+    await expect(
+      persistArticleBatch({
+        batchId: admission.batchId,
+        workflowRunId: wrongWorkflowRunId,
+        siteId: ownerSiteId,
+        plans: [factualPlan(catalogItemId, "seasonal-menu")],
+      }),
+    ).rejects.toThrow("Article batch workflow owner does not match");
+    expect(
+      await db.articleBatch.findUniqueOrThrow({
+        where: { id: admission.batchId },
+        select: { status: true, workflowRunId: true, acceptedCount: true },
+      }),
+    ).toEqual({
+      status: "SUCCEEDED",
+      workflowRunId,
+      acceptedCount: 1,
+    });
+  });
+
+  test("admits one workflow owner and idempotently replays only that owner", async () => {
+    const beginSiteId = await createClaimedSite();
+    const admission = await reserveArticleBatch({
+      siteId: beginSiteId,
+      requestedBy: "concurrent-begin-test",
+      count: 4,
+    });
+    if (!admission.ok) throw new Error(admission.reason);
+    const dispatchLeaseToken = `lease_begin_owner_${randomUUID()}`;
+    await db.articleBatch.update({
+      where: { id: admission.batchId },
+      data: {
+        dispatchLeaseToken,
+        dispatchLeaseUntil: new Date(
+          Date.now() + articleBatchDispatchLeaseMs,
+        ),
+      },
+    });
+
+    const workflowRunIds = Array.from(
+      { length: 8 },
+      (_, index) => `run_begin_owner_${index}_${randomUUID()}`,
+    );
+    const attempts = await Promise.all(
+      workflowRunIds.map((workflowRunId) =>
+        beginArticleBatch(
+          admission.batchId,
+          workflowRunId,
+          dispatchLeaseToken,
+        ),
+      ),
+    );
+    const winnerIndexes = attempts.flatMap((attempt, index) =>
+      attempt === null ? [] : [index],
+    );
+    expect(winnerIndexes).toHaveLength(1);
+    const winnerIndex = winnerIndexes[0];
+    if (winnerIndex === undefined) throw new Error("batch begin had no owner");
+    const winningWorkflowRunId = workflowRunIds[winnerIndex];
+    expect(attempts[winnerIndex]).toEqual({
+      siteId: beginSiteId,
+      requestedCount: 4,
+    });
+
+    const firstTransition = await db.articleBatch.findUniqueOrThrow({
+      where: { id: admission.batchId },
+      select: { status: true, startedAt: true, workflowRunId: true },
+    });
+    expect(firstTransition).toMatchObject({
+      status: "RUNNING",
+      startedAt: expect.any(Date),
+      workflowRunId: winningWorkflowRunId,
+    });
+
+    expect(
+      await beginArticleBatch(admission.batchId, winningWorkflowRunId),
+    ).toEqual({ siteId: beginSiteId, requestedCount: 4 });
+    expect(
+      await beginArticleBatch(
+        admission.batchId,
+        `run_begin_loser_${randomUUID()}`,
+      ),
+    ).toBeNull();
+    expect(
+      await db.articleBatch.findUniqueOrThrow({
+        where: { id: admission.batchId },
+        select: { status: true, startedAt: true, workflowRunId: true },
+      }),
+    ).toEqual(firstTransition);
+
+    await closeArticleBatch({
+      batchId: admission.batchId,
+      workflowRunId: winningWorkflowRunId,
+      status: "ZERO_OUTPUT",
+      statusReason: "TEST_CLEANUP",
+    });
+    const terminalTransition = await db.articleBatch.findUniqueOrThrow({
+      where: { id: admission.batchId },
+      select: { status: true, startedAt: true, workflowRunId: true },
+    });
+    expect(terminalTransition).toMatchObject({
+      status: "ZERO_OUTPUT",
+      startedAt: firstTransition.startedAt,
+      workflowRunId: winningWorkflowRunId,
+    });
+    expect(
+      await beginArticleBatch(admission.batchId, winningWorkflowRunId),
+    ).toBeNull();
+    expect(
+      await db.articleBatch.findUniqueOrThrow({
+        where: { id: admission.batchId },
+        select: { status: true, startedAt: true, workflowRunId: true },
+      }),
+    ).toEqual(terminalTransition);
+  });
+
+  test("honors the same workflow owner when start binds it before begin", async () => {
+    const preboundSiteId = await createClaimedSite();
+    const admission = await reserveArticleBatch({
+      siteId: preboundSiteId,
+      requestedBy: "prebound-begin-test",
+      count: 3,
+    });
+    if (!admission.ok) throw new Error(admission.reason);
+    const workflowRunId = `run_prebound_${randomUUID()}`;
+    await db.articleBatch.update({
+      where: { id: admission.batchId },
+      data: { workflowRunId },
+    });
+
+    expect(
+      await beginArticleBatch(
+        admission.batchId,
+        `run_prebound_loser_${randomUUID()}`,
+      ),
+    ).toBeNull();
+    expect(
+      await beginArticleBatch(admission.batchId, workflowRunId),
+    ).toEqual({ siteId: preboundSiteId, requestedCount: 3 });
+    expect(
+      await db.articleBatch.findUniqueOrThrow({
+        where: { id: admission.batchId },
+        select: { status: true, workflowRunId: true },
+      }),
+    ).toEqual({ status: "RUNNING", workflowRunId });
+
+    await closeArticleBatch({
+      batchId: admission.batchId,
+      workflowRunId,
       status: "ZERO_OUTPUT",
       statusReason: "TEST_CLEANUP",
     });
@@ -410,10 +1812,15 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
         count: 4,
       }),
     ]);
-    const admitted = starts.filter((result) => result.ok);
-    expect(admitted).toHaveLength(1);
-    const first = admitted[0];
+    expect(
+      starts.filter((result) => result.ok && result.acquired),
+    ).toHaveLength(1);
+    const first = starts.find((result) => result.ok && result.acquired);
     if (!first?.ok) throw new Error("paid admission had no winner");
+    for (const result of starts) {
+      if (result.ok) expect(result.batchId).toBe(first.batchId);
+      else expect(result.status).toBe(409);
+    }
     await closeArticleBatch({
       batchId: first.batchId,
       status: "ZERO_OUTPUT",
@@ -438,6 +1845,7 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
     const accountingSiteId = await createClaimedSite();
     const inputs = await loadGenerationInputs(accountingSiteId);
     if (!inputs.ok) throw new Error(inputs.reason);
+    const catalogItemId = inputs.facts.catalogItems[0]!.id;
     const admission = await reserveArticleBatch({
       siteId: accountingSiteId,
       requestedBy: "accounting-test",
@@ -451,15 +1859,10 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
     const persistInput = {
       batchId: admission.batchId,
       siteId: accountingSiteId,
-      facts: inputs.facts,
-      drafts: [
-        factualDraft("accounting-factual", "seasonal-menu"),
+      plans: [
+        factualPlan(catalogItemId, "seasonal-menu"),
         {
-          ...factualDraft("accounting-invented", "first-visit"),
-          bodyMarkdown: "The invented Moonbeam Tart is ready today. ".repeat(15),
-          catalogClaims: [
-            { name: "Moonbeam Tart", price: 12, currency: "EUR" },
-          ],
+          ...factualPlan(`unknown-${randomUUID()}`, "dietary-faqs"),
         },
       ],
     };
@@ -561,14 +1964,14 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
     }
   });
 
-  test("workflow start failures close the reservation without provider work", async () => {
+  test("workflow start failures release the same reservation for retry", async () => {
     const failureSiteId = await createClaimedSite();
     const previousApiKey = process.env.OPENROUTER_API_KEY;
     process.env.OPENROUTER_API_KEY = "test-only-never-sent";
     let startAttempts = 0;
     try {
-      await expect(
-        startArticleBatch(
+      expect(
+        await startArticleBatch(
           {
             siteId: failureSiteId,
             slug: "unused-test-slug",
@@ -580,35 +1983,90 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
             throw new Error("synthetic workflow start failure");
           },
         ),
-      ).rejects.toThrow("synthetic workflow start failure");
+      ).toMatchObject({ ok: false, status: 503 });
+
+      const released = await db.articleBatch.findFirstOrThrow({
+        where: { siteId: failureSiteId },
+        select: {
+          id: true,
+          requestedBy: true,
+          requestedCount: true,
+          acceptedCount: true,
+          rejectedCount: true,
+          status: true,
+          statusReason: true,
+          workflowRunId: true,
+          dispatchLeaseToken: true,
+          dispatchLeaseUntil: true,
+        },
+      });
+      expect(released).toMatchObject({
+        requestedBy: "start-failure-test",
+        requestedCount: 4,
+        acceptedCount: 0,
+        rejectedCount: 0,
+        status: "QUEUED",
+        statusReason: null,
+        workflowRunId: null,
+        dispatchLeaseToken: null,
+        dispatchLeaseUntil: null,
+      });
+
+      const workflowRunId = `run_after_start_retry_${randomUUID()}`;
+      expect(
+        await startArticleBatch(
+          {
+            siteId: failureSiteId,
+            slug: "unused-test-slug",
+            requestedBy: "start-failure-retry",
+            count: 2,
+          },
+          async (batchId, dispatchLeaseToken) => {
+            startAttempts += 1;
+            expect(batchId).toBe(released.id);
+            expect(dispatchLeaseToken).toBeTruthy();
+            return workflowRunId;
+          },
+        ),
+      ).toEqual({ ok: true, runId: workflowRunId });
+      expect(
+        await db.articleBatch.findMany({
+          where: { siteId: failureSiteId },
+          select: {
+            id: true,
+            requestedBy: true,
+            requestedCount: true,
+            status: true,
+            workflowRunId: true,
+          },
+        }),
+      ).toEqual([
+        {
+          id: released.id,
+          requestedBy: "start-failure-test",
+          requestedCount: 4,
+          status: "QUEUED",
+          workflowRunId,
+        },
+      ]);
+      await closeArticleBatch({
+        batchId: released.id,
+        workflowRunId,
+        status: "ZERO_OUTPUT",
+        statusReason: "TEST_CLEANUP",
+      });
     } finally {
       restoreEnvironment("OPENROUTER_API_KEY", previousApiKey);
     }
 
-    expect(startAttempts).toBe(1);
-    expect(
-      await db.articleBatch.findFirstOrThrow({
-        where: { siteId: failureSiteId },
-      }),
-    ).toMatchObject({
-      requestedCount: 4,
-      acceptedCount: 0,
-      rejectedCount: 0,
-      status: "FAILED",
-      statusReason: "WORKFLOW_START_FAILED",
-    });
-    const retry = await reserveArticleBatch({
-      siteId: failureSiteId,
-      requestedBy: "failed-start-retry",
-      count: 4,
-    });
-    expect(retry).toMatchObject({ ok: false, status: 409 });
+    expect(startAttempts).toBe(2);
   });
 
   test("binds the workflow run id after a fast terminal outcome", async () => {
     const fastSiteId = await createClaimedSite();
     const previousApiKey = process.env.OPENROUTER_API_KEY;
     process.env.OPENROUTER_API_KEY = "test-only-never-sent";
+    const workflowRunId = `run_fast_${randomUUID()}`;
     try {
       const result = await startArticleBatch(
         {
@@ -617,14 +2075,19 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
           requestedBy: "fast-terminal-test",
           count: 4,
         },
-        async (batchId) => {
-          await beginArticleBatch(batchId);
+        async (batchId, dispatchLeaseToken) => {
+          await beginArticleBatch(
+            batchId,
+            workflowRunId,
+            dispatchLeaseToken,
+          );
           await closeArticleBatch({
             batchId,
+            workflowRunId,
             status: "ZERO_OUTPUT",
             statusReason: "MODEL_RETURNED_ZERO_DRAFTS",
           });
-          return `run_fast_${randomUUID()}`;
+          return workflowRunId;
         },
       );
       if (!result.ok) throw new Error(result.reason);
@@ -645,7 +2108,7 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
     );
     const slugRow = await db.article.findFirstOrThrow({
       where: { siteId, topicKey: "seasonal-menu" },
-      select: { slug: true },
+      select: { id: true, slug: true },
     });
 
     const site = await db.site.findUniqueOrThrow({
@@ -663,8 +2126,8 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
       await listPublishedArticles({ slug: site!.slug, versionId: "sv_any" }),
     ).toEqual([]);
 
-    await db.article.updateMany({
-      where: { siteId, topicKey: "seasonal-menu" },
+    await db.article.update({
+      where: { id: slugRow.id },
       data: { status: "PUBLISHED", publishedAt: new Date() },
     });
 
@@ -681,6 +2144,97 @@ describe.skipIf(!enabled)("articles PostgreSQL integration", () => {
       articleSlug: slugRow.slug,
     });
     expect(one?.title).toBeTruthy();
+  });
+
+  test("workflow failures preserve provider rejections in the durable outcome", async () => {
+    const failureSiteId = await createClaimedSite();
+    const admission = await reserveArticleBatch({
+      siteId: failureSiteId,
+      requestedBy: "workflow-rejection-carry",
+      count: 2,
+    });
+    if (!admission.ok) throw new Error(admission.reason);
+    const workflowRunId = `run_rejection_carry_${randomUUID()}`;
+    const dispatchLeaseToken = `lease_rejection_carry_${randomUUID()}`;
+    await db.articleBatch.update({
+      where: { id: admission.batchId },
+      data: {
+        dispatchLeaseToken,
+        dispatchLeaseUntil: new Date(Date.now() + articleBatchDispatchLeaseMs),
+      },
+    });
+
+    const [actualWorkflow, actualGeneration] = await Promise.all([
+      import("workflow"),
+      import("@/lib/articles/generation"),
+    ]);
+    try {
+      mock.module("workflow", () => ({
+        ...actualWorkflow,
+        getWorkflowMetadata: () => ({ workflowRunId }),
+        getWritable: () => ({
+          getWriter: () => ({
+            write: async () => undefined,
+            releaseLock: () => undefined,
+          }),
+        }),
+      }));
+      mock.module("@/lib/articles/generation", () => ({
+        ...actualGeneration,
+        generateBatchPlans: async (input: {
+          facts: { catalogItems: Array<{ id: string }> };
+        }) => ({
+          status: "GENERATED" as const,
+          plans: [
+            {
+              ...factualPlan(
+                input.facts.catalogItems[0]!.id,
+                "seasonal-menu",
+              ),
+              priceMode: "exact" as const,
+            },
+          ],
+          rejectedCount: 1,
+        }),
+        persistArticleBatch: async () => {
+          throw new Error("synthetic persistence failure");
+        },
+      }));
+      const { articleBatchWorkflow } = await import("@/workflows/article-batch");
+
+      await expect(
+        articleBatchWorkflow({
+          batchId: admission.batchId,
+          dispatchLeaseToken,
+        }),
+      ).rejects.toThrow("synthetic persistence failure");
+      expect(
+        await db.articleBatch.findUniqueOrThrow({
+          where: { id: admission.batchId },
+          select: {
+            requestedCount: true,
+            acceptedCount: true,
+            rejectedCount: true,
+            status: true,
+            statusReason: true,
+            workflowRunId: true,
+          },
+        }),
+      ).toEqual({
+        requestedCount: 2,
+        acceptedCount: 0,
+        rejectedCount: 1,
+        status: "FAILED",
+        statusReason: "GENERATION_FAILED",
+        workflowRunId,
+      });
+      expect(
+        await db.article.count({ where: { batchId: admission.batchId } }),
+      ).toBe(0);
+    } finally {
+      mock.module("workflow", () => actualWorkflow);
+      mock.module("@/lib/articles/generation", () => actualGeneration);
+    }
   });
 });
 
@@ -754,20 +2308,39 @@ async function createClaimedSite(options: { paid?: boolean } = {}): Promise<stri
   return targetSiteId;
 }
 
-function factualDraft(slug: string, topicKey: string) {
+function factualPlan(
+  catalogItemId: string,
+  topicKey: "seasonal-menu" | "dietary-faqs" | "chef-story",
+) {
+  const templateKey = {
+    "seasonal-menu": "restaurant-current-menu",
+    "dietary-faqs": "restaurant-dietary-enquiry",
+    "chef-story": "restaurant-menu-facts",
+  } as const;
   return {
+    contractVersion: 1 as const,
     topicKey,
-    slug,
-    title: "A factual bakery article",
-    excerpt: "A source-backed look at one familiar bake.",
-    bodyMarkdown:
-      "Our Croissant is folded carefully and baked in small batches each morning. ".repeat(
-        10,
-      ),
-    catalogClaims: [
-      { name: "Croissant", price: null, currency: null },
-    ],
+    templateKey: templateKey[topicKey],
+    catalogItemId,
+    priceMode: "omit" as const,
   };
+}
+
+function catalogItemIdByName(
+  items: Array<{ id: string; name: string }>,
+  name: string,
+): string {
+  const item = items.find((candidate) => candidate.name === name);
+  if (!item) throw new Error(`Catalog item not found: ${name}`);
+  return item.id;
+}
+
+function testPrice(price: number, currency: string, locale: string): string {
+  return new Intl.NumberFormat(locale, {
+    style: "currency",
+    currency,
+    minimumFractionDigits: price % 1 === 0 ? 0 : 2,
+  }).format(price);
 }
 
 function restoreEnvironment(name: string, value: string | undefined): void {

--- a/src/lib/articles/generation.test.ts
+++ b/src/lib/articles/generation.test.ts
@@ -14,67 +14,84 @@ const facts: SiteFacts = {
   phone: null,
   businessHours: [],
   catalogItems: [
-    { name: "Matcha Bun", price: 1_000, currency: "JPY" },
+    {
+      id: "catalog-matcha-bun",
+      name: "Matcha Bun",
+      price: 1_000,
+      currency: "JPY",
+    },
   ],
-  integrationLabels: [],
+  integrationCapabilities: [],
 };
 
+const plan = {
+  contractVersion: 1,
+  topicKey: "seasonal-stock",
+  templateKey: "retail-current-stock",
+  catalogItemId: "catalog-matcha-bun",
+  priceMode: "exact",
+} as const;
+
 describe("article generation model contract", () => {
-  it("puts structured canonical catalog facts and claim rules in the prompt", () => {
+  it("asks only for exact IDs and closed plan fields", () => {
     const prompt = buildArticleBatchPrompt({
       facts,
-      topics: [{ key: "product-guide", title: "A product guide" }],
+      topics: [
+        {
+          key: "seasonal-stock",
+          templateKey: "retail-current-stock",
+          catalogItem: "required",
+        },
+      ],
     });
 
     expect(prompt).toContain(
       JSON.stringify([
-        { name: "Matcha Bun", price: 1_000, currency: "JPY" },
+        {
+          catalogItemId: "catalog-matcha-bun",
+          hasExactPrice: true,
+        },
       ]),
     );
     expect(prompt).toContain(
-      "catalogClaims must enumerate every catalog item named",
+      "Return only contractVersion, topicKey, templateKey, catalogItemId, and priceMode.",
     );
     expect(prompt).toContain(
-      "price/currency pair must be copied exactly from that same catalog item",
+      "topicKey=seasonal-stock; templateKey=retail-current-stock; catalogItem=required",
     );
-    expect(prompt).toContain("[product-guide] A product guide");
+    expect(prompt).not.toContain('"price":1000');
+    expect(prompt).not.toContain('"currency":"JPY"');
+    expect(prompt).not.toContain("Matcha Bun");
+    expect(prompt).not.toContain("Prompt Contract Bakery");
+    expect(prompt).not.toContain("1 Test Street");
+    expect(prompt).not.toContain("bodyMarkdown");
   });
 
-  it("requires bounded structured claims in every model article", () => {
-    const article = {
-      topicKey: "product-guide",
-      slug: "matcha-bun-guide",
-      title: "Matcha Bun guide",
-      excerpt: "What to know.",
-      bodyMarkdown: "A factual body.",
-    };
+  it("accepts only strict closed plans", () => {
+    expect(articleBatchOutputSchema.safeParse({ articles: [plan] }).success).toBe(
+      true,
+    );
 
+    for (const extra of [
+      { title: "Matcha Bun guide" },
+      { excerpt: "What to know" },
+      { bodyMarkdown: "Matcha Bun costs JPY 1000" },
+      { name: "Matcha Bun" },
+      { price: 1_000 },
+      { currency: "JPY" },
+      { range: { from: 1_000 } },
+      { unit: "each" },
+      { text: "Try our Matcha Bun" },
+    ]) {
+      expect(
+        articleBatchOutputSchema.safeParse({
+          articles: [{ ...plan, ...extra }],
+        }).success,
+      ).toBe(false);
+    }
     expect(
-      articleBatchOutputSchema.safeParse({ articles: [article] }).success,
-    ).toBe(false);
-    expect(
-      articleBatchOutputSchema.safeParse({
-        articles: [
-          {
-            ...article,
-            catalogClaims: [
-              { name: "Matcha Bun", price: 1_000, currency: "JPY" },
-            ],
-          },
-        ],
-      }).success,
-    ).toBe(true);
-    expect(
-      articleBatchOutputSchema.safeParse({
-        articles: [
-          {
-            ...article,
-            catalogClaims: [
-              { name: "Matcha Bun", price: 1_000, currency: "jpy" },
-            ],
-          },
-        ],
-      }).success,
+      articleBatchOutputSchema.safeParse({ articles: [plan], prose: "no" })
+        .success,
     ).toBe(false);
   });
 });

--- a/src/lib/articles/generation.test.ts
+++ b/src/lib/articles/generation.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "bun:test";
+import {
+  articleBatchOutputSchema,
+  buildArticleBatchPrompt,
+} from "@/lib/articles/generation";
+import type { SiteFacts } from "@/lib/articles/site-facts";
+
+const facts: SiteFacts = {
+  slug: "prompt-contract",
+  name: "Prompt Contract Bakery",
+  vertical: "FOOD_RETAIL",
+  locale: "en",
+  address: "1 Test Street",
+  phone: null,
+  businessHours: [],
+  catalogItems: [
+    { name: "Matcha Bun", price: 1_000, currency: "JPY" },
+  ],
+  integrationLabels: [],
+};
+
+describe("article generation model contract", () => {
+  it("puts structured canonical catalog facts and claim rules in the prompt", () => {
+    const prompt = buildArticleBatchPrompt({
+      facts,
+      topics: [{ key: "product-guide", title: "A product guide" }],
+    });
+
+    expect(prompt).toContain(
+      JSON.stringify([
+        { name: "Matcha Bun", price: 1_000, currency: "JPY" },
+      ]),
+    );
+    expect(prompt).toContain(
+      "catalogClaims must enumerate every catalog item named",
+    );
+    expect(prompt).toContain(
+      "price/currency pair must be copied exactly from that same catalog item",
+    );
+    expect(prompt).toContain("[product-guide] A product guide");
+  });
+
+  it("requires bounded structured claims in every model article", () => {
+    const article = {
+      topicKey: "product-guide",
+      slug: "matcha-bun-guide",
+      title: "Matcha Bun guide",
+      excerpt: "What to know.",
+      bodyMarkdown: "A factual body.",
+    };
+
+    expect(
+      articleBatchOutputSchema.safeParse({ articles: [article] }).success,
+    ).toBe(false);
+    expect(
+      articleBatchOutputSchema.safeParse({
+        articles: [
+          {
+            ...article,
+            catalogClaims: [
+              { name: "Matcha Bun", price: 1_000, currency: "JPY" },
+            ],
+          },
+        ],
+      }).success,
+    ).toBe(true);
+    expect(
+      articleBatchOutputSchema.safeParse({
+        articles: [
+          {
+            ...article,
+            catalogClaims: [
+              { name: "Matcha Bun", price: 1_000, currency: "jpy" },
+            ],
+          },
+        ],
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/src/lib/articles/generation.ts
+++ b/src/lib/articles/generation.ts
@@ -2,16 +2,20 @@ import { z } from "zod";
 import { generateText, Output } from "ai";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import {
-  checkArticleDraft,
+  checkArticlePlan,
+  generatedArticlePlanSchema,
+  renderArticlePlan,
   selectBatchTopics,
-  type GeneratedArticleDraft,
+  type GeneratedArticlePlan,
 } from "@/lib/articles/composer";
 import type { SiteFacts } from "@/lib/articles/site-facts";
+import { isArticleIntegrationCapability } from "@/lib/articles/integration-capabilities";
 import {
   articleTopicPlanByKey,
   articleTopicPlansFor,
 } from "@/lib/articles/topic-plans";
 import { getDb } from "@/lib/db";
+import { isVerticalCatalogItemVisible } from "@/lib/verticals/registry";
 
 /**
  * Mirrors the site generator's provider policy: one OpenRouter key gates
@@ -42,83 +46,61 @@ function getModel() {
   });
 }
 
-export const articleBatchOutputSchema = z.object({
-  articles: z
-    .array(
-      z.object({
-        topicKey: z.string(),
-        slug: z.string(),
-        title: z.string(),
-        excerpt: z.string(),
-        bodyMarkdown: z.string(),
-        catalogClaims: z
-          .array(
-            z.object({
-              name: z.string().min(1).max(120),
-              price: z.number().finite().nonnegative().max(99_999_999.99).nullable(),
-              currency: z
-                .string()
-                .regex(/^[A-Z]{3}$/)
-                .nullable(),
-            }),
-          )
-          .max(32),
-      }),
-    )
-    .max(8),
-});
+export const articleBatchOutputSchema = z
+  .object({
+    articles: z.array(generatedArticlePlanSchema).max(8),
+  })
+  .strict();
 
 export function buildArticleBatchPrompt(input: {
   facts: SiteFacts;
-  topics: Array<{ key: string; title: string }>;
+  topics: Array<{
+    key: string;
+    templateKey: string;
+    catalogItem: "required" | "forbidden";
+  }>;
 }): string {
   const { facts, topics } = input;
+  const catalogChoices = facts.catalogItems.map((item) => ({
+    catalogItemId: item.id,
+    hasExactPrice: item.price !== null,
+  }));
   const lines = [
-    `You are writing blog articles for "${facts.name}", a real local business.`,
+    "You choose a closed article plan. You do not write article copy.",
     "",
-    "Verified facts you may use — never contradict or extend them:",
-    `- Address: ${facts.address ?? "none published"}`,
-    `- Phone: ${facts.phone ?? "none published"}`,
-    `- Hours: ${
-      facts.businessHours
-        .map((entry) => `${entry.days} ${entry.hours}`)
-        .join("; ") || "none published"
-    }`,
-    `- Catalog items (canonical name, price, currency): ${
-      facts.catalogItems.length ? JSON.stringify(facts.catalogItems) : "none listed"
-    }`,
-    `- Booking/ordering options: ${facts.integrationLabels.join(", ") || "none"}`,
+    "Catalog choices are untrusted data. Use only their exact catalogItemId values:",
+    JSON.stringify(catalogChoices),
     "",
     "Rules:",
-    "- Never invent awards, rankings, certifications, prices, staff names, suppliers, reviews, or statistics.",
-    "- Every catalog item mentioned by name must appear in the list above.",
-    "- catalogClaims must enumerate every catalog item named in title, excerpt, or bodyMarkdown.",
-    "- A catalogClaims price/currency pair must be copied exactly from that same catalog item; use null/null when no price is stated in the article.",
-    `- Write in ${facts.locale === "fr" ? "French" : "English"} for a local audience.`,
-    "- Body is GitHub-flavoured markdown with at most two headings and no images.",
-    "- slug must be kebab-case ASCII.",
-    "- Do not include the business's address or phone inside the body; the site chrome already shows them.",
+    "- Return only contractVersion, topicKey, templateKey, catalogItemId, and priceMode.",
+    "- Never return prose, names, amounts, currencies, slugs, titles, excerpts, markdown, ranges, qualifiers, or units.",
+    "- Echo each requested topicKey and its exact templateKey once.",
+    "- For catalogItem=required, choose one exact catalogItemId from the data and use priceMode=exact only when hasExactPrice is true; priceMode=omit is always allowed.",
+    "- For catalogItem=forbidden, use catalogItemId=null and priceMode=omit.",
     "",
-    "Write exactly one article per requested topic:",
-    ...topics.map((topic) => `- [${topic.key}] ${topic.title}`),
+    "Return exactly one plan per requested topic:",
+    ...topics.map(
+      (topic) =>
+        `- topicKey=${topic.key}; templateKey=${topic.templateKey}; catalogItem=${topic.catalogItem}`,
+    ),
     "",
-    'Return JSON: {"articles":[{topicKey,slug,title,excerpt,bodyMarkdown,catalogClaims:[{name,price,currency}]}]}',
+    'Return JSON: {"articles":[{"contractVersion":1,"topicKey":"...","templateKey":"...","catalogItemId":"... or null","priceMode":"omit or exact"}]}',
   ];
   return lines.join("\n");
 }
 
-export async function generateBatchDrafts(input: {
+export async function generateBatchPlans(input: {
   facts: SiteFacts;
   count: number;
   recentTopicKeys: string[];
-}): Promise<GeneratedBatchDrafts> {
+}): Promise<GeneratedBatchPlans> {
   if (!articleGenerationConfigured()) {
     throw new Error("OPENROUTER_API_KEY is not configured");
   }
-  const plans = articleTopicPlansFor(input.facts.vertical);
+  const topicPlans = articleTopicPlansFor(input.facts.vertical);
   const selected = selectBatchTopics({
     facts: input.facts,
-    plans,
+    plans: topicPlans,
     count: input.count,
     recentTopicKeys: input.recentTopicKeys,
   });
@@ -126,14 +108,22 @@ export async function generateBatchDrafts(input: {
     return {
       status: "SKIPPED",
       statusReason: "NO_SUPPORTABLE_TOPICS",
-      drafts: [],
+      plans: [],
       rejectedCount: 0,
     };
   }
 
   const topics = selected.flatMap((topic) => {
     const plan = articleTopicPlanByKey(input.facts.vertical, topic.key);
-    return plan ? [{ key: plan.key, title: plan.title }] : [];
+    return plan
+      ? [
+          {
+            key: plan.key,
+            templateKey: plan.templateKey,
+            catalogItem: plan.catalogItem,
+          },
+        ]
+      : [];
   });
 
   const { output } = await generateText({
@@ -141,34 +131,40 @@ export async function generateBatchDrafts(input: {
     output: Output.object({
       schema: articleBatchOutputSchema,
       name: "site_article_batch",
-      description: "Locally relevant blog articles for one real business",
+      description: "Closed article template selections for one real business",
     }),
     maxRetries: 2,
     timeout: { totalMs: 55_000, stepMs: 45_000 },
     prompt: buildArticleBatchPrompt({ facts: input.facts, topics }),
   });
 
-  const allowed = new Set(topics.map((topic) => topic.key));
-  const drafts = output.articles
-    .slice(0, topics.length)
-    .filter((draft) => allowed.has(draft.topicKey));
+  const allowed = new Map(topics.map((topic) => [topic.key, topic]));
+  const seen = new Set<string>();
+  const acceptedPlans = output.articles.slice(0, topics.length).filter((plan) => {
+    const topic = allowed.get(plan.topicKey);
+    if (!topic || seen.has(plan.topicKey)) return false;
+    if (topic.templateKey !== plan.templateKey) return false;
+    if (checkArticlePlan(plan, input.facts).length) return false;
+    seen.add(plan.topicKey);
+    return true;
+  });
   return {
     status: "GENERATED",
-    drafts,
-    rejectedCount: output.articles.length - drafts.length,
+    plans: acceptedPlans,
+    rejectedCount: output.articles.length - acceptedPlans.length,
   };
 }
 
-export type GeneratedBatchDrafts =
+export type GeneratedBatchPlans =
   | {
       status: "SKIPPED";
       statusReason: "NO_SUPPORTABLE_TOPICS";
-      drafts: [];
+      plans: [];
       rejectedCount: 0;
     }
   | {
       status: "GENERATED";
-      drafts: GeneratedArticleDraft[];
+      plans: GeneratedArticlePlan[];
       rejectedCount: number;
     };
 
@@ -179,25 +175,19 @@ export type PersistedBatch = {
 };
 
 /**
- * Persists guardrail-passing drafts as DRAFT articles under the batch row that
- * admission reserved before generation. Rejected drafts shrink the batch and
+ * Renders validated plans and persists their snapshots as DRAFT articles under
+ * the batch row reserved before generation. Rejected plans shrink the batch and
  * are counted independently from the immutable requestedCount.
  */
 export async function persistArticleBatch(input: {
   batchId: string;
+  workflowRunId?: string;
   siteId: string;
-  facts: SiteFacts;
-  drafts: GeneratedArticleDraft[];
+  plans: GeneratedArticlePlan[];
   rejectedCount?: number;
   model?: string | null;
 }): Promise<PersistedBatch> {
   const db = getDb();
-  const accepted = input.drafts.filter(
-    (draft) => !checkArticleDraft(draft, input.facts).length,
-  );
-  const rejectedCount =
-    Math.max(0, input.rejectedCount ?? 0) +
-    (input.drafts.length - accepted.length);
 
   return db.$transaction(async (transaction) => {
     const existingBatch = await transaction.articleBatch.findUnique({
@@ -205,12 +195,17 @@ export async function persistArticleBatch(input: {
       select: {
         siteId: true,
         status: true,
+        workflowRunId: true,
         acceptedCount: true,
         rejectedCount: true,
       },
     });
     if (!existingBatch || existingBatch.siteId !== input.siteId) {
       throw new Error("Article batch reservation was not found");
+    }
+    const expectedWorkflowRunId = input.workflowRunId ?? null;
+    if (existingBatch.workflowRunId !== expectedWorkflowRunId) {
+      throw new Error("Article batch workflow owner does not match");
     }
     if (
       existingBatch.status === "SUCCEEDED" ||
@@ -222,12 +217,86 @@ export async function persistArticleBatch(input: {
         rejectedCount: existingBatch.rejectedCount,
       };
     }
-    if (
-      existingBatch.status !== "QUEUED" &&
-      existingBatch.status !== "RUNNING"
-    ) {
-      throw new Error("Article batch reservation is already terminal");
+    if (existingBatch.status !== "RUNNING") {
+      throw new Error("Article batch reservation is not running");
     }
+
+    const selectedCatalogIds = [
+      ...new Set(
+        input.plans.flatMap((plan) =>
+          plan.catalogItemId === null ? [] : [plan.catalogItemId],
+        ),
+      ),
+    ];
+    const [site, catalogItems, integrations] = await Promise.all([
+      transaction.site.findUnique({
+        where: { id: input.siteId },
+        select: {
+          slug: true,
+          name: true,
+          vertical: true,
+          defaultLocale: true,
+          address: true,
+          phone: true,
+          businessHours: true,
+          status: true,
+        },
+      }),
+      transaction.catalogItem.findMany({
+        where: {
+          id: { in: selectedCatalogIds },
+          section: { siteId: input.siteId },
+        },
+        select: {
+          id: true,
+          name: true,
+          price: true,
+          currency: true,
+          available: true,
+          attributes: true,
+        },
+      }),
+      transaction.integration.findMany({
+        where: { siteId: input.siteId, enabled: true },
+        select: { type: true },
+        orderBy: { type: "asc" },
+      }),
+    ]);
+    if (!site) throw new Error("Article batch site was not found");
+
+    const currentFacts: SiteFacts = {
+      slug: site.slug,
+      name: site.name,
+      vertical: site.vertical,
+      locale: site.defaultLocale,
+      address: site.address,
+      phone: site.phone,
+      businessHours: parseBusinessHours(site.businessHours),
+      catalogItems: catalogItems
+        .filter((item) =>
+          isVerticalCatalogItemVisible(site.vertical, {
+            available: item.available,
+            attributes: item.attributes,
+          }),
+        )
+        .map((item) => ({
+          id: item.id,
+          name: item.name,
+          price: item.price === null ? null : Number(item.price),
+          currency: item.currency,
+        })),
+      integrationCapabilities: articleIntegrationCapabilities(integrations),
+    };
+    const accepted =
+      site.status === "CLAIMED" || site.status === "LIVE"
+        ? input.plans.flatMap((plan) => {
+            const rendered = renderArticlePlan(plan, currentFacts);
+            return rendered.ok ? [rendered.draft] : [];
+          })
+        : [];
+    const rejectedCount =
+      Math.max(0, input.rejectedCount ?? 0) +
+      (input.plans.length - accepted.length);
 
     const existingSlugs = new Set(
       (
@@ -246,14 +315,14 @@ export async function persistArticleBatch(input: {
           siteId: input.siteId,
           batchId: input.batchId,
           slug,
-          locale: input.facts.locale,
+          locale: currentFacts.locale,
           title: draft.title.trim(),
           excerpt: draft.excerpt.trim(),
           bodyMarkdown: draft.bodyMarkdown,
           status: "DRAFT",
           topicKey: draft.topicKey,
           topicTitle:
-            articleTopicPlanByKey(input.facts.vertical, draft.topicKey)?.title ??
+            articleTopicPlanByKey(currentFacts.vertical, draft.topicKey)?.title ??
             draft.topicKey,
           generatedByModel: input.model ?? null,
           sourceBatchId: input.batchId,
@@ -269,6 +338,7 @@ export async function persistArticleBatch(input: {
         id: input.batchId,
         siteId: input.siteId,
         status: { in: ["QUEUED", "RUNNING"] },
+        workflowRunId: expectedWorkflowRunId,
       },
       data: {
         acceptedCount: producedCount,
@@ -277,6 +347,8 @@ export async function persistArticleBatch(input: {
         statusReason: status === "REJECTED" ? "ALL_DRAFTS_REJECTED" : null,
         model: input.model ?? null,
         completedAt: new Date(),
+        dispatchLeaseToken: null,
+        dispatchLeaseUntil: null,
       },
     });
     if (completed.count !== 1) {
@@ -286,20 +358,70 @@ export async function persistArticleBatch(input: {
   });
 }
 
-export async function beginArticleBatch(batchId: string): Promise<{
+/**
+ * Claims a queued reservation for one durable workflow run. Workflow retries
+ * recover the same RUNNING row by owner; a distinct run never receives its
+ * generation inputs. Direct non-workflow callers remain one-shot claimants.
+ */
+export async function beginArticleBatch(
+  batchId: string,
+  workflowRunId?: string,
+  dispatchLeaseToken?: string,
+): Promise<{
   siteId: string;
   requestedCount: number;
 } | null> {
   const db = getDb();
-  await db.articleBatch.updateMany({
-    where: { id: batchId, status: "QUEUED" },
-    data: { status: "RUNNING", startedAt: new Date() },
+  const ownerFence =
+    workflowRunId === undefined
+      ? {
+          workflowRunId: null,
+          dispatchLeaseToken: null,
+        }
+      : dispatchLeaseToken === undefined
+        ? { workflowRunId }
+        : {
+            OR: [
+              { workflowRunId: null, dispatchLeaseToken },
+              { workflowRunId },
+            ],
+          };
+  const [started] = await db.articleBatch.updateManyAndReturn({
+    where: {
+      id: batchId,
+      status: "QUEUED",
+      ...ownerFence,
+    },
+    data: {
+      status: "RUNNING",
+      startedAt: new Date(),
+      ...(workflowRunId === undefined ? {} : { workflowRunId }),
+      dispatchLeaseToken: null,
+      dispatchLeaseUntil: null,
+    },
+    select: { siteId: true, requestedCount: true },
   });
+  if (started) return started;
+
+  // A step invocation can commit this transition and crash before Workflow
+  // records step_completed. The retry must recover its own reservation without
+  // reopening it for a distinct workflow run or resetting startedAt.
+  if (workflowRunId === undefined) return null;
   const existing = await db.articleBatch.findUnique({
     where: { id: batchId },
-    select: { siteId: true, requestedCount: true, status: true },
+    select: {
+      siteId: true,
+      requestedCount: true,
+      status: true,
+      workflowRunId: true,
+    },
   });
-  if (!existing || existing.status !== "RUNNING") return null;
+  if (
+    existing?.status !== "RUNNING" ||
+    existing.workflowRunId !== workflowRunId
+  ) {
+    return null;
+  }
   return {
     siteId: existing.siteId,
     requestedCount: existing.requestedCount,
@@ -308,16 +430,22 @@ export async function beginArticleBatch(batchId: string): Promise<{
 
 export async function closeArticleBatch(input: {
   batchId: string;
+  workflowRunId?: string;
   status: "ZERO_OUTPUT" | "REJECTED" | "SKIPPED" | "FAILED";
   statusReason: string;
   rejectedCount?: number;
   expectedStatuses?: Array<"QUEUED" | "RUNNING">;
 }): Promise<boolean> {
   const db = getDb();
+  const expectedWorkflowRunId = input.workflowRunId ?? null;
   const completed = await db.articleBatch.updateMany({
     where: {
       id: input.batchId,
       status: { in: input.expectedStatuses ?? ["QUEUED", "RUNNING"] },
+      workflowRunId: expectedWorkflowRunId,
+      ...(input.workflowRunId === undefined
+        ? { dispatchLeaseToken: null, dispatchLeaseUntil: null }
+        : {}),
     },
     data: {
       acceptedCount: 0,
@@ -325,14 +453,19 @@ export async function closeArticleBatch(input: {
       status: input.status,
       statusReason: input.statusReason,
       completedAt: new Date(),
+      dispatchLeaseToken: null,
+      dispatchLeaseUntil: null,
     },
   });
   if (completed.count === 1) return true;
   const existing = await db.articleBatch.findUnique({
     where: { id: input.batchId },
-    select: { status: true },
+    select: { status: true, workflowRunId: true },
   });
-  return existing?.status === input.status;
+  return (
+    existing?.status === input.status &&
+    existing.workflowRunId === expectedWorkflowRunId
+  );
 }
 
 /** Reads the fact slice + recent topics used for generation in one pass. */
@@ -367,15 +500,22 @@ export async function loadGenerationInputs(siteId: string): Promise<{
       orderBy: { position: "asc" },
       select: {
         items: {
-          select: { name: true, price: true, currency: true },
+          select: {
+            id: true,
+            name: true,
+            price: true,
+            currency: true,
+            available: true,
+            attributes: true,
+          },
           orderBy: { position: "asc" },
         },
       },
     }),
     db.integration.findMany({
-      where: { siteId },
-      select: { label: true },
-      orderBy: { label: "asc" },
+      where: { siteId, enabled: true },
+      select: { type: true },
+      orderBy: { type: "asc" },
     }),
     // The dedupe contract is "topics covered by the two most recent batches",
     // so read batches first and expand from there — scanning articles by
@@ -402,15 +542,6 @@ export async function loadGenerationInputs(siteId: string): Promise<{
     ...new Set(recentBatches.flatMap((batch) => batch.articles.map((a) => a.topicKey))),
   ];
 
-  const businessHours = Array.isArray(site.businessHours)
-    ? (site.businessHours as Array<{ days?: unknown; hours?: unknown }>).flatMap(
-        (entry) =>
-          typeof entry?.days === "string" && typeof entry?.hours === "string"
-            ? [{ days: entry.days, hours: entry.hours }]
-            : [],
-      )
-    : [];
-
   return {
     ok: true,
     facts: {
@@ -420,18 +551,52 @@ export async function loadGenerationInputs(siteId: string): Promise<{
       locale: site.defaultLocale,
       address: site.address,
       phone: site.phone,
-      businessHours,
+      businessHours: parseBusinessHours(site.businessHours),
       catalogItems: sections.flatMap((section) =>
-        section.items.map((item) => ({
-          name: item.name,
-          price: item.price === null ? null : Number(item.price),
-          currency: item.currency,
-        })),
+        section.items
+          .filter((item) =>
+            isVerticalCatalogItemVisible(site.vertical, {
+              available: item.available,
+              attributes: item.attributes,
+            }),
+          )
+          .map((item) => ({
+            id: item.id,
+            name: item.name,
+            price: item.price === null ? null : Number(item.price),
+            currency: item.currency,
+          })),
       ),
-      integrationLabels: integrations.map((integration) => integration.label),
+      integrationCapabilities: articleIntegrationCapabilities(integrations),
     },
     recentTopicKeys,
   };
+}
+
+function articleIntegrationCapabilities(
+  integrations: Array<{ type: string }>,
+): SiteFacts["integrationCapabilities"] {
+  return [
+    ...new Set(
+      integrations.flatMap((integration) =>
+        isArticleIntegrationCapability(integration.type)
+          ? [integration.type]
+          : [],
+      ),
+    ),
+  ];
+}
+
+function parseBusinessHours(
+  value: unknown,
+): Array<{ days: string; hours: string }> {
+  return Array.isArray(value)
+    ? (value as Array<{ days?: unknown; hours?: unknown }>).flatMap((entry) =>
+        typeof entry?.days === "string" && typeof entry?.hours === "string"
+          ? [{ days: entry.days, hours: entry.hours }]
+          : [],
+      )
+    : [];
 }
 
 function dedupeSlug(slug: string, taken: Set<string>): string {

--- a/src/lib/articles/generation.ts
+++ b/src/lib/articles/generation.ts
@@ -42,19 +42,33 @@ function getModel() {
   });
 }
 
-const articleBatchOutputSchema = z.object({
-  articles: z.array(
-    z.object({
-      topicKey: z.string(),
-      slug: z.string(),
-      title: z.string(),
-      excerpt: z.string(),
-      bodyMarkdown: z.string(),
-    }),
-  ),
+export const articleBatchOutputSchema = z.object({
+  articles: z
+    .array(
+      z.object({
+        topicKey: z.string(),
+        slug: z.string(),
+        title: z.string(),
+        excerpt: z.string(),
+        bodyMarkdown: z.string(),
+        catalogClaims: z
+          .array(
+            z.object({
+              name: z.string().min(1).max(120),
+              price: z.number().finite().nonnegative().max(99_999_999.99).nullable(),
+              currency: z
+                .string()
+                .regex(/^[A-Z]{3}$/)
+                .nullable(),
+            }),
+          )
+          .max(32),
+      }),
+    )
+    .max(8),
 });
 
-function buildPrompt(input: {
+export function buildArticleBatchPrompt(input: {
   facts: SiteFacts;
   topics: Array<{ key: string; title: string }>;
 }): string {
@@ -70,12 +84,16 @@ function buildPrompt(input: {
         .map((entry) => `${entry.days} ${entry.hours}`)
         .join("; ") || "none published"
     }`,
-    `- Catalog items: ${facts.catalogItemNames.join(", ") || "none listed"}`,
+    `- Catalog items (canonical name, price, currency): ${
+      facts.catalogItems.length ? JSON.stringify(facts.catalogItems) : "none listed"
+    }`,
     `- Booking/ordering options: ${facts.integrationLabels.join(", ") || "none"}`,
     "",
     "Rules:",
     "- Never invent awards, rankings, certifications, prices, staff names, suppliers, reviews, or statistics.",
     "- Every catalog item mentioned by name must appear in the list above.",
+    "- catalogClaims must enumerate every catalog item named in title, excerpt, or bodyMarkdown.",
+    "- A catalogClaims price/currency pair must be copied exactly from that same catalog item; use null/null when no price is stated in the article.",
     `- Write in ${facts.locale === "fr" ? "French" : "English"} for a local audience.`,
     "- Body is GitHub-flavoured markdown with at most two headings and no images.",
     "- slug must be kebab-case ASCII.",
@@ -84,7 +102,7 @@ function buildPrompt(input: {
     "Write exactly one article per requested topic:",
     ...topics.map((topic) => `- [${topic.key}] ${topic.title}`),
     "",
-    "Return JSON: {\"articles\":[{topicKey,slug,title,excerpt,bodyMarkdown}]}",
+    'Return JSON: {"articles":[{topicKey,slug,title,excerpt,bodyMarkdown,catalogClaims:[{name,price,currency}]}]}',
   ];
   return lines.join("\n");
 }
@@ -93,7 +111,7 @@ export async function generateBatchDrafts(input: {
   facts: SiteFacts;
   count: number;
   recentTopicKeys: string[];
-}): Promise<GeneratedArticleDraft[]> {
+}): Promise<GeneratedBatchDrafts> {
   if (!articleGenerationConfigured()) {
     throw new Error("OPENROUTER_API_KEY is not configured");
   }
@@ -104,7 +122,14 @@ export async function generateBatchDrafts(input: {
     count: input.count,
     recentTopicKeys: input.recentTopicKeys,
   });
-  if (!selected.length) return [];
+  if (!selected.length) {
+    return {
+      status: "SKIPPED",
+      statusReason: "NO_SUPPORTABLE_TOPICS",
+      drafts: [],
+      rejectedCount: 0,
+    };
+  }
 
   const topics = selected.flatMap((topic) => {
     const plan = articleTopicPlanByKey(input.facts.vertical, topic.key);
@@ -120,69 +145,106 @@ export async function generateBatchDrafts(input: {
     }),
     maxRetries: 2,
     timeout: { totalMs: 55_000, stepMs: 45_000 },
-    prompt: buildPrompt({ facts: input.facts, topics }),
+    prompt: buildArticleBatchPrompt({ facts: input.facts, topics }),
   });
 
   const allowed = new Set(topics.map((topic) => topic.key));
-  return output.articles
+  const drafts = output.articles
     .slice(0, topics.length)
-    .filter(
-      (draft): draft is GeneratedArticleDraft =>
-        typeof draft.topicKey === "string" && allowed.has(draft.topicKey),
-    );
+    .filter((draft) => allowed.has(draft.topicKey));
+  return {
+    status: "GENERATED",
+    drafts,
+    rejectedCount: output.articles.length - drafts.length,
+  };
 }
+
+export type GeneratedBatchDrafts =
+  | {
+      status: "SKIPPED";
+      statusReason: "NO_SUPPORTABLE_TOPICS";
+      drafts: [];
+      rejectedCount: 0;
+    }
+  | {
+      status: "GENERATED";
+      drafts: GeneratedArticleDraft[];
+      rejectedCount: number;
+    };
 
 export type PersistedBatch = {
   batchId: string;
   producedCount: number;
+  rejectedCount: number;
 };
 
 /**
- * Persists guardrail-passing drafts as DRAFT articles under a new batch row.
- * Rejected drafts shrink the batch silently — they are recorded on the batch
- * row via producedCount < requestedCount so the operator sees the shortfall.
+ * Persists guardrail-passing drafts as DRAFT articles under the batch row that
+ * admission reserved before generation. Rejected drafts shrink the batch and
+ * are counted independently from the immutable requestedCount.
  */
 export async function persistArticleBatch(input: {
+  batchId: string;
   siteId: string;
-  requestedBy: string;
   facts: SiteFacts;
   drafts: GeneratedArticleDraft[];
+  rejectedCount?: number;
   model?: string | null;
 }): Promise<PersistedBatch> {
   const db = getDb();
   const accepted = input.drafts.filter(
     (draft) => !checkArticleDraft(draft, input.facts).length,
   );
-
-  const existingSlugs = new Set(
-    (
-      await db.article.findMany({
-        where: { siteId: input.siteId },
-        select: { slug: true },
-      })
-    ).map((row) => row.slug),
-  );
+  const rejectedCount =
+    Math.max(0, input.rejectedCount ?? 0) +
+    (input.drafts.length - accepted.length);
 
   return db.$transaction(async (transaction) => {
-    const batch = await transaction.articleBatch.create({
-      data: {
-        siteId: input.siteId,
-        requestedCount: input.drafts.length,
-        producedCount: accepted.length,
-        model: input.model ?? null,
-        requestedBy: input.requestedBy,
-        completedAt: new Date(),
+    const existingBatch = await transaction.articleBatch.findUnique({
+      where: { id: input.batchId },
+      select: {
+        siteId: true,
+        status: true,
+        acceptedCount: true,
+        rejectedCount: true,
       },
-      select: { id: true },
     });
-    let produced = 0;
+    if (!existingBatch || existingBatch.siteId !== input.siteId) {
+      throw new Error("Article batch reservation was not found");
+    }
+    if (
+      existingBatch.status === "SUCCEEDED" ||
+      existingBatch.status === "REJECTED"
+    ) {
+      return {
+        batchId: input.batchId,
+        producedCount: existingBatch.acceptedCount,
+        rejectedCount: existingBatch.rejectedCount,
+      };
+    }
+    if (
+      existingBatch.status !== "QUEUED" &&
+      existingBatch.status !== "RUNNING"
+    ) {
+      throw new Error("Article batch reservation is already terminal");
+    }
+
+    const existingSlugs = new Set(
+      (
+        await transaction.article.findMany({
+          where: { siteId: input.siteId },
+          select: { slug: true },
+        })
+      ).map((row) => row.slug),
+    );
+    let producedCount = 0;
     for (const draft of accepted) {
       const slug = dedupeSlug(draft.slug, existingSlugs);
       existingSlugs.add(slug);
       await transaction.article.create({
         data: {
           siteId: input.siteId,
-          batchId: batch.id,
+          batchId: input.batchId,
           slug,
           locale: input.facts.locale,
           title: draft.title.trim(),
@@ -194,18 +256,83 @@ export async function persistArticleBatch(input: {
             articleTopicPlanByKey(input.facts.vertical, draft.topicKey)?.title ??
             draft.topicKey,
           generatedByModel: input.model ?? null,
-          sourceBatchId: batch.id,
+          sourceBatchId: input.batchId,
         },
         select: { id: true },
       });
-      produced += 1;
+      producedCount += 1;
     }
-    await transaction.articleBatch.update({
-      where: { id: batch.id },
-      data: { producedCount: produced },
+
+    const status = producedCount > 0 ? "SUCCEEDED" : "REJECTED";
+    const completed = await transaction.articleBatch.updateMany({
+      where: {
+        id: input.batchId,
+        siteId: input.siteId,
+        status: { in: ["QUEUED", "RUNNING"] },
+      },
+      data: {
+        acceptedCount: producedCount,
+        rejectedCount,
+        status,
+        statusReason: status === "REJECTED" ? "ALL_DRAFTS_REJECTED" : null,
+        model: input.model ?? null,
+        completedAt: new Date(),
+      },
     });
-    return { batchId: batch.id, producedCount: produced };
+    if (completed.count !== 1) {
+      throw new Error("Article batch terminal transition was lost");
+    }
+    return { batchId: input.batchId, producedCount, rejectedCount };
   });
+}
+
+export async function beginArticleBatch(batchId: string): Promise<{
+  siteId: string;
+  requestedCount: number;
+} | null> {
+  const db = getDb();
+  await db.articleBatch.updateMany({
+    where: { id: batchId, status: "QUEUED" },
+    data: { status: "RUNNING", startedAt: new Date() },
+  });
+  const existing = await db.articleBatch.findUnique({
+    where: { id: batchId },
+    select: { siteId: true, requestedCount: true, status: true },
+  });
+  if (!existing || existing.status !== "RUNNING") return null;
+  return {
+    siteId: existing.siteId,
+    requestedCount: existing.requestedCount,
+  };
+}
+
+export async function closeArticleBatch(input: {
+  batchId: string;
+  status: "ZERO_OUTPUT" | "REJECTED" | "SKIPPED" | "FAILED";
+  statusReason: string;
+  rejectedCount?: number;
+  expectedStatuses?: Array<"QUEUED" | "RUNNING">;
+}): Promise<boolean> {
+  const db = getDb();
+  const completed = await db.articleBatch.updateMany({
+    where: {
+      id: input.batchId,
+      status: { in: input.expectedStatuses ?? ["QUEUED", "RUNNING"] },
+    },
+    data: {
+      acceptedCount: 0,
+      rejectedCount: Math.max(0, input.rejectedCount ?? 0),
+      status: input.status,
+      statusReason: input.statusReason,
+      completedAt: new Date(),
+    },
+  });
+  if (completed.count === 1) return true;
+  const existing = await db.articleBatch.findUnique({
+    where: { id: input.batchId },
+    select: { status: true },
+  });
+  return existing?.status === input.status;
 }
 
 /** Reads the fact slice + recent topics used for generation in one pass. */
@@ -239,7 +366,10 @@ export async function loadGenerationInputs(siteId: string): Promise<{
       where: { siteId },
       orderBy: { position: "asc" },
       select: {
-        items: { select: { name: true }, orderBy: { position: "asc" } },
+        items: {
+          select: { name: true, price: true, currency: true },
+          orderBy: { position: "asc" },
+        },
       },
     }),
     db.integration.findMany({
@@ -251,7 +381,12 @@ export async function loadGenerationInputs(siteId: string): Promise<{
     // so read batches first and expand from there — scanning articles by
     // recency would let a site with many old articles dilute the window.
     db.articleBatch.findMany({
-      where: { siteId, completedAt: { not: null } },
+      where: {
+        siteId,
+        status: "SUCCEEDED",
+        acceptedCount: { gt: 0 },
+        completedAt: { not: null },
+      },
       orderBy: { createdAt: "desc" },
       take: 2,
       select: {
@@ -286,8 +421,12 @@ export async function loadGenerationInputs(siteId: string): Promise<{
       address: site.address,
       phone: site.phone,
       businessHours,
-      catalogItemNames: sections.flatMap((section) =>
-        section.items.map((item) => item.name),
+      catalogItems: sections.flatMap((section) =>
+        section.items.map((item) => ({
+          name: item.name,
+          price: item.price === null ? null : Number(item.price),
+          currency: item.currency,
+        })),
       ),
       integrationLabels: integrations.map((integration) => integration.label),
     },

--- a/src/lib/articles/integration-capabilities.ts
+++ b/src/lib/articles/integration-capabilities.ts
@@ -1,0 +1,18 @@
+export const ARTICLE_INTEGRATION_CAPABILITIES = [
+  "BOOKING",
+  "ORDERING",
+  "DELIVERY",
+  "QUOTE",
+  "CONTACT",
+] as const;
+
+export type ArticleIntegrationCapability =
+  (typeof ARTICLE_INTEGRATION_CAPABILITIES)[number];
+
+export function isArticleIntegrationCapability(
+  value: string,
+): value is ArticleIntegrationCapability {
+  return ARTICLE_INTEGRATION_CAPABILITIES.includes(
+    value as ArticleIntegrationCapability,
+  );
+}

--- a/src/lib/articles/mutation-gate.ts
+++ b/src/lib/articles/mutation-gate.ts
@@ -1,0 +1,25 @@
+import { getDb } from "@/lib/db";
+
+export const ARTICLE_MUTATION_GATE_KEY = "articles.mutations.gated";
+export const ARTICLE_MUTATION_GATE_REASON =
+  "Article changes are temporarily paused for a safe release. Try again later.";
+
+/**
+ * The release gate is deliberately fail closed. A missing row, unreadable
+ * setting, or database error must never let a predecessor/candidate boundary
+ * reopen article generation or publication implicitly.
+ */
+export async function areArticleMutationsGated(): Promise<boolean> {
+  try {
+    const setting = await getDb().operatorSetting.findUnique({
+      where: { key: ARTICLE_MUTATION_GATE_KEY },
+      select: { value: true },
+    });
+    return setting?.value !== false;
+  } catch (error) {
+    console.error("[article-mutations] gate read failed", {
+      error: error instanceof Error ? error.message : "unknown",
+    });
+    return true;
+  }
+}

--- a/src/lib/articles/site-facts.ts
+++ b/src/lib/articles/site-facts.ts
@@ -14,13 +14,17 @@ export type SiteFacts = {
   address: string | null;
   phone: string | null;
   businessHours: Array<{ days: string; hours: string }>;
-  catalogItemNames: string[];
+  catalogItems: Array<{
+    name: string;
+    price: number | null;
+    currency: string;
+  }>;
   integrationLabels: string[];
 };
 
 export function availableFacts(facts: SiteFacts): Set<ArticleFactKey> {
   const available = new Set<ArticleFactKey>();
-  if (facts.catalogItemNames.length > 0) available.add("catalogItems");
+  if (facts.catalogItems.length > 0) available.add("catalogItems");
   if (facts.address?.trim()) available.add("address");
   if (
     facts.businessHours.some(

--- a/src/lib/articles/site-facts.ts
+++ b/src/lib/articles/site-facts.ts
@@ -1,5 +1,6 @@
 import type { VerticalId } from "@/lib/verticals/types";
 import type { ArticleFactKey } from "@/lib/articles/topic-plans";
+import type { ArticleIntegrationCapability } from "@/lib/articles/integration-capabilities";
 
 /**
  * The slice of a published site snapshot the content engine may write about.
@@ -15,11 +16,12 @@ export type SiteFacts = {
   phone: string | null;
   businessHours: Array<{ days: string; hours: string }>;
   catalogItems: Array<{
+    id: string;
     name: string;
     price: number | null;
     currency: string;
   }>;
-  integrationLabels: string[];
+  integrationCapabilities: ArticleIntegrationCapability[];
 };
 
 export function availableFacts(facts: SiteFacts): Set<ArticleFactKey> {
@@ -34,6 +36,5 @@ export function availableFacts(facts: SiteFacts): Set<ArticleFactKey> {
     available.add("businessHours");
   }
   if (facts.phone?.trim()) available.add("phone");
-  if (facts.integrationLabels.length > 0) available.add("integrations");
   return available;
 }

--- a/src/lib/articles/start-batch.ts
+++ b/src/lib/articles/start-batch.ts
@@ -1,15 +1,41 @@
+import { randomUUID } from "node:crypto";
 import { Prisma } from "@/generated/prisma/client";
 import { getDb } from "@/lib/db";
 import {
   articleGenerationConfigured,
   closeArticleBatch,
 } from "@/lib/articles/generation";
+import {
+  ARTICLE_MUTATION_GATE_REASON,
+  areArticleMutationsGated,
+} from "@/lib/articles/mutation-gate";
+import { isArticleBatchWorkflowName } from "@/lib/articles/workflow-state";
 
 const ARTICLE_BATCH_CADENCE_MS = 7 * 24 * 60 * 60_000;
+const ARTICLE_BATCH_DISPATCH_LIMIT = 100;
+export const ARTICLE_BATCH_DISPATCH_LEASE_MS = 5 * 60_000;
+
+type ArticleBatchStartRun = (
+  batchId: string,
+  dispatchLeaseToken: string,
+) => Promise<string>;
+
+export type ArticleWorkflowEngineState = {
+  status: "pending" | "running" | "completed" | "failed" | "cancelled";
+  workflowName: string;
+};
+
+type ReadArticleWorkflowEngineState = (
+  workflowRunId: string,
+) => Promise<ArticleWorkflowEngineState>;
 
 export type ArticleBatchAdmission =
-  | { ok: true; batchId: string }
+  | { ok: true; batchId: string; acquired: boolean }
   | { ok: false; status: 400 | 404 | 409; reason: string };
+
+type ArticleBatchDispatch =
+  | { ok: true; runId: string }
+  | { ok: false; status: 409 | 503; reason: string };
 
 /**
  * Starts a durable article-batch run for a site after the cheap preflight
@@ -24,7 +50,7 @@ export async function startArticleBatch(
     requestedBy: string;
     count: number;
   },
-  startRun: (batchId: string) => Promise<string> = startArticleBatchWorkflow,
+  startRun: ArticleBatchStartRun = startArticleBatchWorkflow,
 ): Promise<
   | { ok: true; runId: string }
   | { ok: false; status: 400 | 404 | 409 | 503; reason: string }
@@ -36,44 +62,12 @@ export async function startArticleBatch(
       reason: "Article generation is not configured.",
     };
   }
+  if (await areArticleMutationsGated()) {
+    return { ok: false, status: 503, reason: ARTICLE_MUTATION_GATE_REASON };
+  }
   const admission = await reserveArticleBatch(input);
   if (!admission.ok) return admission;
-
-  try {
-    const runId = await startRun(admission.batchId);
-    const bound = await getDb().articleBatch.updateMany({
-      where: {
-        id: admission.batchId,
-        workflowRunId: null,
-      },
-      data: { workflowRunId: runId },
-    });
-    if (bound.count !== 1) {
-      const existing = await getDb().articleBatch.findUnique({
-        where: { id: admission.batchId },
-        select: { workflowRunId: true },
-      });
-      if (existing?.workflowRunId !== runId) {
-        throw new Error("Article batch workflow run could not be bound");
-      }
-    }
-    return { ok: true, runId };
-  } catch (error) {
-    try {
-      await closeArticleBatch({
-        batchId: admission.batchId,
-        status: "FAILED",
-        statusReason: "WORKFLOW_START_FAILED",
-        expectedStatuses: ["QUEUED"],
-      });
-    } catch (closeError) {
-      throw new AggregateError(
-        [error, closeError],
-        "Article workflow start failed and its reservation could not be closed",
-      );
-    }
-    throw error;
-  }
+  return dispatchArticleBatch(admission.batchId, startRun);
 }
 
 /**
@@ -135,9 +129,19 @@ export async function reserveArticleBatch(
               siteId: input.siteId,
               status: { in: ["QUEUED", "RUNNING"] },
             },
-            select: { id: true },
+            select: { id: true, status: true, workflowRunId: true },
           });
           if (activeBatch) {
+            if (
+              activeBatch.status === "QUEUED" &&
+              activeBatch.workflowRunId === null
+            ) {
+              return {
+                ok: true,
+                batchId: activeBatch.id,
+                acquired: false,
+              };
+            }
             return {
               ok: false,
               status: 409,
@@ -171,10 +175,11 @@ export async function reserveArticleBatch(
               siteId: input.siteId,
               requestedCount: input.count,
               requestedBy: input.requestedBy,
+              status: "QUEUED",
             },
             select: { id: true },
           });
-          return { ok: true, batchId: batch.id };
+          return { ok: true, batchId: batch.id, acquired: true };
         },
         { isolationLevel: "Serializable" },
       );
@@ -193,11 +198,257 @@ export async function reserveArticleBatch(
   throw new Error("Article batch admission could not be serialized");
 }
 
-async function startArticleBatchWorkflow(batchId: string): Promise<string> {
+/**
+ * Claims one queued reservation for workflow dispatch. The lease fences
+ * concurrent HTTP requests and dispatcher passes before either can enqueue a
+ * workflow. A workflow that starts after its lease was replaced cannot claim
+ * the batch and therefore cannot reach model/provider work.
+ */
+export async function dispatchArticleBatch(
+  batchId: string,
+  startRun: ArticleBatchStartRun = startArticleBatchWorkflow,
+  now = new Date(),
+): Promise<ArticleBatchDispatch> {
+  if (await areArticleMutationsGated()) {
+    return { ok: false, status: 503, reason: ARTICLE_MUTATION_GATE_REASON };
+  }
+  const db = getDb();
+  const dispatchLeaseToken = randomUUID();
+  const dispatchLeaseUntil = new Date(
+    now.getTime() + ARTICLE_BATCH_DISPATCH_LEASE_MS,
+  );
+  const [claimed] = await db.articleBatch.updateManyAndReturn({
+    where: {
+      id: batchId,
+      status: "QUEUED",
+      workflowRunId: null,
+      OR: [
+        {
+          dispatchLeaseToken: null,
+          dispatchLeaseUntil: null,
+        },
+        { dispatchLeaseUntil: { lte: now } },
+      ],
+    },
+    data: { dispatchLeaseToken, dispatchLeaseUntil },
+    select: { id: true },
+  });
+  if (!claimed) return currentArticleBatchDispatch(batchId);
+
+  let runId: string;
+  try {
+    runId = await startRun(batchId, dispatchLeaseToken);
+  } catch {
+    const released = await db.articleBatch.updateMany({
+      where: {
+        id: batchId,
+        status: "QUEUED",
+        workflowRunId: null,
+        dispatchLeaseToken,
+      },
+      data: {
+        dispatchLeaseToken: null,
+        dispatchLeaseUntil: null,
+      },
+    });
+    if (released.count !== 1) {
+      const current = await currentArticleBatchDispatch(batchId);
+      if (current.ok) return current;
+    }
+    return {
+      ok: false,
+      status: 503,
+      reason: "The article workflow could not be started. Try again.",
+    };
+  }
+
+  const bound = await db.articleBatch.updateMany({
+    where: {
+      id: batchId,
+      status: "QUEUED",
+      workflowRunId: null,
+      dispatchLeaseToken,
+    },
+    data: {
+      workflowRunId: runId,
+      dispatchLeaseToken: null,
+      dispatchLeaseUntil: null,
+    },
+  });
+  if (bound.count === 1) return { ok: true, runId };
+
+  const current = await currentArticleBatchDispatch(batchId);
+  if (current.ok) return current;
+  return {
+    ok: false,
+    status: 409,
+    reason: "The article batch dispatch was claimed by another request.",
+  };
+}
+
+/**
+ * Best-effort drain for the process-level runtime. Every row is claimed again
+ * inside dispatchArticleBatch, so overlapping runtime passes and owner-route
+ * requests converge on one live dispatch lease.
+ */
+export async function dispatchQueuedArticleBatches(
+  now = new Date(),
+  startRun: ArticleBatchStartRun = startArticleBatchWorkflow,
+): Promise<{
+  attempted: number;
+  started: number;
+  deferred: number;
+  failedToStart: number;
+}> {
+  if (!articleGenerationConfigured()) {
+    return { attempted: 0, started: 0, deferred: 0, failedToStart: 0 };
+  }
+  if (await areArticleMutationsGated()) {
+    return { attempted: 0, started: 0, deferred: 0, failedToStart: 0 };
+  }
+  const queued = await getDb().articleBatch.findMany({
+    where: {
+      status: "QUEUED",
+      workflowRunId: null,
+      OR: [
+        {
+          dispatchLeaseToken: null,
+          dispatchLeaseUntil: null,
+        },
+        { dispatchLeaseUntil: { lte: now } },
+      ],
+    },
+    orderBy: { createdAt: "asc" },
+    take: ARTICLE_BATCH_DISPATCH_LIMIT,
+    select: { id: true },
+  });
+  let started = 0;
+  let deferred = 0;
+  let failedToStart = 0;
+  for (const batch of queued) {
+    const result = await dispatchArticleBatch(batch.id, startRun, now);
+    if (result.ok) started += 1;
+    else if (result.status === 503) failedToStart += 1;
+    else deferred += 1;
+  }
+  return {
+    attempted: queued.length,
+    started,
+    deferred,
+    failedToStart,
+  };
+}
+
+/**
+ * Reconciles only engine-owned rows whose durable Workflow run is terminal.
+ * Pending/running runs, lookup failures, unknown workflow identities, and
+ * owner races remain untouched. No timestamp participates in this decision.
+ */
+export async function reconcileBoundArticleBatches(
+  readState: ReadArticleWorkflowEngineState = readArticleWorkflowEngineState,
+): Promise<{
+  inspected: number;
+  active: number;
+  closed: number;
+  deferred: number;
+}> {
+  const batches = await getDb().articleBatch.findMany({
+    where: {
+      status: { in: ["QUEUED", "RUNNING"] },
+      workflowRunId: { not: null },
+    },
+    orderBy: { createdAt: "asc" },
+    take: ARTICLE_BATCH_DISPATCH_LIMIT,
+    select: {
+      id: true,
+      status: true,
+      workflowRunId: true,
+      rejectedCount: true,
+    },
+  });
+  let active = 0;
+  let closed = 0;
+  let deferred = 0;
+  for (const batch of batches) {
+    if (batch.status !== "QUEUED" && batch.status !== "RUNNING") {
+      deferred += 1;
+      continue;
+    }
+    const workflowRunId = batch.workflowRunId;
+    if (!workflowRunId) continue;
+    let state: ArticleWorkflowEngineState;
+    try {
+      state = await readState(workflowRunId);
+    } catch {
+      deferred += 1;
+      continue;
+    }
+    if (!isArticleBatchWorkflowName(state.workflowName)) {
+      deferred += 1;
+      continue;
+    }
+    if (state.status === "pending" || state.status === "running") {
+      active += 1;
+      continue;
+    }
+    const statusReason = {
+      completed: "WORKFLOW_COMPLETED_WITHOUT_BATCH_OUTCOME",
+      failed: "WORKFLOW_ENGINE_FAILED",
+      cancelled: "WORKFLOW_ENGINE_CANCELLED",
+    }[state.status];
+    const didClose = await closeArticleBatch({
+      batchId: batch.id,
+      workflowRunId,
+      status: "FAILED",
+      statusReason,
+      rejectedCount: batch.rejectedCount,
+      expectedStatuses: [batch.status],
+    });
+    if (didClose) closed += 1;
+    else deferred += 1;
+  }
+  return { inspected: batches.length, active, closed, deferred };
+}
+
+async function currentArticleBatchDispatch(
+  batchId: string,
+): Promise<ArticleBatchDispatch> {
+  const current = await getDb().articleBatch.findUnique({
+    where: { id: batchId },
+    select: { workflowRunId: true },
+  });
+  if (current?.workflowRunId) {
+    return { ok: true, runId: current.workflowRunId };
+  }
+  return {
+    ok: false,
+    status: 409,
+    reason: "The article batch is already being dispatched.",
+  };
+}
+
+async function startArticleBatchWorkflow(
+  batchId: string,
+  dispatchLeaseToken: string,
+): Promise<string> {
   const { start } = await import("workflow/api");
   const { articleBatchWorkflow } = await import("@/workflows/article-batch");
-  const run = await start(articleBatchWorkflow, [{ batchId }]);
+  const run = await start(articleBatchWorkflow, [
+    { batchId, dispatchLeaseToken },
+  ]);
   return run.runId;
+}
+
+async function readArticleWorkflowEngineState(
+  workflowRunId: string,
+): Promise<ArticleWorkflowEngineState> {
+  const { getRun } = await import("workflow/api");
+  const run = getRun(workflowRunId);
+  const [status, workflowName] = await Promise.all([
+    run.status,
+    run.workflowName,
+  ]);
+  return { status, workflowName };
 }
 
 function isPrismaCode(error: unknown, code: "P2002" | "P2034"): boolean {

--- a/src/lib/articles/start-batch.ts
+++ b/src/lib/articles/start-batch.ts
@@ -1,5 +1,15 @@
+import { Prisma } from "@/generated/prisma/client";
 import { getDb } from "@/lib/db";
-import { articleGenerationConfigured } from "@/lib/articles/generation";
+import {
+  articleGenerationConfigured,
+  closeArticleBatch,
+} from "@/lib/articles/generation";
+
+const ARTICLE_BATCH_CADENCE_MS = 7 * 24 * 60 * 60_000;
+
+export type ArticleBatchAdmission =
+  | { ok: true; batchId: string }
+  | { ok: false; status: 400 | 404 | 409; reason: string };
 
 /**
  * Starts a durable article-batch run for a site after the cheap preflight
@@ -7,12 +17,15 @@ import { articleGenerationConfigured } from "@/lib/articles/generation";
  * route so both the owner dashboard and any future operator trigger share
  * one gate set.
  */
-export async function startArticleBatch(input: {
-  siteId: string;
-  slug: string;
-  requestedBy: string;
-  count: number;
-}): Promise<
+export async function startArticleBatch(
+  input: {
+    siteId: string;
+    slug: string;
+    requestedBy: string;
+    count: number;
+  },
+  startRun: (batchId: string) => Promise<string> = startArticleBatchWorkflow,
+): Promise<
   | { ok: true; runId: string }
   | { ok: false; status: 400 | 404 | 409 | 503; reason: string }
 > {
@@ -23,52 +36,172 @@ export async function startArticleBatch(input: {
       reason: "Article generation is not configured.",
     };
   }
-  const db = getDb();
-  const site = await db.site.findUnique({
-    where: { id: input.siteId },
-    select: { status: true, organizationId: true },
-  });
-  if (!site) return { ok: false, status: 404, reason: "Site not found." };
-  if (site.status !== "CLAIMED" && site.status !== "LIVE") {
-    return {
-      ok: false,
-      status: 409,
-      reason: "Articles are available once the site is claimed.",
-    };
-  }
-  // Pro-plan cadence gate: one in-flight or completed batch per rolling
-  // 7-day window unless the site has an active subscription.
-  const [recentBatch, subscription] = await Promise.all([
-    db.articleBatch.findFirst({
+  const admission = await reserveArticleBatch(input);
+  if (!admission.ok) return admission;
+
+  try {
+    const runId = await startRun(admission.batchId);
+    const bound = await getDb().articleBatch.updateMany({
       where: {
-        siteId: input.siteId,
-        createdAt: { gt: new Date(Date.now() - 7 * 24 * 60 * 60_000) },
+        id: admission.batchId,
+        workflowRunId: null,
       },
-      select: { id: true },
-    }),
-    db.subscription.findUnique({
-      where: { siteId: input.siteId },
-      select: { status: true },
-    }),
-  ]);
-  const paid = subscription?.status === "ACTIVE";
-  if (recentBatch && !paid) {
+      data: { workflowRunId: runId },
+    });
+    if (bound.count !== 1) {
+      const existing = await getDb().articleBatch.findUnique({
+        where: { id: admission.batchId },
+        select: { workflowRunId: true },
+      });
+      if (existing?.workflowRunId !== runId) {
+        throw new Error("Article batch workflow run could not be bound");
+      }
+    }
+    return { ok: true, runId };
+  } catch (error) {
+    try {
+      await closeArticleBatch({
+        batchId: admission.batchId,
+        status: "FAILED",
+        statusReason: "WORKFLOW_START_FAILED",
+        expectedStatuses: ["QUEUED"],
+      });
+    } catch (closeError) {
+      throw new AggregateError(
+        [error, closeError],
+        "Article workflow start failed and its reservation could not be closed",
+      );
+    }
+    throw error;
+  }
+}
+
+/**
+ * Atomically admits one batch for a site's current cadence window. The Site
+ * row is the per-site serialization fence; the partial unique index remains a
+ * database-level backstop against any future admission path skipping it.
+ */
+export async function reserveArticleBatch(
+  input: {
+    siteId: string;
+    requestedBy: string;
+    count: number;
+  },
+  now = new Date(),
+): Promise<ArticleBatchAdmission> {
+  if (!Number.isInteger(input.count) || input.count < 1 || input.count > 8) {
     return {
       ok: false,
-      status: 409,
-      reason:
-        "A batch was generated in the last 7 days. Upgrade to generate more.",
+      status: 400,
+      reason: "Batch size must be between 1 and 8.",
     };
   }
 
+  const db = getDb();
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      return await db.$transaction(
+        async (transaction) => {
+          const locked = await transaction.$queryRaw<Array<{ id: string }>>`
+            SELECT "id"
+            FROM "Site"
+            WHERE "id" = ${input.siteId}
+            FOR UPDATE
+          `;
+          if (!locked.length) {
+            return { ok: false, status: 404, reason: "Site not found." };
+          }
+
+          const site = await transaction.site.findUnique({
+            where: { id: input.siteId },
+            select: {
+              status: true,
+              subscription: { select: { status: true } },
+            },
+          });
+          if (!site) {
+            return { ok: false, status: 404, reason: "Site not found." };
+          }
+          if (site.status !== "CLAIMED" && site.status !== "LIVE") {
+            return {
+              ok: false,
+              status: 409,
+              reason: "Articles are available once the site is claimed.",
+            };
+          }
+
+          const activeBatch = await transaction.articleBatch.findFirst({
+            where: {
+              siteId: input.siteId,
+              status: { in: ["QUEUED", "RUNNING"] },
+            },
+            select: { id: true },
+          });
+          if (activeBatch) {
+            return {
+              ok: false,
+              status: 409,
+              reason: "An article batch is already in progress.",
+            };
+          }
+
+          const paid = site.subscription?.status === "ACTIVE";
+          if (!paid) {
+            const recentBatch = await transaction.articleBatch.findFirst({
+              where: {
+                siteId: input.siteId,
+                createdAt: {
+                  gt: new Date(now.getTime() - ARTICLE_BATCH_CADENCE_MS),
+                },
+              },
+              select: { id: true },
+            });
+            if (recentBatch) {
+              return {
+                ok: false,
+                status: 409,
+                reason:
+                  "A batch was generated in the last 7 days. Upgrade to generate more.",
+              };
+            }
+          }
+
+          const batch = await transaction.articleBatch.create({
+            data: {
+              siteId: input.siteId,
+              requestedCount: input.count,
+              requestedBy: input.requestedBy,
+            },
+            select: { id: true },
+          });
+          return { ok: true, batchId: batch.id };
+        },
+        { isolationLevel: "Serializable" },
+      );
+    } catch (error) {
+      if (isPrismaCode(error, "P2002")) {
+        return {
+          ok: false,
+          status: 409,
+          reason: "An article batch is already in progress.",
+        };
+      }
+      if (attempt < 2 && isPrismaCode(error, "P2034")) continue;
+      throw error;
+    }
+  }
+  throw new Error("Article batch admission could not be serialized");
+}
+
+async function startArticleBatchWorkflow(batchId: string): Promise<string> {
   const { start } = await import("workflow/api");
   const { articleBatchWorkflow } = await import("@/workflows/article-batch");
-  const run = await start(articleBatchWorkflow, [
-    {
-      siteId: input.siteId,
-      requestedBy: input.requestedBy,
-      count: input.count,
-    },
-  ]);
-  return { ok: true, runId: run.runId };
+  const run = await start(articleBatchWorkflow, [{ batchId }]);
+  return run.runId;
+}
+
+function isPrismaCode(error: unknown, code: "P2002" | "P2034"): boolean {
+  return (
+    error instanceof Prisma.PrismaClientKnownRequestError && error.code === code
+  );
 }

--- a/src/lib/articles/topic-plans.ts
+++ b/src/lib/articles/topic-plans.ts
@@ -1,18 +1,62 @@
+import type { ArticleIntegrationCapability } from "@/lib/articles/integration-capabilities";
 import type { VerticalId } from "@/lib/verticals/types";
 
 /**
  * A topic plan names a reusable angle an article can take for a site. The key
  * is stable across sites and batches so the dedupe pass can tell "the same
- * slot refilled" from "a new angle"; the title is the working headline the
- * composer hands the model; `requiredFacts` names site data the article may
+ * slot refilled" from "a new angle"; the title is the repository-owned topic
+ * label; `requiredFacts` names site data the article may
  * only exist if the site actually carries — a neighbourhood guide with no
  * address is exactly the generic filler this engine exists to prevent.
  */
 export type ArticleTopicPlan = {
-  key: string;
+  key: ArticleTopicKey;
   title: string;
   requiredFacts: ArticleFactKey[];
+  requiredAnyIntegrationCapabilities?: ArticleIntegrationCapability[];
+  templateKey: ArticleTemplateKey;
+  catalogItem: "required" | "forbidden";
 };
+
+export const ARTICLE_TOPIC_KEYS = [
+  "seasonal-menu",
+  "neighbourhood-guide",
+  "private-events",
+  "dietary-faqs",
+  "chef-story",
+  "treatment-explainers",
+  "aftercare",
+  "trends",
+  "first-visit",
+  "service-walkthrough",
+  "coverage-area",
+  "quote-guide",
+  "sourcing-story",
+  "seasonal-stock",
+  "ordering-options",
+] as const;
+
+export type ArticleTopicKey = (typeof ARTICLE_TOPIC_KEYS)[number];
+
+export const ARTICLE_TEMPLATE_KEYS = [
+  "restaurant-current-menu",
+  "restaurant-location",
+  "restaurant-group-enquiry",
+  "restaurant-dietary-enquiry",
+  "restaurant-menu-facts",
+  "beauty-treatment-listing",
+  "beauty-aftercare-enquiry",
+  "beauty-current-listing",
+  "beauty-visit-planning",
+  "service-current-listing",
+  "service-location",
+  "service-quote-enquiry",
+  "retail-listing-facts",
+  "retail-current-stock",
+  "retail-ordering-options",
+] as const;
+
+export type ArticleTemplateKey = (typeof ARTICLE_TEMPLATE_KEYS)[number];
 
 /**
  * The site facts a topic may draw on. Each maps to a field the composer
@@ -23,93 +67,125 @@ export type ArticleFactKey =
   | "catalogItems"
   | "address"
   | "businessHours"
-  | "phone"
-  | "integrations";
+  | "phone";
 
 const RESTAURANT_TOPICS: ArticleTopicPlan[] = [
   {
     key: "seasonal-menu",
-    title: "What's in season on our menu right now",
+    title: "A current menu listing",
     requiredFacts: ["catalogItems"],
+    templateKey: "restaurant-current-menu",
+    catalogItem: "required",
   },
   {
     key: "neighbourhood-guide",
-    title: "Where to find us and what else is nearby",
+    title: "How to find us",
     requiredFacts: ["address"],
+    templateKey: "restaurant-location",
+    catalogItem: "forbidden",
   },
   {
     key: "private-events",
-    title: "Booking us for private events and group tables",
-    requiredFacts: ["phone", "integrations"],
+    title: "Making a group enquiry",
+    requiredFacts: ["phone"],
+    requiredAnyIntegrationCapabilities: ["BOOKING", "CONTACT"],
+    templateKey: "restaurant-group-enquiry",
+    catalogItem: "forbidden",
   },
   {
     key: "dietary-faqs",
-    title: "Eating with dietary needs: what we can do",
+    title: "Checking dietary details before ordering",
     requiredFacts: ["catalogItems"],
+    templateKey: "restaurant-dietary-enquiry",
+    catalogItem: "required",
   },
   {
     key: "chef-story",
-    title: "How we cook: our kitchen, our suppliers",
+    title: "What the current menu confirms",
     requiredFacts: ["catalogItems"],
+    templateKey: "restaurant-menu-facts",
+    catalogItem: "required",
   },
 ];
 
 const BEAUTY_TOPICS: ArticleTopicPlan[] = [
   {
     key: "treatment-explainers",
-    title: "Our treatments explained: what to expect",
+    title: "A current treatment listing",
     requiredFacts: ["catalogItems"],
+    templateKey: "beauty-treatment-listing",
+    catalogItem: "required",
   },
   {
     key: "aftercare",
-    title: "Aftercare: keeping your results longer",
+    title: "How to ask about aftercare",
     requiredFacts: ["catalogItems"],
+    templateKey: "beauty-aftercare-enquiry",
+    catalogItem: "required",
   },
   {
     key: "trends",
-    title: "What we're seeing in the chair this season",
+    title: "What the current service list confirms",
     requiredFacts: ["catalogItems"],
+    templateKey: "beauty-current-listing",
+    catalogItem: "required",
   },
   {
     key: "first-visit",
-    title: "Your first visit: how an appointment runs",
+    title: "Planning your first visit",
     requiredFacts: ["businessHours", "address"],
+    templateKey: "beauty-visit-planning",
+    catalogItem: "forbidden",
   },
 ];
 
 const LOCAL_SERVICE_TOPICS: ArticleTopicPlan[] = [
   {
     key: "service-walkthrough",
-    title: "What happens when you book us",
+    title: "A current service listing",
     requiredFacts: ["catalogItems"],
+    templateKey: "service-current-listing",
+    catalogItem: "required",
   },
   {
     key: "coverage-area",
-    title: "Where we work: our coverage area",
+    title: "Where the business is based",
     requiredFacts: ["address"],
+    templateKey: "service-location",
+    catalogItem: "forbidden",
   },
   {
     key: "quote-guide",
-    title: "Getting a quote: what we need to know",
-    requiredFacts: ["phone", "integrations"],
+    title: "How to make a quote enquiry",
+    requiredFacts: ["phone"],
+    requiredAnyIntegrationCapabilities: ["QUOTE", "CONTACT"],
+    templateKey: "service-quote-enquiry",
+    catalogItem: "forbidden",
   },
 ];
 
 const FOOD_RETAIL_TOPICS: ArticleTopicPlan[] = [
   {
     key: "sourcing-story",
-    title: "Where our shelves come from",
+    title: "What a current product listing confirms",
     requiredFacts: ["catalogItems"],
+    templateKey: "retail-listing-facts",
+    catalogItem: "required",
   },
   {
     key: "seasonal-stock",
-    title: "In store this season",
+    title: "A current shop listing",
     requiredFacts: ["catalogItems"],
+    templateKey: "retail-current-stock",
+    catalogItem: "required",
   },
   {
     key: "ordering-options",
     title: "Ways to shop with us",
-    requiredFacts: ["integrations"],
+    requiredFacts: [],
+    requiredAnyIntegrationCapabilities: ["ORDERING", "DELIVERY"],
+    templateKey: "retail-ordering-options",
+    catalogItem: "forbidden",
   },
 ];
 

--- a/src/lib/articles/workflow-state.test.ts
+++ b/src/lib/articles/workflow-state.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import {
+  isArticleBatchQueueIdentifier,
+  isArticleBatchWorkflowName,
+} from "@/lib/articles/workflow-state";
+
+describe("article Workflow identity", () => {
+  it("matches only the exact article workflow module and export", () => {
+    expect(
+      isArticleBatchWorkflowName(
+        "workflow//./src/workflows/article-batch//articleBatchWorkflow",
+      ),
+    ).toBe(true);
+    expect(
+      isArticleBatchWorkflowName(
+        "workflow//./src/workflows/article-batch//anotherWorkflow",
+      ),
+    ).toBe(false);
+    expect(
+      isArticleBatchWorkflowName(
+        "workflow//./src/workflows/lead-outreach//articleBatchWorkflow",
+      ),
+    ).toBe(false);
+  });
+
+  it("covers both Graphile flow and step identifiers for the module", () => {
+    expect(
+      isArticleBatchQueueIdentifier(
+        "workflow//./src/workflows/article-batch//articleBatchWorkflow",
+      ),
+    ).toBe(true);
+    expect(
+      isArticleBatchQueueIdentifier(
+        "step//./src/workflows/article-batch//persistBatchStep",
+      ),
+    ).toBe(true);
+    expect(
+      isArticleBatchQueueIdentifier(
+        "step//./src/workflows/source-monitoring//persistBatchStep",
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/lib/articles/workflow-state.ts
+++ b/src/lib/articles/workflow-state.ts
@@ -1,0 +1,21 @@
+import {
+  parseStepName,
+  parseWorkflowName,
+} from "workflow/observability";
+
+export const ARTICLE_BATCH_WORKFLOW_SHORT_NAME = "articleBatchWorkflow";
+const ARTICLE_BATCH_WORKFLOW_MODULE = "./src/workflows/article-batch";
+
+export function isArticleBatchWorkflowName(name: string): boolean {
+  const parsed = parseWorkflowName(name);
+  return (
+    parsed?.shortName === ARTICLE_BATCH_WORKFLOW_SHORT_NAME &&
+    parsed.moduleSpecifier === ARTICLE_BATCH_WORKFLOW_MODULE
+  );
+}
+/** Identifies both flow and step Graphile messages for the article workflow. */
+export function isArticleBatchQueueIdentifier(name: string): boolean {
+  const workflow = parseWorkflowName(name);
+  if (workflow) return isArticleBatchWorkflowName(name);
+  return parseStepName(name)?.moduleSpecifier === ARTICLE_BATCH_WORKFLOW_MODULE;
+}

--- a/src/lib/customer-article-discovery.test.ts
+++ b/src/lib/customer-article-discovery.test.ts
@@ -7,6 +7,7 @@ import {
   buildCustomerRobots,
   buildCustomerRootSitemap,
   buildCustomerRss,
+  serializeCustomerArticleJsonLd,
   type CustomerDiscoveryArticle,
 } from "@/lib/customer-article-discovery";
 
@@ -254,6 +255,26 @@ describe("customer RSS and article identity", () => {
       });
     });
   }
+
+  it("serializes the rendered public JSON-LD sink without script breakouts", () => {
+    const hostileName = "</script><script>alert(1)</script>\u2028shop\u2029";
+    const serialized = serializeCustomerArticleJsonLd({
+      origin: customerOrigins[0]!,
+      site: { ...site, name: hostileName },
+      article: articles[0]!,
+    });
+
+    expect(serialized).not.toContain("<");
+    expect(serialized).not.toContain("\u2028");
+    expect(serialized).not.toContain("\u2029");
+    expect(serialized).toContain("\\u003c/script>");
+    expect(serialized).toContain("\\u2028");
+    expect(serialized).toContain("\\u2029");
+    expect(JSON.parse(serialized)).toMatchObject({
+      author: { name: hostileName },
+      publisher: { name: hostileName },
+    });
+  });
 });
 
 function assertCustomerUrls(origin: string, urls: string[]): void {

--- a/src/lib/customer-article-discovery.ts
+++ b/src/lib/customer-article-discovery.ts
@@ -1,5 +1,6 @@
 import type { Metadata, MetadataRoute } from "next";
 import type { PublishedArticle } from "@/lib/articles/public-articles";
+import { serializeJsonLd } from "@/lib/json-ld";
 import { canonicalSiteLocale, localeHref } from "@/lib/site-surface";
 
 export type CustomerDiscoverySite = {
@@ -204,10 +205,7 @@ export function serializeCustomerArticleJsonLd(input: {
   site: CustomerDiscoverySite;
   article: CustomerDiscoveryArticle;
 }): string {
-  return JSON.stringify(buildCustomerArticleJsonLd(input)).replaceAll(
-    "<",
-    "\\u003c",
-  );
+  return serializeJsonLd(buildCustomerArticleJsonLd(input));
 }
 
 export function buildCustomerRss(input: {

--- a/src/lib/food-retail-json-ld.ts
+++ b/src/lib/food-retail-json-ld.ts
@@ -1,4 +1,5 @@
 import type { SiteDraftView } from "@/lib/site-draft";
+import { serializeJsonLd } from "@/lib/json-ld";
 import type { FoodShopType } from "@/lib/verticals/food-retail/schema";
 
 type FoodRetailBusinessType = "Bakery" | "GroceryStore" | "Store";
@@ -150,7 +151,7 @@ export function buildFoodRetailJsonLd(
 }
 
 export function serializeFoodRetailJsonLd(draft: SiteDraftView): string {
-  return JSON.stringify(buildFoodRetailJsonLd(draft)).replaceAll("<", "\\u003c");
+  return serializeJsonLd(buildFoodRetailJsonLd(draft));
 }
 
 function isFoodShopType(value: unknown): value is FoodShopType {

--- a/src/lib/json-ld.test.ts
+++ b/src/lib/json-ld.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "bun:test";
+import { serializeJsonLd } from "@/lib/json-ld";
+
+describe("JSON-LD serialization", () => {
+  it("escapes script openings and JavaScript line separators without changing values", () => {
+    const value = {
+      headline: "</script><script>alert(1)</script>",
+      description: "before\u2028middle\u2029after",
+    };
+
+    const serialized = serializeJsonLd(value);
+
+    expect(serialized).not.toContain("<");
+    expect(serialized).not.toContain("\u2028");
+    expect(serialized).not.toContain("\u2029");
+    expect(serialized).toContain("\\u003c/script>");
+    expect(serialized).toContain("\\u2028");
+    expect(serialized).toContain("\\u2029");
+    expect(JSON.parse(serialized)).toEqual(value);
+  });
+});

--- a/src/lib/json-ld.ts
+++ b/src/lib/json-ld.ts
@@ -1,0 +1,18 @@
+/**
+ * Serializes JSON-LD for embedding in a native script element.
+ *
+ * JSON.stringify does not make HTML script contents safe on its own. Escaping
+ * tag openings prevents `</script>` breakouts, while escaping the JavaScript
+ * line separators keeps the payload safe for consumers that parse it as
+ * script source instead of JSON.
+ */
+export function serializeJsonLd(value: unknown): string {
+  const serialized = JSON.stringify(value);
+  if (serialized === undefined) {
+    throw new TypeError("JSON-LD must be JSON-serializable");
+  }
+  return serialized
+    .replaceAll("<", "\\u003c")
+    .replaceAll("\u2028", "\\u2028")
+    .replaceAll("\u2029", "\\u2029");
+}

--- a/src/lib/local-service-json-ld.ts
+++ b/src/lib/local-service-json-ld.ts
@@ -1,4 +1,5 @@
 import type { SiteDraftView } from "@/lib/site-draft";
+import { serializeJsonLd } from "@/lib/json-ld";
 
 const schemaTypes = {
   plumber: "Plumber",
@@ -193,10 +194,7 @@ function schemaOpeningDays(value: string): string | null {
 }
 
 export function serializeLocalServiceJsonLd(draft: SiteDraftView): string {
-  return JSON.stringify(buildLocalServiceJsonLd(draft)).replaceAll(
-    "<",
-    "\\u003c",
-  );
+  return serializeJsonLd(buildLocalServiceJsonLd(draft));
 }
 
 function record(value: unknown): Record<string, unknown> {

--- a/src/lib/restaurant-json-ld.ts
+++ b/src/lib/restaurant-json-ld.ts
@@ -1,4 +1,5 @@
 import type { SiteDraftView } from "@/lib/site-draft";
+import { serializeJsonLd } from "@/lib/json-ld";
 
 export type RestaurantJsonLd = {
   "@context": "https://schema.org";
@@ -56,7 +57,7 @@ export function buildRestaurantJsonLd(draft: SiteDraftView): RestaurantJsonLd {
 }
 
 export function serializeRestaurantJsonLd(draft: SiteDraftView): string {
-  return JSON.stringify(buildRestaurantJsonLd(draft)).replaceAll("<", "\\u003c");
+  return serializeJsonLd(buildRestaurantJsonLd(draft));
 }
 
 function stripHash(url: string): string {

--- a/src/lib/verticals/registry.test.ts
+++ b/src/lib/verticals/registry.test.ts
@@ -11,6 +11,7 @@ import { foodRetailConfig } from "@/lib/verticals/food-retail/config";
 import { localServiceConfig } from "@/lib/verticals/local-service/config";
 import {
   isVerticalClaimEnabled,
+  isVerticalCatalogItemVisible,
   isVerticalPublicationEnabled,
   isVerticalPubliclyAccessible,
   isVerticalPubliclyLaunched,
@@ -48,6 +49,39 @@ describe("vertical registry", () => {
     for (const id of listVerticalIds()) {
       expect(resolveVerticalConfig(id).id).toBe(id);
     }
+  });
+
+  it("shares storefront catalog visibility and fails closed on malformed attributes", () => {
+    expect(
+      isVerticalCatalogItemVisible(Vertical.RESTAURANT, {
+        available: false,
+        attributes: {},
+      }),
+    ).toBe(false);
+    expect(
+      isVerticalCatalogItemVisible(Vertical.RESTAURANT, {
+        available: null,
+        attributes: {},
+      }),
+    ).toBe(true);
+    expect(
+      isVerticalCatalogItemVisible(Vertical.FOOD_RETAIL, {
+        available: true,
+        attributes: { visible: false },
+      }),
+    ).toBe(false);
+    expect(
+      isVerticalCatalogItemVisible(Vertical.FOOD_RETAIL, {
+        available: false,
+        attributes: { visible: true },
+      }),
+    ).toBe(true);
+    expect(
+      isVerticalCatalogItemVisible(Vertical.RESTAURANT, {
+        available: true,
+        attributes: { dietaryLabels: "not-an-array" },
+      }),
+    ).toBe(false);
   });
 
   it("requires one vertical-specific lead discovery adapter per enum entry", () => {

--- a/src/lib/verticals/registry.ts
+++ b/src/lib/verticals/registry.ts
@@ -42,6 +42,26 @@ export function resolveVerticalConfig(id: VerticalId): ErasedVerticalConfig {
   return registry[id];
 }
 
+/**
+ * Applies the same catalog visibility capability as the storefront renderer.
+ * Stored attribute bags are parsed through the owning vertical first; malformed
+ * legacy/direct-DB values fail closed instead of reaching a vertical predicate.
+ */
+export function isVerticalCatalogItemVisible(
+  id: VerticalId,
+  item: { available: boolean | null; attributes: unknown },
+): boolean {
+  const config = resolveVerticalConfig(id);
+  const parsedAttributes = config.itemAttributesSchema.safeParse(item.attributes);
+  if (!parsedAttributes.success) return false;
+  return (
+    config.presentation.isItemVisible?.({
+      available: item.available,
+      attributes: parsedAttributes.data,
+    }) ?? item.available !== false
+  );
+}
+
 export function listVerticalIds(): VerticalId[] {
   return Object.keys(registry) as VerticalId[];
 }

--- a/src/workflows/article-batch.ts
+++ b/src/workflows/article-batch.ts
@@ -1,7 +1,7 @@
-import { getWritable } from "workflow";
+import { getWorkflowMetadata, getWritable } from "workflow";
 import type { SiteFacts } from "@/lib/articles/site-facts";
-import type { GeneratedArticleDraft } from "@/lib/articles/composer";
-import type { GeneratedBatchDrafts } from "@/lib/articles/generation";
+import type { GeneratedArticlePlan } from "@/lib/articles/composer";
+import type { GeneratedBatchPlans } from "@/lib/articles/generation";
 
 /**
  * Durable article-batch generation for one site.
@@ -11,7 +11,7 @@ import type { GeneratedBatchDrafts } from "@/lib/articles/generation";
  * steps resumes instead of re-running. The generation library is imported
  * dynamically inside steps because it transitively reaches Prisma and the AI
  * SDK, which must not enter the orchestrator bundle (see the note at the top
- * of `lead-outreach.ts`). The `SiteFacts`/`GeneratedArticleDraft` imports here
+ * of `lead-outreach.ts`). The `SiteFacts`/`GeneratedArticlePlan` imports here
  * are type-only and vanish at build time.
  */
 
@@ -23,17 +23,25 @@ export type ArticleBatchEvent =
 
 export async function articleBatchWorkflow(input: {
   batchId: string;
+  dispatchLeaseToken: string;
 }): Promise<void> {
   "use workflow";
 
+  const { workflowRunId } = getWorkflowMetadata();
+  let knownRejectedCount = 0;
   try {
-    const reservation = await beginBatchStep(input.batchId);
+    const reservation = await beginBatchStep(
+      input.batchId,
+      workflowRunId,
+      input.dispatchLeaseToken,
+    );
     if (!reservation) return;
 
     const loaded = await loadInputsStep(reservation.siteId);
     if (!loaded.ok) {
       await closeBatchStep({
         batchId: input.batchId,
+        workflowRunId,
         status: "SKIPPED",
         statusReason: "SITE_INELIGIBLE",
       });
@@ -42,14 +50,16 @@ export async function articleBatchWorkflow(input: {
     }
 
     await emit({ type: "progress", message: "Selecting topics" });
-    const generated = await generateDraftsStep({
+    const generated = await generatePlansStep({
       facts: loaded.facts,
       recentTopicKeys: loaded.recentTopicKeys,
       count: reservation.requestedCount,
     });
+    knownRejectedCount = generated.rejectedCount;
     if (generated.status === "SKIPPED") {
       await closeBatchStep({
         batchId: input.batchId,
+        workflowRunId,
         status: "SKIPPED",
         statusReason: generated.statusReason,
       });
@@ -59,10 +69,11 @@ export async function articleBatchWorkflow(input: {
       });
       return;
     }
-    if (!generated.drafts.length) {
+    if (!generated.plans.length) {
       const rejected = generated.rejectedCount > 0;
       await closeBatchStep({
         batchId: input.batchId,
+        workflowRunId,
         status: rejected ? "REJECTED" : "ZERO_OUTPUT",
         statusReason: rejected
           ? "INVALID_MODEL_OUTPUT"
@@ -72,17 +83,17 @@ export async function articleBatchWorkflow(input: {
       await emit({
         type: "skipped",
         reason: rejected
-          ? "No returned draft matched a requested topic."
-          : "The generation run returned no drafts.",
+          ? "No returned plan matched a requested topic."
+          : "The generation run returned no plans.",
       });
       return;
     }
 
     const persisted = await persistBatchStep({
       batchId: input.batchId,
+      workflowRunId,
       siteId: reservation.siteId,
-      facts: loaded.facts,
-      drafts: generated.drafts,
+      plans: generated.plans,
       rejectedCount: generated.rejectedCount,
     });
 
@@ -96,8 +107,10 @@ export async function articleBatchWorkflow(input: {
       error instanceof Error ? error.message : "Article batch failed.";
     await closeBatchStep({
       batchId: input.batchId,
+      workflowRunId,
       status: "FAILED",
       statusReason: "GENERATION_FAILED",
+      rejectedCount: knownRejectedCount,
     });
     await emit({ type: "failed", message });
     throw error;
@@ -114,13 +127,17 @@ async function emit(event: ArticleBatchEvent): Promise<void> {
   }
 }
 
-async function beginBatchStep(batchId: string): Promise<{
+async function beginBatchStep(
+  batchId: string,
+  workflowRunId: string,
+  dispatchLeaseToken: string,
+): Promise<{
   siteId: string;
   requestedCount: number;
 } | null> {
   "use step";
   const { beginArticleBatch } = await import("@/lib/articles/generation");
-  return beginArticleBatch(batchId);
+  return beginArticleBatch(batchId, workflowRunId, dispatchLeaseToken);
 }
 
 async function loadInputsStep(
@@ -134,21 +151,21 @@ async function loadInputsStep(
   return loadGenerationInputs(siteId);
 }
 
-async function generateDraftsStep(input: {
+async function generatePlansStep(input: {
   facts: SiteFacts;
   recentTopicKeys: string[];
   count: number;
-}): Promise<GeneratedBatchDrafts> {
+}): Promise<GeneratedBatchPlans> {
   "use step";
-  const { generateBatchDrafts } = await import("@/lib/articles/generation");
-  return generateBatchDrafts(input);
+  const { generateBatchPlans } = await import("@/lib/articles/generation");
+  return generateBatchPlans(input);
 }
 
 async function persistBatchStep(input: {
   batchId: string;
+  workflowRunId: string;
   siteId: string;
-  facts: SiteFacts;
-  drafts: GeneratedArticleDraft[];
+  plans: GeneratedArticlePlan[];
   rejectedCount: number;
 }): Promise<{ batchId: string; producedCount: number }> {
   "use step";
@@ -158,6 +175,7 @@ async function persistBatchStep(input: {
 
 async function closeBatchStep(input: {
   batchId: string;
+  workflowRunId: string;
   status: "ZERO_OUTPUT" | "REJECTED" | "SKIPPED" | "FAILED";
   statusReason: string;
   rejectedCount?: number;

--- a/src/workflows/article-batch.ts
+++ b/src/workflows/article-batch.ts
@@ -1,6 +1,7 @@
 import { getWritable } from "workflow";
 import type { SiteFacts } from "@/lib/articles/site-facts";
 import type { GeneratedArticleDraft } from "@/lib/articles/composer";
+import type { GeneratedBatchDrafts } from "@/lib/articles/generation";
 
 /**
  * Durable article-batch generation for one site.
@@ -21,38 +22,68 @@ export type ArticleBatchEvent =
   | { type: "failed"; message: string };
 
 export async function articleBatchWorkflow(input: {
-  siteId: string;
-  requestedBy: string;
-  count?: number;
+  batchId: string;
 }): Promise<void> {
   "use workflow";
 
   try {
-    const loaded = await loadInputsStep(input.siteId);
+    const reservation = await beginBatchStep(input.batchId);
+    if (!reservation) return;
+
+    const loaded = await loadInputsStep(reservation.siteId);
     if (!loaded.ok) {
+      await closeBatchStep({
+        batchId: input.batchId,
+        status: "SKIPPED",
+        statusReason: "SITE_INELIGIBLE",
+      });
       await emit({ type: "skipped", reason: loaded.reason });
       return;
     }
 
     await emit({ type: "progress", message: "Selecting topics" });
-    const drafts = await generateDraftsStep({
+    const generated = await generateDraftsStep({
       facts: loaded.facts,
       recentTopicKeys: loaded.recentTopicKeys,
-      count: input.count ?? 4,
+      count: reservation.requestedCount,
     });
-    if (!drafts.length) {
+    if (generated.status === "SKIPPED") {
+      await closeBatchStep({
+        batchId: input.batchId,
+        status: "SKIPPED",
+        statusReason: generated.statusReason,
+      });
       await emit({
         type: "skipped",
-        reason: "No supportable topic produced an acceptable draft.",
+        reason: "No supportable topic is available for this site's facts.",
+      });
+      return;
+    }
+    if (!generated.drafts.length) {
+      const rejected = generated.rejectedCount > 0;
+      await closeBatchStep({
+        batchId: input.batchId,
+        status: rejected ? "REJECTED" : "ZERO_OUTPUT",
+        statusReason: rejected
+          ? "INVALID_MODEL_OUTPUT"
+          : "MODEL_RETURNED_ZERO_DRAFTS",
+        rejectedCount: generated.rejectedCount,
+      });
+      await emit({
+        type: "skipped",
+        reason: rejected
+          ? "No returned draft matched a requested topic."
+          : "The generation run returned no drafts.",
       });
       return;
     }
 
     const persisted = await persistBatchStep({
-      siteId: input.siteId,
-      requestedBy: input.requestedBy,
+      batchId: input.batchId,
+      siteId: reservation.siteId,
       facts: loaded.facts,
-      drafts,
+      drafts: generated.drafts,
+      rejectedCount: generated.rejectedCount,
     });
 
     await emit({
@@ -63,6 +94,11 @@ export async function articleBatchWorkflow(input: {
   } catch (error) {
     const message =
       error instanceof Error ? error.message : "Article batch failed.";
+    await closeBatchStep({
+      batchId: input.batchId,
+      status: "FAILED",
+      statusReason: "GENERATION_FAILED",
+    });
     await emit({ type: "failed", message });
     throw error;
   }
@@ -76,6 +112,15 @@ async function emit(event: ArticleBatchEvent): Promise<void> {
   } finally {
     writer.releaseLock();
   }
+}
+
+async function beginBatchStep(batchId: string): Promise<{
+  siteId: string;
+  requestedCount: number;
+} | null> {
+  "use step";
+  const { beginArticleBatch } = await import("@/lib/articles/generation");
+  return beginArticleBatch(batchId);
 }
 
 async function loadInputsStep(
@@ -93,19 +138,31 @@ async function generateDraftsStep(input: {
   facts: SiteFacts;
   recentTopicKeys: string[];
   count: number;
-}): Promise<GeneratedArticleDraft[]> {
+}): Promise<GeneratedBatchDrafts> {
   "use step";
   const { generateBatchDrafts } = await import("@/lib/articles/generation");
   return generateBatchDrafts(input);
 }
 
 async function persistBatchStep(input: {
+  batchId: string;
   siteId: string;
-  requestedBy: string;
   facts: SiteFacts;
   drafts: GeneratedArticleDraft[];
+  rejectedCount: number;
 }): Promise<{ batchId: string; producedCount: number }> {
   "use step";
   const { persistArticleBatch } = await import("@/lib/articles/generation");
   return persistArticleBatch(input);
+}
+
+async function closeBatchStep(input: {
+  batchId: string;
+  status: "ZERO_OUTPUT" | "REJECTED" | "SKIPPED" | "FAILED";
+  statusReason: string;
+  rejectedCount?: number;
+}): Promise<boolean> {
+  "use step";
+  const { closeArticleBatch } = await import("@/lib/articles/generation");
+  return closeArticleBatch(input);
 }


### PR DESCRIPTION
## Summary

- reserve article batches atomically before provider work, bind workflow ownership with replay-safe CAS semantics, and dispatch/reconcile queued work from durable Workflow state
- persist requested, accepted, rejected, and terminal outcome state without aging healthy runs from passive timestamps
- replace free-form factual parsing with deterministic, typed, catalog-ID-backed article plans; revalidate enabled integration capabilities and storefront visibility before persistence
- keep arbitrary catalog names out of public article prose and centralize safe JSON-LD serialization at the customer article sink
- add an expand-compatible, transactional article-ledger migration that preserves the physical `producedCount` column for predecessor writers
- gate article mutations through the blue-green drain/stop/recheck/start/verify rollout, leaving incompatible rollback closed

## Verification

- Prisma format, validate, generate, migrate deploy, and migrate status
- fresh 31-migration deployment, including 10:00 predecessor then 11:00 article ledger
- full unit suite: 1,065 passed, 110 skipped, 0 failed
- full opt-in PostgreSQL/Workflow suite: 89 passed, 1 skipped, 0 failed
- focused article/JSON-LD/rollout suite: 83 passed, 0 failed
- article PostgreSQL concurrency/outcome suite: 36 passed, 0 failed
- ESLint, TypeScript, design lint, shellcheck, bash syntax
- Next.js production build: 54/54 static pages generated
- cold-cache brand/font contract and zero-vulnerability `bun audit`
- executable article rollout failure-path harness
- independent exact-head review: approved with no P0-P3 findings
- staged and branch secret scan: clean; only the deliberate `test-only-never-sent` fixture matched

## Rollout

The migration lands closed. Deployment must keep article mutations gated while migrations run, Workflow/Graphile and article work quiesce, the predecessor worker stops, and quiescence is rechecked. The candidate starts and is verified before the operator explicitly ungates. An incompatible rollback remains gated.

Closes #130
