### PR TITLE
fix(bookings): fail closed without live-site admission

### DIFF
--- a/src/app/api/sites/[slug]/booking-requests/route.ts
+++ b/src/app/api/sites/[slug]/booking-requests/route.ts
@@ -6,25 +6,37 @@ import {
   resolveAnalyticsSiteForHeaders,
 } from "@/lib/analytics";
 import {
+  admitLiveBookingRequest,
+  BOOKING_REQUEST_ADMISSION_REJECTED_MESSAGE,
+  BOOKING_REQUEST_ADMISSION_REJECTED_STATUS,
+} from "@/lib/booking-request-admission";
+import {
   bookingRequestInputSchema,
   createBookingRequest,
   notifyOwnerOfBookingRequest,
 } from "@/lib/booking-requests";
 import { getDb } from "@/lib/db";
 import { limitBookingRequest } from "@/lib/rate-limit";
+import { liveSiteVersionId } from "@/lib/site-surface";
 
 export const runtime = "nodejs";
 
 type RouteContext = { params: Promise<{ slug: string }> };
 
+function rejectedAdmissionResponse() {
+  return NextResponse.json(
+    { error: BOOKING_REQUEST_ADMISSION_REJECTED_MESSAGE },
+    { status: BOOKING_REQUEST_ADMISSION_REJECTED_STATUS },
+  );
+}
+
 /**
  * The one unauthenticated write a generated site exposes to its visitors.
  *
- * Metered before anything else runs, validated against a closed schema, and
- * answered with either the visitor's own validation problem or a fixed generic
- * message — the same redaction posture as the import route, for the same reason:
- * this is a public endpoint and internal failure text is not the caller's
- * business.
+ * Metered before anything else runs. Persist and notify only after a
+ * proxy-attested live slug/version matches the route, the current published
+ * snapshot, and the live-host resolver. Every admission failure uses one
+ * visitor-safe body so the caller cannot probe whether a slug exists.
  */
 export async function POST(request: Request, { params }: RouteContext) {
   const { slug } = await params;
@@ -52,6 +64,10 @@ export async function POST(request: Request, { params }: RouteContext) {
     const parsed = bookingRequestInputSchema.parse(await request.json());
     const { analyticsVisitId, ...input } = parsed;
 
+    if (!liveSiteVersionId(request.headers, slug)) {
+      return rejectedAdmissionResponse();
+    }
+
     if (!process.env.DATABASE_URL) {
       return NextResponse.json(
         { error: "Booking requests are temporarily unavailable" },
@@ -59,49 +75,43 @@ export async function POST(request: Request, { params }: RouteContext) {
       );
     }
 
-    const site = await getDb().site.findUnique({
-      where: { slug },
-      select: {
-        id: true,
-        name: true,
-        slug: true,
-        organizationId: true,
-        // Decides which niche the owner's notification is sent as.
-        vertical: true,
-      },
+    const site = await admitLiveBookingRequest({
+      slug,
+      headers: request.headers,
+      lookupSite: (liveSlug) =>
+        getDb().site.findUnique({
+          where: { slug: liveSlug },
+          select: {
+            id: true,
+            name: true,
+            slug: true,
+            organizationId: true,
+            vertical: true,
+            status: true,
+            publishedSiteVersionId: true,
+            publishedSiteVersion: {
+              select: { id: true, siteId: true, publishedAt: true },
+            },
+          },
+        }),
+      resolveLiveHost: resolveAnalyticsSiteForHeaders,
     });
-    if (!site) {
-      return NextResponse.json({ error: "Site not found" }, { status: 404 });
-    }
-
-    let liveAnalyticsSiteId: string | null = null;
-    try {
-      const analyticsSite = await resolveAnalyticsSiteForHeaders(
-        request.headers,
-      );
-      if (analyticsSite?.id === site.id) liveAnalyticsSiteId = site.id;
-    } catch (error) {
-      console.error("[booking-request] analytics host check failed", {
-        slug,
-        error: error instanceof Error ? error.message : "unknown",
-      });
-    }
+    if (!site) return rejectedAdmissionResponse();
 
     const created = await createBookingRequest(
       site,
       input,
-      liveAnalyticsSiteId ? LIVE_BOOKING_REQUEST_SOURCE : "site-form",
+      LIVE_BOOKING_REQUEST_SOURCE,
     );
-    if (liveAnalyticsSiteId && analyticsVisitId) {
+    if (analyticsVisitId) {
       after(async () => {
         try {
           await recordLeadCreatedEvent({
-            siteId: liveAnalyticsSiteId,
+            siteId: site.id,
             visitId: analyticsVisitId,
           });
         } catch (error) {
           console.error("[booking-request] lead analytics dropped", {
-            slug,
             bookingRequestId: created.id,
             error: error instanceof Error ? error.message : "unknown",
           });
@@ -123,7 +133,6 @@ export async function POST(request: Request, { params }: RouteContext) {
     }
 
     console.error("[booking-request] failed", {
-      slug,
       error: error instanceof Error ? error.message : "unknown",
     });
     return NextResponse.json(

--- a/src/lib/booking-request-admission.test.ts
+++ b/src/lib/booking-request-admission.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it, mock } from "bun:test";
+import { Vertical } from "@/generated/prisma/enums";
+import {
+  admitLiveBookingRequest,
+  type BookingRequestAdmissionSite,
+  type BookingRequestLiveHost,
+} from "@/lib/booking-request-admission";
+import {
+  LIVE_SITE_SLUG_HEADER,
+  LIVE_SITE_VERSION_HEADER,
+} from "@/lib/site-surface";
+
+const SLUG = "chez-lea";
+const VERSION_ID = "sv_live";
+const SITE_ID = "site_1";
+
+const liveSite: BookingRequestAdmissionSite = {
+  id: SITE_ID,
+  name: "Chez Léa",
+  slug: SLUG,
+  organizationId: "org_1",
+  vertical: Vertical.RESTAURANT,
+  status: "LIVE",
+  publishedSiteVersionId: VERSION_ID,
+  publishedSiteVersion: {
+    id: VERSION_ID,
+    siteId: SITE_ID,
+    publishedAt: new Date("2026-08-01T00:00:00.000Z"),
+  },
+};
+
+function liveHeaders(
+  slug = SLUG,
+  versionId = VERSION_ID,
+): Headers {
+  return new Headers({
+    [LIVE_SITE_SLUG_HEADER]: slug,
+    [LIVE_SITE_VERSION_HEADER]: versionId,
+  });
+}
+
+function lookups(options?: {
+  site?: BookingRequestAdmissionSite | null;
+  host?: BookingRequestLiveHost | null;
+  hostError?: Error;
+}) {
+  const lookupSite = mock(
+    async (): Promise<BookingRequestAdmissionSite | null> => {
+      if (options && "site" in options) return options.site ?? null;
+      return liveSite;
+    },
+  );
+  const resolveLiveHost = mock(
+    async (): Promise<BookingRequestLiveHost | null> => {
+      if (options?.hostError) throw options.hostError;
+      if (options && "host" in options) return options.host ?? null;
+      return { id: SITE_ID, slug: SLUG };
+    },
+  );
+  return { lookupSite, resolveLiveHost };
+}
+
+describe("live booking-request admission", () => {
+  it("admits a matching proxy-attested live slug and current published version", async () => {
+    const { lookupSite, resolveLiveHost } = lookups();
+
+    await expect(
+      admitLiveBookingRequest({
+        slug: SLUG,
+        headers: liveHeaders(),
+        lookupSite,
+        resolveLiveHost,
+      }),
+    ).resolves.toEqual(liveSite);
+    expect(lookupSite).toHaveBeenCalledTimes(1);
+    expect(resolveLiveHost).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects missing markers without looking up the site or live host", async () => {
+    const { lookupSite, resolveLiveHost } = lookups();
+
+    await expect(
+      admitLiveBookingRequest({
+        slug: SLUG,
+        headers: new Headers(),
+        lookupSite,
+        resolveLiveHost,
+      }),
+    ).resolves.toBeNull();
+    expect(lookupSite).not.toHaveBeenCalled();
+    expect(resolveLiveHost).not.toHaveBeenCalled();
+  });
+
+  it("rejects a spoofed slug marker without looking up the site or live host", async () => {
+    const { lookupSite, resolveLiveHost } = lookups();
+
+    await expect(
+      admitLiveBookingRequest({
+        slug: SLUG,
+        headers: liveHeaders("someone-elses-site"),
+        lookupSite,
+        resolveLiveHost,
+      }),
+    ).resolves.toBeNull();
+    expect(lookupSite).not.toHaveBeenCalled();
+    expect(resolveLiveHost).not.toHaveBeenCalled();
+  });
+
+  it("rejects a route slug that does not match the attested live slug", async () => {
+    const { lookupSite, resolveLiveHost } = lookups();
+
+    await expect(
+      admitLiveBookingRequest({
+        slug: "other-site",
+        headers: liveHeaders(),
+        lookupSite,
+        resolveLiveHost,
+      }),
+    ).resolves.toBeNull();
+    expect(lookupSite).not.toHaveBeenCalled();
+    expect(resolveLiveHost).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing site without asking the live-host resolver", async () => {
+    const { lookupSite, resolveLiveHost } = lookups({ site: null });
+
+    await expect(
+      admitLiveBookingRequest({
+        slug: SLUG,
+        headers: liveHeaders(),
+        lookupSite,
+        resolveLiveHost,
+      }),
+    ).resolves.toBeNull();
+    expect(lookupSite).toHaveBeenCalledTimes(1);
+    expect(resolveLiveHost).not.toHaveBeenCalled();
+  });
+
+  it("rejects a paused site without asking the live-host resolver", async () => {
+    const { lookupSite, resolveLiveHost } = lookups({
+      site: { ...liveSite, status: "PAUSED" },
+    });
+
+    await expect(
+      admitLiveBookingRequest({
+        slug: SLUG,
+        headers: liveHeaders(),
+        lookupSite,
+        resolveLiveHost,
+      }),
+    ).resolves.toBeNull();
+    expect(lookupSite).toHaveBeenCalledTimes(1);
+    expect(resolveLiveHost).not.toHaveBeenCalled();
+  });
+
+  it("rejects a preview-only site without asking the live-host resolver", async () => {
+    const { lookupSite, resolveLiveHost } = lookups({
+      site: { ...liveSite, status: "PREVIEW_READY" },
+    });
+
+    await expect(
+      admitLiveBookingRequest({
+        slug: SLUG,
+        headers: liveHeaders(),
+        lookupSite,
+        resolveLiveHost,
+      }),
+    ).resolves.toBeNull();
+    expect(resolveLiveHost).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unpublished site without asking the live-host resolver", async () => {
+    const { lookupSite, resolveLiveHost } = lookups({
+      site: {
+        ...liveSite,
+        publishedSiteVersionId: null,
+        publishedSiteVersion: null,
+      },
+    });
+
+    await expect(
+      admitLiveBookingRequest({
+        slug: SLUG,
+        headers: liveHeaders(),
+        lookupSite,
+        resolveLiveHost,
+      }),
+    ).resolves.toBeNull();
+    expect(resolveLiveHost).not.toHaveBeenCalled();
+  });
+
+  it("rejects a stale attested version without asking the live-host resolver", async () => {
+    const { lookupSite, resolveLiveHost } = lookups();
+
+    await expect(
+      admitLiveBookingRequest({
+        slug: SLUG,
+        headers: liveHeaders(SLUG, "sv_stale"),
+        lookupSite,
+        resolveLiveHost,
+      }),
+    ).resolves.toBeNull();
+    expect(lookupSite).toHaveBeenCalledTimes(1);
+    expect(resolveLiveHost).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the live-host resolver returns null", async () => {
+    const { lookupSite, resolveLiveHost } = lookups({ host: null });
+
+    await expect(
+      admitLiveBookingRequest({
+        slug: SLUG,
+        headers: liveHeaders(),
+        lookupSite,
+        resolveLiveHost,
+      }),
+    ).resolves.toBeNull();
+    expect(lookupSite).toHaveBeenCalledTimes(1);
+    expect(resolveLiveHost).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects when the live-host resolver throws", async () => {
+    const { lookupSite, resolveLiveHost } = lookups({
+      hostError: new Error("resolver unavailable"),
+    });
+
+    await expect(
+      admitLiveBookingRequest({
+        slug: SLUG,
+        headers: liveHeaders(),
+        lookupSite,
+        resolveLiveHost,
+      }),
+    ).resolves.toBeNull();
+    expect(resolveLiveHost).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a live-host resolver result for a different site", async () => {
+    const { lookupSite, resolveLiveHost } = lookups({
+      host: { id: "site_other", slug: "other-site" },
+    });
+
+    await expect(
+      admitLiveBookingRequest({
+        slug: SLUG,
+        headers: liveHeaders(),
+        lookupSite,
+        resolveLiveHost,
+      }),
+    ).resolves.toBeNull();
+  });
+});

--- a/src/lib/booking-request-admission.ts
+++ b/src/lib/booking-request-admission.ts
@@ -1,0 +1,68 @@
+import type { BookingRequestSite } from "@/lib/booking-requests";
+import {
+  hasPublicPublishedSnapshot,
+  type PublishedDomainRecord,
+} from "@/lib/domain-routing";
+import { liveSiteVersionId } from "@/lib/site-surface";
+
+/**
+ * Visitor-safe copy for every public booking-request admission failure.
+ * Distinct 404/403 bodies would let a caller probe whether a slug exists.
+ */
+export const BOOKING_REQUEST_ADMISSION_REJECTED_MESSAGE =
+  "Your request could not be sent. Try again in a moment.";
+
+export const BOOKING_REQUEST_ADMISSION_REJECTED_STATUS = 404;
+
+export type BookingRequestAdmissionSite = BookingRequestSite & {
+  status: PublishedDomainRecord["site"]["status"];
+  publishedSiteVersionId: string | null;
+  publishedSiteVersion: PublishedDomainRecord["site"]["publishedSiteVersion"];
+};
+
+export type BookingRequestLiveHost = {
+  id: string;
+  slug: string;
+};
+
+export type BookingRequestSiteLookup = (
+  slug: string,
+) => Promise<BookingRequestAdmissionSite | null>;
+
+export type BookingRequestLiveHostLookup = (
+  headers: Headers,
+) => Promise<BookingRequestLiveHost | null>;
+
+/**
+ * Fail-closed gate for the unauthenticated booking-request write.
+ *
+ * Proxy-attested slug/version must match the route, the site's current
+ * published snapshot, and the live-host resolver. Missing markers, paused or
+ * unpublished sites, stale versions, and resolver misses all return null with
+ * no distinction the caller can use to probe slug existence.
+ */
+export async function admitLiveBookingRequest(input: {
+  slug: string;
+  headers: Headers;
+  lookupSite: BookingRequestSiteLookup;
+  resolveLiveHost: BookingRequestLiveHostLookup;
+}): Promise<BookingRequestAdmissionSite | null> {
+  const versionId = liveSiteVersionId(input.headers, input.slug);
+  if (!versionId) return null;
+
+  const site = await input.lookupSite(input.slug);
+  if (!site) return null;
+  if (!hasPublicPublishedSnapshot(site)) return null;
+  if (site.publishedSiteVersionId !== versionId) return null;
+
+  let liveHost: BookingRequestLiveHost | null;
+  try {
+    liveHost = await input.resolveLiveHost(input.headers);
+  } catch {
+    return null;
+  }
+  if (!liveHost || liveHost.id !== site.id || liveHost.slug !== site.slug) {
+    return null;
+  }
+  return site;
+}

--- a/src/lib/booking-request-route.test.ts
+++ b/src/lib/booking-request-route.test.ts
@@ -1,0 +1,337 @@
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import { Vertical } from "@/generated/prisma/enums";
+import {
+  BOOKING_REQUEST_ADMISSION_REJECTED_MESSAGE,
+  BOOKING_REQUEST_ADMISSION_REJECTED_STATUS,
+  type BookingRequestAdmissionSite,
+} from "@/lib/booking-request-admission";
+import { rateLimitTestModule } from "@/lib/complete-test-module-mocks";
+import {
+  LIVE_SITE_SLUG_HEADER,
+  LIVE_SITE_VERSION_HEADER,
+} from "@/lib/site-surface";
+
+mock.module("server-only", () => ({}));
+
+const SLUG = "chez-lea";
+const VERSION_ID = "sv_live";
+const SITE_ID = "site_1";
+const LIVE_SOURCE = "live-site-form";
+
+const liveSite: BookingRequestAdmissionSite = {
+  id: SITE_ID,
+  name: "Chez Léa",
+  slug: SLUG,
+  organizationId: "org_1",
+  vertical: Vertical.RESTAURANT,
+  status: "LIVE",
+  publishedSiteVersionId: VERSION_ID,
+  publishedSiteVersion: {
+    id: VERSION_ID,
+    siteId: SITE_ID,
+    publishedAt: new Date("2026-08-01T00:00:00.000Z"),
+  },
+};
+
+const createdRequest = {
+  id: "br_1",
+  name: "Ada",
+  email: "ada@example.test",
+  phone: null,
+  requestedAt: null,
+  partySize: null,
+  notes: null,
+  createdAt: new Date("2026-08-20T12:00:00.000Z"),
+};
+
+const callOrder: string[] = [];
+let rateLimitResult = {
+  success: true,
+  remaining: 7,
+  reset: Date.now() + 60_000,
+  reason: undefined as "limited" | "unavailable" | undefined,
+};
+let siteRow: BookingRequestAdmissionSite | null = liveSite;
+let liveHost: { id: string; slug: string } | null = {
+  id: SITE_ID,
+  slug: SLUG,
+};
+let liveHostError: Error | null = null;
+
+const limitBookingRequest = mock(async () => {
+  callOrder.push("rateLimit");
+  return rateLimitResult;
+});
+const findUnique = mock(async () => {
+  callOrder.push("db");
+  return siteRow;
+});
+const resolveAnalyticsSiteForHeaders = mock(async () => {
+  callOrder.push("resolver");
+  if (liveHostError) throw liveHostError;
+  return liveHost;
+});
+const createBookingRequest = mock(async () => {
+  callOrder.push("create");
+  return createdRequest;
+});
+const notifyOwnerOfBookingRequest = mock(async () => {
+  callOrder.push("notify");
+  return true;
+});
+const recordLeadCreatedEvent = mock(async () => "created" as const);
+
+const bookingRequestsActual = await import("@/lib/booking-requests");
+
+mock.module("@/lib/rate-limit", () => ({
+  ...rateLimitTestModule,
+  limitBookingRequest,
+}));
+mock.module("@/lib/db", () => ({
+  getDb: () => ({
+    site: { findUnique },
+  }),
+}));
+mock.module("@/lib/analytics", () => ({
+  LIVE_BOOKING_REQUEST_SOURCE: LIVE_SOURCE,
+  recordLeadCreatedEvent,
+  resolveAnalyticsSiteForHeaders,
+}));
+mock.module("@/lib/booking-requests", () => ({
+  bookingRequestInputSchema: bookingRequestsActual.bookingRequestInputSchema,
+  createBookingRequest,
+  notifyOwnerOfBookingRequest,
+}));
+
+const { POST } = await import(
+  "@/app/api/sites/[slug]/booking-requests/route"
+);
+
+const previousDatabaseUrl = process.env.DATABASE_URL;
+
+describe("public booking-request route admission", () => {
+  beforeEach(() => {
+    process.env.DATABASE_URL = "postgresql://unused-by-mocked-test.invalid/db";
+    callOrder.length = 0;
+    rateLimitResult = {
+      success: true,
+      remaining: 7,
+      reset: Date.now() + 60_000,
+      reason: undefined,
+    };
+    siteRow = liveSite;
+    liveHost = { id: SITE_ID, slug: SLUG };
+    liveHostError = null;
+    limitBookingRequest.mockClear();
+    findUnique.mockClear();
+    resolveAnalyticsSiteForHeaders.mockClear();
+    createBookingRequest.mockClear();
+    notifyOwnerOfBookingRequest.mockClear();
+    recordLeadCreatedEvent.mockClear();
+  });
+
+  afterAll(() => {
+    if (previousDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = previousDatabaseUrl;
+  });
+
+  it("rate-limits before lookup, resolve, create, or notify", async () => {
+    rateLimitResult = {
+      success: false,
+      remaining: 0,
+      reset: Date.now() + 60_000,
+      reason: "limited",
+    };
+
+    const response = await postBooking();
+
+    expect(response.status).toBe(429);
+    expect(callOrder).toEqual(["rateLimit"]);
+    expect(findUnique).not.toHaveBeenCalled();
+    expect(resolveAnalyticsSiteForHeaders).not.toHaveBeenCalled();
+    expect(createBookingRequest).not.toHaveBeenCalled();
+    expect(notifyOwnerOfBookingRequest).not.toHaveBeenCalled();
+  });
+
+  it("rejects missing markers and factory-host posts without writing", async () => {
+    const response = await postBooking({ headers: new Headers() });
+
+    expect(await rejection(response)).toEqual(uniformRejection);
+    expect(callOrder).toEqual(["rateLimit"]);
+    expect(findUnique).not.toHaveBeenCalled();
+    expect(resolveAnalyticsSiteForHeaders).not.toHaveBeenCalled();
+    expect(createBookingRequest).not.toHaveBeenCalled();
+    expect(notifyOwnerOfBookingRequest).not.toHaveBeenCalled();
+  });
+
+  it("rejects spoofed live-site markers without writing", async () => {
+    const response = await postBooking({
+      headers: liveHeaders("someone-elses-site"),
+    });
+
+    expect(await rejection(response)).toEqual(uniformRejection);
+    expect(createBookingRequest).not.toHaveBeenCalled();
+    expect(notifyOwnerOfBookingRequest).not.toHaveBeenCalled();
+    expect(findUnique).not.toHaveBeenCalled();
+    expect(resolveAnalyticsSiteForHeaders).not.toHaveBeenCalled();
+  });
+
+  it("rejects a paused site without writing", async () => {
+    siteRow = { ...liveSite, status: "PAUSED" };
+
+    const response = await postBooking();
+
+    expect(await rejection(response)).toEqual(uniformRejection);
+    expect(callOrder).toEqual(["rateLimit", "db"]);
+    expect(resolveAnalyticsSiteForHeaders).not.toHaveBeenCalled();
+    expect(createBookingRequest).not.toHaveBeenCalled();
+    expect(notifyOwnerOfBookingRequest).not.toHaveBeenCalled();
+  });
+
+  it("rejects a preview-only site without writing", async () => {
+    siteRow = { ...liveSite, status: "PREVIEW_READY" };
+
+    const response = await postBooking();
+
+    expect(await rejection(response)).toEqual(uniformRejection);
+    expect(createBookingRequest).not.toHaveBeenCalled();
+    expect(notifyOwnerOfBookingRequest).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unpublished site without writing", async () => {
+    siteRow = {
+      ...liveSite,
+      publishedSiteVersionId: null,
+      publishedSiteVersion: null,
+    };
+
+    const response = await postBooking();
+
+    expect(await rejection(response)).toEqual(uniformRejection);
+    expect(createBookingRequest).not.toHaveBeenCalled();
+    expect(notifyOwnerOfBookingRequest).not.toHaveBeenCalled();
+  });
+
+  it("rejects a stale attested version without writing", async () => {
+    const response = await postBooking({
+      headers: liveHeaders(SLUG, "sv_stale"),
+    });
+
+    expect(await rejection(response)).toEqual(uniformRejection);
+    expect(callOrder).toEqual(["rateLimit", "db"]);
+    expect(resolveAnalyticsSiteForHeaders).not.toHaveBeenCalled();
+    expect(createBookingRequest).not.toHaveBeenCalled();
+    expect(notifyOwnerOfBookingRequest).not.toHaveBeenCalled();
+  });
+
+  it("rejects a mismatched route slug without writing", async () => {
+    const response = await postBooking({ slug: "other-site" });
+
+    expect(await rejection(response)).toEqual(uniformRejection);
+    expect(findUnique).not.toHaveBeenCalled();
+    expect(resolveAnalyticsSiteForHeaders).not.toHaveBeenCalled();
+    expect(createBookingRequest).not.toHaveBeenCalled();
+    expect(notifyOwnerOfBookingRequest).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unknown slug with the same body as a paused live site", async () => {
+    siteRow = null;
+
+    const response = await postBooking();
+
+    expect(await rejection(response)).toEqual(uniformRejection);
+    expect(callOrder).toEqual(["rateLimit", "db"]);
+    expect(createBookingRequest).not.toHaveBeenCalled();
+    expect(notifyOwnerOfBookingRequest).not.toHaveBeenCalled();
+  });
+
+  it("rejects a null live-host resolver without writing", async () => {
+    liveHost = null;
+
+    const response = await postBooking();
+
+    expect(await rejection(response)).toEqual(uniformRejection);
+    expect(callOrder).toEqual(["rateLimit", "db", "resolver"]);
+    expect(createBookingRequest).not.toHaveBeenCalled();
+    expect(notifyOwnerOfBookingRequest).not.toHaveBeenCalled();
+  });
+
+  it("rejects a live-host resolver error without writing", async () => {
+    liveHostError = new Error("resolver unavailable");
+
+    const response = await postBooking();
+
+    expect(await rejection(response)).toEqual(uniformRejection);
+    expect(callOrder).toEqual(["rateLimit", "db", "resolver"]);
+    expect(createBookingRequest).not.toHaveBeenCalled();
+    expect(notifyOwnerOfBookingRequest).not.toHaveBeenCalled();
+  });
+
+  it("persists and notifies only after a matching live admission", async () => {
+    const response = await postBooking();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true, notified: true });
+    expect(callOrder).toEqual([
+      "rateLimit",
+      "db",
+      "resolver",
+      "create",
+      "notify",
+    ]);
+    expect(createBookingRequest).toHaveBeenCalledWith(
+      liveSite,
+      expect.objectContaining({
+        name: "Ada",
+        email: "ada@example.test",
+      }),
+      LIVE_SOURCE,
+    );
+    expect(notifyOwnerOfBookingRequest).toHaveBeenCalledWith(
+      liveSite,
+      createdRequest,
+    );
+  });
+});
+
+const uniformRejection = {
+  status: BOOKING_REQUEST_ADMISSION_REJECTED_STATUS,
+  error: BOOKING_REQUEST_ADMISSION_REJECTED_MESSAGE,
+};
+
+async function rejection(response: Response) {
+  const payload = (await response.json()) as { error?: string };
+  return { status: response.status, error: payload.error };
+}
+
+function liveHeaders(slug = SLUG, versionId = VERSION_ID) {
+  return new Headers({
+    [LIVE_SITE_SLUG_HEADER]: slug,
+    [LIVE_SITE_VERSION_HEADER]: versionId,
+  });
+}
+
+function postBooking(options?: {
+  slug?: string;
+  headers?: Headers;
+  body?: Record<string, unknown>;
+}) {
+  const headers = options?.headers ?? liveHeaders();
+  headers.set("content-type", "application/json");
+  return POST(
+    new Request(
+      `https://chez-lea.restofront.com/api/sites/${options?.slug ?? SLUG}/booking-requests`,
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify(
+          options?.body ?? {
+            name: "Ada",
+            email: "ada@example.test",
+          },
+        ),
+      },
+    ),
+    { params: Promise.resolve({ slug: options?.slug ?? SLUG }) },
+  );
+}


### PR DESCRIPTION
Closes #139

## Problem
`POST /api/sites/[slug]/booking-requests` persisted and notified whenever a site row existed. Live-host resolution was best-effort: missing markers, factory/preview hosts, paused or unpublished sites, and resolver failures still created leads.

## Change
- Rate-limit first, then require a proxy-attested live slug/version that matches the route, the current published snapshot, and `resolveAnalyticsSiteForHeaders`.
- Persist and notify only after that complete admission check succeeds, always as `live-site-form`.
- Use one visitor-safe 404 (`Your request could not be sent. Try again in a moment.`) for missing/spoofed markers, factory hosts, paused/preview/unpublished/stale/mismatched sites, and resolver null/error. That body does not disclose whether a slug exists.
- Drop admission-failure logs that named the slug.

## Tests
- Focused admission and route tests assert DB/create/notify/resolver call boundaries and keep rate-limit first.
- Proxy, domain-routing, and analytics-policy regressions stay green.

## Non-goals
No CAPTCHA, analytics behavior, DNS, deploy, or release changes.