### PR TITLE
fix(beauty): split publication read from owner mutation

### DIFF
--- a/src/app/create/import-studio.tsx
+++ b/src/app/create/import-studio.tsx
@@ -88,13 +88,13 @@ const verticalCopy = {
     placeholder: "salon.com or salon name",
     opening: "Opening the salon",
     idlePrompt:
-      "Paste a website or salon name. The preview stays private until it is claimed and paid.",
+      "Paste a website or salon name. The preview stays private and is not chargeable.",
     recovering:
       "The shape is already here. We are recovering the real service list, imagery and existing links now.",
     emptyStatePrompt:
       "Start with a website or salon name. No account is needed to see the result.",
     claimHint:
-      "Review the services and existing links, then claim the founding plan to keep this site current.",
+      "Review the recovered services and booking links in this private preview.",
     catalogStage: "Recover services and prices",
     // No ordering or delivery: a salon has nothing to deliver, which is the same
     // reason `beauty/providers.ts` ships no hints for those integration types.
@@ -578,7 +578,7 @@ export function ImportStudio({
               <p className="mt-2 text-xs leading-5 text-muted-foreground">
                 {isVerticalClaimEnabled(site.vertical)
                   ? copy.claimHint
-                  : "Claiming and checkout remain unavailable until this vertical has reviewed launch configuration."}
+                  : "This vertical is a non-chargeable private preview. Owner tools are not available yet."}
               </p>
               {externalPreviewAvailable ? (
                 <div className="mt-4 grid gap-2">

--- a/src/app/dashboard/unsupported-vertical-dashboard.tsx
+++ b/src/app/dashboard/unsupported-vertical-dashboard.tsx
@@ -6,8 +6,9 @@ import type { BrandIdentity } from "@/lib/brand";
 import type { Vertical } from "@/generated/prisma/enums";
 
 /**
- * Restaurant owns the full editor today. Other verticals can import and claim,
- * but must not fall through to the restaurant sample draft under the real slug.
+ * Restaurant owns the full editor today. Verticals without a dedicated
+ * owner-review dashboard can still import a private preview, but must not
+ * fall through to the restaurant sample draft under the real slug.
  */
 export function UnsupportedVerticalDashboard({
   email,
@@ -44,12 +45,12 @@ export function UnsupportedVerticalDashboard({
               <span className="font-medium text-foreground">
                 {vertical.toLowerCase()}
               </span>{" "}
-              site. Import, claim, and hosting already work; the dashboard editor
-              still ships restaurant-first so we do not risk rewriting your
-              content as a restaurant sample.
+              site. This is a private, non-chargeable preview. The dashboard
+              editor still ships restaurant-first so we do not risk rewriting
+              your content as a restaurant sample.
             </p>
             <p>
-              Open the private preview to review the generated site, or switch
+              Open the private preview to inspect the generated site, or switch
               workspace if you manage a restaurant as well.
             </p>
             <div className="flex flex-wrap gap-3 pt-2">

--- a/src/app/niche/[vertical]/page.tsx
+++ b/src/app/niche/[vertical]/page.tsx
@@ -23,6 +23,7 @@ import { nicheFontVariables } from "@/components/fonts/niche-font-scope";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
+  isVerticalClaimEnabled,
   isVerticalPubliclyAccessible,
   listPublicVerticals,
   resolveVerticalBySlug,
@@ -140,6 +141,9 @@ export default async function NichePage({
   const { marketing } = resolveVerticalConfig(id);
   const slug = verticalSlug(id);
   const fontVariables = nicheFontVariables(id);
+  const acquisitionPricing = isVerticalClaimEnabled(id)
+    ? marketing.pricing
+    : undefined;
   // Every route out of this page carries the niche, so a lead is attached to the
   // vertical that produced it before the studio ever opens.
   const createHref = `/create?vertical=${slug}`;
@@ -149,7 +153,7 @@ export default async function NichePage({
       ? [{ href: "#themes", label: marketing.themeGallery.label }]
       : []),
     { href: "#features", label: "What stays yours" },
-    { href: "#pricing", label: "Pricing" },
+    ...(acquisitionPricing ? [{ href: "#pricing", label: "Pricing" }] : []),
   ];
   const formCopy = {
     vertical: slug,
@@ -388,90 +392,92 @@ export default async function NichePage({
           </div>
         </section>
 
-        <section
-          id="pricing"
-          className="mx-auto max-w-7xl px-5 py-24 lg:px-8 lg:py-32"
-        >
-          <div className="mx-auto max-w-2xl text-center">
-            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary">
-              {marketing.pricing.eyebrow}
-            </p>
-            <h2 className="font-display mt-4 text-6xl leading-[0.92] tracking-[-0.045em]">
-              {marketing.pricing.headline}
-            </h2>
-            <p className="mt-5 text-muted-foreground">
-              {marketing.pricing.copy}
-            </p>
-          </div>
-          <div
-            className={`mx-auto mt-12 grid gap-5 ${
-              marketing.pricing.plans.length > 1
-                ? "max-w-4xl md:grid-cols-2"
-                : "max-w-xl"
-            }`}
+        {acquisitionPricing ? (
+          <section
+            id="pricing"
+            className="mx-auto max-w-7xl px-5 py-24 lg:px-8 lg:py-32"
           >
-            {marketing.pricing.plans.map((plan) => (
-              <div
-                key={plan.name}
-                className={
-                  plan.featured
-                    ? "rounded-3xl border border-primary/40 bg-primary p-7 text-primary-foreground shadow-xl"
-                    : "rounded-3xl border bg-card p-7"
-                }
-              >
-                <div className="flex items-center justify-between">
-                  <p className="text-sm font-semibold">{plan.name}</p>
-                  {plan.badge ? (
-                    <Badge className="bg-white/15 text-white">
-                      {plan.badge}
-                    </Badge>
-                  ) : null}
-                </div>
-                <p className="mt-5 font-display text-6xl tracking-[-0.05em]">
-                  {plan.price}
-                  <span
-                    className={`font-sans text-sm tracking-normal ${
+            <div className="mx-auto max-w-2xl text-center">
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary">
+                {acquisitionPricing.eyebrow}
+              </p>
+              <h2 className="font-display mt-4 text-6xl leading-[0.92] tracking-[-0.045em]">
+                {acquisitionPricing.headline}
+              </h2>
+              <p className="mt-5 text-muted-foreground">
+                {acquisitionPricing.copy}
+              </p>
+            </div>
+            <div
+              className={`mx-auto mt-12 grid gap-5 ${
+                acquisitionPricing.plans.length > 1
+                  ? "max-w-4xl md:grid-cols-2"
+                  : "max-w-xl"
+              }`}
+            >
+              {acquisitionPricing.plans.map((plan) => (
+                <div
+                  key={plan.name}
+                  className={
+                    plan.featured
+                      ? "rounded-3xl border border-primary/40 bg-primary p-7 text-primary-foreground shadow-xl"
+                      : "rounded-3xl border bg-card p-7"
+                  }
+                >
+                  <div className="flex items-center justify-between">
+                    <p className="text-sm font-semibold">{plan.name}</p>
+                    {plan.badge ? (
+                      <Badge className="bg-white/15 text-white">
+                        {plan.badge}
+                      </Badge>
+                    ) : null}
+                  </div>
+                  <p className="mt-5 font-display text-6xl tracking-[-0.05em]">
+                    {plan.price}
+                    <span
+                      className={`font-sans text-sm tracking-normal ${
+                        plan.featured ? "text-white/70" : "text-muted-foreground"
+                      }`}
+                    >
+                      {plan.cadence}
+                    </span>
+                  </p>
+                  <p
+                    className={`mt-3 text-sm ${
                       plan.featured ? "text-white/70" : "text-muted-foreground"
                     }`}
                   >
-                    {plan.cadence}
-                  </span>
-                </p>
-                <p
-                  className={`mt-3 text-sm ${
-                    plan.featured ? "text-white/70" : "text-muted-foreground"
-                  }`}
-                >
-                  {plan.copy}
-                </p>
-                <ul className="mt-7 space-y-3 text-sm">
-                  {plan.features.map((feature) => (
-                    <li key={feature} className="flex items-center gap-2">
-                      <Check
-                        className={`size-4 ${
-                          plan.featured ? "" : "text-primary"
-                        }`}
-                      />{" "}
-                      {feature}
-                    </li>
-                  ))}
-                </ul>
-                <Button
-                  render={<Link href={createHref} />}
-                  nativeButton={false}
-                  variant={plan.featured ? "secondary" : "outline"}
-                  className={`mt-8 w-full ${
-                    plan.featured
-                      ? "bg-white text-primary hover:bg-white/90"
-                      : ""
-                  }`}
-                >
-                  Build a free preview
-                </Button>
-              </div>
-            ))}
-          </div>
-        </section>
+                    {plan.copy}
+                  </p>
+                  <ul className="mt-7 space-y-3 text-sm">
+                    {plan.features.map((feature) => (
+                      <li key={feature} className="flex items-center gap-2">
+                        <Check
+                          className={`size-4 ${
+                            plan.featured ? "" : "text-primary"
+                          }`}
+                        />{" "}
+                        {feature}
+                      </li>
+                    ))}
+                  </ul>
+                  <Button
+                    render={<Link href={createHref} />}
+                    nativeButton={false}
+                    variant={plan.featured ? "secondary" : "outline"}
+                    className={`mt-8 w-full ${
+                      plan.featured
+                        ? "bg-white text-primary hover:bg-white/90"
+                        : ""
+                    }`}
+                  >
+                    Build a free preview
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </section>
+        ) : null}
 
         <section className="paper-grid border-t">
           <div className="mx-auto flex max-w-5xl flex-col items-center px-5 py-24 text-center lg:py-32">

--- a/src/lib/dashboard-tabs-surface.test.ts
+++ b/src/lib/dashboard-tabs-surface.test.ts
@@ -28,6 +28,9 @@ const sitePublication = await Bun.file(
   new URL("./site-publication.ts", import.meta.url),
 ).text();
 const sites = await Bun.file(new URL("./sites.ts", import.meta.url)).text();
+const publicationCapability = await Bun.file(
+  new URL("./site-publication-capability.ts", import.meta.url),
+).text();
 const translationRegenerationRoute = await Bun.file(
   new URL(
     "../app/api/sites/[slug]/translations/[locale]/regenerate/route.ts",
@@ -90,6 +93,13 @@ describe("dashboard tab and settings surface", () => {
       ),
     ).toHaveLength(2);
     expect(sites).toContain("!isVerticalPublicationEnabled(version.vertical)");
+    expect(sites).not.toContain("isVerticalPublicationMutationEnabled");
+    expect(publicationCapability).toContain(
+      "isVerticalPublicationMutationEnabled",
+    );
+    expect(publicationCapability).not.toContain(
+      "isVerticalPublicationEnabled(vertical)",
+    );
   });
 
   it("carries the universal draft revision through auxiliary owner mutations", () => {

--- a/src/lib/owner-site-save.ts
+++ b/src/lib/owner-site-save.ts
@@ -4,7 +4,10 @@ import {
   DraftRevisionConflictError,
   updateSiteDraft,
 } from "@/lib/site-persistence";
-import { resolveVerticalConfig } from "@/lib/verticals/registry";
+import {
+  isVerticalOwnerReviewSupported,
+  resolveVerticalConfig,
+} from "@/lib/verticals/registry";
 
 type OwnerSiteSaveAccess = {
   site: { vertical: Vertical };
@@ -25,11 +28,11 @@ export async function saveAuthorizedSiteDraft(
   input: unknown,
   saveDraft: OwnerSiteDraftUpdater = updateSiteDraft,
 ) {
-  if (access.site.vertical === Vertical.BEAUTY) {
+  if (!isVerticalOwnerReviewSupported(access.site.vertical)) {
     return Response.json(
       {
         error:
-          "Owner editing for this vertical is not available yet. Use import and claim flows until the vertical editor ships.",
+          "Owner editing for this vertical is not available yet. Use the private preview until the vertical editor ships.",
       },
       { status: 409 },
     );

--- a/src/lib/sign-in-surface.test.ts
+++ b/src/lib/sign-in-surface.test.ts
@@ -38,7 +38,7 @@ describe("sign-in surface", () => {
       brand: beautyMarketing.brand,
       inverse: false,
       copy: {
-        title: "Open your salon.",
+        title: "Open your salon preview.",
         emailPlaceholder: "owner@salon.com",
         createHref: "/create?vertical=beauty",
       },

--- a/src/lib/site-owner-route.test.ts
+++ b/src/lib/site-owner-route.test.ts
@@ -119,6 +119,22 @@ describe("owner site save revision contract", () => {
     expect(updateSiteDraft).not.toHaveBeenCalled();
   });
 
+  it("rejects beauty owner saves without promising claim or checkout", async () => {
+    const response = await saveAuthorizedSiteDraft(
+      "atelier-coupe",
+      { ...access, site: { vertical: Vertical.BEAUTY } },
+      { expectedRevision: currentRevision },
+      updateSiteDraft,
+    );
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({
+      error:
+        "Owner editing for this vertical is not available yet. Use the private preview until the vertical editor ships.",
+    });
+    expect(updateSiteDraft).not.toHaveBeenCalled();
+  });
+
   it("persists a schema-valid local-service draft with optimistic concurrency", async () => {
     const response = await saveAuthorizedSiteDraft(
       sampleLocalServiceSiteDraft.slug,

--- a/src/lib/site-publication-capability.test.ts
+++ b/src/lib/site-publication-capability.test.ts
@@ -2,14 +2,37 @@ import { describe, expect, it } from "bun:test";
 import { Vertical } from "@/generated/prisma/enums";
 import {
   assertVerticalPublicationEnabled,
+  PUBLICATION_UNAVAILABLE_MESSAGE,
   publicationCapabilityFailureResponse,
+  SitePublicationCapabilityError,
 } from "@/lib/site-publication-capability";
 
+const ownerReviewVerticals = [
+  Vertical.RESTAURANT,
+  Vertical.FOOD_RETAIL,
+  Vertical.LOCAL_SERVICE,
+] as const;
+
 describe("site publication capability", () => {
-  it("allows reviewed publication for every registered SMB vertical", () => {
-    for (const vertical of Object.values(Vertical)) {
+  it("allows reviewed publication mutation for verticals with owner-review workflows", () => {
+    for (const vertical of ownerReviewVerticals) {
       expect(publicationCapabilityFailureResponse(vertical)).toBeNull();
       expect(() => assertVerticalPublicationEnabled(vertical)).not.toThrow();
     }
+  });
+
+  it("fails closed for beauty owner publication mutation", async () => {
+    const response = publicationCapabilityFailureResponse(Vertical.BEAUTY);
+    expect(response).not.toBeNull();
+    expect(response?.status).toBe(409);
+    expect(await response?.json()).toEqual({
+      error: PUBLICATION_UNAVAILABLE_MESSAGE,
+    });
+    expect(() => assertVerticalPublicationEnabled(Vertical.BEAUTY)).toThrow(
+      SitePublicationCapabilityError,
+    );
+    expect(() => assertVerticalPublicationEnabled(Vertical.BEAUTY)).toThrow(
+      PUBLICATION_UNAVAILABLE_MESSAGE,
+    );
   });
 });

--- a/src/lib/site-publication-capability.ts
+++ b/src/lib/site-publication-capability.ts
@@ -1,5 +1,5 @@
 import type { VerticalId } from "@/lib/verticals/types";
-import { isVerticalPublicationEnabled } from "@/lib/verticals/registry";
+import { isVerticalPublicationMutationEnabled } from "@/lib/verticals/registry";
 
 export const PUBLICATION_UNAVAILABLE_MESSAGE =
   "Publishing is not available for this vertical";
@@ -13,7 +13,7 @@ export class SitePublicationCapabilityError extends Error {
 
 /** Shared fail-closed assertion used by publish and rollback services. */
 export function assertVerticalPublicationEnabled(vertical: VerticalId): void {
-  if (!isVerticalPublicationEnabled(vertical)) {
+  if (!isVerticalPublicationMutationEnabled(vertical)) {
     throw new SitePublicationCapabilityError();
   }
 }
@@ -25,7 +25,7 @@ export function assertVerticalPublicationEnabled(vertical: VerticalId): void {
 export function publicationCapabilityFailureResponse(
   vertical: VerticalId,
 ): Response | null {
-  if (isVerticalPublicationEnabled(vertical)) return null;
+  if (isVerticalPublicationMutationEnabled(vertical)) return null;
   return Response.json(
     { error: PUBLICATION_UNAVAILABLE_MESSAGE },
     { status: 409 },

--- a/src/lib/verticals/beauty/config.ts
+++ b/src/lib/verticals/beauty/config.ts
@@ -79,6 +79,7 @@ export const beautyConfig = {
   marketing: beautyMarketing,
   claimMode: "disabled",
   publicationEnabled: true,
+  publicationMutationEnabled: false,
   integrationTypes: ["booking", "social"],
   attributesSchema: beautyAttributesSchema,
   attributeDefaults: {

--- a/src/lib/verticals/beauty/lifecycle.test.ts
+++ b/src/lib/verticals/beauty/lifecycle.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "bun:test";
+import { Vertical } from "@/generated/prisma/enums";
+import { beautyMarketing } from "@/lib/verticals/beauty/marketing";
+import { beautyConfig } from "@/lib/verticals/beauty/config";
+import {
+  isVerticalClaimEnabled,
+  isVerticalOwnerReviewSupported,
+  isVerticalPublicationEnabled,
+  isVerticalPublicationMutationEnabled,
+  resolveVerticalConfig,
+} from "@/lib/verticals/registry";
+
+const importStudio = await Bun.file(
+  new URL("../../../app/create/import-studio.tsx", import.meta.url),
+).text();
+const nichePage = await Bun.file(
+  new URL("../../../app/niche/[vertical]/page.tsx", import.meta.url),
+).text();
+const claimPage = await Bun.file(
+  new URL("../../../app/claim/[slug]/page.tsx", import.meta.url),
+).text();
+const checkoutRoute = await Bun.file(
+  new URL("../../../app/api/checkout/route.ts", import.meta.url),
+).text();
+const unsupportedDashboard = await Bun.file(
+  new URL(
+    "../../../app/dashboard/unsupported-vertical-dashboard.tsx",
+    import.meta.url,
+  ),
+).text();
+const dashboardPage = await Bun.file(
+  new URL("../../../app/dashboard/page.tsx", import.meta.url),
+).text();
+const ownerSiteSave = await Bun.file(
+  new URL("../../owner-site-save.ts", import.meta.url),
+).text();
+const claimInvitations = await Bun.file(
+  new URL("../../claim-invitations.ts", import.meta.url),
+).text();
+
+const forbiddenLifecyclePromise = new RegExp(
+  [
+    "\\$49",
+    "\\bclaim(?:s|ed|ing)?\\b",
+    "\\bpay(?:ment|ing)?\\b",
+    "\\bpaid\\b",
+    "checkout",
+    "custom[- ]domain",
+    "owner editing",
+    "\\bpublish(?:ing|ed)?\\b",
+    "publication",
+    "go live",
+    "monitor(?:ing)?",
+  ].join("|"),
+  "i",
+);
+
+function beautyCopyBlock(source: string): string {
+  const start = source.indexOf("[Vertical.BEAUTY]");
+  const next = source.indexOf("[Vertical.LOCAL_SERVICE]", start);
+  expect(start).toBeGreaterThan(-1);
+  expect(next).toBeGreaterThan(start);
+  return source.slice(start, next);
+}
+
+describe("beauty lifecycle contract", () => {
+  it("keeps public preview while disabling claim and owner publication mutation", () => {
+    expect(beautyConfig.claimMode).toBe("disabled");
+    expect(beautyConfig.marketing.publiclyAccessible).toBe(true);
+    expect(isVerticalClaimEnabled(Vertical.BEAUTY)).toBe(false);
+    expect(isVerticalPublicationEnabled(Vertical.BEAUTY)).toBe(true);
+    expect(isVerticalOwnerReviewSupported(Vertical.BEAUTY)).toBe(false);
+    expect(isVerticalPublicationMutationEnabled(Vertical.BEAUTY)).toBe(false);
+    expect(resolveVerticalConfig(Vertical.BEAUTY).marketing.pricing).toBeUndefined();
+  });
+
+  it("does not advertise claim, payment, domain, editing, publication or monitoring", () => {
+    const marketingBlob = JSON.stringify(beautyMarketing);
+    expect(marketingBlob).not.toMatch(forbiddenLifecyclePromise);
+    expect(beautyCopyBlock(importStudio)).not.toMatch(forbiddenLifecyclePromise);
+    expect(unsupportedDashboard).not.toMatch(forbiddenLifecyclePromise);
+    expect(ownerSiteSave).not.toMatch(/import and claim flows/i);
+    expect(ownerSiteSave).toContain(
+      "Use the private preview until the vertical editor ships.",
+    );
+  });
+
+  it("hides acquisition pricing on the public niche page while claiming is disabled", () => {
+    expect(nichePage).toContain("isVerticalClaimEnabled(id)");
+    expect(nichePage).toContain("acquisitionPricing");
+    expect(nichePage).toContain('href: "#pricing"');
+    expect(nichePage).toContain("<ImportForm");
+    expect(beautyMarketing.form.submitLabel).toBe("Show my preview");
+  });
+
+  it("keeps claim invitations and checkout fail-closed for beauty", () => {
+    expect(claimPage).toContain("isVerticalClaimEnabled(site.vertical)");
+    expect(checkoutRoute).toContain(
+      "isVerticalClaimEnabled(invitation.vertical)",
+    );
+    expect(claimInvitations).toContain(
+      "if (!isVerticalClaimEnabled(site.vertical)) throw notClaimable();",
+    );
+    expect(claimInvitations).toContain('"not_claimable"');
+    expect(importStudio).toContain(
+      "{isVerticalClaimEnabled(site.vertical) ? (",
+    );
+    expect(importStudio).toContain("Private pilot preview");
+  });
+
+  it("routes beauty to the unsupported dashboard instead of an owner-review workflow", () => {
+    expect(dashboardPage).toContain("UnsupportedVerticalDashboard");
+    expect(dashboardPage).toContain(
+      "access.site.vertical !== Vertical.RESTAURANT",
+    );
+    expect(dashboardPage).toContain("Vertical.FOOD_RETAIL");
+    expect(dashboardPage).toContain("Vertical.LOCAL_SERVICE");
+    expect(unsupportedDashboard).toContain("private, non-chargeable preview");
+  });
+});

--- a/src/lib/verticals/beauty/marketing.ts
+++ b/src/lib/verticals/beauty/marketing.ts
@@ -1,9 +1,11 @@
 import type { VerticalMarketing } from "@/lib/verticals/types";
 
 /**
- * Built for public preview, but owner claim stays disabled until its dedicated
- * dashboard and evidence review are complete. It has no standalone domain —
- * hence no `hostnames` and a null `domain`.
+ * Built for public preview. Owner acquisition stays disabled until its
+ * dedicated dashboard and evidence review are complete. It has no standalone
+ * domain — hence no `hostnames` and a null `domain`. Pricing and founding-plan
+ * copy are omitted: this is an explicitly non-chargeable pilot, not a sellable
+ * niche.
  *
  * `heroVisual: "none"` because the restaurant transformation mock is a menu PDF
  * turning into a menu — dressing it up as a salon would be a lie about what the
@@ -18,14 +20,18 @@ export const beautyMarketing = {
   // record, a verified sender, and these two strings — in that order.
   email: null,
   audience: "salons and barbers",
-  tagline: "A service list and a booking button, always up to date.",
+  tagline: "A service list and a booking button, recovered from the source.",
   heroVisual: "none",
   hero: {
-    badge: "Your old site in. A finished one out.",
+    badge: "Your old site in. A finished preview out.",
     headline: "Every service, priced and bookable.",
     subheadline:
-      "Give us the salon. Get back a mobile-first website with the full service list, durations and prices already inside—and keep the booking system your clients already use.",
-    proofPoints: ["No setup call", "Private preview first", "$49/month"],
+      "Give us the salon. Get back a private mobile-first preview with the full service list, durations and prices already inside—keeping the booking system your clients already use.",
+    proofPoints: [
+      "No setup call",
+      "Private preview first",
+      "Non-chargeable pilot",
+    ],
   },
   form: {
     placeholder: "Salon website or name",
@@ -34,11 +40,11 @@ export const beautyMarketing = {
     pendingLabel: "Opening your salon",
   },
   signIn: {
-    title: "Open your salon.",
+    title: "Open your salon preview.",
     description:
-      "Enter the owner email used when the website was claimed. No password needed.",
+      "Enter the email used when this private preview was created. No password needed.",
     emailPlaceholder: "owner@salon.com",
-    emptyPrompt: "No site yet?",
+    emptyPrompt: "No preview yet?",
     createLabel: "Build a preview",
     createHref: "/create?vertical=beauty",
   },
@@ -55,8 +61,8 @@ export const beautyMarketing = {
     },
     {
       number: "03",
-      title: "Claim it and go live",
-      copy: "Claim the founding plan, connect the domain, and keep the booking system already taking appointments.",
+      title: "Keep it private for now",
+      copy: "This is a non-chargeable pilot. The preview stays private while Salonfront is still in preview.",
     },
   ],
   valueProps: {
@@ -81,8 +87,8 @@ export const beautyMarketing = {
       },
       {
         icon: "refresh",
-        title: "Always-current presence",
-        copy: "Prices, hours and integration checks become an ongoing service, not another redesign project.",
+        title: "A recovered snapshot of today",
+        copy: "Prices, hours and booking links come from the current source site, ready to inspect in the private preview.",
       },
     ],
   },
@@ -92,7 +98,7 @@ export const beautyMarketing = {
     imageAlt: "Salon interior photographed in natural light",
     eyebrow: "Credible imagery, not fantasy results",
     headline: "Fill the visual gaps without faking the work.",
-    copy: "Salonfront prioritises real source photography, then creates complementary editorial images for missing categories. Skin, hair and nail results are never regenerated, and every generated asset stays reviewable before publishing.",
+    copy: "Salonfront prioritises real source photography, then creates complementary editorial images for missing categories. Skin, hair and nail results are never regenerated.",
     assurances: [
       {
         icon: "shield",
@@ -100,34 +106,13 @@ export const beautyMarketing = {
       },
       {
         icon: "cursor",
-        copy: "One click to regenerate, replace or remove any image",
-      },
-    ],
-  },
-  pricing: {
-    eyebrow: "Simple ongoing care",
-    headline: "Less than one empty chair.",
-    copy: "Preview first. Pay only when the salon wants to claim and publish it. Local currency is shown at checkout.",
-    plans: [
-      {
-        name: "Founding",
-        price: "$49",
-        cadence: "/month",
-        copy: "One maintained, mobile-first salon website on the business's own domain.",
-        features: [
-          "Mobile-first website and service list",
-          "Existing booking links",
-          "Custom domain and SSL",
-          "Owner editing and source monitoring",
-        ],
-        featured: true,
-        badge: "Founding offer",
+        copy: "Every recovered image stays inspectable in the private preview",
       },
     ],
   },
   closing: {
     headline: "See the salon before asking it to change.",
-    copy: "Paste one website. Salonfront will do the first draft.",
+    copy: "Paste one website. Salonfront will do the first draft. Nothing is billed.",
   },
   footerTagline: "Every service, priced and bookable.",
 } satisfies VerticalMarketing;

--- a/src/lib/verticals/food-retail/config.ts
+++ b/src/lib/verticals/food-retail/config.ts
@@ -136,6 +136,7 @@ export const foodRetailConfig = {
   marketing: foodRetailMarketing,
   claimMode: "factory",
   publicationEnabled: true,
+  publicationMutationEnabled: true,
   integrationTypes: ["ordering", "delivery", "social"],
   attributesSchema: foodRetailAttributesSchema,
   attributeDefaults: {

--- a/src/lib/verticals/local-service/config.ts
+++ b/src/lib/verticals/local-service/config.ts
@@ -157,6 +157,7 @@ export const localServiceConfig = {
   marketing: localServiceMarketing,
   claimMode: "factory",
   publicationEnabled: true,
+  publicationMutationEnabled: true,
   draftGenerationStrategy: "deterministic-only",
   integrationTypes: ["quote", "contact", "booking", "social"],
   attributesSchema: localServiceAttributesSchema,

--- a/src/lib/verticals/registry.test.ts
+++ b/src/lib/verticals/registry.test.ts
@@ -12,7 +12,9 @@ import { localServiceConfig } from "@/lib/verticals/local-service/config";
 import {
   isVerticalClaimEnabled,
   isVerticalCatalogItemVisible,
+  isVerticalOwnerReviewSupported,
   isVerticalPublicationEnabled,
+  isVerticalPublicationMutationEnabled,
   isVerticalPubliclyAccessible,
   isVerticalPubliclyLaunched,
   listMarketingVerticals,
@@ -351,13 +353,44 @@ describe("niche routing", () => {
     expect(isVerticalClaimEnabled(Vertical.BEAUTY)).toBe(false);
     expect(isVerticalClaimEnabled(Vertical.LOCAL_SERVICE)).toBe(true);
     expect(isVerticalClaimEnabled(Vertical.FOOD_RETAIL)).toBe(true);
+    for (const id of listVerticalIds()) {
+      if (isVerticalClaimEnabled(id)) {
+        expect(resolveVerticalConfig(id).marketing.pricing).toBeDefined();
+      }
+    }
   });
 
-  it("enables reviewed publication for every registered SMB vertical", () => {
+  it("keeps existing published snapshots renderable independently of owner mutation", () => {
     expect(isVerticalPublicationEnabled(Vertical.RESTAURANT)).toBe(true);
     expect(isVerticalPublicationEnabled(Vertical.BEAUTY)).toBe(true);
     expect(isVerticalPublicationEnabled(Vertical.LOCAL_SERVICE)).toBe(true);
     expect(isVerticalPublicationEnabled(Vertical.FOOD_RETAIL)).toBe(true);
+  });
+
+  it("does not enable owner publication mutation without a supported owner-review workflow", () => {
+    expect(isVerticalOwnerReviewSupported(Vertical.RESTAURANT)).toBe(true);
+    expect(isVerticalOwnerReviewSupported(Vertical.FOOD_RETAIL)).toBe(true);
+    expect(isVerticalOwnerReviewSupported(Vertical.LOCAL_SERVICE)).toBe(true);
+    expect(isVerticalOwnerReviewSupported(Vertical.BEAUTY)).toBe(false);
+
+    expect(isVerticalPublicationMutationEnabled(Vertical.RESTAURANT)).toBe(true);
+    expect(isVerticalPublicationMutationEnabled(Vertical.FOOD_RETAIL)).toBe(
+      true,
+    );
+    expect(isVerticalPublicationMutationEnabled(Vertical.LOCAL_SERVICE)).toBe(
+      true,
+    );
+    expect(isVerticalPublicationMutationEnabled(Vertical.BEAUTY)).toBe(false);
+    expect(beautyConfig.publicationMutationEnabled).toBe(false);
+
+    for (const id of listVerticalIds()) {
+      if (resolveVerticalConfig(id).publicationMutationEnabled) {
+        expect(isVerticalOwnerReviewSupported(id)).toBe(true);
+      }
+      if (!isVerticalOwnerReviewSupported(id)) {
+        expect(isVerticalPublicationMutationEnabled(id)).toBe(false);
+      }
+    }
   });
 
   it("keeps local service gated until public access, domain, routing and sender are real", () => {

--- a/src/lib/verticals/registry.ts
+++ b/src/lib/verticals/registry.ts
@@ -191,12 +191,35 @@ export function isVerticalClaimEnabled(id: VerticalId): boolean {
 }
 
 /**
- * Publication is a separate capability from rendering, importing and claim.
- * Keeping it explicit prevents a private vertical from inheriting the shared
- * snapshot and rollback engine merely because its schema is registered.
+ * Dedicated owner-review dashboards currently exist for restaurant,
+ * food-retail and local-service. Beauty still uses UnsupportedVerticalDashboard.
+ */
+export function isVerticalOwnerReviewSupported(id: VerticalId): boolean {
+  return (
+    id === Vertical.RESTAURANT ||
+    id === Vertical.FOOD_RETAIL ||
+    id === Vertical.LOCAL_SERVICE
+  );
+}
+
+/**
+ * Whether an already-published snapshot may be rendered. Independent of
+ * whether owners may create or roll back snapshots.
  */
 export function isVerticalPublicationEnabled(id: VerticalId): boolean {
   return resolveVerticalConfig(id).publicationEnabled;
+}
+
+/**
+ * Owner publish/rollback. Fail closed unless the vertical both opts in and
+ * ships a supported owner-review workflow — otherwise a preview-only
+ * vertical could inherit mutation from a leftover config flag.
+ */
+export function isVerticalPublicationMutationEnabled(id: VerticalId): boolean {
+  const config = resolveVerticalConfig(id);
+  return (
+    config.publicationMutationEnabled && isVerticalOwnerReviewSupported(id)
+  );
 }
 
 /** Every vertical intentionally exposed by the shared public niche route. */

--- a/src/lib/verticals/restaurant/config.ts
+++ b/src/lib/verticals/restaurant/config.ts
@@ -113,6 +113,7 @@ export const restaurantConfig = {
   marketing: restaurantMarketing,
   claimMode: "niche",
   publicationEnabled: true,
+  publicationMutationEnabled: true,
   integrationTypes: ["booking", "ordering", "delivery", "social"],
   attributesSchema: restaurantAttributesSchema,
   attributeDefaults: {

--- a/src/lib/verticals/restaurant/marketing.test.ts
+++ b/src/lib/verticals/restaurant/marketing.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from "bun:test";
 import { readFile } from "node:fs/promises";
-import { beautyMarketing } from "@/lib/verticals/beauty/marketing";
+import { Vertical } from "@/generated/prisma/enums";
 import { foodRetailMarketing } from "@/lib/verticals/food-retail/marketing";
 import { localServiceMarketing } from "@/lib/verticals/local-service/marketing";
 import { restaurantMarketing } from "@/lib/verticals/restaurant/marketing";
+import {
+  isVerticalClaimEnabled,
+  listVerticalIds,
+  resolveVerticalConfig,
+} from "@/lib/verticals/registry";
 
 /**
  * GTM audit + first-customer runbook: launch is one $49/month founding plan.
@@ -39,18 +44,26 @@ describe("Restofront founding offer", () => {
     );
   });
 
-  it("shares one founding price while keeping vertical feature lists scoped", () => {
-    for (const marketing of [
-      restaurantMarketing,
-      beautyMarketing,
-      foodRetailMarketing,
-      localServiceMarketing,
-    ]) {
-      expect(marketing.pricing.plans).toHaveLength(1);
-      expect(marketing.pricing.plans[0]?.price).toBe("$49");
-      expect(marketing.pricing.copy).toContain("Local currency");
+  it("shares one founding price on claim-enabled verticals while keeping feature lists scoped", () => {
+    const claimEnabledMarketing = listVerticalIds()
+      .filter(isVerticalClaimEnabled)
+      .map((id) => resolveVerticalConfig(id).marketing);
+
+    expect(claimEnabledMarketing.map((marketing) => marketing.brand.name)).toEqual(
+      expect.arrayContaining([
+        restaurantMarketing.brand.name,
+        foodRetailMarketing.brand.name,
+        localServiceMarketing.brand.name,
+      ]),
+    );
+    expect(isVerticalClaimEnabled(Vertical.BEAUTY)).toBe(false);
+
+    for (const marketing of claimEnabledMarketing) {
+      expect(marketing.pricing?.plans).toHaveLength(1);
+      expect(marketing.pricing?.plans[0]?.price).toBe("$49");
+      expect(marketing.pricing?.copy).toContain("Local currency");
     }
-    expect(beautyMarketing.pricing.plans[0]?.features).not.toEqual(
+    expect(foodRetailMarketing.pricing.plans[0]?.features).not.toEqual(
       restaurantMarketing.pricing.plans[0]?.features,
     );
   });

--- a/src/lib/verticals/types.ts
+++ b/src/lib/verticals/types.ts
@@ -236,7 +236,11 @@ export type VerticalMarketing = {
     copy: string;
     assurances: { icon: MarketingIconName; copy: string }[];
   };
-  pricing: {
+  /**
+   * Public founding offer. Omitted while claiming is disabled so a
+   * preview-only vertical cannot advertise a plan it cannot sell.
+   */
+  pricing?: {
     eyebrow: string;
     headline: string;
     copy: string;
@@ -267,11 +271,17 @@ export type VerticalConfig<
    */
   claimMode: "disabled" | "factory" | "niche";
   /**
-   * Whether owner-reviewed drafts may create or roll back public snapshots.
-   * This is explicit and server-enforced: a registered vertical can support
-   * private imports and previews without accidentally inheriting publication.
+   * Whether an already-published snapshot may be rendered on the public
+   * storefront. Independent of whether owners may create or roll back
+   * snapshots: flipping this off would hide existing live sites.
    */
   publicationEnabled: boolean;
+  /**
+   * Whether owners may create or roll back public snapshots. Requires a
+   * supported owner-review workflow; a vertical that only imports and
+   * previews must leave this off.
+   */
+  publicationMutationEnabled: boolean;
   /**
    * Model assistance is the compatibility default. Evidence-sensitive verticals
    * can opt into deterministic reconstruction and skip text generation entirely.


### PR DESCRIPTION
Closes #138

## Summary

Beauty was a preview-only vertical (`claimMode: "disabled"`) whose public copy and mutation contract still promised claim, billing, owner editing, publication, domains, and monitoring. Flipping `publicationEnabled` would have hidden any existing Beauty snapshots on the public read path.

This splits snapshot **rendering** from owner **mutation**, then aligns acquisition surfaces with capability truth.

- `/niche/beauty` stays public and still offers preview creation.
- Acquisition presentation is derived from `isVerticalClaimEnabled`: no pricing nav or founding-plan section while claiming is disabled.
- Beauty marketing, Import Studio, unsupported dashboard, and owner-save copy describe a non-chargeable private pilot — no `$49`, claim, payment, custom-domain, owner-editing, publication, or monitoring promise.
- Owner publish/rollback now fail closed on `publicationMutationEnabled` (AND a supported owner-review dashboard). Beauty returns the standard 409.
- `publicationEnabled` remains true so existing published Beauty snapshots still render.
- Registry invariant: owner publication mutation cannot be on without restaurant / food-retail / local-service owner-review support.

Restaurant, food-retail, and local-service launch gates are unchanged.

## Files

- `src/lib/verticals/types.ts` — split `publicationEnabled` (read) from `publicationMutationEnabled` (write); pricing optional while claiming is disabled
- `src/lib/verticals/registry.ts` — owner-review helper, mutation helper fail-closed
- `src/lib/verticals/{beauty,restaurant,food-retail,local-service}/config.ts` — Beauty mutation off; launched verticals still on
- `src/lib/verticals/beauty/marketing.ts` — non-chargeable pilot copy; no pricing block
- `src/lib/site-publication-capability.ts` — publish/rollback use mutation capability
- `src/lib/sites.ts` — unchanged; still gates snapshot reads on `publicationEnabled`
- `src/app/niche/[vertical]/page.tsx` — hide pricing unless claim is enabled and a plan exists
- `src/app/create/import-studio.tsx` — Beauty/pilot copy
- `src/app/dashboard/unsupported-vertical-dashboard.tsx` — no claim/hosting promise
- `src/lib/owner-site-save.ts` — capability-gated 409 without claim language
- Tests: `src/lib/verticals/beauty/lifecycle.test.ts` plus registry, capability, marketing, import, owner-save, dashboard surface updates

## Verification

```
bun test src/lib/verticals/beauty/lifecycle.test.ts \
  src/lib/verticals/registry.test.ts \
  src/lib/site-publication-capability.test.ts \
  src/lib/verticals/restaurant/marketing.test.ts \
  src/lib/sign-in-surface.test.ts \
  src/lib/dashboard-tabs-surface.test.ts \
  src/lib/site-owner-route.test.ts \
  src/lib/food-retail-claim-gate.test.ts
# 55 pass, 0 fail

bun run lint
# pass

node node_modules/next/dist/bin/next typegen && bunx tsc --noEmit
# pass

git diff --check
# pass
```

## Residual risk

- Beauty claiming, billing, owner editing, domains, and monitoring remain unlaunched by design.
- Existing published Beauty snapshots stay renderable; no production data mutation in this PR.
- Owner-review support is currently the restaurant / food-retail / local-service dashboard set. A new vertical with `publicationMutationEnabled: true` but no dedicated dashboard will fail closed at runtime and in registry tests.
- Exact-head PR CI is the merge gate.