### PR TITLE
ci(deps): submit complete Bun lockfile graph

### DIFF
--- a/.github/workflows/bun-dependency-snapshot.yml
+++ b/.github/workflows/bun-dependency-snapshot.yml
@@ -1,0 +1,106 @@
+name: Bun dependency snapshot
+
+on:
+  pull_request:
+    paths:
+      - "package.json"
+      - "bun.lock"
+      - "src/lib/bun-dependency-snapshot.ts"
+      - "src/lib/bun-dependency-snapshot.test.ts"
+      - "src/lib/bun-dependency-snapshot-contract.test.ts"
+      - "scripts/build-bun-dependency-snapshot.ts"
+      - ".github/workflows/bun-dependency-snapshot.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "package.json"
+      - "bun.lock"
+      - "src/lib/bun-dependency-snapshot.ts"
+      - "src/lib/bun-dependency-snapshot.test.ts"
+      - "src/lib/bun-dependency-snapshot-contract.test.ts"
+      - "scripts/build-bun-dependency-snapshot.ts"
+      - ".github/workflows/bun-dependency-snapshot.yml"
+  schedule:
+    - cron: "47 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Check snapshot parser and permission contract
+        run: bun test src/lib/bun-dependency-snapshot.test.ts src/lib/bun-dependency-snapshot-contract.test.ts
+
+      - name: Build lockfile snapshot
+        run: bun scripts/build-bun-dependency-snapshot.ts --output bun-dependency-snapshot.json
+
+      - name: Upload snapshot evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: bun-dependency-snapshot
+          path: bun-dependency-snapshot.json
+          if-no-files-found: warn
+
+  submit:
+    if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Build lockfile snapshot
+        run: bun scripts/build-bun-dependency-snapshot.ts --output bun-dependency-snapshot.json
+
+      - name: Submit snapshot to GitHub
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          api_url="${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/dependency-graph/snapshots"
+          http_code="$(curl -sS -o snapshot-submit-response.json -w "%{http_code}" \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2026-03-10" \
+            --data-binary @bun-dependency-snapshot.json \
+            "${api_url}")"
+          if [[ "${http_code}" != "201" ]]; then
+            echo "Dependency snapshot submission failed with HTTP ${http_code}" >&2
+            cat snapshot-submit-response.json >&2
+            exit 1
+          fi
+          result="$(bun -e 'const response = await Bun.file("snapshot-submit-response.json").json(); if (response === null) { throw new Error("missing result"); } if (typeof response !== "object") { throw new Error("missing result"); } if (Array.isArray(response)) { throw new Error("missing result"); } const result = response.result; if (typeof result !== "string") { throw new Error("missing result"); } if (result.length === 0) { throw new Error("missing result"); } process.stdout.write(result)')"
+          if [[ "${result}" == "INVALID" ]]; then
+            echo "GitHub rejected the dependency snapshot as INVALID" >&2
+            cat snapshot-submit-response.json >&2
+            exit 1
+          fi
+          echo "Submitted bun.lock snapshot result=${result}"

--- a/docs/operations/github-governance.md
+++ b/docs/operations/github-governance.md
@@ -97,9 +97,54 @@ sent to that registry instead and can be skipped if it has no advisory endpoint.
 This repository's audit is an intentional disclosure of its public
 package/version graph to npm. The workflow supplies no source, secrets, customer
 data, private-registry credentials, registry configuration, or writable token,
-and none may be added to make an audit pass. This workflow does not submit a
-dependency graph to GitHub; complete Bun dependency submission is tracked
-separately in #153.
+and none may be added to make an audit pass. Complete Bun dependency submission
+is owned by `.github/workflows/bun-dependency-snapshot.yml` and is not part of
+this audit job.
+
+### Bun lockfile dependency submission
+
+GitHub's automatic dependency submission has no Bun builder, so the live SBOM
+endpoint otherwise reports only the repository root, direct `package.json`
+entries, and Actions dependencies. `.github/workflows/bun-dependency-snapshot.yml`
+parses the committed text `bun.lock` with `scripts/build-bun-dependency-snapshot.ts`
+and `src/lib/bun-dependency-snapshot.ts`. It does not run `bun install`, resolve
+floating versions, or mutate `package.json` / `bun.lock`.
+
+The workflow default permission is `contents: read`. A `validate` job runs on
+path-filtered pull requests, path-filtered `main` pushes, the daily 04:47 UTC
+schedule, and `workflow_dispatch`. It reconstructs the snapshot, runs the parser
+and permission contract tests, and uploads a `bun-dependency-snapshot` artifact.
+The `submit` job is the only job with `contents: write`. It runs only when
+`github.ref == refs/heads/main` and the event is `push`, `schedule`, or
+`workflow_dispatch`, after `validate` succeeds. Pull requests never receive
+write permission and never POST to the dependency-graph API. The workflow uses
+the default `github.token` only; no repository, package-registry, customer, or
+deployment secrets are in scope.
+
+Idempotency depends on a stable pair that GitHub keeps unique:
+
+- `job.correlator` = `Bun dependency snapshot submit`
+- `detector.name` = `cornershopdev-bun-lockfile`
+
+Do not rename the workflow, the `submit` job, or the detector. Repeating the
+same lockfile replaces the previous snapshot for that pair; a changed lockfile
+replaces it without accumulating stale packages. Failure fails this workflow
+only. It is not a required runtime merge check and must not be folded into
+`ci.yml`.
+
+To inspect evidence, download the `bun-dependency-snapshot` artifact from the
+workflow run and confirm the resolved package count, representative production
+transitives, and representative development transitives. After this workflow
+reaches `main`, reconcile the live SBOM endpoint
+(`/repos/{owner}/{repo}/dependency-graph/sbom`) and record the resulting
+package count before closing #153. Do not call live SBOM mutate APIs from a
+laptop or from an untrusted pull request.
+
+To roll back, disable the "Bun dependency snapshot" workflow in the Actions
+tab or revert the workflow file. The last accepted snapshot remains until
+another trusted run submits a replacement with the same correlator and
+detector. Do not add `pull_request_target`, registry credentials, or
+`contents: write` on the validate/pull-request path.
 
 When the audit fails:
 

