### PR TITLE
fix(articles): brand live blog and deny unsafe links

### DIFF
--- a/src/app/preview/[slug]/[locale]/page.tsx
+++ b/src/app/preview/[slug]/[locale]/page.tsx
@@ -9,6 +9,7 @@ import {
   previewMetadata,
 } from "@/lib/preview-metadata";
 import { getSiteLocales, localizeSiteDraft } from "@/lib/site-draft";
+import { resolveStorefrontBlogHref } from "@/lib/articles/public-articles";
 import { liveSiteVersionId } from "@/lib/site-surface";
 import {
   findSiteView,
@@ -58,9 +59,12 @@ export async function generateMetadata({
 export default async function LocalizedPreviewPage({ params }: PageProps) {
   const { slug, locale } = await params;
   const versionId = liveSiteVersionId(await headers(), slug);
-  const site = versionId
-    ? await getCachedPublishedSiteView(slug, versionId)
-    : await findSiteView(slug);
+  const [site, blogHref] = await Promise.all([
+    versionId
+      ? getCachedPublishedSiteView(slug, versionId)
+      : findSiteView(slug),
+    resolveStorefrontBlogHref({ slug, versionId }),
+  ]);
   if (!site) notFound();
   const isLiveSurface = versionId !== null;
   const locales = getSiteLocales(site.draft);
@@ -75,6 +79,7 @@ export default async function LocalizedPreviewPage({ params }: PageProps) {
       localeBasePath={isLiveSurface ? "/" : `/preview/${slug}`}
       availableLocales={locales}
       analyticsEnabled={isLiveSurface}
+      blogHref={blogHref}
     />
   );
 }

--- a/src/app/preview/[slug]/blog/[articleSlug]/page.tsx
+++ b/src/app/preview/[slug]/blog/[articleSlug]/page.tsx
@@ -4,11 +4,13 @@ import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { unstable_cache } from "next/cache";
 import { ArticleMarkdown } from "@/components/article-markdown";
+import { CustomerArticleChrome } from "@/components/customer-article-chrome";
 import {
   articleCacheTagFor,
   getPublishedArticle,
   type PublishedArticle,
 } from "@/lib/articles/public-articles";
+import { approvedArticleDestinations } from "@/lib/articles/safe-article-href";
 import {
   buildCustomerArticleMetadata,
   serializeCustomerArticleJsonLd,
@@ -72,35 +74,50 @@ export default async function ArticlePage({ params }: PageProps) {
   });
 
   return (
-    <main className="mx-auto w-full max-w-2xl px-6 py-16">
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: jsonLd }}
-      />
-      <article>
-        <header>
-          <h1 className="text-3xl font-semibold">{article.title}</h1>
-          <time
-            dateTime={article.publishedAt.toISOString()}
-            className="mt-2 block text-sm opacity-60"
+    <CustomerArticleChrome
+      draft={site.draft}
+      vertical={site.vertical}
+      locale={site.draft.defaultLocale}
+      analyticsEnabled
+    >
+      <main className="mx-auto w-full max-w-2xl px-6 py-16">
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: jsonLd }}
+        />
+        <article>
+          <header>
+            <h1 className="text-3xl font-semibold">{article.title}</h1>
+            <time
+              dateTime={article.publishedAt.toISOString()}
+              className="mt-2 block text-sm opacity-60"
+            >
+              {article.publishedAt.toLocaleDateString(undefined, {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              })}
+            </time>
+          </header>
+          <div className="mt-8">
+            <ArticleMarkdown
+              markdown={article.bodyMarkdown}
+              approvedDestinations={approvedArticleDestinations(
+                site.draft.integrations,
+              )}
+            />
+          </div>
+        </article>
+        <p className="mt-12">
+          <Link
+            href="/"
+            className="inline-flex min-h-11 items-center underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2"
           >
-            {article.publishedAt.toLocaleDateString(undefined, {
-              year: "numeric",
-              month: "long",
-              day: "numeric",
-            })}
-          </time>
-        </header>
-        <div className="mt-8">
-          <ArticleMarkdown markdown={article.bodyMarkdown} />
-        </div>
-      </article>
-      <p className="mt-12">
-        <Link href="/" className="underline underline-offset-4">
-          Back to the site
-        </Link>
-      </p>
-    </main>
+            Back to the site
+          </Link>
+        </p>
+      </main>
+    </CustomerArticleChrome>
   );
 }
 

