### PR TITLE
fix(claim): resolve offer copy from vertical config

### DIFF
--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -28,6 +28,7 @@ import { limitClaimCheckout } from "@/lib/rate-limit";
 import { isSameOriginMutation } from "@/lib/request-origin";
 import { getStripe } from "@/lib/stripe";
 import { secureCookieRequired } from "@/lib/first-customer-test-mode";
+import { resolveClaimLaunchOfferForVertical } from "@/lib/claim-launch-offer";
 import { isVerticalClaimEnabled } from "@/lib/verticals/registry";
 
 const requestSchema = z.object({
@@ -83,6 +84,13 @@ export async function POST(request: Request) {
         409,
         "This site already has an owner or is not available to claim.",
         invitation.id,
+      );
+    }
+    const offer = resolveClaimLaunchOfferForVertical(invitation.vertical);
+    if (!offer || offer.planId !== plan) {
+      return Response.json(
+        { error: "Claim checkout is temporarily unavailable." },
+        { status: 503 },
       );
     }
     const stripe = getStripe();

--- a/src/app/claim/[slug]/claim-panel.tsx
+++ b/src/app/claim/[slug]/claim-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, type FormEvent } from "react";
 import Link from "next/link";
 import {
   ArrowRight,
@@ -12,31 +12,17 @@ import {
 import { SiteRenderer } from "@/components/site-renderer";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Field } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
-import type { SiteDraftView } from "@/lib/site-draft";
-import { restaurantMarketing } from "@/lib/verticals/restaurant/marketing";
-import type { VerticalId } from "@/lib/verticals/types";
-
-/**
- * Launch sells one founding plan through the single configured STRIPE_PRICE_ID.
- */
-const CLAIM_CHECKOUT_PLAN_ID = "founding" as const;
-const foundingPlan = restaurantMarketing.pricing.plans[0];
+import type { ClaimPanelProps } from "@/lib/claim-launch-offer";
 
 export function ClaimPanel({
   slug,
   vertical,
   fallbackDraft,
   checkoutReturn,
-}: {
-  slug: string;
-  vertical: VerticalId;
-  fallbackDraft: SiteDraftView;
-  checkoutReturn: {
-    sessionId: string;
-    claimInvitationId: string;
-  } | null;
-}) {
+  offer,
+}: ClaimPanelProps) {
   const draft = fallbackDraft;
   const [email, setEmail] = useState("");
   const [loading, setLoading] = useState(Boolean(checkoutReturn));
@@ -160,7 +146,7 @@ export function ClaimPanel({
   }
 
   async function checkout() {
-    if (!invitationToken) return;
+    if (!invitationToken || !offer) return;
     setLoading(true);
     setError(null);
     try {
@@ -168,7 +154,7 @@ export function ClaimPanel({
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          plan: CLAIM_CHECKOUT_PLAN_ID,
+          plan: offer.planId,
           siteSlug: slug,
           invitationToken,
         }),
@@ -188,6 +174,14 @@ export function ClaimPanel({
       setLoading(false);
     }
   }
+
+  function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!offer || loading || (!invitationToken && !email)) return;
+    void (invitationToken ? checkout() : requestInvitation());
+  }
+
+  const errorSummaryId = "claim-error-summary";
 
   return (
     <div className="grid lg:grid-cols-[1fr_0.9fr]">
@@ -244,111 +238,146 @@ export function ClaimPanel({
             </p>
           ) : null}
 
-          <div className="mt-8">
-            <div className="rounded-2xl border border-primary bg-primary/5 p-5 ring-2 ring-primary/12">
-              <div className="flex items-start justify-between gap-5">
-                <div>
-                  <div className="flex items-center gap-2">
-                    <span className="font-semibold">{foundingPlan.name}</span>
-                    {foundingPlan.badge ? (
-                      <Badge className="text-[10px]">{foundingPlan.badge}</Badge>
-                    ) : null}
+          {offer ? (
+            <div className="mt-8">
+              <div className="rounded-2xl border border-primary bg-primary/5 p-5 ring-2 ring-primary/12">
+                <div className="flex items-start justify-between gap-5">
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <span className="font-semibold">{offer.name}</span>
+                      {offer.badge ? (
+                        <Badge className="text-[10px]">{offer.badge}</Badge>
+                      ) : null}
+                    </div>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {offer.copy}
+                    </p>
                   </div>
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    {foundingPlan.copy}
+                  <span className="font-display text-4xl">
+                    {offer.price}
+                    <small className="font-sans text-xs text-muted-foreground">
+                      {offer.cadence}
+                    </small>
+                  </span>
+                </div>
+                <div className="mt-4 grid gap-2 sm:grid-cols-2">
+                  {offer.features.map((feature) => (
+                    <span
+                      key={feature}
+                      className="flex items-center gap-1.5 text-xs"
+                    >
+                      <Check className="size-3 text-primary" /> {feature}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </div>
+          ) : checkoutReturn ? null : (
+            <div
+              className="mt-8 rounded-2xl border border-destructive/30 bg-destructive/5 p-5"
+              role="status"
+            >
+              <p className="text-sm font-medium">
+                Claiming is unavailable for {draft.name}.
+              </p>
+              <p className="mt-2 text-xs leading-5 text-muted-foreground">
+                The launch offer for this site is not configured, so checkout
+                cannot start. Ask the operator who sent this preview to try
+                again once the offer is available.
+              </p>
+            </div>
+          )}
+
+          {offer ? (
+            <form onSubmit={submit} className="mt-7">
+              {invitationToken ? (
+                <div className="rounded-xl border border-primary/30 bg-primary/5 p-4">
+                  <p className="text-sm font-medium">Ownership link ready</p>
+                  <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                    Checkout will verify that this one-time link belongs to this
+                    site and the email approved for it.
                   </p>
                 </div>
-                <span className="font-display text-4xl">
-                  {foundingPlan.price}
-                  <small className="font-sans text-xs text-muted-foreground">
-                    {foundingPlan.cadence}
-                  </small>
-                </span>
-              </div>
-              <div className="mt-4 grid gap-2 sm:grid-cols-2">
-                {foundingPlan.features.map((feature) => (
-                  <span
-                    key={feature}
-                    className="flex items-center gap-1.5 text-xs"
-                  >
-                    <Check className="size-3 text-primary" /> {feature}
-                  </span>
-                ))}
-              </div>
-            </div>
-          </div>
-
-          {invitationToken ? (
-            <div className="mt-7 rounded-xl border border-primary/30 bg-primary/5 p-4">
-              <p className="text-sm font-medium">Ownership link ready</p>
-              <p className="mt-1 text-xs leading-5 text-muted-foreground">
-                Checkout will verify that this one-time link belongs to this
-                site and the email approved for it.
+              ) : (
+                <Field
+                  label="Business owner email"
+                  controlId="claim-email"
+                  description="Use the email shown on the source website or an address on that exact domain. Concierge-approved owners can use the address the operator approved."
+                >
+                  <Input
+                    type="email"
+                    name="email"
+                    autoComplete="email"
+                    required
+                    value={email}
+                    onChange={(event) => {
+                      setEmail(event.target.value);
+                      setInvitationSent(false);
+                    }}
+                    placeholder={offer.emailPlaceholder}
+                    className="h-11"
+                    aria-invalid={error && !invitationToken ? true : undefined}
+                    aria-describedby={
+                      error ? errorSummaryId : undefined
+                    }
+                  />
+                </Field>
+              )}
+              {invitationSent ? (
+                <p
+                  className="mt-3 rounded-lg bg-primary/8 px-3 py-2 text-xs text-primary"
+                  role="status"
+                >
+                  Check that inbox for the 48-hour one-time ownership link.
+                </p>
+              ) : null}
+              {error ? (
+                <p
+                  id={errorSummaryId}
+                  className="mt-3 rounded-lg bg-destructive/8 px-3 py-2 text-xs text-destructive"
+                  role="alert"
+                >
+                  {error}
+                </p>
+              ) : null}
+              <Button
+                type="submit"
+                size="lg"
+                className="mt-4 h-12 w-full"
+                disabled={(!invitationToken && !email) || loading}
+              >
+                {loading ? (
+                  <>
+                    <LoaderCircle className="animate-spin" />
+                    {invitationToken
+                      ? "Opening secure checkout"
+                      : "Sending ownership link"}
+                  </>
+                ) : invitationToken ? (
+                  <>
+                    Claim and continue <ArrowRight />
+                  </>
+                ) : (
+                  <>
+                    Verify ownership by email <ArrowRight />
+                  </>
+                )}
+              </Button>
+              <p className="mt-3 text-center text-[11px] leading-5 text-muted-foreground">
+                {invitationToken
+                  ? "Secure subscription checkout by Stripe. The invitation is accepted only after checkout completes."
+                  : "No checkout or owner account can start until the approved email opens its one-time link."}
               </p>
-            </div>
-          ) : (
-            <>
-              <label className="mt-7 block text-xs font-medium" htmlFor="email">
-                Business owner email
-              </label>
-              <Input
-                id="email"
-                type="email"
-                value={email}
-                onChange={(event) => {
-                  setEmail(event.target.value);
-                  setInvitationSent(false);
-                }}
-                placeholder="owner@restaurant.com"
-                className="mt-2 h-11"
-              />
-              <p className="mt-2 text-[11px] leading-5 text-muted-foreground">
-                Use the email shown on the source website or an address on that
-                exact domain. Concierge-approved owners can use the address the
-                operator approved.
-              </p>
-            </>
-          )}
-          {invitationSent ? (
-            <p className="mt-3 rounded-lg bg-primary/8 px-3 py-2 text-xs text-primary">
-              Check that inbox for the 48-hour one-time ownership link.
-            </p>
-          ) : null}
-          {error ? (
-            <p className="mt-3 rounded-lg bg-destructive/8 px-3 py-2 text-xs text-destructive">
+            </form>
+          ) : error ? (
+            <p
+              id={errorSummaryId}
+              className="mt-3 rounded-lg bg-destructive/8 px-3 py-2 text-xs text-destructive"
+              role="alert"
+            >
               {error}
             </p>
           ) : null}
-          <Button
-            size="lg"
-            className="mt-4 h-12 w-full"
-            disabled={(!invitationToken && !email) || loading}
-            onClick={() =>
-              void (invitationToken ? checkout() : requestInvitation())
-            }
-          >
-            {loading ? (
-              <>
-                <LoaderCircle className="animate-spin" />
-                {invitationToken
-                  ? "Opening secure checkout"
-                  : "Sending ownership link"}
-              </>
-            ) : invitationToken ? (
-              <>
-                Claim and continue <ArrowRight />
-              </>
-            ) : (
-              <>
-                Verify ownership by email <ArrowRight />
-              </>
-            )}
-          </Button>
-          <p className="mt-3 text-center text-[11px] leading-5 text-muted-foreground">
-            {invitationToken
-              ? "Secure subscription checkout by Stripe. The invitation is accepted only after checkout completes."
-              : "No checkout or owner account can start until the approved email opens its one-time link."}
-          </p>
         </div>
       </aside>
     </div>

--- a/src/app/claim/[slug]/page.tsx
+++ b/src/app/claim/[slug]/page.tsx
@@ -5,11 +5,8 @@ import { ArrowLeft } from "lucide-react";
 import { Brand } from "@/components/brand";
 import { ClaimPanel } from "@/app/claim/[slug]/claim-panel";
 import { Button } from "@/components/ui/button";
+import { claimPageState } from "@/lib/claim-launch-offer";
 import { findSiteView } from "@/lib/sites";
-import {
-  isVerticalClaimEnabled,
-  resolveVerticalConfig,
-} from "@/lib/verticals/registry";
 
 type ClaimPageProps = {
   params: Promise<{ slug: string }>;
@@ -26,11 +23,10 @@ export async function generateMetadata({
   params,
 }: ClaimPageProps): Promise<Metadata> {
   const { slug } = await params;
-  const site = await findSiteView(slug);
-  if (!site || !isVerticalClaimEnabled(site.vertical)) notFound();
-  const brand = resolveVerticalConfig(site.vertical).marketing.brand;
+  const state = claimPageState(await findSiteView(slug));
+  if (state.kind === "not_found") notFound();
   return {
-    title: { absolute: `Claim your ${brand.name} site` },
+    title: { absolute: `Claim your ${state.brand.name} site` },
     robots: { index: false, follow: false },
   };
 }
@@ -41,12 +37,8 @@ export default async function ClaimPage({
 }: ClaimPageProps) {
   const { slug } = await params;
   const query = await searchParams;
-  const site = await findSiteView(slug);
-  if (!site || !isVerticalClaimEnabled(site.vertical)) notFound();
-
-  // The site itself knows which niche produced it, which is a stronger signal
-  // than the Host header: an owner can reach their claim link from anywhere.
-  const brand = resolveVerticalConfig(site.vertical).marketing.brand;
+  const state = claimPageState(await findSiteView(slug));
+  if (state.kind === "not_found") notFound();
 
   return (
     <main className="min-h-screen">
@@ -54,12 +46,13 @@ export default async function ClaimPage({
         <Button render={<Link href="/create" />} variant="ghost" size="icon-sm">
           <ArrowLeft />
         </Button>
-        <Brand {...brand} />
+        <Brand {...state.brand} />
       </header>
       <ClaimPanel
         slug={slug}
-        vertical={site.vertical}
-        fallbackDraft={site.draft}
+        vertical={state.vertical}
+        fallbackDraft={state.draft}
+        offer={state.offer}
         checkoutReturn={
           query.checkout === "processing" && query.session_id && query.claim_id
             ? {

--- a/src/lib/claim-launch-offer.test.ts
+++ b/src/lib/claim-launch-offer.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "bun:test";
+import { Vertical } from "@/generated/prisma/enums";
+import { FOUNDING_PLAN_ID, FOUNDING_PRICE } from "@/lib/billing-plans";
+import {
+  CLAIM_CHECKOUT_PLAN_ID,
+  claimPageState,
+  foundingOfferDisplay,
+  resolveClaimLaunchOffer,
+  resolveClaimLaunchOfferForVertical,
+} from "@/lib/claim-launch-offer";
+import { sampleSiteDraft } from "@/lib/restaurant";
+import { sampleFoodRetailDraft } from "@/lib/verticals/food-retail/fixtures";
+import { foodRetailMarketing } from "@/lib/verticals/food-retail/marketing";
+import { sampleLocalServiceSiteDraft } from "@/lib/verticals/local-service/fixtures";
+import { localServiceMarketing } from "@/lib/verticals/local-service/marketing";
+import { restaurantMarketing } from "@/lib/verticals/restaurant/marketing";
+import type { VerticalMarketing } from "@/lib/verticals/types";
+
+const claimPanel = await Bun.file(
+  new URL("../app/claim/[slug]/claim-panel.tsx", import.meta.url),
+).text();
+const claimPage = await Bun.file(
+  new URL("../app/claim/[slug]/page.tsx", import.meta.url),
+).text();
+const checkoutRoute = await Bun.file(
+  new URL("../app/api/checkout/route.ts", import.meta.url),
+).text();
+
+describe("claim launch offer mapping", () => {
+  it("prints the founding Stripe contract as the shared display price", () => {
+    expect(CLAIM_CHECKOUT_PLAN_ID).toBe(FOUNDING_PLAN_ID);
+    expect(FOUNDING_PRICE).toMatchObject({
+      currency: "usd",
+      unitAmount: 4_900,
+      interval: "month",
+      intervalCount: 1,
+    });
+    expect(foundingOfferDisplay()).toEqual({
+      price: "$49",
+      cadence: "/month",
+      currency: "usd",
+    });
+    expect(
+      foundingOfferDisplay({ ...FOUNDING_PRICE, unitAmount: 2_550 }),
+    ).toBeNull();
+  });
+
+  it("resolves restaurant, food-retail, and local-service from their own marketing", () => {
+    const display = foundingOfferDisplay();
+    expect(display).not.toBeNull();
+
+    const restaurant = resolveClaimLaunchOffer(restaurantMarketing);
+    const foodRetail = resolveClaimLaunchOffer(foodRetailMarketing);
+    const localService = resolveClaimLaunchOffer(localServiceMarketing);
+
+    expect(restaurant).toMatchObject({
+      planId: CLAIM_CHECKOUT_PLAN_ID,
+      name: "Founding",
+      price: display!.price,
+      cadence: display!.cadence,
+      currency: display!.currency,
+      emailPlaceholder: "owner@restaurant.com",
+      copy: restaurantMarketing.pricing.plans[0].copy,
+      features: restaurantMarketing.pricing.plans[0].features,
+    });
+    expect(foodRetail).toMatchObject({
+      planId: CLAIM_CHECKOUT_PLAN_ID,
+      name: "Founding",
+      price: display!.price,
+      cadence: display!.cadence,
+      emailPlaceholder: "owner@shop.com",
+      copy: foodRetailMarketing.pricing.plans[0].copy,
+      features: foodRetailMarketing.pricing.plans[0].features,
+    });
+    expect(localService).toMatchObject({
+      planId: CLAIM_CHECKOUT_PLAN_ID,
+      name: "Founding",
+      price: display!.price,
+      cadence: display!.cadence,
+      emailPlaceholder: "owner@business.com",
+      copy: localServiceMarketing.pricing.plans[0].copy,
+      features: localServiceMarketing.pricing.plans[0].features,
+    });
+
+    expect(foodRetail?.copy).not.toBe(restaurant?.copy);
+    expect(localService?.copy).not.toBe(restaurant?.copy);
+    expect(foodRetail?.features).not.toEqual(restaurant?.features);
+    expect(localService?.features).not.toEqual(restaurant?.features);
+    expect(resolveClaimLaunchOfferForVertical(Vertical.RESTAURANT)).toEqual(
+      restaurant,
+    );
+    expect(resolveClaimLaunchOfferForVertical(Vertical.FOOD_RETAIL)).toEqual(
+      foodRetail,
+    );
+    expect(resolveClaimLaunchOfferForVertical(Vertical.LOCAL_SERVICE)).toEqual(
+      localService,
+    );
+  });
+
+  it("fails closed instead of borrowing another vertical's plan", () => {
+    expect(resolveClaimLaunchOffer(wrongPriceMarketing())).toBeNull();
+    expect(resolveClaimLaunchOffer(unnamedPlanMarketing())).toBeNull();
+    expect(resolveClaimLaunchOffer(blankEmailMarketing())).toBeNull();
+    expect(
+      resolveClaimLaunchOffer(wrongPriceMarketing(restaurantMarketing)),
+    ).toBeNull();
+  });
+
+  it("keeps the claim UI and checkout on the same mapping", async () => {
+    expect(claimPanel).not.toContain("restaurantMarketing");
+    expect(claimPanel).not.toContain("owner@restaurant.com");
+    expect(claimPanel).toContain("plan: offer.planId");
+    expect(claimPanel).toContain("offer.emailPlaceholder");
+    expect(claimPanel).toContain('role="alert"');
+    expect(claimPanel).toContain('id={errorSummaryId}');
+    expect(claimPanel).toContain("<form onSubmit={submit}");
+    expect(claimPanel).toContain('type="submit"');
+    expect(claimPage).toContain("claimPageState");
+    expect(claimPage).toContain("offer={state.offer}");
+    expect(checkoutRoute).toContain("resolveClaimLaunchOfferForVertical");
+    expect(checkoutRoute).toContain("offer.planId !== plan");
+    expect(checkoutRoute).toContain("isVerticalClaimEnabled(invitation.vertical)");
+  });
+});
+
+describe("claim page route state", () => {
+  it("brands restaurant, food-retail, and local-service from their verticals", () => {
+    const restaurant = claimPageState({
+      vertical: Vertical.RESTAURANT,
+      draft: sampleSiteDraft,
+    });
+    const foodRetail = claimPageState({
+      vertical: Vertical.FOOD_RETAIL,
+      draft: sampleFoodRetailDraft,
+    });
+    const localService = claimPageState({
+      vertical: Vertical.LOCAL_SERVICE,
+      draft: sampleLocalServiceSiteDraft,
+    });
+
+    expect(restaurant).toMatchObject({
+      kind: "ready",
+      brand: { name: "Restofrontapp" },
+      offer: resolveClaimLaunchOffer(restaurantMarketing),
+      vertical: Vertical.RESTAURANT,
+    });
+    expect(foodRetail).toMatchObject({
+      kind: "ready",
+      brand: { name: "Shopfront Food" },
+      offer: resolveClaimLaunchOffer(foodRetailMarketing),
+      vertical: Vertical.FOOD_RETAIL,
+    });
+    expect(localService).toMatchObject({
+      kind: "ready",
+      brand: { name: "Tradefront" },
+      offer: resolveClaimLaunchOffer(localServiceMarketing),
+      vertical: Vertical.LOCAL_SERVICE,
+    });
+    expect(foodRetail.kind === "ready" && foodRetail.offer?.emailPlaceholder).toBe(
+      "owner@shop.com",
+    );
+    expect(
+      localService.kind === "ready" && localService.offer?.emailPlaceholder,
+    ).toBe("owner@business.com");
+  });
+
+  it("404s disabled verticals and missing sites without borrowing a plan", () => {
+    expect(claimPageState(null)).toEqual({ kind: "not_found" });
+    expect(
+      claimPageState({
+        vertical: Vertical.BEAUTY,
+        draft: sampleSiteDraft,
+      }),
+    ).toEqual({ kind: "not_found" });
+  });
+});
+
+function wrongPriceMarketing(
+  base: VerticalMarketing = foodRetailMarketing,
+): VerticalMarketing {
+  const [plan] = base.pricing.plans;
+  return {
+    ...base,
+    pricing: {
+      ...base.pricing,
+      plans: [{ ...plan, price: "$25" }],
+    },
+  };
+}
+
+function unnamedPlanMarketing(): VerticalMarketing {
+  const [plan] = localServiceMarketing.pricing.plans;
+  return {
+    ...localServiceMarketing,
+    pricing: {
+      ...localServiceMarketing.pricing,
+      plans: [{ ...plan, name: "Starter" }],
+    },
+  };
+}
+
+function blankEmailMarketing(): VerticalMarketing {
+  return {
+    ...foodRetailMarketing,
+    signIn: {
+      ...foodRetailMarketing.signIn,
+      emailPlaceholder: "   ",
+    },
+  };
+}

--- a/src/lib/claim-launch-offer.test.ts
+++ b/src/lib/claim-launch-offer.test.ts
@@ -172,25 +172,36 @@ describe("claim page route state", () => {
   });
 });
 
+function requirePricing(
+  marketing: VerticalMarketing,
+): NonNullable<VerticalMarketing["pricing"]> {
+  if (!marketing.pricing) {
+    throw new Error("fixture marketing must declare a founding offer");
+  }
+  return marketing.pricing;
+}
+
 function wrongPriceMarketing(
   base: VerticalMarketing = foodRetailMarketing,
 ): VerticalMarketing {
-  const [plan] = base.pricing.plans;
+  const pricing = requirePricing(base);
+  const [plan] = pricing.plans;
   return {
     ...base,
     pricing: {
-      ...base.pricing,
+      ...pricing,
       plans: [{ ...plan, price: "$25" }],
     },
   };
 }
 
 function unnamedPlanMarketing(): VerticalMarketing {
-  const [plan] = localServiceMarketing.pricing.plans;
+  const pricing = requirePricing(localServiceMarketing);
+  const [plan] = pricing.plans;
   return {
     ...localServiceMarketing,
     pricing: {
-      ...localServiceMarketing.pricing,
+      ...pricing,
       plans: [{ ...plan, name: "Starter" }],
     },
   };

--- a/src/lib/claim-launch-offer.test.ts
+++ b/src/lib/claim-launch-offer.test.ts
@@ -40,9 +40,6 @@ describe("claim launch offer mapping", () => {
       cadence: "/month",
       currency: "usd",
     });
-    expect(
-      foundingOfferDisplay({ ...FOUNDING_PRICE, unitAmount: 2_550 }),
-    ).toBeNull();
   });
 
   it("resolves restaurant, food-retail, and local-service from their own marketing", () => {

--- a/src/lib/claim-launch-offer.ts
+++ b/src/lib/claim-launch-offer.ts
@@ -86,10 +86,11 @@ export function resolveClaimLaunchOffer(
   marketing: VerticalMarketing,
 ): ClaimLaunchOffer | null {
   const display = foundingOfferDisplay();
+  const pricing = marketing.pricing;
   const emailPlaceholder = marketing.signIn.emailPlaceholder.trim();
-  if (!display || emailPlaceholder.length === 0) return null;
+  if (!display || !pricing || emailPlaceholder.length === 0) return null;
 
-  const matches = marketing.pricing.plans.filter((plan) =>
+  const matches = pricing.plans.filter((plan) =>
     isValidFoundingPlan(plan, display),
   );
   const plan = matches.length === 1 ? matches[0] : undefined;

--- a/src/lib/claim-launch-offer.ts
+++ b/src/lib/claim-launch-offer.ts
@@ -1,0 +1,143 @@
+import {
+  FOUNDING_PLAN_ID,
+  FOUNDING_PRICE,
+  type BillingPlanId,
+} from "@/lib/billing-plans";
+import type { BrandIdentity } from "@/lib/brand";
+import type { SiteDraftView } from "@/lib/site-draft";
+import {
+  isVerticalClaimEnabled,
+  resolveVerticalConfig,
+} from "@/lib/verticals/registry";
+import type {
+  MarketingPlan,
+  VerticalId,
+  VerticalMarketing,
+} from "@/lib/verticals/types";
+
+/**
+ * Checkout's plan literal and the claim UI's displayed founding offer must
+ * resolve from this mapping. A vertical may print its own copy and features,
+ * but never a different price, cadence, or plan id than the Stripe contract.
+ */
+export const CLAIM_CHECKOUT_PLAN_ID = FOUNDING_PLAN_ID;
+
+export type FoundingOfferDisplay = {
+  price: string;
+  cadence: string;
+  currency: typeof FOUNDING_PRICE.currency;
+};
+
+export type ClaimLaunchOffer = {
+  planId: BillingPlanId;
+  name: string;
+  price: string;
+  cadence: string;
+  currency: typeof FOUNDING_PRICE.currency;
+  copy: string;
+  features: string[];
+  badge: string | null;
+  emailPlaceholder: string;
+};
+
+export type ClaimCheckoutReturn = {
+  sessionId: string;
+  claimInvitationId: string;
+};
+
+export type ClaimPanelProps = {
+  slug: string;
+  vertical: VerticalId;
+  fallbackDraft: SiteDraftView;
+  checkoutReturn: ClaimCheckoutReturn | null;
+  offer: ClaimLaunchOffer | null;
+};
+
+export type ClaimPageSite = {
+  vertical: VerticalId;
+  draft: SiteDraftView;
+};
+
+export type ClaimPageState =
+  | { kind: "not_found" }
+  | {
+      kind: "ready";
+      brand: BrandIdentity;
+      offer: ClaimLaunchOffer | null;
+      vertical: VerticalId;
+      draft: SiteDraftView;
+    };
+
+export function foundingOfferDisplay(
+  price: typeof FOUNDING_PRICE = FOUNDING_PRICE,
+): FoundingOfferDisplay | null {
+  if (price.currency !== "usd") return null;
+  if (price.intervalCount !== 1) return null;
+  const majorUnits = price.unitAmount / 100;
+  if (!Number.isInteger(majorUnits) || majorUnits <= 0) return null;
+  return {
+    price: `$${majorUnits}`,
+    cadence: `/${price.interval}`,
+    currency: price.currency,
+  };
+}
+
+export function resolveClaimLaunchOffer(
+  marketing: VerticalMarketing,
+): ClaimLaunchOffer | null {
+  const display = foundingOfferDisplay();
+  const emailPlaceholder = marketing.signIn.emailPlaceholder.trim();
+  if (!display || emailPlaceholder.length === 0) return null;
+
+  const matches = marketing.pricing.plans.filter((plan) =>
+    isValidFoundingPlan(plan, display),
+  );
+  const plan = matches.length === 1 ? matches[0] : undefined;
+  if (!plan) return null;
+
+  return {
+    planId: CLAIM_CHECKOUT_PLAN_ID,
+    name: plan.name,
+    price: plan.price,
+    cadence: plan.cadence,
+    currency: display.currency,
+    copy: plan.copy,
+    features: [...plan.features],
+    badge: plan.badge ?? null,
+    emailPlaceholder,
+  };
+}
+
+export function resolveClaimLaunchOfferForVertical(
+  id: VerticalId,
+): ClaimLaunchOffer | null {
+  return resolveClaimLaunchOffer(resolveVerticalConfig(id).marketing);
+}
+
+export function claimPageState(site: ClaimPageSite | null): ClaimPageState {
+  if (!site || !isVerticalClaimEnabled(site.vertical)) {
+    return { kind: "not_found" };
+  }
+  const config = resolveVerticalConfig(site.vertical);
+  return {
+    kind: "ready",
+    brand: config.marketing.brand,
+    offer: resolveClaimLaunchOffer(config.marketing),
+    vertical: site.vertical,
+    draft: site.draft,
+  };
+}
+
+function isValidFoundingPlan(
+  plan: MarketingPlan,
+  display: FoundingOfferDisplay,
+): boolean {
+  return (
+    plan.name.trim().toLowerCase() === CLAIM_CHECKOUT_PLAN_ID &&
+    plan.featured === true &&
+    plan.price === display.price &&
+    plan.cadence === display.cadence &&
+    plan.copy.trim().length > 0 &&
+    plan.features.length > 0
+  );
+}

--- a/src/lib/claim-page.test.tsx
+++ b/src/lib/claim-page.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ClaimPanel } from "@/app/claim/[slug]/claim-panel";
+import { Vertical } from "@/generated/prisma/enums";
+import { claimPageState } from "@/lib/claim-launch-offer";
+import { sampleSiteDraft } from "@/lib/restaurant";
+import type { SiteDraftView } from "@/lib/site-draft";
+import { sampleFoodRetailDraft } from "@/lib/verticals/food-retail/fixtures";
+import { sampleLocalServiceSiteDraft } from "@/lib/verticals/local-service/fixtures";
+import type { VerticalId } from "@/lib/verticals/types";
+
+describe("claim page route surface", () => {
+  it("renders restaurant brand and founding identity", () => {
+    const { brand, html } = renderClaimRoute(
+      Vertical.RESTAURANT,
+      sampleSiteDraft,
+    );
+    expect(brand).toBe("Restofrontapp");
+    expect(html).toContain("Claim Osteria Luna");
+    expect(html).toContain('placeholder="owner@restaurant.com"');
+    expect(html).toContain("Mobile-first website and menu");
+  });
+
+  it("renders food-retail brand and founding identity", () => {
+    const { brand, html } = renderClaimRoute(
+      Vertical.FOOD_RETAIL,
+      sampleFoodRetailDraft,
+    );
+    expect(brand).toBe("Shopfront Food");
+    expect(html).toContain("Claim Maison Levain");
+    expect(html).toContain('placeholder="owner@shop.com"');
+    expect(html).toContain("Mobile-first product ranges");
+    expect(html).not.toContain("owner@restaurant.com");
+    expect(html).not.toContain("Restofrontapp");
+  });
+
+  it("renders local-service brand and founding identity", () => {
+    const { brand, html } = renderClaimRoute(
+      Vertical.LOCAL_SERVICE,
+      sampleLocalServiceSiteDraft,
+    );
+    expect(brand).toBe("Tradefront");
+    expect(html).toContain("Claim Harbour Electrical");
+    expect(html).toContain('placeholder="owner@business.com"');
+    expect(html).toContain("Phone, WhatsApp and quote actions");
+    expect(html).not.toContain("owner@restaurant.com");
+    expect(html).not.toContain("Restofrontapp");
+  });
+
+  it("keeps beauty and missing sites behind the claim gate", () => {
+    expect(
+      claimPageState({
+        vertical: Vertical.BEAUTY,
+        draft: sampleSiteDraft,
+      }).kind,
+    ).toBe("not_found");
+    expect(claimPageState(null).kind).toBe("not_found");
+  });
+});
+
+function renderClaimRoute(vertical: VerticalId, draft: SiteDraftView) {
+  const state = claimPageState({ vertical, draft });
+  expect(state.kind).toBe("ready");
+  if (state.kind !== "ready") throw new Error("expected a claimable site");
+  return {
+    brand: state.brand.name,
+    html: renderToStaticMarkup(
+      <ClaimPanel
+        slug={draft.slug}
+        vertical={state.vertical}
+        fallbackDraft={state.draft}
+        offer={state.offer}
+        checkoutReturn={null}
+      />,
+    ),
+  };
+}

--- a/src/lib/claim-panel.test.tsx
+++ b/src/lib/claim-panel.test.tsx
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ClaimPanel } from "@/app/claim/[slug]/claim-panel";
+import { Vertical } from "@/generated/prisma/enums";
+import {
+  resolveClaimLaunchOffer,
+  type ClaimLaunchOffer,
+} from "@/lib/claim-launch-offer";
+import type { VerticalId } from "@/lib/verticals/types";
+import { sampleSiteDraft } from "@/lib/restaurant";
+import type { SiteDraftView } from "@/lib/site-draft";
+import { sampleFoodRetailDraft } from "@/lib/verticals/food-retail/fixtures";
+import { foodRetailMarketing } from "@/lib/verticals/food-retail/marketing";
+import { sampleLocalServiceSiteDraft } from "@/lib/verticals/local-service/fixtures";
+import { localServiceMarketing } from "@/lib/verticals/local-service/marketing";
+import { restaurantMarketing } from "@/lib/verticals/restaurant/marketing";
+
+describe("claim panel offer identity", () => {
+  it("renders the restaurant founding offer and email example", () => {
+    const html = renderPanel({
+      vertical: Vertical.RESTAURANT,
+      draft: sampleSiteDraft,
+      offer: requireOffer(restaurantMarketing),
+    });
+
+    expect(html).toContain("Claim Osteria Luna");
+    expect(html).toContain("Founding");
+    expect(html).toContain("$49");
+    expect(html).toContain("/month");
+    expect(html).toContain("mobile-first restaurant website");
+    expect(html).toContain('placeholder="owner@restaurant.com"');
+    expect(html).toContain("Mobile-first website and menu");
+    expect(html).not.toContain("owner@shop.com");
+    expectAccessibleClaimForm(html);
+  });
+
+  it("renders the food-retail founding offer instead of restaurant copy", () => {
+    const html = renderPanel({
+      vertical: Vertical.FOOD_RETAIL,
+      draft: sampleFoodRetailDraft,
+      offer: requireOffer(foodRetailMarketing),
+    });
+
+    expect(html).toContain("Claim Maison Levain");
+    expect(html).toContain("mobile-first food-retail website");
+    expect(html).toContain("Mobile-first product ranges");
+    expect(html).toContain('placeholder="owner@shop.com"');
+    expect(html).not.toContain("owner@restaurant.com");
+    expect(html).not.toContain("restaurant website");
+    expect(html).not.toContain("Existing booking and ordering links");
+    expectAccessibleClaimForm(html);
+  });
+
+  it("renders the local-service founding offer instead of restaurant copy", () => {
+    const html = renderPanel({
+      vertical: Vertical.LOCAL_SERVICE,
+      draft: sampleLocalServiceSiteDraft,
+      offer: requireOffer(localServiceMarketing),
+    });
+
+    expect(html).toContain("Claim Harbour Electrical");
+    expect(html).toContain("complete local-service website");
+    expect(html).toContain("Phone, WhatsApp and quote actions");
+    expect(html).toContain('placeholder="owner@business.com"');
+    expect(html).not.toContain("owner@restaurant.com");
+    expect(html).not.toContain("restaurant website");
+    expectAccessibleClaimForm(html);
+  });
+
+  it("fails closed with an actionable unavailable state when no launch offer exists", () => {
+    const html = renderPanel({
+      vertical: Vertical.FOOD_RETAIL,
+      draft: sampleFoodRetailDraft,
+      offer: null,
+    });
+
+    expect(html).toContain("Claiming is unavailable for Maison Levain.");
+    expect(html).toContain("role=\"status\"");
+    expect(html).toContain("launch offer for this site is not configured");
+    expect(html).not.toContain("Founding");
+    expect(html).not.toContain("$49");
+    expect(html).not.toContain("owner@restaurant.com");
+    expect(html).not.toContain("owner@shop.com");
+    expect(html).not.toContain("Verify ownership by email");
+    expect(html).not.toContain('id="claim-email"');
+    expect(html).not.toContain("<form");
+  });
+
+  it("keeps Stripe return reconciliation when the offer later becomes unavailable", () => {
+    const html = renderPanel({
+      vertical: Vertical.FOOD_RETAIL,
+      draft: sampleFoodRetailDraft,
+      offer: null,
+      checkoutReturn: {
+        sessionId: "cs_test_123",
+        claimInvitationId: "claim_123",
+      },
+    });
+
+    expect(html).toContain("Payment received. Finalizing the owner account");
+    expect(html).not.toContain("Claiming is unavailable");
+    expect(html).not.toContain("Verify ownership by email");
+  });
+});
+
+function renderPanel(input: {
+  vertical: VerticalId;
+  draft: SiteDraftView;
+  offer: ClaimLaunchOffer | null;
+  checkoutReturn?: {
+    sessionId: string;
+    claimInvitationId: string;
+  } | null;
+}) {
+  return renderToStaticMarkup(
+    <ClaimPanel
+      slug={input.draft.slug}
+      vertical={input.vertical}
+      fallbackDraft={input.draft}
+      offer={input.offer}
+      checkoutReturn={input.checkoutReturn ?? null}
+    />,
+  );
+}
+
+function requireOffer(
+  marketing: Parameters<typeof resolveClaimLaunchOffer>[0],
+): ClaimLaunchOffer {
+  const offer = resolveClaimLaunchOffer(marketing);
+  expect(offer).not.toBeNull();
+  return offer!;
+}
+
+function expectAccessibleClaimForm(html: string) {
+  expect(html).toContain("<form");
+  expect(html).toContain('type="submit"');
+  const email = associatedControl(html, "Business owner email", "input");
+  expect(email.id).toBe("claim-email");
+  expect(attribute(email.attributes, "type")).toBe("email");
+  expect(html).toContain(`id="${email.id}-description"`);
+  expect(html).toContain(`for="${email.id}"`);
+}
+
+function associatedControl(
+  html: string,
+  label: string,
+  tag: "input" | "select" | "textarea",
+) {
+  const labelMatch = html.match(
+    new RegExp(
+      `<label\\b[^>]*\\bfor="([^"]+)"[^>]*>${escapeRegex(label)}</label>`,
+    ),
+  );
+  expect(labelMatch, `Expected a visible label named “${label}”`).not.toBeNull();
+  const id = labelMatch![1];
+  const control = html.match(
+    new RegExp(`<${tag}\\b([^>]*\\bid="${escapeRegex(id)}"[^>]*)>`, "i"),
+  );
+  expect(control, `Expected <${tag} id="${id}">`).not.toBeNull();
+  return { id, attributes: control![1] };
+}
+
+function attribute(attributes: string, name: string) {
+  return attributes.match(new RegExp(`\\b${name}="([^"]*)"`))?.[1];
+}
+
+function escapeRegex(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/lib/food-retail-claim-gate.test.ts
+++ b/src/lib/food-retail-claim-gate.test.ts
@@ -32,9 +32,10 @@ describe("food retail factory claim gate", () => {
     expect(importStudio).toContain(
       "{isVerticalClaimEnabled(site.vertical) ? (",
     );
-    expect(claimPage).toContain("isVerticalClaimEnabled(site.vertical)");
+    expect(claimPage).toContain("claimPageState");
     expect(checkoutRoute).toContain(
       "isVerticalClaimEnabled(invitation.vertical)",
     );
+    expect(checkoutRoute).toContain("resolveClaimLaunchOfferForVertical");
   });
 });

--- a/src/lib/verticals/beauty/lifecycle.test.ts
+++ b/src/lib/verticals/beauty/lifecycle.test.ts
@@ -19,6 +19,9 @@ const nichePage = await Bun.file(
 const claimPage = await Bun.file(
   new URL("../../../app/claim/[slug]/page.tsx", import.meta.url),
 ).text();
+const claimLaunchOffer = await Bun.file(
+  new URL("../../claim-launch-offer.ts", import.meta.url),
+).text();
 const checkoutRoute = await Bun.file(
   new URL("../../../app/api/checkout/route.ts", import.meta.url),
 ).text();
@@ -94,7 +97,11 @@ describe("beauty lifecycle contract", () => {
   });
 
   it("keeps claim invitations and checkout fail-closed for beauty", () => {
-    expect(claimPage).toContain("isVerticalClaimEnabled(site.vertical)");
+    expect(claimLaunchOffer).toContain(
+      "if (!site || !isVerticalClaimEnabled(site.vertical))",
+    );
+    expect(claimLaunchOffer).toContain('kind: "not_found"');
+    expect(claimPage).toContain("claimPageState");
     expect(checkoutRoute).toContain(
       "isVerticalClaimEnabled(invitation.vertical)",
     );

--- a/src/lib/verticals/restaurant/marketing.test.ts
+++ b/src/lib/verticals/restaurant/marketing.test.ts
@@ -69,9 +69,13 @@ describe("Restofront founding offer", () => {
   });
 
   it("checks out the founding plan against the single STRIPE_PRICE_ID", async () => {
-    const [panel, checkoutRoute] = await Promise.all([
+    const [panel, mapping, checkoutRoute] = await Promise.all([
       readFile(
         new URL("../../../app/claim/[slug]/claim-panel.tsx", import.meta.url),
+        "utf8",
+      ),
+      readFile(
+        new URL("../../claim-launch-offer.ts", import.meta.url),
         "utf8",
       ),
       readFile(
@@ -79,11 +83,14 @@ describe("Restofront founding offer", () => {
         "utf8",
       ),
     ]);
-    expect(panel).toContain('CLAIM_CHECKOUT_PLAN_ID = "founding"');
-    expect(panel).toContain("restaurantMarketing.pricing.plans[0]");
+    expect(mapping).toContain("CLAIM_CHECKOUT_PLAN_ID = FOUNDING_PLAN_ID");
+    expect(mapping).toContain("foundingOfferDisplay");
+    expect(panel).toContain("plan: offer.planId");
+    expect(panel).not.toContain("restaurantMarketing");
     expect(panel).not.toContain("price: 25");
     expect(panel).not.toContain("price: 50");
     expect(panel).not.toContain("$25");
     expect(checkoutRoute).toContain("adaptive_pricing: { enabled: true }");
+    expect(checkoutRoute).toContain("resolveClaimLaunchOfferForVertical");
   });
 });


### PR DESCRIPTION
## Summary

- resolve claim plan name, copy, display price/currency/cadence, and email examples from the site's `VerticalConfig` against the founding Stripe contract
- stop importing restaurant marketing from the claim panel; checkout uses the same mapping and fails closed at 503 when a claim-enabled vertical has no valid launch offer
- keep invitation, exact-domain email, Stripe return reconciliation, and disabled-vertical (beauty) gates intact
- add restaurant, food-retail, and local-service fixtures plus an unavailable-offer path, with Field/form keyboard, label, and error-summary behavior preserved

## Verification

- focused claim mapping/panel/page tests: 21 passed, 0 failed
- related restaurant marketing and food-retail claim-gate tests: passed
- ESLint: passed
- `bunx tsc --noEmit`: no claim-related errors (pre-existing `RouteContext` names exist outside this change; `next build` TypeScript passed)
- `git diff --check`: clean
- Next.js production build: compiled, TypeScript finished, 54/54 static pages generated

Closes #149