--- a/scripts/build-bun-dependency-snapshot.ts
+++ b/scripts/build-bun-dependency-snapshot.ts
@@ -1,0 +1,59 @@
+import { resolve } from "node:path";
+import {
+  assertGithubDependencySnapshot,
+  BUN_DEPENDENCY_SNAPSHOT_CORRELATOR,
+  buildBunDependencySnapshot,
+  snapshotSummary,
+} from "@/lib/bun-dependency-snapshot";
+
+const outputPath = requiredOption("--output");
+const repoRoot = resolve(process.env.GITHUB_WORKSPACE ?? process.cwd());
+const sha = requiredEnv("GITHUB_SHA");
+const ref = requiredEnv("GITHUB_REF");
+const runId = process.env.GITHUB_RUN_ID ?? "local-dry-run";
+const serverUrl = process.env.GITHUB_SERVER_URL;
+const repository = process.env.GITHUB_REPOSITORY;
+
+const [packageJsonSource, lockfileSource] = await Promise.all([
+  Bun.file(resolve(repoRoot, "package.json")).text(),
+  Bun.file(resolve(repoRoot, "bun.lock")).text(),
+]);
+
+const snapshot = buildBunDependencySnapshot({
+  packageJsonSource,
+  lockfileSource,
+  sha,
+  ref,
+  scanned: new Date().toISOString(),
+  job: {
+    id: runId,
+    correlator: BUN_DEPENDENCY_SNAPSHOT_CORRELATOR,
+    htmlUrl:
+      serverUrl && repository
+        ? `${serverUrl}/${repository}/actions/runs/${runId}`
+        : undefined,
+  },
+});
+
+assertGithubDependencySnapshot(snapshot);
+await Bun.write(outputPath, `${JSON.stringify(snapshot, null, 2)}\n`);
+process.stderr.write(`${JSON.stringify(snapshotSummary(snapshot))}\n`);
+
+function requiredOption(flag: string): string {
+  const index = process.argv.indexOf(flag);
+  const value = index >= 0 ? process.argv[index + 1] : undefined;
+  if (!value || value.startsWith("--")) {
+    process.stderr.write(`Missing required ${flag} path.\n`);
+    process.exit(1);
+  }
+  return resolve(value);
+}
+
+function requiredEnv(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    process.stderr.write(`Missing required environment variable ${name}.\n`);
+    process.exit(1);
+  }
+  return value;
+}