--- a/src/app/preview/[slug]/blog/page.tsx
+++ b/src/app/preview/[slug]/blog/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { unstable_cache } from "next/cache";
+import { CustomerArticleChrome } from "@/components/customer-article-chrome";
 import {
   articleCacheTagFor,
   listPublishedArticles,
@@ -53,32 +54,39 @@ export default async function BlogIndexPage({ params }: PageProps) {
   if (!site || !articles.length) notFound();
 
   return (
-    <main className="mx-auto w-full max-w-2xl px-6 py-16">
-      <h1 className="text-3xl font-semibold">{site.draft.name} Blog</h1>
-      <ul className="mt-10 space-y-10">
-        {articles.map((article) => (
-          <li key={article.slug}>
-            <Link
-              href={`/blog/${article.slug}`}
-              className="text-xl font-medium underline-offset-4 hover:underline"
-            >
-              {article.title}
-            </Link>
-            <p className="mt-2 opacity-75">{article.excerpt}</p>
-            <time
-              dateTime={article.publishedAt.toISOString()}
-              className="mt-1 block text-sm opacity-60"
-            >
-              {article.publishedAt.toLocaleDateString(undefined, {
-                year: "numeric",
-                month: "long",
-                day: "numeric",
-              })}
-            </time>
-          </li>
-        ))}
-      </ul>
-    </main>
+    <CustomerArticleChrome
+      draft={site.draft}
+      vertical={site.vertical}
+      locale={site.draft.defaultLocale}
+      analyticsEnabled
+    >
+      <main className="mx-auto w-full max-w-2xl px-6 py-16">
+        <h1 className="text-3xl font-semibold">{site.draft.name} Blog</h1>
+        <ul className="mt-10 space-y-10">
+          {articles.map((article) => (
+            <li key={article.slug}>
+              <Link
+                href={`/blog/${article.slug}`}
+                className="text-xl font-medium underline-offset-4 hover:underline"
+              >
+                {article.title}
+              </Link>
+              <p className="mt-2 opacity-75">{article.excerpt}</p>
+              <time
+                dateTime={article.publishedAt.toISOString()}
+                className="mt-1 block text-sm opacity-60"
+              >
+                {article.publishedAt.toLocaleDateString(undefined, {
+                  year: "numeric",
+                  month: "long",
+                  day: "numeric",
+                })}
+              </time>
+            </li>
+          ))}
+        </ul>
+      </main>
+    </CustomerArticleChrome>
   );
 }
 

--- a/src/app/preview/[slug]/page.tsx
+++ b/src/app/preview/[slug]/page.tsx
@@ -9,6 +9,7 @@ import {
   previewMetadata,
 } from "@/lib/preview-metadata";
 import { getSiteLocales } from "@/lib/site-draft";
+import { resolveStorefrontBlogHref } from "@/lib/articles/public-articles";
 import { liveSiteVersionId } from "@/lib/site-surface";
 import {
   findSiteView,
@@ -44,9 +45,12 @@ export async function generateMetadata({
 export default async function PreviewPage({ params }: PageProps) {
   const { slug } = await params;
   const versionId = liveSiteVersionId(await headers(), slug);
-  const site = versionId
-    ? await getCachedPublishedSiteView(slug, versionId)
-    : await findSiteView(slug);
+  const [site, blogHref] = await Promise.all([
+    versionId
+      ? getCachedPublishedSiteView(slug, versionId)
+      : findSiteView(slug),
+    resolveStorefrontBlogHref({ slug, versionId }),
+  ]);
   if (!site) notFound();
   const isLiveSurface = versionId !== null;
   return (
@@ -58,6 +62,7 @@ export default async function PreviewPage({ params }: PageProps) {
       localeBasePath={isLiveSurface ? "/" : `/preview/${slug}`}
       availableLocales={getSiteLocales(site.draft)}
       analyticsEnabled={isLiveSurface}
+      blogHref={blogHref}
     />
   );
 }

--- a/src/app/pro/[slug]/[locale]/page.tsx
+++ b/src/app/pro/[slug]/[locale]/page.tsx
@@ -15,6 +15,7 @@ import {
   previewMetadata,
 } from "@/lib/preview-metadata";
 import { getSiteLocales, localizeSiteDraft } from "@/lib/site-draft";
+import { resolveStorefrontBlogHref } from "@/lib/articles/public-articles";
 import { liveSiteVersionId } from "@/lib/site-surface";
 import {
   findSiteView,
@@ -68,9 +69,12 @@ export default async function ProLocalizedSitePage({ params }: PageProps) {
   const { slug, locale } = await params;
   if (!isCornershopProClient(slug)) notFound();
   const versionId = liveSiteVersionId(await headers(), slug);
-  const site = versionId
-    ? await getCachedPublishedSiteView(slug, versionId)
-    : await findSiteView(slug);
+  const [site, blogHref] = await Promise.all([
+    versionId
+      ? getCachedPublishedSiteView(slug, versionId)
+      : findSiteView(slug),
+    resolveStorefrontBlogHref({ slug, versionId }),
+  ]);
   if (!site || !isTrustedCornershopProSite(slug, site.draft)) notFound();
   const isLiveSurface = versionId !== null;
   const locales = getSiteLocales(site.draft);
@@ -85,6 +89,7 @@ export default async function ProLocalizedSitePage({ params }: PageProps) {
       localeBasePath={isLiveSurface ? "/" : proSiteBasePath(slug)}
       availableLocales={locales}
       analyticsEnabled={isLiveSurface}
+      blogHref={blogHref}
     />
   );
 }

--- a/src/app/pro/[slug]/page.tsx
+++ b/src/app/pro/[slug]/page.tsx
@@ -15,6 +15,7 @@ import {
   previewMetadata,
 } from "@/lib/preview-metadata";
 import { getSiteLocales } from "@/lib/site-draft";
+import { resolveStorefrontBlogHref } from "@/lib/articles/public-articles";
 import { liveSiteVersionId } from "@/lib/site-surface";
 import {
   findSiteView,
@@ -54,9 +55,12 @@ export default async function ProSitePage({ params }: PageProps) {
   const { slug } = await params;
   if (!isCornershopProClient(slug)) notFound();
   const versionId = liveSiteVersionId(await headers(), slug);
-  const site = versionId
-    ? await getCachedPublishedSiteView(slug, versionId)
-    : await findSiteView(slug);
+  const [site, blogHref] = await Promise.all([
+    versionId
+      ? getCachedPublishedSiteView(slug, versionId)
+      : findSiteView(slug),
+    resolveStorefrontBlogHref({ slug, versionId }),
+  ]);
   if (!site || !isTrustedCornershopProSite(slug, site.draft)) notFound();
   const isLiveSurface = versionId !== null;
   return (
@@ -68,6 +72,7 @@ export default async function ProSitePage({ params }: PageProps) {
       localeBasePath={isLiveSurface ? "/" : proSiteBasePath(slug)}
       availableLocales={getSiteLocales(site.draft)}
       analyticsEnabled={isLiveSurface}
+      blogHref={blogHref}
     />
   );
 }

--- a/src/components/article-markdown.test.tsx
+++ b/src/components/article-markdown.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ArticleMarkdown } from "@/components/article-markdown";
+
+const approved = ["https://www.sevenrooms.com/explore/osteria-luna"];
+
+describe("article markdown rendering", () => {
+  it("keeps safe same-origin paths, anchors, and approved destinations as links", () => {
+    const markup = renderToStaticMarkup(
+      <ArticleMarkdown
+        markdown={[
+          "See the [menu](/menu) or [visit](#visit).",
+          `Book via [SevenRooms](${approved[0]}).`,
+        ].join("\n\n")}
+        approvedDestinations={approved}
+      />,
+    );
+
+    expect(markup).toContain('href="/menu"');
+    expect(markup).toContain('href="#visit"');
+    expect(markup).toContain(`href="${approved[0]}"`);
+    expect(markup).toContain('rel="noreferrer"');
+    expect(markup).not.toContain("data-analytics-cta");
+  });
+
+  it.each([
+    ["protocol-relative", "[x](//attacker.example)"],
+    ["backslash", "[x](/\\attacker.example)"],
+    ["credentialed", "[x](https://user:pass@sevenrooms.com/explore)"],
+    ["control character", "[x](https://exa\u0001mple.com)"],
+    ["unsupported external", "[x](https://attacker.example/menu)"],
+  ])("renders %s destinations as text", (_label, markdown) => {
+    const markup = renderToStaticMarkup(
+      <ArticleMarkdown markdown={markdown} approvedDestinations={approved} />,
+    );
+    expect(markup).not.toContain("<a ");
+    expect(markup).toContain(markdown);
+  });
+});

--- a/src/components/article-markdown.tsx
+++ b/src/components/article-markdown.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { isSafeArticleHref } from "@/lib/articles/safe-article-href";
 
 /**
  * Renders the bounded markdown subset the article generator is prompted to
@@ -12,11 +13,24 @@ import type { ReactNode } from "react";
 const HEADING = /^(#{1,3})\s+(.*)$/;
 const LIST_ITEM = /^[-*]\s+(.*)$/;
 
-export function ArticleMarkdown({ markdown }: { markdown: string }) {
-  return <div className="space-y-4">{renderBlocks(markdown)}</div>;
+export function ArticleMarkdown({
+  markdown,
+  approvedDestinations = [],
+}: {
+  markdown: string;
+  approvedDestinations?: readonly string[];
+}) {
+  return (
+    <div className="space-y-4">
+      {renderBlocks(markdown, approvedDestinations)}
+    </div>
+  );
 }
 
-function renderBlocks(markdown: string): ReactNode[] {
+function renderBlocks(
+  markdown: string,
+  approvedDestinations: readonly string[],
+): ReactNode[] {
   const nodes: ReactNode[] = [];
   const lines = markdown.replace(/\r\n/g, "\n").split("\n");
   let paragraph: string[] = [];
@@ -26,7 +40,7 @@ function renderBlocks(markdown: string): ReactNode[] {
   const flushParagraph = () => {
     if (!paragraph.length) return;
     const text = paragraph.join(" ");
-    nodes.push(<p key={key++}>{renderInline(text)}</p>);
+    nodes.push(<p key={key++}>{renderInline(text, approvedDestinations)}</p>);
     paragraph = [];
   };
   const flushList = () => {
@@ -34,7 +48,7 @@ function renderBlocks(markdown: string): ReactNode[] {
     nodes.push(
       <ul key={key++} className="list-disc space-y-1 pl-6">
         {listItems.map((item, index) => (
-          <li key={index}>{renderInline(item)}</li>
+          <li key={index}>{renderInline(item, approvedDestinations)}</li>
         ))}
       </ul>,
     );
@@ -54,17 +68,20 @@ function renderBlocks(markdown: string): ReactNode[] {
       flushList();
       const level = heading[1]?.length ?? 1;
       const text = heading[2] ?? "";
-      if (level === 1) nodes.push(<h2 key={key++}>{renderInline(text)}</h2>);
+      if (level === 1)
+        nodes.push(
+          <h2 key={key++}>{renderInline(text, approvedDestinations)}</h2>,
+        );
       else if (level === 2)
         nodes.push(
           <h3 key={key++} className="pt-2">
-            {renderInline(text)}
+            {renderInline(text, approvedDestinations)}
           </h3>,
         );
       else
         nodes.push(
           <h4 key={key++} className="pt-2">
-            {renderInline(text)}
+            {renderInline(text, approvedDestinations)}
           </h4>,
         );
       continue;
@@ -86,7 +103,10 @@ function renderBlocks(markdown: string): ReactNode[] {
 const INLINE_PATTERN =
   /\*\*([^*]+)\*\*|\*([^*]+)\*|\[([^\]]+)\]\(([^)\s]+)\)/g;
 
-function renderInline(text: string): ReactNode[] {
+function renderInline(
+  text: string,
+  approvedDestinations: readonly string[],
+): ReactNode[] {
   const nodes: ReactNode[] = [];
   let lastIndex = 0;
   let key = 0;
@@ -98,9 +118,21 @@ function renderInline(text: string): ReactNode[] {
       nodes.push(<strong key={key++}>{bold}</strong>);
     } else if (em !== undefined) {
       nodes.push(<em key={key++}>{em}</em>);
-    } else if (linkText !== undefined && href !== undefined && isSafeHref(href)) {
+    } else if (
+      linkText !== undefined &&
+      href !== undefined &&
+      isSafeArticleHref(href, approvedDestinations)
+    ) {
+      const isExternal = href.startsWith("https://");
       nodes.push(
-        <a key={key++} href={href} className="underline">
+        <a
+          key={key++}
+          href={href}
+          className="underline"
+          {...(isExternal
+            ? { target: "_blank", rel: "noreferrer" }
+            : undefined)}
+        >
           {linkText}
         </a>,
       );
@@ -111,12 +143,4 @@ function renderInline(text: string): ReactNode[] {
   }
   if (lastIndex < text.length) nodes.push(text.slice(lastIndex));
   return nodes;
-}
-
-/**
- * Only relative paths and http(s) links render as anchors; anything else
- * (`javascript:`, `data:`) degrades to its literal text.
- */
-function isSafeHref(href: string): boolean {
-  return /^(https?:\/\/|\/|#)/i.test(href);
 }

--- a/src/components/customer-article-chrome.tsx
+++ b/src/components/customer-article-chrome.tsx
@@ -1,0 +1,82 @@
+import type { ReactNode } from "react";
+import { SiteAnalytics } from "@/components/site-analytics";
+import { SiteBrand } from "@/components/site-brand";
+import { StorefrontBlogNav } from "@/components/storefront-blog-nav";
+import {
+  resolveStorefrontPrimaryAction,
+  STOREFRONT_BLOG_HREF,
+} from "@/lib/articles/storefront-journey";
+import type { SiteDraftView } from "@/lib/site-draft";
+import { getSiteDictionary, localizeIntegrationUrl } from "@/lib/site-i18n";
+import { resolveVerticalConfig } from "@/lib/verticals/registry";
+import type { VerticalId } from "@/lib/verticals/types";
+
+/**
+ * Customer identity, palette, home navigation, and the published snapshot's
+ * primary conversion action. Blog index and article pages share this chrome so
+ * they cannot drift onto a factory-like surface.
+ */
+export function CustomerArticleChrome({
+  draft,
+  vertical,
+  locale = draft.defaultLocale,
+  analyticsEnabled = false,
+  children,
+}: {
+  draft: SiteDraftView;
+  vertical: VerticalId;
+  locale?: string;
+  analyticsEnabled?: boolean;
+  children: ReactNode;
+}) {
+  const config = resolveVerticalConfig(vertical);
+  const dictionary = getSiteDictionary(config, locale);
+  const primaryAction = resolveStorefrontPrimaryAction(draft, vertical);
+
+  return (
+    <div
+      lang={locale}
+      data-article-storefront
+      className="min-h-screen font-sans"
+      style={
+        {
+          "--site-bg": draft.palette.background,
+          "--site-fg": draft.palette.foreground,
+          "--site-accent": draft.palette.accent,
+          "--site-accent-fg": draft.palette.accentForeground ?? "#ffffff",
+          background: "var(--site-bg)",
+          color: "var(--site-fg)",
+        } as React.CSSProperties
+      }
+    >
+      {analyticsEnabled ? <SiteAnalytics siteSlug={draft.slug} /> : null}
+      <header className="relative z-20 flex flex-wrap items-center justify-between gap-3 border-b border-current/10 p-4 sm:p-5 md:p-8">
+        <SiteBrand
+          draft={draft}
+          href="/"
+          className="min-w-0 break-words text-lg leading-tight sm:text-xl md:text-2xl"
+        />
+        <div className="flex flex-wrap items-center justify-end gap-3">
+          <StorefrontBlogNav
+            href={STOREFRONT_BLOG_HREF}
+            isLiveSurface={analyticsEnabled}
+            label={dictionary.blogNav}
+          />
+          {primaryAction ? (
+            <a
+              href={localizeIntegrationUrl(primaryAction.url, locale)}
+              data-analytics-cta
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex min-h-11 items-center justify-center rounded-full px-4 py-2 text-center text-xs font-bold text-[var(--site-accent-fg)] focus-visible:outline-2 focus-visible:outline-offset-2"
+              style={{ background: "var(--site-accent)" }}
+            >
+              {primaryAction.label}
+            </a>
+          ) : null}
+        </div>
+      </header>
+      {children}
+    </div>
+  );
+}

--- a/src/components/restaurant-themes/after-dark.tsx
+++ b/src/components/restaurant-themes/after-dark.tsx
@@ -7,6 +7,7 @@ import {
   sourceBrandPalette,
   themeStyle,
   ThemeAnalytics,
+  ThemeBlogNav,
   ThemeBusinessHours,
   ThemeContact,
   ThemeExternalAction,
@@ -27,6 +28,7 @@ export function AfterDarkTheme({
   dictionary,
   embedded = false,
   analyticsEnabled = false,
+  blogHref,
 }: RestaurantThemeRendererProps) {
   const booking = draft.integrations.find(
     (integration) =>
@@ -76,6 +78,11 @@ export function AfterDarkTheme({
               defaultLocale={draft.defaultLocale}
               label={dictionary.language}
               className="border-white/30"
+            />
+            <ThemeBlogNav
+              href={blogHref}
+              enabled={analyticsEnabled}
+              label={dictionary.blogNav}
             />
             {eventLink ? (
               <ThemeExternalAction

--- a/src/components/restaurant-themes/counter-service.tsx
+++ b/src/components/restaurant-themes/counter-service.tsx
@@ -6,6 +6,7 @@ import {
   sourceBrandPalette,
   themeStyle,
   ThemeAnalytics,
+  ThemeBlogNav,
   ThemeBusinessHours,
   ThemeContact,
   ThemeExternalAction,
@@ -26,6 +27,7 @@ export function CounterServiceTheme({
   dictionary,
   embedded = false,
   analyticsEnabled = false,
+  blogHref,
 }: RestaurantThemeRendererProps) {
   const ordering = draft.integrations.find(
     (integration) =>
@@ -64,6 +66,11 @@ export function CounterServiceTheme({
             availableLocales={availableLocales}
             defaultLocale={draft.defaultLocale}
             label={dictionary.language}
+          />
+          <ThemeBlogNav
+            href={blogHref}
+            enabled={analyticsEnabled}
+            label={dictionary.blogNav}
           />
           <ThemeLocation
             draft={draft}

--- a/src/components/restaurant-themes/daylight-cafe.tsx
+++ b/src/components/restaurant-themes/daylight-cafe.tsx
@@ -6,6 +6,7 @@ import {
   sourceBrandPalette,
   themeStyle,
   ThemeAnalytics,
+  ThemeBlogNav,
   ThemeBusinessHours,
   ThemeContact,
   ThemeExternalAction,
@@ -26,6 +27,7 @@ export function DaylightCafeTheme({
   dictionary,
   embedded = false,
   analyticsEnabled = false,
+  blogHref,
 }: RestaurantThemeRendererProps) {
   const ordering = draft.integrations.find(
     (integration) =>
@@ -64,6 +66,11 @@ export function DaylightCafeTheme({
             availableLocales={availableLocales}
             defaultLocale={draft.defaultLocale}
             label={dictionary.language}
+          />
+          <ThemeBlogNav
+            href={blogHref}
+            enabled={analyticsEnabled}
+            label={dictionary.blogNav}
           />
           {ordering ? (
             <ThemeExternalAction

--- a/src/components/restaurant-themes/family-feast.tsx
+++ b/src/components/restaurant-themes/family-feast.tsx
@@ -6,6 +6,7 @@ import {
   sourceBrandPalette,
   themeStyle,
   ThemeAnalytics,
+  ThemeBlogNav,
   ThemeBusinessHours,
   ThemeContact,
   ThemeExternalAction,
@@ -26,6 +27,7 @@ export function FamilyFeastTheme({
   dictionary,
   embedded = false,
   analyticsEnabled = false,
+  blogHref,
 }: RestaurantThemeRendererProps) {
   const booking = draft.integrations.find(
     (integration) =>
@@ -69,6 +71,11 @@ export function FamilyFeastTheme({
             availableLocales={availableLocales}
             defaultLocale={draft.defaultLocale}
             label={dictionary.language}
+          />
+          <ThemeBlogNav
+            href={blogHref}
+            enabled={analyticsEnabled}
+            label={dictionary.blogNav}
           />
           {primaryAction ? (
             <ThemeExternalAction

--- a/src/components/restaurant-themes/neighborhood-table.tsx
+++ b/src/components/restaurant-themes/neighborhood-table.tsx
@@ -6,6 +6,7 @@ import {
   sourceBrandPalette,
   themeStyle,
   ThemeAnalytics,
+  ThemeBlogNav,
   ThemeBusinessHours,
   ThemeContact,
   ThemeExternalAction,
@@ -26,6 +27,7 @@ export function NeighborhoodTableTheme({
   dictionary,
   embedded = false,
   analyticsEnabled = false,
+  blogHref,
 }: RestaurantThemeRendererProps) {
   const booking = draft.integrations.find(
     (integration) =>
@@ -63,6 +65,11 @@ export function NeighborhoodTableTheme({
             availableLocales={availableLocales}
             defaultLocale={draft.defaultLocale}
             label={dictionary.language}
+          />
+          <ThemeBlogNav
+            href={blogHref}
+            enabled={analyticsEnabled}
+            label={dictionary.blogNav}
           />
           {booking ? (
             <ThemeExternalAction

--- a/src/components/restaurant-themes/shared.tsx
+++ b/src/components/restaurant-themes/shared.tsx
@@ -1,6 +1,7 @@
 import { ArrowUpRight, MapPin } from "lucide-react";
 import Link from "next/link";
 import { SiteAnalytics } from "@/components/site-analytics";
+import { StorefrontBlogNav } from "@/components/storefront-blog-nav";
 import { localizeIntegrationUrl } from "@/lib/site-i18n";
 import { localeHref } from "@/lib/site-surface";
 import { serializeRestaurantJsonLd } from "@/lib/restaurant-json-ld";
@@ -20,6 +21,7 @@ export type RestaurantThemeRendererProps = {
   dictionary: Record<string, string>;
   embedded?: boolean;
   analyticsEnabled?: boolean;
+  blogHref?: string | null;
 };
 
 export type RestaurantThemeRendererInputProps = Omit<
@@ -204,6 +206,27 @@ export function ThemeExternalAction({
       {integration.label}
       <ArrowUpRight className="size-4 shrink-0" />
     </a>
+  );
+}
+
+export function ThemeBlogNav({
+  href,
+  enabled,
+  label,
+  className,
+}: {
+  href?: string | null;
+  enabled: boolean;
+  label: string;
+  className?: string;
+}) {
+  return (
+    <StorefrontBlogNav
+      href={href}
+      isLiveSurface={enabled}
+      label={label}
+      className={className}
+    />
   );
 }
 

--- a/src/components/restaurant-themes/terroir-editorial.tsx
+++ b/src/components/restaurant-themes/terroir-editorial.tsx
@@ -6,6 +6,7 @@ import {
   sourceBrandPalette,
   themeStyle,
   ThemeAnalytics,
+  ThemeBlogNav,
   ThemeBusinessHours,
   ThemeContact,
   ThemeExternalAction,
@@ -26,6 +27,7 @@ export function TerroirEditorialTheme({
   dictionary,
   embedded = false,
   analyticsEnabled = false,
+  blogHref,
 }: RestaurantThemeRendererProps) {
   const booking = draft.integrations.find(
     (integration) =>
@@ -67,6 +69,11 @@ export function TerroirEditorialTheme({
             availableLocales={availableLocales}
             defaultLocale={draft.defaultLocale}
             label={dictionary.language}
+          />
+          <ThemeBlogNav
+            href={blogHref}
+            enabled={analyticsEnabled}
+            label={dictionary.blogNav}
           />
           {booking ? (
             <ThemeExternalAction

--- a/src/components/site-renderer.tsx
+++ b/src/components/site-renderer.tsx
@@ -18,6 +18,7 @@ import { RestaurantThemeRenderer } from "@/components/restaurant-themes/restaura
 import { RestaurantStructuredData } from "@/components/restaurant-themes/shared";
 import { SiteAnalytics } from "@/components/site-analytics";
 import { SiteBrand, SourceNavigation } from "@/components/site-brand";
+import { StorefrontBlogNav } from "@/components/storefront-blog-nav";
 import { SitePhotoGallery } from "@/components/site-photo-gallery";
 import { Vertical } from "@/generated/prisma/enums";
 import { resolveBookingEmbed } from "@/lib/booking-embed";
@@ -54,6 +55,7 @@ type SiteRendererProps = {
   availableLocales?: string[];
   analyticsEnabled?: boolean;
   theme?: SiteThemeView;
+  blogHref?: string | null;
 };
 
 export function SiteRenderer({
@@ -65,6 +67,7 @@ export function SiteRenderer({
   availableLocales = [draft.defaultLocale],
   analyticsEnabled = false,
   theme,
+  blogHref,
 }: SiteRendererProps) {
   const config = resolveVerticalConfig(vertical);
   const dictionary = getSiteDictionary(config, locale);
@@ -92,6 +95,7 @@ export function SiteRenderer({
           dictionary={dictionary}
           embedded={embedded}
           analyticsEnabled={analyticsEnabled}
+          blogHref={blogHref}
         />
       );
     }
@@ -215,6 +219,12 @@ export function SiteRenderer({
           )}
         />
         <div className="contents sm:flex sm:shrink-0 sm:items-center sm:gap-2">
+          <StorefrontBlogNav
+            href={blogHref}
+            isLiveSurface={analyticsEnabled}
+            label={dictionary.blogNav}
+            className={immersiveHero ? "text-white" : undefined}
+          />
           {localeBasePath && availableLocales.length > 1 ? (
             <nav
               aria-label={dictionary.language}

--- a/src/components/storefront-blog-nav.tsx
+++ b/src/components/storefront-blog-nav.tsx
@@ -1,0 +1,32 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * One shared Blog entry for live renderer themes. The href is only present when
+ * the attested published version has articles; preview and unpublished
+ * surfaces pass a null href or `isLiveSurface={false}` and render nothing.
+ */
+export function StorefrontBlogNav({
+  href,
+  label,
+  isLiveSurface = false,
+  className,
+}: {
+  href?: string | null;
+  label: string;
+  isLiveSurface?: boolean;
+  className?: string;
+}) {
+  if (!isLiveSurface || !href) return null;
+  return (
+    <a
+      href={href}
+      data-storefront-nav="blog"
+      className={cn(
+        "inline-flex min-h-11 items-center text-sm font-semibold opacity-80 transition-opacity hover:opacity-100 focus-visible:outline-2 focus-visible:outline-offset-2",
+        className,
+      )}
+    >
+      {label}
+    </a>
+  );
+}

--- a/src/lib/articles/public-articles.test.ts
+++ b/src/lib/articles/public-articles.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
 mock.module("server-only", () => ({}));
+mock.module("next/cache", () => ({
+  unstable_cache: <T extends (...args: never[]) => unknown>(callback: T): T =>
+    callback,
+}));
 
 type ArticleRow = {
   slug: string;
@@ -16,6 +20,7 @@ let findFirstInput: unknown;
 let manyRows: ArticleRow[] = [];
 let firstRow: ArticleRow | null = null;
 let findManyCalls = 0;
+let findFirstCalls = 0;
 
 mock.module("@/lib/db", () => ({
   getDb: () => ({
@@ -26,6 +31,7 @@ mock.module("@/lib/db", () => ({
         return manyRows;
       },
       findFirst: async (input: unknown) => {
+        findFirstCalls += 1;
         findFirstInput = input;
         return firstRow;
       },
@@ -36,8 +42,10 @@ mock.module("@/lib/db", () => ({
 const {
   CUSTOMER_SITEMAP_ARTICLE_LIMIT,
   getPublishedArticle,
+  hasPublishedArticles,
   listPublishedArticles,
   listPublishedArticlesForSitemap,
+  resolveStorefrontBlogHref,
 } = await import("@/lib/articles/public-articles");
 
 const publishedAt = new Date("2026-08-20T10:00:00.000Z");
@@ -57,6 +65,7 @@ describe("public article exclusion", () => {
     manyRows = [];
     firstRow = null;
     findManyCalls = 0;
+    findFirstCalls = 0;
   });
 
   it("returns nothing and never queries without a proxy-attested version", async () => {
@@ -162,5 +171,51 @@ describe("public article exclusion", () => {
         articleSlug: row.slug,
       }),
     ).toBeNull();
+  });
+
+  it("never queries article existence without a proxy-attested version", async () => {
+    expect(
+      await hasPublishedArticles({
+        slug: "maison-levain",
+        versionId: null,
+      }),
+    ).toBe(false);
+    expect(findFirstCalls).toBe(0);
+    expect(await resolveStorefrontBlogHref({ slug: "maison-levain", versionId: null })).toBeNull();
+    expect(findFirstCalls).toBe(0);
+  });
+
+  it("exposes a live Blog href only when the attested version has published articles", async () => {
+    firstRow = row;
+    expect(
+      await hasPublishedArticles({
+        slug: "maison-levain",
+        versionId: "version_1",
+      }),
+    ).toBe(true);
+    expect(await resolveStorefrontBlogHref({
+      slug: "maison-levain",
+      versionId: "version_1",
+    })).toBe("/blog");
+    expect(findFirstInput).toMatchObject({
+      where: {
+        site: { slug: "maison-levain" },
+        status: "PUBLISHED",
+        publishedAt: { not: null },
+      },
+      select: { id: true },
+    });
+
+    firstRow = null;
+    expect(
+      await hasPublishedArticles({
+        slug: "maison-levain",
+        versionId: "version_1",
+      }),
+    ).toBe(false);
+    expect(await resolveStorefrontBlogHref({
+      slug: "maison-levain",
+      versionId: "version_1",
+    })).toBeNull();
   });
 });

--- a/src/lib/articles/public-articles.ts
+++ b/src/lib/articles/public-articles.ts
@@ -1,4 +1,5 @@
 import "server-only";
+import { unstable_cache } from "next/cache";
 import { getDb } from "@/lib/db";
 import { previewCacheTagFor } from "@/lib/site-surface";
 
@@ -108,6 +109,39 @@ export async function listPublishedArticlesForSitemap(input: {
         ]
       : [],
   );
+}
+
+export async function hasPublishedArticles(input: {
+  slug: string;
+  versionId: string | null;
+}): Promise<boolean> {
+  if (!input.versionId) return false;
+  const row = await getDb().article.findFirst({
+    where: publishedArticleWhere(input.slug),
+    select: { id: true },
+  });
+  return Boolean(row);
+}
+
+/**
+ * Live renderer Blog href for an attested published version. Missing
+ * attestation, unpublished snapshots, and zero-article sites stay null so
+ * preview chrome cannot grow a Blog entry.
+ */
+export async function resolveStorefrontBlogHref(input: {
+  slug: string;
+  versionId: string | null;
+}): Promise<string | null> {
+  if (!input.versionId) return null;
+  const cached = unstable_cache(
+    () => hasPublishedArticles({ slug: input.slug, versionId: input.versionId }),
+    ["published-articles-exist", input.slug],
+    {
+      revalidate: 30,
+      tags: [articleCacheTagFor(input.slug)],
+    },
+  );
+  return (await cached()) ? "/blog" : null;
 }
 
 export async function getPublishedArticle(input: {

--- a/src/lib/articles/safe-article-href.test.ts
+++ b/src/lib/articles/safe-article-href.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test";
+import {
+  approvedArticleDestinations,
+  isSafeArticleHref,
+} from "@/lib/articles/safe-article-href";
+
+const approved = ["https://www.sevenrooms.com/explore/osteria-luna"];
+
+describe("article markdown href policy", () => {
+  it.each(["/menu", "/blog/summer-bread-guide", "/menu?service=dinner", "/#visit"])(
+    "allows same-origin path %s",
+    (href) => {
+      expect(isSafeArticleHref(href, approved)).toBe(true);
+    },
+  );
+
+  it.each(["#visit", "#menu", "#content"])(
+    "allows fragment anchor %s",
+    (href) => {
+      expect(isSafeArticleHref(href, approved)).toBe(true);
+    },
+  );
+
+  it("allows an exact published integration destination", () => {
+    expect(isSafeArticleHref(approved[0]!, approved)).toBe(true);
+  });
+
+  it.each([
+    "//attacker.example",
+    "//attacker.example/menu",
+    "/\\attacker.example/menu",
+    "https:\\attacker.example/menu",
+    "https://user:pass@sevenrooms.com/explore",
+    "https://www.sevenrooms.com:8443/explore",
+    "https://exa\u0001mple.com/menu",
+    "javascript:alert(1)",
+    "data:text/html,<script>alert(1)</script>",
+    "vbscript:msgbox(1)",
+    "https://attacker.example/menu",
+    "http://www.sevenrooms.com/explore/osteria-luna",
+    "https://www.opentable.com/r/other-restaurant",
+    "#javascript:alert(1)",
+    "#//attacker.example",
+    "/javascript:alert(1)",
+    "https://www.sevenrooms.com/explore/osteria-luna/extra",
+  ])("rejects unsafe href %s", (href) => {
+    expect(isSafeArticleHref(href, approved)).toBe(false);
+  });
+
+  it("ignores disabled integrations and malformed destinations", () => {
+    expect(
+      approvedArticleDestinations([
+        { enabled: true, url: approved[0]! },
+        { enabled: false, url: "https://www.opentable.com/r/hidden" },
+        { enabled: true, url: "javascript:alert(1)" },
+        { enabled: true, url: "http://insecure.example/order" },
+      ]),
+    ).toEqual([approved[0]]);
+    expect(
+      isSafeArticleHref("https://www.opentable.com/r/hidden", [
+        "https://www.opentable.com/r/hidden",
+      ]),
+    ).toBe(true);
+    expect(
+      isSafeArticleHref(
+        "https://www.opentable.com/r/hidden",
+        approvedArticleDestinations([
+          { enabled: false, url: "https://www.opentable.com/r/hidden" },
+        ]),
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/lib/articles/safe-article-href.ts
+++ b/src/lib/articles/safe-article-href.ts
@@ -1,0 +1,84 @@
+import { safeExternalHttpsUrlSchema } from "@/lib/verticals/schema";
+
+const UNSAFE_CHARS = /[\\\u0000-\u001f\u007f]/;
+
+/**
+ * Deny-by-default destinations for generated article markdown.
+ *
+ * Safe values are same-origin relative paths, fragment anchors, and the exact
+ * HTTPS integration URLs already stored on the published site draft. Protocol-
+ * relative, backslash, credentialed, control-character, and any other external
+ * href degrade to text instead of becoming an anchor.
+ */
+export function isSafeArticleHref(
+  href: string,
+  approvedDestinations: readonly string[] = [],
+): boolean {
+  if (!href || href !== href.trim() || UNSAFE_CHARS.test(href)) return false;
+  if (/\s/.test(href) || /%00/i.test(href)) return false;
+
+  if (href.startsWith("#")) return isSafeFragment(href);
+  if (href.startsWith("/") && !href.startsWith("//")) {
+    return isSafeSameOriginPath(href);
+  }
+  return isExactApprovedDestination(href, approvedDestinations);
+}
+
+export function approvedArticleDestinations(
+  integrations: ReadonlyArray<{ enabled: boolean; url: string }>,
+): string[] {
+  return [
+    ...new Set(
+      integrations.flatMap((integration) =>
+        integration.enabled &&
+        safeExternalHttpsUrlSchema.safeParse(integration.url).success
+          ? [integration.url]
+          : [],
+      ),
+    ),
+  ];
+}
+
+function isSafeFragment(href: string): boolean {
+  if (href.length < 2) return false;
+  if (href.includes(":") || href.includes("//") || href.includes("@")) {
+    return false;
+  }
+  return true;
+}
+
+function isSafeSameOriginPath(href: string): boolean {
+  if (href.includes(":") || href.includes("@")) return false;
+  return true;
+}
+
+function isExactApprovedDestination(
+  href: string,
+  approvedDestinations: readonly string[],
+): boolean {
+  if (!safeExternalHttpsUrlSchema.safeParse(href).success) return false;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(href);
+  } catch {
+    return false;
+  }
+  if (
+    parsed.protocol !== "https:" ||
+    parsed.username ||
+    parsed.password ||
+    parsed.port
+  ) {
+    return false;
+  }
+
+  return approvedDestinations.some((destination) => {
+    if (destination === href) return true;
+    try {
+      return new URL(destination).href === parsed.href;
+    } catch {
+      return false;
+    }
+  });
+}

--- a/src/lib/articles/storefront-journey.test.tsx
+++ b/src/lib/articles/storefront-journey.test.tsx
@@ -1,0 +1,301 @@
+import { describe, expect, it } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ArticleMarkdown } from "@/components/article-markdown";
+import { CustomerArticleChrome } from "@/components/customer-article-chrome";
+import { RestaurantThemeRenderer } from "@/components/restaurant-themes/restaurant-theme-renderer";
+import { SiteRenderer } from "@/components/site-renderer";
+import { approvedArticleDestinations } from "@/lib/articles/safe-article-href";
+import {
+  resolveStorefrontPrimaryAction,
+  storefrontBlogHref,
+} from "@/lib/articles/storefront-journey";
+import { analyticsEventInputSchema } from "@/lib/analytics-contract";
+import { restaurantThemeSelectionSchema } from "@/lib/site-themes/restaurant/contracts";
+import { restaurantThemeFixtures } from "@/lib/site-themes/restaurant/fixtures";
+import { listRestaurantThemeManifests } from "@/lib/site-themes/restaurant/registry";
+import { sampleFoodRetailDraft } from "@/lib/verticals/food-retail/fixtures";
+import { restaurantConfig } from "@/lib/verticals/restaurant/config";
+import {
+  restaurantSiteDraftSchema,
+  sampleSiteDraft,
+} from "@/lib/verticals/restaurant/schema";
+
+const publishedDraft = restaurantSiteDraftSchema.parse({
+  ...sampleSiteDraft,
+  name: "Published Osteria",
+  palette: {
+    background: "#f4efe5",
+    foreground: "#1d241f",
+    accent: "#a5482d",
+  },
+  integrations: [
+    {
+      type: "booking",
+      label: "Book a table",
+      provider: "SevenRooms",
+      url: "https://www.sevenrooms.com/explore/osteria-luna",
+      enabled: true,
+      venueId: null,
+    },
+  ],
+});
+
+const draftSnapshot = restaurantSiteDraftSchema.parse({
+  ...sampleSiteDraft,
+  name: "Draft Kitchen Rewrite",
+  palette: {
+    background: "#111111",
+    foreground: "#eeeeee",
+    accent: "#ff00aa",
+  },
+  integrations: [],
+});
+
+describe("storefront blog href conditions", () => {
+  it("stays absent on preview, unpublished, and zero-article surfaces", () => {
+    expect(
+      storefrontBlogHref({ isLiveSurface: false, hasPublishedArticles: true }),
+    ).toBeNull();
+    expect(
+      storefrontBlogHref({ isLiveSurface: true, hasPublishedArticles: false }),
+    ).toBeNull();
+    expect(
+      storefrontBlogHref({ isLiveSurface: false, hasPublishedArticles: false }),
+    ).toBeNull();
+  });
+
+  it("returns the live Blog path only for an attested version with articles", () => {
+    expect(
+      storefrontBlogHref({ isLiveSurface: true, hasPublishedArticles: true }),
+    ).toBe("/blog");
+  });
+});
+
+describe("shared live renderer blog navigation", () => {
+  it("does not expose Blog on preview or unpublished shared surfaces", () => {
+    const preview = renderToStaticMarkup(
+      <SiteRenderer
+        draft={sampleSiteDraft}
+        vertical={restaurantConfig.id}
+        blogHref="/blog"
+      />,
+    );
+    const unpublished = renderToStaticMarkup(
+      <SiteRenderer
+        draft={sampleSiteDraft}
+        vertical={restaurantConfig.id}
+        analyticsEnabled
+      />,
+    );
+    const foodRetail = renderToStaticMarkup(
+      <SiteRenderer draft={sampleFoodRetailDraft} vertical="FOOD_RETAIL" />,
+    );
+
+    expect(preview).not.toContain('data-storefront-nav="blog"');
+    expect(unpublished).not.toContain('data-storefront-nav="blog"');
+    expect(foodRetail).not.toContain('data-storefront-nav="blog"');
+  });
+
+  it("exposes Blog on the shared live renderer only when that version has articles", () => {
+    const live = renderToStaticMarkup(
+      <SiteRenderer
+        draft={sampleSiteDraft}
+        vertical={restaurantConfig.id}
+        analyticsEnabled
+        blogHref="/blog"
+      />,
+    );
+    const zeroArticle = renderToStaticMarkup(
+      <SiteRenderer
+        draft={sampleSiteDraft}
+        vertical={restaurantConfig.id}
+        analyticsEnabled
+        blogHref={null}
+      />,
+    );
+
+    expect(live).toContain('data-storefront-nav="blog"');
+    expect(live).toContain('href="/blog"');
+    expect(zeroArticle).not.toContain('data-storefront-nav="blog"');
+  });
+});
+
+describe("restaurant live renderer blog navigation", () => {
+  it("does not expose Blog on preview or zero-article restaurant themes", () => {
+    for (const manifest of listRestaurantThemeManifests()) {
+      const fixture = restaurantThemeFixtures[manifest.id];
+      const selection = restaurantThemeSelectionSchema.parse(
+        fixture.attributes.themeSelection,
+      );
+      const preview = renderToStaticMarkup(
+        <RestaurantThemeRenderer
+          draft={fixture}
+          selection={selection}
+          blogHref="/blog"
+        />,
+      );
+      const zeroArticle = renderToStaticMarkup(
+        <RestaurantThemeRenderer
+          draft={fixture}
+          selection={selection}
+          analyticsEnabled
+        />,
+      );
+
+      expect(preview).not.toContain('data-storefront-nav="blog"');
+      expect(zeroArticle).not.toContain('data-storefront-nav="blog"');
+    }
+  });
+
+  it("exposes one Blog entry on every live restaurant theme with published articles", () => {
+    for (const manifest of listRestaurantThemeManifests()) {
+      const fixture = restaurantThemeFixtures[manifest.id];
+      const selection = restaurantThemeSelectionSchema.parse(
+        fixture.attributes.themeSelection,
+      );
+      const html = renderToStaticMarkup(
+        <RestaurantThemeRenderer
+          draft={fixture}
+          selection={selection}
+          analyticsEnabled
+          blogHref="/blog"
+        />,
+      );
+
+      expect(html).toContain('data-storefront-nav="blog"');
+      expect(html).toContain('href="/blog"');
+      expect(html.split('data-storefront-nav="blog"')).toHaveLength(2);
+    }
+  });
+});
+
+describe("published article storefront chrome", () => {
+  it("renders the exact authorized published identity instead of a later draft", () => {
+    const published = renderToStaticMarkup(
+      <CustomerArticleChrome
+        draft={publishedDraft}
+        vertical={restaurantConfig.id}
+        analyticsEnabled
+      >
+        <p>Article body stays in the page, not in analytics.</p>
+      </CustomerArticleChrome>,
+    );
+    const isolated = renderToStaticMarkup(
+      <CustomerArticleChrome
+        draft={draftSnapshot}
+        vertical={restaurantConfig.id}
+        analyticsEnabled
+      >
+        <p>Draft-only copy</p>
+      </CustomerArticleChrome>,
+    );
+
+    expect(published).toContain("Published Osteria");
+    expect(published).toContain("#f4efe5");
+    expect(published).not.toContain("Draft Kitchen Rewrite");
+    expect(published).not.toContain("#ff00aa");
+    expect(isolated).toContain("Draft Kitchen Rewrite");
+    expect(isolated).not.toContain("Published Osteria");
+  });
+
+  it("provides keyboard-accessible home navigation and an evidence-backed conversion action", () => {
+    const markup = renderToStaticMarkup(
+      <CustomerArticleChrome
+        draft={publishedDraft}
+        vertical={restaurantConfig.id}
+        analyticsEnabled
+      >
+        <p>Back to the site</p>
+      </CustomerArticleChrome>,
+    );
+    const action = resolveStorefrontPrimaryAction(
+      publishedDraft,
+      restaurantConfig.id,
+    );
+
+    expect(action?.url).toBe(
+      "https://www.sevenrooms.com/explore/osteria-luna",
+    );
+    expect(markup).toContain('href="/"');
+    expect(markup).toContain("Published Osteria");
+    expect(markup).toContain("Back to the site");
+    expect(markup).toContain('href="https://www.sevenrooms.com/explore/osteria-luna"');
+    expect(markup).toContain("Book a table");
+    expect(markup).toContain("data-analytics-cta");
+    expect(markup).toContain("min-h-11");
+  });
+
+  it("does not invent a conversion action the published snapshot does not carry", () => {
+    const markup = renderToStaticMarkup(
+      <CustomerArticleChrome
+        draft={draftSnapshot}
+        vertical={restaurantConfig.id}
+        analyticsEnabled
+      >
+        <p>No CTA</p>
+      </CustomerArticleChrome>,
+    );
+
+    expect(resolveStorefrontPrimaryAction(draftSnapshot, restaurantConfig.id)).toBeNull();
+    expect(markup).not.toContain("data-analytics-cta");
+  });
+});
+
+describe("article storefront analytics minimization", () => {
+  it("preserves CTA semantics without recording article body or URL data", () => {
+    const articleBody =
+      "Private article body that mentions https://article.example/secret-path";
+    const articleUrl = "/blog/summer-bread-guide";
+    const markup = renderToStaticMarkup(
+      <CustomerArticleChrome
+        draft={publishedDraft}
+        vertical={restaurantConfig.id}
+        analyticsEnabled
+      >
+        <ArticleMarkdown
+          markdown={`Read more at [home](/) or [book](${publishedDraft.integrations[0]?.url}). ${articleBody}`}
+          approvedDestinations={approvedArticleDestinations(
+            publishedDraft.integrations,
+          )}
+        />
+      </CustomerArticleChrome>,
+    );
+
+    const ctaMarkup = markup.match(
+      /<a[^>]*data-analytics-cta[^>]*>[\s\S]*?<\/a>/,
+    )?.[0];
+    expect(ctaMarkup).toBeDefined();
+    expect(ctaMarkup).toContain("Book a table");
+    expect(ctaMarkup).not.toContain(articleBody);
+    expect(ctaMarkup).not.toContain(articleUrl);
+    expect(ctaMarkup).not.toContain("article.example");
+
+    const bodyLink = markup.match(
+      /<a[^>]*href="https:\/\/www\.sevenrooms\.com\/explore\/osteria-luna"[^>]*>[\s\S]*?<\/a>/g,
+    );
+    expect(bodyLink?.some((link) => !link.includes("data-analytics-cta"))).toBe(
+      true,
+    );
+
+    expect(
+      analyticsEventInputSchema.parse({
+        id: "5cd2b4dd-c6d5-4bfb-b453-2d12b349c27a",
+        visitId: "aa508bd0-43a1-4559-88ff-127fcf981bab",
+        type: "CTA_CLICK",
+      }),
+    ).toEqual({
+      id: "5cd2b4dd-c6d5-4bfb-b453-2d12b349c27a",
+      visitId: "aa508bd0-43a1-4559-88ff-127fcf981bab",
+      type: "CTA_CLICK",
+    });
+    expect(() =>
+      analyticsEventInputSchema.parse({
+        id: "5cd2b4dd-c6d5-4bfb-b453-2d12b349c27a",
+        visitId: "aa508bd0-43a1-4559-88ff-127fcf981bab",
+        type: "CTA_CLICK",
+        url: articleUrl,
+        body: articleBody,
+      }),
+    ).toThrow();
+  });
+});

--- a/src/lib/articles/storefront-journey.ts
+++ b/src/lib/articles/storefront-journey.ts
@@ -1,0 +1,61 @@
+import type { SiteDraftView, SiteIntegrationView } from "@/lib/site-draft";
+import { resolveVerticalConfig } from "@/lib/verticals/registry";
+import type { VerticalId } from "@/lib/verticals/types";
+
+export const STOREFRONT_BLOG_HREF = "/blog";
+
+const actionPriority = {
+  booking: ["booking", "ordering"],
+  ordering: ["ordering", "booking"],
+  quote: ["quote", "contact", "booking", "ordering"],
+  contact: ["contact", "quote", "booking", "ordering"],
+} as const;
+
+export type StorefrontBlogHrefInput = {
+  isLiveSurface: boolean;
+  hasPublishedArticles: boolean;
+};
+
+/**
+ * Live renderer themes expose one Blog entry only when the attested published
+ * version actually has published articles. Preview, unpublished, and
+ * zero-article surfaces keep the href absent.
+ */
+export function storefrontBlogHref(
+  input: StorefrontBlogHrefInput,
+): string | null {
+  if (!input.isLiveSurface || !input.hasPublishedArticles) return null;
+  return STOREFRONT_BLOG_HREF;
+}
+
+/**
+ * The same conversion-first integration the live renderer would put in the
+ * header. Blog chrome must not invent a CTA the published snapshot does not
+ * already carry.
+ */
+export function resolveStorefrontPrimaryAction(
+  draft: SiteDraftView,
+  vertical: VerticalId,
+): SiteIntegrationView | null {
+  const config = resolveVerticalConfig(vertical);
+  const allowedTypes = new Set(config.integrationTypes);
+  const integrations = draft.integrations.filter(
+    (integration) =>
+      integration.enabled && allowedTypes.has(integration.type),
+  );
+  const booking = integrations.find(
+    (integration) => integration.type === "booking",
+  );
+  const ordering = integrations.find((integration) =>
+    ["ordering", "delivery"].includes(integration.type),
+  );
+  const quote = integrations.find((integration) => integration.type === "quote");
+  const contact = integrations.find(
+    (integration) => integration.type === "contact",
+  );
+  const actions = { booking, ordering, quote, contact };
+  const [primaryAction] = actionPriority[
+    config.rendererCapabilities(draft.attributes).primaryAction
+  ].flatMap((type) => (actions[type] ? [actions[type]] : []));
+  return primaryAction ?? null;
+}

--- a/src/lib/site-i18n.ts
+++ b/src/lib/site-i18n.ts
@@ -43,6 +43,7 @@ const sharedSiteDictionary = {
     bookingRequestPreviewNotice: "This is a preview — requests are not sent.",
     bookingEmbedPreviewNotice: "Booking widget shown on the live site.",
     pickupHeading: "Pickup",
+    blogNav: "Blog",
   },
   fr: {
     bookingRequestName: "Votre nom",
@@ -62,6 +63,7 @@ const sharedSiteDictionary = {
     bookingEmbedPreviewNotice:
       "Widget de réservation affiché sur le site en ligne.",
     pickupHeading: "Retrait",
+    blogNav: "Blog",
   },
 } satisfies Record<string, Record<string, string>>;
 


### PR DESCRIPTION
Closes #154

Published articles now ride the same attested snapshot as the live storefront, and article markdown no longer treats protocol-relative URLs as safe.

## What changed

- Blog index and article pages wrap customer chrome from `getCachedPublishedSiteView(slug, versionId)`: identity, palette, keyboard-accessible home navigation, and the published snapshot's primary conversion action.
- Shared `SiteRenderer` and all six restaurant themes expose one Blog nav entry only on live surfaces when that attested version has published articles. Preview, unpublished, zero-article, and embedded surfaces stay dark.
- Markdown hrefs are deny-by-default. Allowed: same-origin paths starting with a single `/`, fragment anchors, and exact enabled integration URLs from the published draft. Protocol-relative, backslash, credentialed, control-character, and unsupported external destinations render as text.
- Live blog chrome uses the existing `data-analytics-cta` contract. CTA events remain `{ id, visitId, type }` and do not record article body or URL data.

## Tests

- Markdown attack cases and approved-destination allow-list
- Shared and restaurant renderer Blog nav conditions
- Immutable-version isolation for article existence / chrome identity
- Zero-article and unpublished surfaces
- Keyboard-accessible home navigation and evidence-backed conversion
- Analytics payload minimization

`bun test` on the focused files: 49 pass. `bun run lint` is clean. `bunx tsc --noEmit` has no errors in changed files (pre-existing `RouteContext` errors remain in unrelated API routes). `git diff --check` is clean.

## Non-goals

Article generation and owner-review behavior (#136) are untouched.