--- a/src/lib/bun-dependency-snapshot-contract.test.ts
+++ b/src/lib/bun-dependency-snapshot-contract.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "bun:test";
+import {
+  BUN_DEPENDENCY_SNAPSHOT_CORRELATOR,
+  BUN_DEPENDENCY_SNAPSHOT_DETECTOR_NAME,
+  BUN_DEPENDENCY_SNAPSHOT_SUBMIT_JOB,
+  BUN_DEPENDENCY_SNAPSHOT_VALIDATE_JOB,
+  BUN_DEPENDENCY_SNAPSHOT_WORKFLOW_NAME,
+} from "@/lib/bun-dependency-snapshot";
+
+const repoRoot = new URL("../..", import.meta.url);
+
+async function readRepoFile(relativePath: string): Promise<string> {
+  return Bun.file(new URL(relativePath, repoRoot)).text();
+}
+
+type WorkflowStep = {
+  name?: string;
+  uses?: string;
+  if?: string;
+  shell?: string;
+  run?: string;
+  env?: Record<string, unknown>;
+  with?: Record<string, unknown>;
+};
+
+type SnapshotWorkflow = {
+  name: string;
+  on: {
+    pull_request: { paths: string[] };
+    push: { branches: string[]; paths: string[] };
+    schedule: Array<{ cron: string }>;
+    workflow_dispatch: null;
+  };
+  permissions: Record<string, string>;
+  jobs: {
+    validate: {
+      "runs-on": string;
+      permissions?: Record<string, string>;
+      steps: WorkflowStep[];
+    };
+    submit: {
+      if: string;
+      needs: string;
+      "runs-on": string;
+      permissions: Record<string, string>;
+      steps: WorkflowStep[];
+    };
+  };
+};
+
+const [workflowSource, scriptSource] = await Promise.all([
+  readRepoFile(".github/workflows/bun-dependency-snapshot.yml"),
+  readRepoFile("scripts/build-bun-dependency-snapshot.ts"),
+]);
+const workflow = Bun.YAML.parse(workflowSource) as SnapshotWorkflow;
+
+const snapshotPaths = [
+  "package.json",
+  "bun.lock",
+  "src/lib/bun-dependency-snapshot.ts",
+  "src/lib/bun-dependency-snapshot.test.ts",
+  "src/lib/bun-dependency-snapshot-contract.test.ts",
+  "scripts/build-bun-dependency-snapshot.ts",
+  ".github/workflows/bun-dependency-snapshot.yml",
+];
+
+describe("bun dependency snapshot workflow", () => {
+  it("keeps a stable detector correlator and trusted-only submit job", () => {
+    expect(workflow.name).toBe(BUN_DEPENDENCY_SNAPSHOT_WORKFLOW_NAME);
+    expect(Object.keys(workflow.jobs)).toEqual([
+      BUN_DEPENDENCY_SNAPSHOT_VALIDATE_JOB,
+      BUN_DEPENDENCY_SNAPSHOT_SUBMIT_JOB,
+    ]);
+    expect(
+      `${workflow.name} ${BUN_DEPENDENCY_SNAPSHOT_SUBMIT_JOB}`,
+    ).toBe(BUN_DEPENDENCY_SNAPSHOT_CORRELATOR);
+    expect(BUN_DEPENDENCY_SNAPSHOT_DETECTOR_NAME).toBe(
+      "cornershopdev-bun-lockfile",
+    );
+    expect(workflow.jobs.submit.if).toBe(
+      "${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}",
+    );
+    expect(workflow.jobs.submit.needs).toBe("validate");
+  });
+
+  it("runs with the bounded event and least-privilege contract", () => {
+    expect(workflow.on.pull_request.paths).toEqual(snapshotPaths);
+    expect(workflow.on.push).toEqual({
+      branches: ["main"],
+      paths: snapshotPaths,
+    });
+    expect(workflow.on.schedule).toEqual([{ cron: "47 4 * * *" }]);
+    expect("workflow_dispatch" in workflow.on).toBe(true);
+    expect(workflow.permissions).toEqual({ contents: "read" });
+    expect(workflow.jobs.validate["runs-on"]).toBe("ubuntu-latest");
+    expect(workflow.jobs.validate.permissions).toBeUndefined();
+    expect(workflow.jobs.submit["runs-on"]).toBe("ubuntu-latest");
+    expect(workflow.jobs.submit.permissions).toEqual({ contents: "write" });
+  });
+
+  it("pins the lockfile-only parser, evidence upload, and trusted submit steps", () => {
+    const validateSteps = workflow.jobs.validate.steps;
+    const submitSteps = workflow.jobs.submit.steps;
+    const checkout = validateSteps.find(
+      (step) => step.uses === "actions/checkout@v7",
+    );
+    const setupBun = validateSteps.find(
+      (step) => step.uses === "oven-sh/setup-bun@v2",
+    );
+    const tests = validateSteps.find(
+      (step) => step.name === "Check snapshot parser and permission contract",
+    );
+    const build = validateSteps.find(
+      (step) => step.name === "Build lockfile snapshot",
+    );
+    const upload = validateSteps.find(
+      (step) => step.uses === "actions/upload-artifact@v7",
+    );
+    const submit = submitSteps.find(
+      (step) => step.name === "Submit snapshot to GitHub",
+    );
+
+    expect(
+      validateSteps.flatMap((step) => (step.uses ? [step.uses] : [])),
+    ).toEqual([
+      "actions/checkout@v7",
+      "oven-sh/setup-bun@v2",
+      "actions/upload-artifact@v7",
+    ]);
+    expect(
+      submitSteps.flatMap((step) => (step.uses ? [step.uses] : [])),
+    ).toEqual(["actions/checkout@v7", "oven-sh/setup-bun@v2"]);
+    expect(checkout?.with).toEqual({ "persist-credentials": false });
+    expect(setupBun?.with).toEqual({ "bun-version": "1.3.14" });
+    expect(tests?.run).toBe(
+      "bun test src/lib/bun-dependency-snapshot.test.ts src/lib/bun-dependency-snapshot-contract.test.ts",
+    );
+    expect(build?.run).toBe(
+      "bun scripts/build-bun-dependency-snapshot.ts --output bun-dependency-snapshot.json",
+    );
+    expect(upload?.if).toBe("always()");
+    expect(upload?.with).toEqual({
+      name: "bun-dependency-snapshot",
+      path: "bun-dependency-snapshot.json",
+      "if-no-files-found": "warn",
+    });
+    expect(submit?.env).toEqual({ GITHUB_TOKEN: "${{ github.token }}" });
+    expect(submit?.shell).toBe("bash");
+    expect(submit?.run).toContain("set -euo pipefail");
+    expect(submit?.run).toContain("/dependency-graph/snapshots");
+    expect(submit?.run).toContain("X-GitHub-Api-Version: 2026-03-10");
+    expect(submit?.run).toContain("--data-binary @bun-dependency-snapshot.json");
+    expect(submit?.run).toContain('http_code}" != "201"');
+    expect(submit?.run).toContain('result}" == "INVALID"');
+  });
+
+  it("does not introduce privileged, registry, or failure-swallowing paths", () => {
+    for (const forbidden of [
+      "pull_request_target",
+      "secrets.",
+      "BUN_AUTH_TOKEN",
+      "NPM_CONFIG_USERCONFIG",
+      "_authToken",
+      "registry-url",
+      "registries:",
+      "id-token: write",
+      "packages: write",
+      "pull-requests: write",
+      "actions: write",
+      "continue-on-error",
+      "set +e",
+      "bun install",
+      "persist-credentials: true",
+      "token:",
+      "npx ",
+      "npm ",
+      "yarn ",
+      "pnpm ",
+    ]) {
+      expect(workflowSource).not.toContain(forbidden);
+    }
+    expect(workflowSource).not.toMatch(/\$\{\{\s*secrets\./);
+    expect(workflowSource.match(/contents:\s*write/g)).toEqual([
+      "contents: write",
+    ]);
+    expect(workflow.jobs.validate.permissions).toBeUndefined();
+    expect(scriptSource).not.toContain("bun install");
+    expect(scriptSource).not.toContain("dependency-graph/snapshots");
+  });
+});

--- a/src/lib/bun-dependency-snapshot.test.ts
+++ b/src/lib/bun-dependency-snapshot.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from "bun:test";
+import {
+  assertGithubDependencySnapshot,
+  assertGithubDependencySnapshotShape,
+  BUN_DEPENDENCY_SNAPSHOT_CORRELATOR,
+  BUN_DEPENDENCY_SNAPSHOT_DETECTOR_NAME,
+  BUN_DEPENDENCY_SNAPSHOT_DETECTOR_URL,
+  BUN_DEPENDENCY_SNAPSHOT_DETECTOR_VERSION,
+  BUN_DEPENDENCY_SNAPSHOT_MANIFEST_NAME,
+  BUN_DEPENDENCY_SNAPSHOT_MIN_RESOLVED_PACKAGES,
+  buildBunDependencySnapshot,
+  GITHUB_LIVE_SBOM_DIRECT_ENTRY_CEILING,
+  npmPackageUrl,
+  snapshotSummary,
+} from "@/lib/bun-dependency-snapshot";
+
+const repoRoot = new URL("../..", import.meta.url);
+const scanned = "2026-08-25T00:00:00.000Z";
+const sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const ref = "refs/heads/main";
+
+const fixturePackageJson = `{
+  "name": "fixture",
+  "dependencies": {
+    "left-pad": "1.3.0"
+  },
+  "devDependencies": {
+    "@types/node": "24.3.0",
+    "typescript": "5.8.2"
+  }
+}`;
+
+const fixtureLockfile = `{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "fixture",
+      "dependencies": {
+        "left-pad": "1.3.0",
+      },
+      "devDependencies": {
+        "@types/node": "24.3.0",
+        "typescript": "5.8.2",
+      },
+    },
+  },
+  "packages": {
+    "@types/node": ["@types/node@24.3.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-test"],
+    "left-pad": ["left-pad@1.3.0", "", { "dependencies": { "nanoid": "3.3.18" } }, "sha512-test"],
+    "left-pad/nanoid": ["nanoid@5.1.16", "", {}, "sha512-test"],
+    "nanoid": ["nanoid@3.3.18", "", {}, "sha512-test"],
+    "typescript": ["typescript@5.8.2", "", {}, "sha512-test"],
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-test"],
+  },
+}`;
+
+function fixtureSnapshot() {
+  return buildBunDependencySnapshot({
+    packageJsonSource: fixturePackageJson,
+    lockfileSource: fixtureLockfile,
+    sha,
+    ref,
+    scanned,
+    job: { id: "run-1", correlator: BUN_DEPENDENCY_SNAPSHOT_CORRELATOR },
+  });
+}
+
+describe("npm package URLs", () => {
+  it("encodes scoped and unscoped names with exact versions", () => {
+    expect(npmPackageUrl("left-pad", "1.3.0")).toBe("pkg:npm/left-pad@1.3.0");
+    expect(npmPackageUrl("@types/node", "24.3.0")).toBe(
+      "pkg:npm/%40types/node@24.3.0",
+    );
+  });
+});
+
+describe("bun.lock snapshot builder", () => {
+  it("classifies direct, nested, and development packages from the lockfile", () => {
+    const snapshot = fixtureSnapshot();
+    assertGithubDependencySnapshotShape(snapshot);
+    const resolved =
+      snapshot.manifests[BUN_DEPENDENCY_SNAPSHOT_MANIFEST_NAME].resolved;
+
+    expect(resolved[npmPackageUrl("left-pad", "1.3.0")]).toEqual({
+      package_url: "pkg:npm/left-pad@1.3.0",
+      relationship: "direct",
+      scope: "runtime",
+      dependencies: ["pkg:npm/nanoid@5.1.16"],
+    });
+    expect(resolved[npmPackageUrl("nanoid", "5.1.16")]).toEqual({
+      package_url: "pkg:npm/nanoid@5.1.16",
+      relationship: "indirect",
+      scope: "runtime",
+    });
+    expect(resolved[npmPackageUrl("nanoid", "3.3.18")]).toEqual({
+      package_url: "pkg:npm/nanoid@3.3.18",
+      relationship: "indirect",
+      scope: "development",
+    });
+    expect(resolved[npmPackageUrl("typescript", "5.8.2")]).toEqual({
+      package_url: "pkg:npm/typescript@5.8.2",
+      relationship: "direct",
+      scope: "development",
+    });
+    expect(resolved[npmPackageUrl("@types/node", "24.3.0")]).toEqual({
+      package_url: "pkg:npm/%40types/node@24.3.0",
+      relationship: "direct",
+      scope: "development",
+      dependencies: ["pkg:npm/undici-types@7.16.0"],
+    });
+    expect(snapshot.detector).toEqual({
+      name: BUN_DEPENDENCY_SNAPSHOT_DETECTOR_NAME,
+      version: BUN_DEPENDENCY_SNAPSHOT_DETECTOR_VERSION,
+      url: BUN_DEPENDENCY_SNAPSHOT_DETECTOR_URL,
+    });
+    expect(snapshot.job.correlator).toBe(BUN_DEPENDENCY_SNAPSHOT_CORRELATOR);
+  });
+
+  it("is deterministic for the same lockfile and scan metadata", () => {
+    expect(JSON.stringify(fixtureSnapshot())).toBe(
+      JSON.stringify(fixtureSnapshot()),
+    );
+  });
+
+  it("does not resolve floating versions or mutate the committed sources", () => {
+    const packageJsonSource = fixturePackageJson;
+    const lockfileSource = fixtureLockfile;
+    buildBunDependencySnapshot({
+      packageJsonSource,
+      lockfileSource,
+      sha,
+      ref,
+      scanned,
+      job: { id: "run-1", correlator: BUN_DEPENDENCY_SNAPSHOT_CORRELATOR },
+    });
+    expect(packageJsonSource).toBe(fixturePackageJson);
+    expect(lockfileSource).toBe(fixtureLockfile);
+  });
+
+  it("rejects lockfiles that are missing a declared package", () => {
+    expect(() =>
+      buildBunDependencySnapshot({
+        packageJsonSource: fixturePackageJson,
+        lockfileSource: fixtureLockfile.replace(
+          '    "typescript": ["typescript@5.8.2", "", {}, "sha512-test"],\n',
+          "",
+        ),
+        sha,
+        ref,
+        scanned,
+        job: { id: "run-1", correlator: BUN_DEPENDENCY_SNAPSHOT_CORRELATOR },
+      }),
+    ).toThrow("bun.lock is missing typescript");
+  });
+});
+
+describe("committed bun.lock graph", () => {
+  it("submits a complete lockfile graph instead of the direct-only GitHub SBOM", async () => {
+    const [packageJsonSource, lockfileSource] = await Promise.all([
+      Bun.file(new URL("package.json", repoRoot)).text(),
+      Bun.file(new URL("bun.lock", repoRoot)).text(),
+    ]);
+    const packageJson = JSON.parse(packageJsonSource) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    const snapshot = buildBunDependencySnapshot({
+      packageJsonSource,
+      lockfileSource,
+      sha,
+      ref,
+      scanned,
+      job: {
+        id: "committed-lockfile",
+        correlator: BUN_DEPENDENCY_SNAPSHOT_CORRELATOR,
+      },
+    });
+    assertGithubDependencySnapshot(snapshot);
+
+    const resolved =
+      snapshot.manifests[BUN_DEPENDENCY_SNAPSHOT_MANIFEST_NAME].resolved;
+    const summary = snapshotSummary(snapshot);
+    const directNames = [
+      ...Object.keys(packageJson.dependencies ?? {}),
+      ...Object.keys(packageJson.devDependencies ?? {}),
+    ];
+
+    expect(summary.resolved).toBeGreaterThan(
+      GITHUB_LIVE_SBOM_DIRECT_ENTRY_CEILING,
+    );
+    expect(summary.resolved).toBeGreaterThanOrEqual(
+      BUN_DEPENDENCY_SNAPSHOT_MIN_RESOLVED_PACKAGES,
+    );
+    expect(summary.direct).toBe(directNames.length);
+    expect(summary.indirect).toBeGreaterThan(summary.direct);
+    expect(summary.runtime).toBeGreaterThan(0);
+    expect(summary.development).toBeGreaterThan(0);
+
+    expect(resolved[npmPackageUrl("next", "16.3.1")]?.relationship).toBe(
+      "direct",
+    );
+    expect(resolved[npmPackageUrl("next", "16.3.1")]?.scope).toBe("runtime");
+    expect(resolved[npmPackageUrl("typescript", "6.0.3")]?.relationship).toBe(
+      "direct",
+    );
+    expect(resolved[npmPackageUrl("typescript", "6.0.3")]?.scope).toBe(
+      "development",
+    );
+    expect(resolved[npmPackageUrl("@ai-sdk/gateway", "4.0.59")]).toEqual({
+      package_url: "pkg:npm/%40ai-sdk/gateway@4.0.59",
+      relationship: "indirect",
+      scope: "runtime",
+      dependencies: [
+        "pkg:npm/%40ai-sdk/provider-utils@5.0.28",
+        "pkg:npm/%40ai-sdk/provider@4.0.7",
+        "pkg:npm/%40vercel/oidc@3.2.0",
+      ],
+    });
+    expect(resolved[npmPackageUrl("axe-core", "4.13.0")]?.relationship).toBe(
+      "indirect",
+    );
+    expect(resolved[npmPackageUrl("axe-core", "4.13.0")]?.scope).toBe(
+      "development",
+    );
+    expect(resolved[npmPackageUrl("nanoid", "5.1.16")]?.relationship).toBe(
+      "indirect",
+    );
+    expect(resolved[npmPackageUrl("nanoid", "3.3.18")]?.package_url).toBe(
+      "pkg:npm/nanoid@3.3.18",
+    );
+    expect(packageJson.dependencies?.["@ai-sdk/gateway"]).toBeUndefined();
+    expect(packageJson.devDependencies?.["axe-core"]).toBeUndefined();
+    expect(lockfileSource).toContain('"@ai-sdk/gateway@4.0.59"');
+    expect(lockfileSource).toContain('"axe-core@');
+  });
+});

--- a/src/lib/bun-dependency-snapshot.ts
+++ b/src/lib/bun-dependency-snapshot.ts
@@ -1,0 +1,539 @@
+export const BUN_DEPENDENCY_SNAPSHOT_WORKFLOW_NAME =
+  "Bun dependency snapshot";
+export const BUN_DEPENDENCY_SNAPSHOT_VALIDATE_JOB = "validate";
+export const BUN_DEPENDENCY_SNAPSHOT_SUBMIT_JOB = "submit";
+export const BUN_DEPENDENCY_SNAPSHOT_CORRELATOR = `${BUN_DEPENDENCY_SNAPSHOT_WORKFLOW_NAME} ${BUN_DEPENDENCY_SNAPSHOT_SUBMIT_JOB}`;
+export const BUN_DEPENDENCY_SNAPSHOT_DETECTOR_NAME =
+  "cornershopdev-bun-lockfile";
+export const BUN_DEPENDENCY_SNAPSHOT_DETECTOR_VERSION = "1";
+export const BUN_DEPENDENCY_SNAPSHOT_DETECTOR_URL =
+  "https://github.com/cornershopdev/cornershop.dev";
+export const BUN_DEPENDENCY_SNAPSHOT_MANIFEST_NAME = "bun.lock";
+export const BUN_DEPENDENCY_SNAPSHOT_VERSION = 0;
+export const GITHUB_LIVE_SBOM_DIRECT_ENTRY_CEILING = 49;
+export const BUN_DEPENDENCY_SNAPSHOT_MIN_RESOLVED_PACKAGES = 200;
+
+const GITHUB_SNAPSHOT_SHA_PATTERN = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/;
+const NPM_PURL_PATTERN = /^pkg:npm\/(?:%40[^/@]+\/)?[^/@]+@.+$/;
+
+export type DependencyRelationship = "direct" | "indirect";
+export type DependencyScope = "runtime" | "development";
+
+export type GithubSnapshotJob = {
+  id: string;
+  correlator: string;
+  html_url?: string;
+};
+
+export type GithubSnapshotDetector = {
+  name: string;
+  version: string;
+  url: string;
+};
+
+export type GithubResolvedDependency = {
+  package_url: string;
+  relationship: DependencyRelationship;
+  scope: DependencyScope;
+  dependencies?: string[];
+};
+
+export type GithubSnapshotManifest = {
+  name: string;
+  file: {
+    source_location: string;
+  };
+  resolved: Record<string, GithubResolvedDependency>;
+};
+
+export type GithubDependencySnapshot = {
+  version: number;
+  sha: string;
+  ref: string;
+  job: GithubSnapshotJob;
+  detector: GithubSnapshotDetector;
+  scanned: string;
+  manifests: Record<string, GithubSnapshotManifest>;
+};
+
+export type SnapshotJobContext = {
+  id: string;
+  correlator: string;
+  htmlUrl?: string;
+};
+
+export type SnapshotBuildInput = {
+  packageJsonSource: string;
+  lockfileSource: string;
+  sha: string;
+  ref: string;
+  job: SnapshotJobContext;
+  scanned: string;
+};
+
+type StringMap = Record<string, string>;
+
+type PackageManifest = {
+  dependencies: StringMap;
+  devDependencies: StringMap;
+  optionalDependencies: StringMap;
+};
+
+type LockPackage = {
+  name: string;
+  version: string;
+  purl: string;
+  dependencies: StringMap;
+};
+
+type WalkScope = DependencyScope;
+
+export function npmPackageUrl(name: string, version: string): string {
+  if (!name || !version) {
+    throw new Error("npm package URL requires a name and version.");
+  }
+  if (name.startsWith("@")) {
+    const slash = name.indexOf("/");
+    if (slash <= 1 || slash === name.length - 1) {
+      throw new Error(`Invalid scoped package name: ${name}`);
+    }
+    const scope = name.slice(0, slash);
+    const pkg = name.slice(slash + 1);
+    return `pkg:npm/${encodeURIComponent(scope)}/${encodeURIComponent(pkg)}@${encodeURIComponent(version)}`;
+  }
+  return `pkg:npm/${encodeURIComponent(name)}@${encodeURIComponent(version)}`;
+}
+
+export function parseJsonDocument(source: string): unknown {
+  return JSON.parse(stripJsonDocumentNoise(source));
+}
+
+export function buildBunDependencySnapshot(
+  input: SnapshotBuildInput,
+): GithubDependencySnapshot {
+  if (!GITHUB_SNAPSHOT_SHA_PATTERN.test(input.sha)) {
+    throw new Error("Snapshot SHA must be a 40- or 64-character hex commit.");
+  }
+  if (!input.ref.startsWith("refs/")) {
+    throw new Error("Snapshot ref must be a fully qualified git ref.");
+  }
+  if (!input.job.id.trim() || !input.job.correlator.trim()) {
+    throw new Error("Snapshot job id and correlator are required.");
+  }
+  if (Number.isNaN(Date.parse(input.scanned))) {
+    throw new Error("Snapshot scanned time must be an ISO-8601 timestamp.");
+  }
+
+  const manifest = parsePackageManifest(input.packageJsonSource);
+  const lockfile = parseBunLockfile(input.lockfileSource);
+  assertManifestMatchesLockfile(manifest, lockfile.root);
+
+  const packages = parseLockPackages(lockfile.packages);
+  const resolved = resolveGraph(manifest, packages);
+
+  const job: GithubSnapshotJob = {
+    id: input.job.id,
+    correlator: input.job.correlator,
+  };
+  if (input.job.htmlUrl) job.html_url = input.job.htmlUrl;
+
+  return {
+    version: BUN_DEPENDENCY_SNAPSHOT_VERSION,
+    sha: input.sha,
+    ref: input.ref,
+    job,
+    detector: {
+      name: BUN_DEPENDENCY_SNAPSHOT_DETECTOR_NAME,
+      version: BUN_DEPENDENCY_SNAPSHOT_DETECTOR_VERSION,
+      url: BUN_DEPENDENCY_SNAPSHOT_DETECTOR_URL,
+    },
+    scanned: input.scanned,
+    manifests: {
+      [BUN_DEPENDENCY_SNAPSHOT_MANIFEST_NAME]: {
+        name: BUN_DEPENDENCY_SNAPSHOT_MANIFEST_NAME,
+        file: { source_location: BUN_DEPENDENCY_SNAPSHOT_MANIFEST_NAME },
+        resolved,
+      },
+    },
+  };
+}
+
+export function assertGithubDependencySnapshotShape(
+  snapshot: GithubDependencySnapshot,
+): void {
+  if (snapshot.version !== BUN_DEPENDENCY_SNAPSHOT_VERSION) {
+    throw new Error("Snapshot version must be 0.");
+  }
+  if (!GITHUB_SNAPSHOT_SHA_PATTERN.test(snapshot.sha)) {
+    throw new Error("Snapshot SHA must be a 40- or 64-character hex commit.");
+  }
+  if (!snapshot.ref.startsWith("refs/")) {
+    throw new Error("Snapshot ref must be a fully qualified git ref.");
+  }
+  if (
+    snapshot.detector.name !== BUN_DEPENDENCY_SNAPSHOT_DETECTOR_NAME ||
+    snapshot.detector.version !== BUN_DEPENDENCY_SNAPSHOT_DETECTOR_VERSION ||
+    snapshot.detector.url !== BUN_DEPENDENCY_SNAPSHOT_DETECTOR_URL
+  ) {
+    throw new Error("Snapshot detector identity is not stable.");
+  }
+  if (snapshot.job.correlator !== BUN_DEPENDENCY_SNAPSHOT_CORRELATOR) {
+    throw new Error("Snapshot correlator is not the stable submit key.");
+  }
+  const manifest = snapshot.manifests[BUN_DEPENDENCY_SNAPSHOT_MANIFEST_NAME];
+  if (!manifest) {
+    throw new Error("Snapshot is missing the bun.lock manifest.");
+  }
+  const resolvedEntries = Object.entries(manifest.resolved);
+  const seenPurls = new Set<string>();
+  for (const [key, dependency] of resolvedEntries) {
+    if (key !== dependency.package_url) {
+      throw new Error(`Resolved key ${key} does not match package_url.`);
+    }
+    if (seenPurls.has(dependency.package_url)) {
+      throw new Error(`Duplicate package URL ${dependency.package_url}.`);
+    }
+    seenPurls.add(dependency.package_url);
+    if (!NPM_PURL_PATTERN.test(dependency.package_url)) {
+      throw new Error(`Invalid npm package URL ${dependency.package_url}.`);
+    }
+    if (
+      dependency.relationship !== "direct" &&
+      dependency.relationship !== "indirect"
+    ) {
+      throw new Error(`Invalid relationship for ${dependency.package_url}.`);
+    }
+    if (dependency.scope !== "runtime" && dependency.scope !== "development") {
+      throw new Error(`Invalid scope for ${dependency.package_url}.`);
+    }
+    for (const child of dependency.dependencies ?? []) {
+      if (!NPM_PURL_PATTERN.test(child)) {
+        throw new Error(`Invalid child package URL ${child}.`);
+      }
+    }
+  }
+}
+
+export function assertGithubDependencySnapshot(
+  snapshot: GithubDependencySnapshot,
+): void {
+  assertGithubDependencySnapshotShape(snapshot);
+  const resolvedCount = Object.keys(
+    snapshot.manifests[BUN_DEPENDENCY_SNAPSHOT_MANIFEST_NAME]?.resolved ?? {},
+  ).length;
+  if (resolvedCount < BUN_DEPENDENCY_SNAPSHOT_MIN_RESOLVED_PACKAGES) {
+    throw new Error(
+      `Snapshot resolved ${resolvedCount} packages; expected more than the GitHub direct-only graph.`,
+    );
+  }
+}
+
+export function snapshotSummary(snapshot: GithubDependencySnapshot): {
+  manifest: string;
+  resolved: number;
+  direct: number;
+  indirect: number;
+  runtime: number;
+  development: number;
+} {
+  const resolved = Object.values(
+    snapshot.manifests[BUN_DEPENDENCY_SNAPSHOT_MANIFEST_NAME]?.resolved ?? {},
+  );
+  return {
+    manifest: BUN_DEPENDENCY_SNAPSHOT_MANIFEST_NAME,
+    resolved: resolved.length,
+    direct: resolved.filter((entry) => entry.relationship === "direct").length,
+    indirect: resolved.filter((entry) => entry.relationship === "indirect")
+      .length,
+    runtime: resolved.filter((entry) => entry.scope === "runtime").length,
+    development: resolved.filter((entry) => entry.scope === "development")
+      .length,
+  };
+}
+
+function parsePackageManifest(source: string): PackageManifest {
+  const parsed = JSON.parse(source) as unknown;
+  if (!isRecord(parsed)) throw new Error("package.json must be an object.");
+  return {
+    dependencies: optionalStringMap(parsed.dependencies, "dependencies"),
+    devDependencies: optionalStringMap(
+      parsed.devDependencies,
+      "devDependencies",
+    ),
+    optionalDependencies: optionalStringMap(
+      parsed.optionalDependencies,
+      "optionalDependencies",
+    ),
+  };
+}
+
+type ParsedLockfile = {
+  lockfileVersion: number;
+  root: PackageManifest;
+  packages: Record<string, unknown>;
+};
+
+function parseBunLockfile(source: string): ParsedLockfile {
+  const parsed = parseJsonDocument(source);
+  if (!isRecord(parsed)) throw new Error("bun.lock must be an object.");
+  if (parsed.lockfileVersion !== 1) {
+    throw new Error("bun.lock lockfileVersion must be 1.");
+  }
+  if (!isRecord(parsed.workspaces) || !isRecord(parsed.workspaces[""])) {
+    throw new Error("bun.lock is missing the root workspace.");
+  }
+  if (!isRecord(parsed.packages)) {
+    throw new Error("bun.lock is missing the packages map.");
+  }
+  const rootWorkspace = parsed.workspaces[""];
+  return {
+    lockfileVersion: 1,
+    root: {
+      dependencies: optionalStringMap(
+        rootWorkspace.dependencies,
+        "workspaces[\"\"].dependencies",
+      ),
+      devDependencies: optionalStringMap(
+        rootWorkspace.devDependencies,
+        "workspaces[\"\"].devDependencies",
+      ),
+      optionalDependencies: optionalStringMap(
+        rootWorkspace.optionalDependencies,
+        "workspaces[\"\"].optionalDependencies",
+      ),
+    },
+    packages: parsed.packages,
+  };
+}
+
+function assertManifestMatchesLockfile(
+  manifest: PackageManifest,
+  lockRoot: PackageManifest,
+): void {
+  for (const field of [
+    "dependencies",
+    "devDependencies",
+    "optionalDependencies",
+  ] as const) {
+    const declared = Object.keys(manifest[field]).sort();
+    const locked = Object.keys(lockRoot[field]).sort();
+    if (declared.join("\0") !== locked.join("\0")) {
+      throw new Error(
+        `package.json ${field} do not match bun.lock workspace ${field}.`,
+      );
+    }
+  }
+}
+
+function parseLockPackages(
+  packages: Record<string, unknown>,
+): Map<string, LockPackage> {
+  const parsed = new Map<string, LockPackage>();
+  for (const [key, value] of Object.entries(packages)) {
+    if (!Array.isArray(value) || typeof value[0] !== "string") {
+      throw new Error(`bun.lock package ${key} is not a resolved tuple.`);
+    }
+    const identity = parseNpmIdentity(value[0]);
+    const metadata = isRecord(value[2]) ? value[2] : {};
+    parsed.set(key, {
+      name: identity.name,
+      version: identity.version,
+      purl: npmPackageUrl(identity.name, identity.version),
+      dependencies: {
+        ...optionalStringMap(metadata.dependencies, `${key}.dependencies`),
+        ...optionalStringMap(
+          metadata.optionalDependencies,
+          `${key}.optionalDependencies`,
+        ),
+      },
+    });
+  }
+  return parsed;
+}
+
+function parseNpmIdentity(identity: string): { name: string; version: string } {
+  if (
+    identity.includes(":") ||
+    identity.includes(" ") ||
+    identity.includes("\\")
+  ) {
+    throw new Error(`Unsupported bun.lock package identity: ${identity}`);
+  }
+  if (identity.startsWith("@")) {
+    const separator = identity.indexOf("@", 1);
+    if (separator <= 1 || separator === identity.length - 1) {
+      throw new Error(`Invalid scoped package identity: ${identity}`);
+    }
+    const name = identity.slice(0, separator);
+    if (!name.includes("/")) {
+      throw new Error(`Invalid scoped package identity: ${identity}`);
+    }
+    return { name, version: identity.slice(separator + 1) };
+  }
+  const separator = identity.indexOf("@");
+  if (separator <= 0 || separator === identity.length - 1) {
+    throw new Error(`Invalid package identity: ${identity}`);
+  }
+  return {
+    name: identity.slice(0, separator),
+    version: identity.slice(separator + 1),
+  };
+}
+
+function resolveGraph(
+  manifest: PackageManifest,
+  packages: Map<string, LockPackage>,
+): Record<string, GithubResolvedDependency> {
+  const nodes = new Map<
+    string,
+    {
+      relationship: DependencyRelationship;
+      scope: DependencyScope;
+      children: Set<string>;
+    }
+  >();
+
+  const visit = (
+    parentName: string | null,
+    depName: string,
+    relationship: DependencyRelationship,
+    scope: WalkScope,
+  ) => {
+    const resolved = lookupPackage(packages, parentName, depName);
+    const existing = nodes.get(resolved.purl);
+    if (existing) {
+      if (relationship === "direct") existing.relationship = "direct";
+      if (scope === "runtime") existing.scope = "runtime";
+      return;
+    }
+    const children = new Set<string>();
+    nodes.set(resolved.purl, { relationship, scope, children });
+    for (const childName of Object.keys(resolved.dependencies).sort()) {
+      const child = lookupPackage(packages, resolved.name, childName);
+      children.add(child.purl);
+      visit(resolved.name, childName, "indirect", scope);
+    }
+  };
+
+  for (const name of [
+    ...Object.keys(manifest.dependencies),
+    ...Object.keys(manifest.optionalDependencies),
+  ].sort()) {
+    visit(null, name, "direct", "runtime");
+  }
+  for (const name of Object.keys(manifest.devDependencies).sort()) {
+    visit(null, name, "direct", "development");
+  }
+
+  for (const pkg of packages.values()) {
+    if (nodes.has(pkg.purl)) continue;
+    nodes.set(pkg.purl, {
+      relationship: "indirect",
+      scope: "development",
+      children: new Set(
+        Object.keys(pkg.dependencies)
+          .sort()
+          .map((childName) => lookupPackage(packages, pkg.name, childName).purl),
+      ),
+    });
+  }
+
+  const resolved: Record<string, GithubResolvedDependency> = {};
+  for (const purl of [...nodes.keys()].sort()) {
+    const node = nodes.get(purl);
+    if (!node) continue;
+    const entry: GithubResolvedDependency = {
+      package_url: purl,
+      relationship: node.relationship,
+      scope: node.scope,
+    };
+    if (node.children.size > 0) {
+      entry.dependencies = [...node.children].sort();
+    }
+    resolved[purl] = entry;
+  }
+  return resolved;
+}
+
+function lookupPackage(
+  packages: Map<string, LockPackage>,
+  parentName: string | null,
+  depName: string,
+): LockPackage {
+  const nested = parentName ? packages.get(`${parentName}/${depName}`) : undefined;
+  const resolved = nested ?? packages.get(depName);
+  if (!resolved) {
+    const parent = parentName ?? "workspace";
+    throw new Error(`bun.lock is missing ${depName} required by ${parent}.`);
+  }
+  return resolved;
+}
+
+function optionalStringMap(value: unknown, label: string): StringMap {
+  if (value === undefined) return {};
+  if (!isRecord(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+  const result: StringMap = {};
+  for (const [key, mapped] of Object.entries(value)) {
+    if (typeof mapped !== "string") {
+      throw new Error(`${label}.${key} must be a string.`);
+    }
+    result[key] = mapped;
+  }
+  return result;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stripJsonDocumentNoise(source: string): string {
+  let result = "";
+  let index = 0;
+  while (index < source.length) {
+    const char = source[index];
+    if (char === "\"") {
+      let cursor = index + 1;
+      while (cursor < source.length) {
+        if (source[cursor] === "\\") {
+          cursor += 2;
+          continue;
+        }
+        if (source[cursor] === "\"") {
+          cursor += 1;
+          break;
+        }
+        cursor += 1;
+      }
+      result += source.slice(index, cursor);
+      index = cursor;
+      continue;
+    }
+    if (char === "/" && source[index + 1] === "/") {
+      index += 2;
+      while (index < source.length && source[index] !== "\n") index += 1;
+      continue;
+    }
+    if (char === "/" && source[index + 1] === "*") {
+      index += 2;
+      while (
+        index + 1 < source.length &&
+        !(source[index] === "*" && source[index + 1] === "/")
+      ) {
+        index += 1;
+      }
+      index += 2;
+      continue;
+    }
+    result += char;
+    index += 1;
+  }
+
+  let stripped = result;
+  for (;;) {
+    const next = stripped.replace(/,(\s*[}\]])/g, "$1");
+    if (next === stripped) return stripped;
+    stripped = next;
+  }
+}


### PR DESCRIPTION
Closes #153

## Summary
GitHub's live SBOM currently sees only the direct `package.json` graph (49 entries). This adds an in-repo Bun lockfile parser and a least-privilege workflow that submits the complete resolved graph from committed `package.json` + `bun.lock`.

- Parser/builder: `src/lib/bun-dependency-snapshot.ts`
- CLI (generate only, never POSTs): `scripts/build-bun-dependency-snapshot.ts`
- Workflow: `.github/workflows/bun-dependency-snapshot.yml`
  - `validate` on PR/`main`/schedule/dispatch with `contents: read`; uploads a dry-run artifact
  - `submit` only on trusted `main` + `push|schedule|workflow_dispatch` with isolated `contents: write`
- Stable correlator `Bun dependency snapshot submit` and detector `cornershopdev-bun-lockfile` so resubmits replace rather than accumulate
- Governance runbook updated with ownership, evidence inspection, rollback/disable, and post-merge SBOM reconciliation

## Dry-run evidence
Local build of the committed lockfile:

- **1324** resolved packages (vs GitHub's 49-entry direct-only graph)
- 44 direct / 1280 indirect
- 657 runtime / 667 development
- Includes transitives not in `package.json`, e.g. `@ai-sdk/gateway@4.0.59` (runtime) and `axe-core@4.13.0` (development)

No `bun install`, no floating resolution, no mutation of `package.json` / `bun.lock`, and no snapshot POST from this laptop.

## Verification
- `bun test src/lib/bun-dependency-snapshot.test.ts src/lib/bun-dependency-snapshot-contract.test.ts` — 10 pass
- `bun run lint` — pass
- `actionlint .github/workflows/bun-dependency-snapshot.yml` — pass
- `git diff --check` — pass
- `bunx tsc --noEmit` — no errors in new files; remaining `RouteContext` errors are pre-existing (missing `.next/types` without `next build`)

## Residual
After merge, the trusted workflow must run on `main` before the live SBOM endpoint can be reconciled. Record the resulting package count / representative transitives, then mark #153 done. Do not treat this PR as that reconciliation.