### PR TITLE
fix(a11y): name create, sign-in, claim, and booking funnels

### DIFF
--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -28,6 +28,7 @@ import { limitClaimCheckout } from "@/lib/rate-limit";
 import { isSameOriginMutation } from "@/lib/request-origin";
 import { getStripe } from "@/lib/stripe";
 import { secureCookieRequired } from "@/lib/first-customer-test-mode";
+import { resolveClaimLaunchOfferForVertical } from "@/lib/claim-launch-offer";
 import { isVerticalClaimEnabled } from "@/lib/verticals/registry";
 
 const requestSchema = z.object({
@@ -83,6 +84,13 @@ export async function POST(request: Request) {
         409,
         "This site already has an owner or is not available to claim.",
         invitation.id,
+      );
+    }
+    const offer = resolveClaimLaunchOfferForVertical(invitation.vertical);
+    if (!offer || offer.planId !== plan) {
+      return Response.json(
+        { error: "Claim checkout is temporarily unavailable." },
+        { status: 503 },
       );
     }
     const stripe = getStripe();

--- a/src/app/claim/[slug]/claim-panel.tsx
+++ b/src/app/claim/[slug]/claim-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, type FormEvent } from "react";
 import Link from "next/link";
 import {
   ArrowRight,
@@ -12,31 +12,17 @@ import {
 import { SiteRenderer } from "@/components/site-renderer";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Field } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
-import type { SiteDraftView } from "@/lib/site-draft";
-import { restaurantMarketing } from "@/lib/verticals/restaurant/marketing";
-import type { VerticalId } from "@/lib/verticals/types";
-
-/**
- * Launch sells one founding plan through the single configured STRIPE_PRICE_ID.
- */
-const CLAIM_CHECKOUT_PLAN_ID = "founding" as const;
-const foundingPlan = restaurantMarketing.pricing.plans[0];
+import type { ClaimPanelProps } from "@/lib/claim-launch-offer";
 
 export function ClaimPanel({
   slug,
   vertical,
   fallbackDraft,
   checkoutReturn,
-}: {
-  slug: string;
-  vertical: VerticalId;
-  fallbackDraft: SiteDraftView;
-  checkoutReturn: {
-    sessionId: string;
-    claimInvitationId: string;
-  } | null;
-}) {
+  offer,
+}: ClaimPanelProps) {
   const draft = fallbackDraft;
   const [email, setEmail] = useState("");
   const [loading, setLoading] = useState(Boolean(checkoutReturn));
@@ -160,7 +146,7 @@ export function ClaimPanel({
   }
 
   async function checkout() {
-    if (!invitationToken) return;
+    if (!invitationToken || !offer) return;
     setLoading(true);
     setError(null);
     try {
@@ -168,7 +154,7 @@ export function ClaimPanel({
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          plan: CLAIM_CHECKOUT_PLAN_ID,
+          plan: offer.planId,
           siteSlug: slug,
           invitationToken,
         }),
@@ -188,6 +174,14 @@ export function ClaimPanel({
       setLoading(false);
     }
   }
+
+  function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!offer || loading || (!invitationToken && !email)) return;
+    void (invitationToken ? checkout() : requestInvitation());
+  }
+
+  const errorSummaryId = "claim-error-summary";
 
   return (
     <div className="grid lg:grid-cols-[1fr_0.9fr]">
@@ -244,111 +238,146 @@ export function ClaimPanel({
             </p>
           ) : null}
 
-          <div className="mt-8">
-            <div className="rounded-2xl border border-primary bg-primary/5 p-5 ring-2 ring-primary/12">
-              <div className="flex items-start justify-between gap-5">
-                <div>
-                  <div className="flex items-center gap-2">
-                    <span className="font-semibold">{foundingPlan.name}</span>
-                    {foundingPlan.badge ? (
-                      <Badge className="text-[10px]">{foundingPlan.badge}</Badge>
-                    ) : null}
+          {offer ? (
+            <div className="mt-8">
+              <div className="rounded-2xl border border-primary bg-primary/5 p-5 ring-2 ring-primary/12">
+                <div className="flex items-start justify-between gap-5">
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <span className="font-semibold">{offer.name}</span>
+                      {offer.badge ? (
+                        <Badge className="text-[10px]">{offer.badge}</Badge>
+                      ) : null}
+                    </div>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {offer.copy}
+                    </p>
                   </div>
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    {foundingPlan.copy}
+                  <span className="font-display text-4xl">
+                    {offer.price}
+                    <small className="font-sans text-xs text-muted-foreground">
+                      {offer.cadence}
+                    </small>
+                  </span>
+                </div>
+                <div className="mt-4 grid gap-2 sm:grid-cols-2">
+                  {offer.features.map((feature) => (
+                    <span
+                      key={feature}
+                      className="flex items-center gap-1.5 text-xs"
+                    >
+                      <Check className="size-3 text-primary" /> {feature}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </div>
+          ) : checkoutReturn ? null : (
+            <div
+              className="mt-8 rounded-2xl border border-destructive/30 bg-destructive/5 p-5"
+              role="status"
+            >
+              <p className="text-sm font-medium">
+                Claiming is unavailable for {draft.name}.
+              </p>
+              <p className="mt-2 text-xs leading-5 text-muted-foreground">
+                The launch offer for this site is not configured, so checkout
+                cannot start. Ask the operator who sent this preview to try
+                again once the offer is available.
+              </p>
+            </div>
+          )}
+
+          {offer ? (
+            <form onSubmit={submit} className="mt-7">
+              {invitationToken ? (
+                <div className="rounded-xl border border-primary/30 bg-primary/5 p-4">
+                  <p className="text-sm font-medium">Ownership link ready</p>
+                  <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                    Checkout will verify that this one-time link belongs to this
+                    site and the email approved for it.
                   </p>
                 </div>
-                <span className="font-display text-4xl">
-                  {foundingPlan.price}
-                  <small className="font-sans text-xs text-muted-foreground">
-                    {foundingPlan.cadence}
-                  </small>
-                </span>
-              </div>
-              <div className="mt-4 grid gap-2 sm:grid-cols-2">
-                {foundingPlan.features.map((feature) => (
-                  <span
-                    key={feature}
-                    className="flex items-center gap-1.5 text-xs"
-                  >
-                    <Check className="size-3 text-primary" /> {feature}
-                  </span>
-                ))}
-              </div>
-            </div>
-          </div>
-
-          {invitationToken ? (
-            <div className="mt-7 rounded-xl border border-primary/30 bg-primary/5 p-4">
-              <p className="text-sm font-medium">Ownership link ready</p>
-              <p className="mt-1 text-xs leading-5 text-muted-foreground">
-                Checkout will verify that this one-time link belongs to this
-                site and the email approved for it.
+              ) : (
+                <Field
+                  label="Business owner email"
+                  controlId="claim-email"
+                  description="Use the email shown on the source website or an address on that exact domain. Concierge-approved owners can use the address the operator approved."
+                >
+                  <Input
+                    type="email"
+                    name="email"
+                    autoComplete="email"
+                    required
+                    value={email}
+                    onChange={(event) => {
+                      setEmail(event.target.value);
+                      setInvitationSent(false);
+                    }}
+                    placeholder={offer.emailPlaceholder}
+                    className="h-11"
+                    aria-invalid={error && !invitationToken ? true : undefined}
+                    aria-describedby={
+                      error ? errorSummaryId : undefined
+                    }
+                  />
+                </Field>
+              )}
+              {invitationSent ? (
+                <p
+                  className="mt-3 rounded-lg bg-primary/8 px-3 py-2 text-xs text-primary"
+                  role="status"
+                >
+                  Check that inbox for the 48-hour one-time ownership link.
+                </p>
+              ) : null}
+              {error ? (
+                <p
+                  id={errorSummaryId}
+                  className="mt-3 rounded-lg bg-destructive/8 px-3 py-2 text-xs text-destructive"
+                  role="alert"
+                >
+                  {error}
+                </p>
+              ) : null}
+              <Button
+                type="submit"
+                size="lg"
+                className="mt-4 h-12 w-full"
+                disabled={(!invitationToken && !email) || loading}
+              >
+                {loading ? (
+                  <>
+                    <LoaderCircle className="animate-spin" />
+                    {invitationToken
+                      ? "Opening secure checkout"
+                      : "Sending ownership link"}
+                  </>
+                ) : invitationToken ? (
+                  <>
+                    Claim and continue <ArrowRight />
+                  </>
+                ) : (
+                  <>
+                    Verify ownership by email <ArrowRight />
+                  </>
+                )}
+              </Button>
+              <p className="mt-3 text-center text-[11px] leading-5 text-muted-foreground">
+                {invitationToken
+                  ? "Secure subscription checkout by Stripe. The invitation is accepted only after checkout completes."
+                  : "No checkout or owner account can start until the approved email opens its one-time link."}
               </p>
-            </div>
-          ) : (
-            <>
-              <label className="mt-7 block text-xs font-medium" htmlFor="email">
-                Business owner email
-              </label>
-              <Input
-                id="email"
-                type="email"
-                value={email}
-                onChange={(event) => {
-                  setEmail(event.target.value);
-                  setInvitationSent(false);
-                }}
-                placeholder="owner@restaurant.com"
-                className="mt-2 h-11"
-              />
-              <p className="mt-2 text-[11px] leading-5 text-muted-foreground">
-                Use the email shown on the source website or an address on that
-                exact domain. Concierge-approved owners can use the address the
-                operator approved.
-              </p>
-            </>
-          )}
-          {invitationSent ? (
-            <p className="mt-3 rounded-lg bg-primary/8 px-3 py-2 text-xs text-primary">
-              Check that inbox for the 48-hour one-time ownership link.
-            </p>
-          ) : null}
-          {error ? (
-            <p className="mt-3 rounded-lg bg-destructive/8 px-3 py-2 text-xs text-destructive">
+            </form>
+          ) : error ? (
+            <p
+              id={errorSummaryId}
+              className="mt-3 rounded-lg bg-destructive/8 px-3 py-2 text-xs text-destructive"
+              role="alert"
+            >
               {error}
             </p>
           ) : null}
-          <Button
-            size="lg"
-            className="mt-4 h-12 w-full"
-            disabled={(!invitationToken && !email) || loading}
-            onClick={() =>
-              void (invitationToken ? checkout() : requestInvitation())
-            }
-          >
-            {loading ? (
-              <>
-                <LoaderCircle className="animate-spin" />
-                {invitationToken
-                  ? "Opening secure checkout"
-                  : "Sending ownership link"}
-              </>
-            ) : invitationToken ? (
-              <>
-                Claim and continue <ArrowRight />
-              </>
-            ) : (
-              <>
-                Verify ownership by email <ArrowRight />
-              </>
-            )}
-          </Button>
-          <p className="mt-3 text-center text-[11px] leading-5 text-muted-foreground">
-            {invitationToken
-              ? "Secure subscription checkout by Stripe. The invitation is accepted only after checkout completes."
-              : "No checkout or owner account can start until the approved email opens its one-time link."}
-          </p>
         </div>
       </aside>
     </div>

--- a/src/app/claim/[slug]/claim-panel.tsx
+++ b/src/app/claim/[slug]/claim-panel.tsx
@@ -232,7 +232,12 @@ export function ClaimPanel({
             website and domain stay untouched until the final DNS step.
           </p>
           {checkoutReturn ? (
-            <p className="mt-4 rounded-xl border bg-muted/45 px-4 py-3 text-xs leading-5">
+            <p
+              className="mt-4 rounded-xl border bg-muted/45 px-4 py-3 text-xs leading-5"
+              role="status"
+              aria-live="polite"
+              aria-busy={loading && !error}
+            >
               Payment received. Finalizing the owner account from Stripe&apos;s
               signed webhook…
             </p>
@@ -289,7 +294,7 @@ export function ClaimPanel({
           )}
 
           {offer ? (
-            <form onSubmit={submit} className="mt-7">
+            <form onSubmit={submit} className="mt-7" aria-busy={loading}>
               {invitationToken ? (
                 <div className="rounded-xl border border-primary/30 bg-primary/5 p-4">
                   <p className="text-sm font-medium">Ownership link ready</p>
@@ -327,6 +332,7 @@ export function ClaimPanel({
                 <p
                   className="mt-3 rounded-lg bg-primary/8 px-3 py-2 text-xs text-primary"
                   role="status"
+                  aria-live="polite"
                 >
                   Check that inbox for the 48-hour one-time ownership link.
                 </p>
@@ -345,10 +351,11 @@ export function ClaimPanel({
                 size="lg"
                 className="mt-4 h-12 w-full"
                 disabled={(!invitationToken && !email) || loading}
+                aria-busy={loading}
               >
                 {loading ? (
                   <>
-                    <LoaderCircle className="animate-spin" />
+                    <LoaderCircle className="animate-spin" aria-hidden="true" />
                     {invitationToken
                       ? "Opening secure checkout"
                       : "Sending ownership link"}

--- a/src/app/claim/[slug]/page.tsx
+++ b/src/app/claim/[slug]/page.tsx
@@ -5,11 +5,8 @@ import { ArrowLeft } from "lucide-react";
 import { Brand } from "@/components/brand";
 import { ClaimPanel } from "@/app/claim/[slug]/claim-panel";
 import { Button } from "@/components/ui/button";
+import { claimPageState } from "@/lib/claim-launch-offer";
 import { findSiteView } from "@/lib/sites";
-import {
-  isVerticalClaimEnabled,
-  resolveVerticalConfig,
-} from "@/lib/verticals/registry";
 
 type ClaimPageProps = {
   params: Promise<{ slug: string }>;
@@ -26,11 +23,10 @@ export async function generateMetadata({
   params,
 }: ClaimPageProps): Promise<Metadata> {
   const { slug } = await params;
-  const site = await findSiteView(slug);
-  if (!site || !isVerticalClaimEnabled(site.vertical)) notFound();
-  const brand = resolveVerticalConfig(site.vertical).marketing.brand;
+  const state = claimPageState(await findSiteView(slug));
+  if (state.kind === "not_found") notFound();
   return {
-    title: { absolute: `Claim your ${brand.name} site` },
+    title: { absolute: `Claim your ${state.brand.name} site` },
     robots: { index: false, follow: false },
   };
 }
@@ -41,12 +37,8 @@ export default async function ClaimPage({
 }: ClaimPageProps) {
   const { slug } = await params;
   const query = await searchParams;
-  const site = await findSiteView(slug);
-  if (!site || !isVerticalClaimEnabled(site.vertical)) notFound();
-
-  // The site itself knows which niche produced it, which is a stronger signal
-  // than the Host header: an owner can reach their claim link from anywhere.
-  const brand = resolveVerticalConfig(site.vertical).marketing.brand;
+  const state = claimPageState(await findSiteView(slug));
+  if (state.kind === "not_found") notFound();
 
   return (
     <main className="min-h-screen">
@@ -54,12 +46,13 @@ export default async function ClaimPage({
         <Button render={<Link href="/create" />} variant="ghost" size="icon-sm">
           <ArrowLeft />
         </Button>
-        <Brand {...brand} />
+        <Brand {...state.brand} />
       </header>
       <ClaimPanel
         slug={slug}
-        vertical={site.vertical}
-        fallbackDraft={site.draft}
+        vertical={state.vertical}
+        fallbackDraft={state.draft}
+        offer={state.offer}
         checkoutReturn={
           query.checkout === "processing" && query.session_id && query.claim_id
             ? {

--- a/src/app/claim/[slug]/page.tsx
+++ b/src/app/claim/[slug]/page.tsx
@@ -43,7 +43,12 @@ export default async function ClaimPage({
   return (
     <main className="min-h-screen">
       <header className="flex h-16 items-center gap-4 border-b px-5">
-        <Button render={<Link href="/create" />} variant="ghost" size="icon-sm">
+        <Button
+          render={<Link href="/create" aria-label="Back to create" />}
+          nativeButton={false}
+          variant="ghost"
+          size="icon-sm"
+        >
           <ArrowLeft />
         </Button>
         <Brand {...state.brand} />

--- a/src/app/create/import-studio.tsx
+++ b/src/app/create/import-studio.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type ComponentProps } from "react";
 import Link from "next/link";
 import {
   ArrowLeft,
@@ -19,6 +19,7 @@ import { Brand } from "@/components/brand";
 import { InstantSitePreview } from "@/components/instant-restaurant-preview";
 import { SiteRenderer } from "@/components/site-renderer";
 import { Button } from "@/components/ui/button";
+import { Field } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { Progress } from "@/components/ui/progress";
 import type { BrandContext } from "@/lib/brand-context";
@@ -47,6 +48,7 @@ type Stage = {
 type VerticalCopy = {
   label: string;
   eyebrow: string;
+  sourceLabel: string;
   placeholder: string;
   opening: string;
   idlePrompt: string;
@@ -63,6 +65,7 @@ const verticalCopy = {
   [Vertical.RESTAURANT]: {
     label: "Restaurant",
     eyebrow: "New restaurant",
+    sourceLabel: "Restaurant website or name",
     placeholder: "restaurant.com or restaurant name",
     opening: "Opening the restaurant",
     idlePrompt:
@@ -85,6 +88,7 @@ const verticalCopy = {
   [Vertical.BEAUTY]: {
     label: "Salon & barber",
     eyebrow: "New salon",
+    sourceLabel: "Salon website or name",
     placeholder: "salon.com or salon name",
     opening: "Opening the salon",
     idlePrompt:
@@ -109,6 +113,7 @@ const verticalCopy = {
   [Vertical.LOCAL_SERVICE]: {
     label: "Local trade",
     eyebrow: "New local trade",
+    sourceLabel: "Trade website or business name",
     placeholder: "trade website or business name",
     opening: "Opening the trade business",
     idlePrompt:
@@ -131,6 +136,7 @@ const verticalCopy = {
   [Vertical.FOOD_RETAIL]: {
     label: "Local food shop",
     eyebrow: "New food shop",
+    sourceLabel: "Shop website or name",
     placeholder: "bakery.com or shop name",
     opening: "Opening the shop",
     idlePrompt:
@@ -445,6 +451,7 @@ export function ImportStudio({
 
           <form
             className="mt-7 space-y-3"
+            aria-busy={loading}
             onSubmit={(event) => {
               event.preventDefault();
               void runImport();
@@ -469,24 +476,30 @@ export function ImportStudio({
                 </Button>
               ))}
             </div>
-            <div className="relative">
-              <Globe2 className="absolute left-3 top-3 size-4 text-muted-foreground" />
-              <Input
+            <Field
+              label={copy.sourceLabel}
+              controlId="import-source"
+            >
+              <ImportSourceControl
                 value={source}
                 onChange={(event) => setSource(event.target.value)}
                 placeholder={copy.placeholder}
-                className="h-10 pl-9"
                 disabled={loading}
+                autoComplete="url"
+                name="source"
+                aria-invalid={error ? true : undefined}
+                aria-describedby={error ? "import-source-error" : undefined}
               />
-            </div>
+            </Field>
             <Button
               type="submit"
               className="w-full"
               disabled={!source.trim() || loading}
+              aria-busy={loading}
             >
               {loading ? (
                 <>
-                  <LoaderCircle className="animate-spin" />
+                  <LoaderCircle className="animate-spin" aria-hidden="true" />
                   Finishing the details
                 </>
               ) : (
@@ -499,7 +512,12 @@ export function ImportStudio({
           </form>
 
           {loading || site ? (
-            <div className="mt-8">
+            <div
+              className="mt-8"
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+            >
               <div className="flex items-center justify-between text-xs">
                 <span className="font-medium">{message}</span>
                 <span className="font-mono text-muted-foreground">
@@ -546,8 +564,15 @@ export function ImportStudio({
 
           {error ? (
             <div className="mt-6 rounded-xl border border-destructive/25 bg-destructive/5 p-4">
-              <div className="flex gap-2 text-sm text-destructive">
-                <CircleAlert className="mt-0.5 size-4 shrink-0" />
+              <div
+                id="import-source-error"
+                className="flex gap-2 text-sm text-destructive"
+                role="alert"
+              >
+                <CircleAlert
+                  className="mt-0.5 size-4 shrink-0"
+                  aria-hidden="true"
+                />
                 <span>{error}</span>
               </div>
               <div className="mt-4 flex gap-2">
@@ -662,5 +687,17 @@ export function ImportStudio({
         </section>
       </div>
     </main>
+  );
+}
+
+function ImportSourceControl(props: ComponentProps<typeof Input>) {
+  return (
+    <div className="relative">
+      <Globe2
+        aria-hidden="true"
+        className="pointer-events-none absolute left-3 top-3 size-4 text-muted-foreground"
+      />
+      <Input {...props} className="h-10 pl-9" />
+    </div>
   );
 }

--- a/src/app/create/import-studio.tsx
+++ b/src/app/create/import-studio.tsx
@@ -88,13 +88,13 @@ const verticalCopy = {
     placeholder: "salon.com or salon name",
     opening: "Opening the salon",
     idlePrompt:
-      "Paste a website or salon name. The preview stays private until it is claimed and paid.",
+      "Paste a website or salon name. The preview stays private and is not chargeable.",
     recovering:
       "The shape is already here. We are recovering the real service list, imagery and existing links now.",
     emptyStatePrompt:
       "Start with a website or salon name. No account is needed to see the result.",
     claimHint:
-      "Review the services and existing links, then claim the founding plan to keep this site current.",
+      "Review the recovered services and booking links in this private preview.",
     catalogStage: "Recover services and prices",
     // No ordering or delivery: a salon has nothing to deliver, which is the same
     // reason `beauty/providers.ts` ships no hints for those integration types.
@@ -578,7 +578,7 @@ export function ImportStudio({
               <p className="mt-2 text-xs leading-5 text-muted-foreground">
                 {isVerticalClaimEnabled(site.vertical)
                   ? copy.claimHint
-                  : "Claiming and checkout remain unavailable until this vertical has reviewed launch configuration."}
+                  : "This vertical is a non-chargeable private preview. Owner tools are not available yet."}
               </p>
               {externalPreviewAvailable ? (
                 <div className="mt-4 grid gap-2">

--- a/src/app/dashboard/unsupported-vertical-dashboard.tsx
+++ b/src/app/dashboard/unsupported-vertical-dashboard.tsx
@@ -6,8 +6,9 @@ import type { BrandIdentity } from "@/lib/brand";
 import type { Vertical } from "@/generated/prisma/enums";
 
 /**
- * Restaurant owns the full editor today. Other verticals can import and claim,
- * but must not fall through to the restaurant sample draft under the real slug.
+ * Restaurant owns the full editor today. Verticals without a dedicated
+ * owner-review dashboard can still import a private preview, but must not
+ * fall through to the restaurant sample draft under the real slug.
  */
 export function UnsupportedVerticalDashboard({
   email,
@@ -44,12 +45,12 @@ export function UnsupportedVerticalDashboard({
               <span className="font-medium text-foreground">
                 {vertical.toLowerCase()}
               </span>{" "}
-              site. Import, claim, and hosting already work; the dashboard editor
-              still ships restaurant-first so we do not risk rewriting your
-              content as a restaurant sample.
+              site. This is a private, non-chargeable preview. The dashboard
+              editor still ships restaurant-first so we do not risk rewriting
+              your content as a restaurant sample.
             </p>
             <p>
-              Open the private preview to review the generated site, or switch
+              Open the private preview to inspect the generated site, or switch
               workspace if you manage a restaurant as well.
             </p>
             <div className="flex flex-wrap gap-3 pt-2">

--- a/src/app/niche/[vertical]/page.tsx
+++ b/src/app/niche/[vertical]/page.tsx
@@ -23,6 +23,7 @@ import { nicheFontVariables } from "@/components/fonts/niche-font-scope";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
+  isVerticalClaimEnabled,
   isVerticalPubliclyAccessible,
   listPublicVerticals,
   resolveVerticalBySlug,
@@ -140,6 +141,9 @@ export default async function NichePage({
   const { marketing } = resolveVerticalConfig(id);
   const slug = verticalSlug(id);
   const fontVariables = nicheFontVariables(id);
+  const acquisitionPricing = isVerticalClaimEnabled(id)
+    ? marketing.pricing
+    : undefined;
   // Every route out of this page carries the niche, so a lead is attached to the
   // vertical that produced it before the studio ever opens.
   const createHref = `/create?vertical=${slug}`;
@@ -149,7 +153,7 @@ export default async function NichePage({
       ? [{ href: "#themes", label: marketing.themeGallery.label }]
       : []),
     { href: "#features", label: "What stays yours" },
-    { href: "#pricing", label: "Pricing" },
+    ...(acquisitionPricing ? [{ href: "#pricing", label: "Pricing" }] : []),
   ];
   const formCopy = {
     vertical: slug,
@@ -388,90 +392,92 @@ export default async function NichePage({
           </div>
         </section>
 
-        <section
-          id="pricing"
-          className="mx-auto max-w-7xl px-5 py-24 lg:px-8 lg:py-32"
-        >
-          <div className="mx-auto max-w-2xl text-center">
-            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary">
-              {marketing.pricing.eyebrow}
-            </p>
-            <h2 className="font-display mt-4 text-6xl leading-[0.92] tracking-[-0.045em]">
-              {marketing.pricing.headline}
-            </h2>
-            <p className="mt-5 text-muted-foreground">
-              {marketing.pricing.copy}
-            </p>
-          </div>
-          <div
-            className={`mx-auto mt-12 grid gap-5 ${
-              marketing.pricing.plans.length > 1
-                ? "max-w-4xl md:grid-cols-2"
-                : "max-w-xl"
-            }`}
+        {acquisitionPricing ? (
+          <section
+            id="pricing"
+            className="mx-auto max-w-7xl px-5 py-24 lg:px-8 lg:py-32"
           >
-            {marketing.pricing.plans.map((plan) => (
-              <div
-                key={plan.name}
-                className={
-                  plan.featured
-                    ? "rounded-3xl border border-primary/40 bg-primary p-7 text-primary-foreground shadow-xl"
-                    : "rounded-3xl border bg-card p-7"
-                }
-              >
-                <div className="flex items-center justify-between">
-                  <p className="text-sm font-semibold">{plan.name}</p>
-                  {plan.badge ? (
-                    <Badge className="bg-white/15 text-white">
-                      {plan.badge}
-                    </Badge>
-                  ) : null}
-                </div>
-                <p className="mt-5 font-display text-6xl tracking-[-0.05em]">
-                  {plan.price}
-                  <span
-                    className={`font-sans text-sm tracking-normal ${
+            <div className="mx-auto max-w-2xl text-center">
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary">
+                {acquisitionPricing.eyebrow}
+              </p>
+              <h2 className="font-display mt-4 text-6xl leading-[0.92] tracking-[-0.045em]">
+                {acquisitionPricing.headline}
+              </h2>
+              <p className="mt-5 text-muted-foreground">
+                {acquisitionPricing.copy}
+              </p>
+            </div>
+            <div
+              className={`mx-auto mt-12 grid gap-5 ${
+                acquisitionPricing.plans.length > 1
+                  ? "max-w-4xl md:grid-cols-2"
+                  : "max-w-xl"
+              }`}
+            >
+              {acquisitionPricing.plans.map((plan) => (
+                <div
+                  key={plan.name}
+                  className={
+                    plan.featured
+                      ? "rounded-3xl border border-primary/40 bg-primary p-7 text-primary-foreground shadow-xl"
+                      : "rounded-3xl border bg-card p-7"
+                  }
+                >
+                  <div className="flex items-center justify-between">
+                    <p className="text-sm font-semibold">{plan.name}</p>
+                    {plan.badge ? (
+                      <Badge className="bg-white/15 text-white">
+                        {plan.badge}
+                      </Badge>
+                    ) : null}
+                  </div>
+                  <p className="mt-5 font-display text-6xl tracking-[-0.05em]">
+                    {plan.price}
+                    <span
+                      className={`font-sans text-sm tracking-normal ${
+                        plan.featured ? "text-white/70" : "text-muted-foreground"
+                      }`}
+                    >
+                      {plan.cadence}
+                    </span>
+                  </p>
+                  <p
+                    className={`mt-3 text-sm ${
                       plan.featured ? "text-white/70" : "text-muted-foreground"
                     }`}
                   >
-                    {plan.cadence}
-                  </span>
-                </p>
-                <p
-                  className={`mt-3 text-sm ${
-                    plan.featured ? "text-white/70" : "text-muted-foreground"
-                  }`}
-                >
-                  {plan.copy}
-                </p>
-                <ul className="mt-7 space-y-3 text-sm">
-                  {plan.features.map((feature) => (
-                    <li key={feature} className="flex items-center gap-2">
-                      <Check
-                        className={`size-4 ${
-                          plan.featured ? "" : "text-primary"
-                        }`}
-                      />{" "}
-                      {feature}
-                    </li>
-                  ))}
-                </ul>
-                <Button
-                  render={<Link href={createHref} />}
-                  nativeButton={false}
-                  variant={plan.featured ? "secondary" : "outline"}
-                  className={`mt-8 w-full ${
-                    plan.featured
-                      ? "bg-white text-primary hover:bg-white/90"
-                      : ""
-                  }`}
-                >
-                  Build a free preview
-                </Button>
-              </div>
-            ))}
-          </div>
-        </section>
+                    {plan.copy}
+                  </p>
+                  <ul className="mt-7 space-y-3 text-sm">
+                    {plan.features.map((feature) => (
+                      <li key={feature} className="flex items-center gap-2">
+                        <Check
+                          className={`size-4 ${
+                            plan.featured ? "" : "text-primary"
+                          }`}
+                        />{" "}
+                        {feature}
+                      </li>
+                    ))}
+                  </ul>
+                  <Button
+                    render={<Link href={createHref} />}
+                    nativeButton={false}
+                    variant={plan.featured ? "secondary" : "outline"}
+                    className={`mt-8 w-full ${
+                      plan.featured
+                        ? "bg-white text-primary hover:bg-white/90"
+                        : ""
+                    }`}
+                  >
+                    Build a free preview
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </section>
+        ) : null}
 
         <section className="paper-grid border-t">
           <div className="mx-auto flex max-w-5xl flex-col items-center px-5 py-24 text-center lg:py-32">

--- a/src/app/sign-in/auth-shell.tsx
+++ b/src/app/sign-in/auth-shell.tsx
@@ -29,7 +29,14 @@ export function AuthShell({
         )}
       >
         <Button
-          render={<Link href={backHref} prefetch={false} />}
+          render={
+            <Link
+              href={backHref}
+              prefetch={false}
+              aria-label={`Back to ${surface.brand.name}`}
+            />
+          }
+          nativeButton={false}
           variant="ghost"
           size="icon-sm"
           className={

--- a/src/app/sign-in/sign-in-form.tsx
+++ b/src/app/sign-in/sign-in-form.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { ArrowRight, Check, LoaderCircle, Mail } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Field } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import type { SignInCopy } from "@/lib/sign-in-surface";
 import { cn } from "@/lib/utils";
@@ -21,6 +22,12 @@ export function SignInForm({
   const [loading, setLoading] = useState(false);
   const [sent, setSent] = useState(false);
   const [error, setError] = useState<string | null>(initialError);
+  const headingRef = useRef<HTMLHeadingElement>(null);
+
+  useEffect(() => {
+    if (!sent) return;
+    headingRef.current?.focus();
+  }, [sent]);
 
   async function submit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -55,6 +62,8 @@ export function SignInForm({
         {sent ? <Check className="size-5" /> : <Mail className="size-5" />}
       </span>
       <h1
+        ref={headingRef}
+        tabIndex={sent ? -1 : undefined}
         className={cn(
           "mt-5 leading-none tracking-[-0.045em]",
           inverse
@@ -64,28 +73,38 @@ export function SignInForm({
       >
         {sent ? "Check your inbox." : copy.title}
       </h1>
-      <p className="mt-4 text-sm leading-6 text-muted-foreground">
+      <p
+        className="mt-4 text-sm leading-6 text-muted-foreground"
+        role={sent ? "status" : undefined}
+        aria-live={sent ? "polite" : undefined}
+      >
         {sent
           ? `If an account exists for ${email}, a secure sign-in link should arrive shortly.`
           : copy.description}
       </p>
       {!sent ? (
-        <form onSubmit={submit} className="mt-7 space-y-3">
-          <Input
-            type="email"
-            value={email}
-            onChange={(event) => setEmail(event.target.value)}
-            placeholder={copy.emailPlaceholder}
-            className="h-11"
-            required
-          />
-          {error ? (
-            <p className="rounded-lg bg-destructive/8 px-3 py-2 text-xs text-destructive">
-              {error}
-            </p>
-          ) : null}
-          <Button type="submit" className="h-11 w-full" disabled={loading}>
-            {loading ? <LoaderCircle className="animate-spin" /> : null}
+        <form onSubmit={submit} className="mt-7 space-y-3" aria-busy={loading}>
+          <Field label="Email" controlId="sign-in-email" error={error}>
+            <Input
+              type="email"
+              name="email"
+              autoComplete="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              placeholder={copy.emailPlaceholder}
+              className="h-11"
+              required
+            />
+          </Field>
+          <Button
+            type="submit"
+            className="h-11 w-full"
+            disabled={loading}
+            aria-busy={loading}
+          >
+            {loading ? (
+              <LoaderCircle className="animate-spin" aria-hidden="true" />
+            ) : null}
             Email me a secure link
             {!loading ? <ArrowRight /> : null}
           </Button>

--- a/src/components/booking-request-form.tsx
+++ b/src/components/booking-request-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { getAnalyticsVisitId } from "@/lib/analytics-browser";
 
 export type BookingRequestFormCopy = {
@@ -27,8 +27,10 @@ type BookingRequestFormProps = {
 const fieldClassName =
   "w-full rounded-xl border border-current/20 bg-transparent px-3 py-2 text-sm outline-none placeholder:opacity-50 focus:border-current/45";
 
+const fieldWrapClassName = "flex flex-col gap-1.5";
+
 const labelClassName =
-  "flex flex-col gap-1.5 text-xs font-semibold uppercase tracking-[0.1em] opacity-70";
+  "text-xs font-semibold uppercase tracking-[0.1em] opacity-70";
 
 /**
  * The fallback booking surface: a site with no provider to embed still has to be
@@ -48,10 +50,18 @@ export function BookingRequestForm({
 }: BookingRequestFormProps) {
   const [status, setStatus] = useState<"idle" | "sending" | "sent">("idle");
   const [error, setError] = useState<string | null>(null);
+  const successRef = useRef<HTMLParagraphElement>(null);
+  const sending = status === "sending";
+  const errorId = "booking-request-error";
+
+  useEffect(() => {
+    if (status !== "sent") return;
+    successRef.current?.focus();
+  }, [status]);
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (embedded || status === "sending") return;
+    if (embedded || sending) return;
 
     const form = new FormData(event.currentTarget);
     const read = (key: string) => {
@@ -99,81 +109,123 @@ export function BookingRequestForm({
 
   if (status === "sent") {
     return (
-      <p className="rounded-2xl border border-current/15 px-5 py-6 text-sm opacity-80">
+      <p
+        ref={successRef}
+        tabIndex={-1}
+        role="status"
+        aria-live="polite"
+        className="rounded-2xl border border-current/15 px-5 py-6 text-sm opacity-80"
+      >
         {copy.success}
       </p>
     );
   }
 
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+    <form
+      onSubmit={handleSubmit}
+      className="flex flex-col gap-4"
+      aria-busy={sending}
+    >
       <div className="grid gap-4 sm:grid-cols-2">
-        <label className={labelClassName}>
-          {copy.name}
+        <div className={fieldWrapClassName}>
+          <label htmlFor="booking-request-name" className={labelClassName}>
+            {copy.name}
+          </label>
           <input
+            id="booking-request-name"
             name="name"
             required
             maxLength={120}
             autoComplete="name"
             className={fieldClassName}
+            aria-invalid={error ? true : undefined}
+            aria-describedby={error ? errorId : undefined}
           />
-        </label>
-        <label className={labelClassName}>
-          {copy.email}
+        </div>
+        <div className={fieldWrapClassName}>
+          <label htmlFor="booking-request-email" className={labelClassName}>
+            {copy.email}
+          </label>
           <input
+            id="booking-request-email"
             name="email"
             type="email"
             maxLength={180}
             autoComplete="email"
             className={fieldClassName}
+            aria-invalid={error ? true : undefined}
+            aria-describedby={error ? errorId : undefined}
           />
-        </label>
-        <label className={labelClassName}>
-          {copy.phone}
+        </div>
+        <div className={fieldWrapClassName}>
+          <label htmlFor="booking-request-phone" className={labelClassName}>
+            {copy.phone}
+          </label>
           <input
+            id="booking-request-phone"
             name="phone"
             type="tel"
             maxLength={40}
             autoComplete="tel"
             className={fieldClassName}
+            aria-invalid={error ? true : undefined}
+            aria-describedby={error ? errorId : undefined}
           />
-        </label>
-        <label className={labelClassName}>
-          {copy.when}
+        </div>
+        <div className={fieldWrapClassName}>
+          <label htmlFor="booking-request-when" className={labelClassName}>
+            {copy.when}
+          </label>
           <input
+            id="booking-request-when"
             name="requestedAt"
             type="datetime-local"
             className={fieldClassName}
+            aria-invalid={error ? true : undefined}
+            aria-describedby={error ? errorId : undefined}
           />
-        </label>
-        <label className={labelClassName}>
-          {copy.partySize}
+        </div>
+        <div className={fieldWrapClassName}>
+          <label htmlFor="booking-request-party-size" className={labelClassName}>
+            {copy.partySize}
+          </label>
           <input
+            id="booking-request-party-size"
             name="partySize"
             type="number"
             min={1}
             max={200}
             className={fieldClassName}
+            aria-invalid={error ? true : undefined}
+            aria-describedby={error ? errorId : undefined}
           />
-        </label>
+        </div>
       </div>
-      <label className={labelClassName}>
-        <span>
+      <div className={fieldWrapClassName}>
+        <label htmlFor="booking-request-notes" className={labelClassName}>
           {copy.notes}{" "}
           <span className="font-normal normal-case tracking-normal opacity-60">
             ({copy.optional})
           </span>
-        </span>
+        </label>
         <textarea
+          id="booking-request-notes"
           name="notes"
           rows={3}
           maxLength={1000}
           className={fieldClassName}
+          aria-invalid={error ? true : undefined}
+          aria-describedby={error ? errorId : undefined}
         />
-      </label>
+      </div>
 
       {error ? (
-        <p role="alert" className="text-sm font-medium opacity-90">
+        <p
+          id={errorId}
+          role="alert"
+          className="text-sm font-medium opacity-90"
+        >
           {error}
         </p>
       ) : null}
@@ -181,11 +233,12 @@ export function BookingRequestForm({
       <div className="flex flex-wrap items-center gap-3">
         <button
           type="submit"
-          disabled={embedded || status === "sending"}
+          disabled={embedded || sending}
+          aria-busy={sending}
           className="inline-flex min-h-11 items-center justify-center rounded-full px-6 text-sm font-semibold text-white disabled:opacity-60"
           style={{ background: "var(--site-accent)" }}
         >
-          {status === "sending" ? copy.sending : copy.submit}
+          {sending ? copy.sending : copy.submit}
         </button>
         {embedded ? (
           <span className="text-xs opacity-60">{copy.previewNotice}</span>

--- a/src/lib/claim-launch-offer.test.ts
+++ b/src/lib/claim-launch-offer.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "bun:test";
+import { Vertical } from "@/generated/prisma/enums";
+import { FOUNDING_PLAN_ID, FOUNDING_PRICE } from "@/lib/billing-plans";
+import {
+  CLAIM_CHECKOUT_PLAN_ID,
+  claimPageState,
+  foundingOfferDisplay,
+  resolveClaimLaunchOffer,
+  resolveClaimLaunchOfferForVertical,
+} from "@/lib/claim-launch-offer";
+import { sampleSiteDraft } from "@/lib/restaurant";
+import { sampleFoodRetailDraft } from "@/lib/verticals/food-retail/fixtures";
+import { foodRetailMarketing } from "@/lib/verticals/food-retail/marketing";
+import { sampleLocalServiceSiteDraft } from "@/lib/verticals/local-service/fixtures";
+import { localServiceMarketing } from "@/lib/verticals/local-service/marketing";
+import { restaurantMarketing } from "@/lib/verticals/restaurant/marketing";
+import type { VerticalMarketing } from "@/lib/verticals/types";
+
+const claimPanel = await Bun.file(
+  new URL("../app/claim/[slug]/claim-panel.tsx", import.meta.url),
+).text();
+const claimPage = await Bun.file(
+  new URL("../app/claim/[slug]/page.tsx", import.meta.url),
+).text();
+const checkoutRoute = await Bun.file(
+  new URL("../app/api/checkout/route.ts", import.meta.url),
+).text();
+
+describe("claim launch offer mapping", () => {
+  it("prints the founding Stripe contract as the shared display price", () => {
+    expect(CLAIM_CHECKOUT_PLAN_ID).toBe(FOUNDING_PLAN_ID);
+    expect(FOUNDING_PRICE).toMatchObject({
+      currency: "usd",
+      unitAmount: 4_900,
+      interval: "month",
+      intervalCount: 1,
+    });
+    expect(foundingOfferDisplay()).toEqual({
+      price: "$49",
+      cadence: "/month",
+      currency: "usd",
+    });
+    expect(
+      foundingOfferDisplay({ ...FOUNDING_PRICE, unitAmount: 2_550 }),
+    ).toBeNull();
+  });
+
+  it("resolves restaurant, food-retail, and local-service from their own marketing", () => {
+    const display = foundingOfferDisplay();
+    expect(display).not.toBeNull();
+
+    const restaurant = resolveClaimLaunchOffer(restaurantMarketing);
+    const foodRetail = resolveClaimLaunchOffer(foodRetailMarketing);
+    const localService = resolveClaimLaunchOffer(localServiceMarketing);
+
+    expect(restaurant).toMatchObject({
+      planId: CLAIM_CHECKOUT_PLAN_ID,
+      name: "Founding",
+      price: display!.price,
+      cadence: display!.cadence,
+      currency: display!.currency,
+      emailPlaceholder: "owner@restaurant.com",
+      copy: restaurantMarketing.pricing.plans[0].copy,
+      features: restaurantMarketing.pricing.plans[0].features,
+    });
+    expect(foodRetail).toMatchObject({
+      planId: CLAIM_CHECKOUT_PLAN_ID,
+      name: "Founding",
+      price: display!.price,
+      cadence: display!.cadence,
+      emailPlaceholder: "owner@shop.com",
+      copy: foodRetailMarketing.pricing.plans[0].copy,
+      features: foodRetailMarketing.pricing.plans[0].features,
+    });
+    expect(localService).toMatchObject({
+      planId: CLAIM_CHECKOUT_PLAN_ID,
+      name: "Founding",
+      price: display!.price,
+      cadence: display!.cadence,
+      emailPlaceholder: "owner@business.com",
+      copy: localServiceMarketing.pricing.plans[0].copy,
+      features: localServiceMarketing.pricing.plans[0].features,
+    });
+
+    expect(foodRetail?.copy).not.toBe(restaurant?.copy);
+    expect(localService?.copy).not.toBe(restaurant?.copy);
+    expect(foodRetail?.features).not.toEqual(restaurant?.features);
+    expect(localService?.features).not.toEqual(restaurant?.features);
+    expect(resolveClaimLaunchOfferForVertical(Vertical.RESTAURANT)).toEqual(
+      restaurant,
+    );
+    expect(resolveClaimLaunchOfferForVertical(Vertical.FOOD_RETAIL)).toEqual(
+      foodRetail,
+    );
+    expect(resolveClaimLaunchOfferForVertical(Vertical.LOCAL_SERVICE)).toEqual(
+      localService,
+    );
+  });
+
+  it("fails closed instead of borrowing another vertical's plan", () => {
+    expect(resolveClaimLaunchOffer(wrongPriceMarketing())).toBeNull();
+    expect(resolveClaimLaunchOffer(unnamedPlanMarketing())).toBeNull();
+    expect(resolveClaimLaunchOffer(blankEmailMarketing())).toBeNull();
+    expect(
+      resolveClaimLaunchOffer(wrongPriceMarketing(restaurantMarketing)),
+    ).toBeNull();
+  });
+
+  it("keeps the claim UI and checkout on the same mapping", async () => {
+    expect(claimPanel).not.toContain("restaurantMarketing");
+    expect(claimPanel).not.toContain("owner@restaurant.com");
+    expect(claimPanel).toContain("plan: offer.planId");
+    expect(claimPanel).toContain("offer.emailPlaceholder");
+    expect(claimPanel).toContain('role="alert"');
+    expect(claimPanel).toContain('id={errorSummaryId}');
+    expect(claimPanel).toContain("<form onSubmit={submit}");
+    expect(claimPanel).toContain('type="submit"');
+    expect(claimPage).toContain("claimPageState");
+    expect(claimPage).toContain("offer={state.offer}");
+    expect(checkoutRoute).toContain("resolveClaimLaunchOfferForVertical");
+    expect(checkoutRoute).toContain("offer.planId !== plan");
+    expect(checkoutRoute).toContain("isVerticalClaimEnabled(invitation.vertical)");
+  });
+});
+
+describe("claim page route state", () => {
+  it("brands restaurant, food-retail, and local-service from their verticals", () => {
+    const restaurant = claimPageState({
+      vertical: Vertical.RESTAURANT,
+      draft: sampleSiteDraft,
+    });
+    const foodRetail = claimPageState({
+      vertical: Vertical.FOOD_RETAIL,
+      draft: sampleFoodRetailDraft,
+    });
+    const localService = claimPageState({
+      vertical: Vertical.LOCAL_SERVICE,
+      draft: sampleLocalServiceSiteDraft,
+    });
+
+    expect(restaurant).toMatchObject({
+      kind: "ready",
+      brand: { name: "Restofrontapp" },
+      offer: resolveClaimLaunchOffer(restaurantMarketing),
+      vertical: Vertical.RESTAURANT,
+    });
+    expect(foodRetail).toMatchObject({
+      kind: "ready",
+      brand: { name: "Shopfront Food" },
+      offer: resolveClaimLaunchOffer(foodRetailMarketing),
+      vertical: Vertical.FOOD_RETAIL,
+    });
+    expect(localService).toMatchObject({
+      kind: "ready",
+      brand: { name: "Tradefront" },
+      offer: resolveClaimLaunchOffer(localServiceMarketing),
+      vertical: Vertical.LOCAL_SERVICE,
+    });
+    expect(foodRetail.kind === "ready" && foodRetail.offer?.emailPlaceholder).toBe(
+      "owner@shop.com",
+    );
+    expect(
+      localService.kind === "ready" && localService.offer?.emailPlaceholder,
+    ).toBe("owner@business.com");
+  });
+
+  it("404s disabled verticals and missing sites without borrowing a plan", () => {
+    expect(claimPageState(null)).toEqual({ kind: "not_found" });
+    expect(
+      claimPageState({
+        vertical: Vertical.BEAUTY,
+        draft: sampleSiteDraft,
+      }),
+    ).toEqual({ kind: "not_found" });
+  });
+});
+
+function wrongPriceMarketing(
+  base: VerticalMarketing = foodRetailMarketing,
+): VerticalMarketing {
+  const [plan] = base.pricing.plans;
+  return {
+    ...base,
+    pricing: {
+      ...base.pricing,
+      plans: [{ ...plan, price: "$25" }],
+    },
+  };
+}
+
+function unnamedPlanMarketing(): VerticalMarketing {
+  const [plan] = localServiceMarketing.pricing.plans;
+  return {
+    ...localServiceMarketing,
+    pricing: {
+      ...localServiceMarketing.pricing,
+      plans: [{ ...plan, name: "Starter" }],
+    },
+  };
+}
+
+function blankEmailMarketing(): VerticalMarketing {
+  return {
+    ...foodRetailMarketing,
+    signIn: {
+      ...foodRetailMarketing.signIn,
+      emailPlaceholder: "   ",
+    },
+  };
+}

--- a/src/lib/claim-launch-offer.test.ts
+++ b/src/lib/claim-launch-offer.test.ts
@@ -13,6 +13,7 @@ import { sampleFoodRetailDraft } from "@/lib/verticals/food-retail/fixtures";
 import { foodRetailMarketing } from "@/lib/verticals/food-retail/marketing";
 import { sampleLocalServiceSiteDraft } from "@/lib/verticals/local-service/fixtures";
 import { localServiceMarketing } from "@/lib/verticals/local-service/marketing";
+import { beautyMarketing } from "@/lib/verticals/beauty/marketing";
 import { restaurantMarketing } from "@/lib/verticals/restaurant/marketing";
 import type { VerticalMarketing } from "@/lib/verticals/types";
 
@@ -101,6 +102,7 @@ describe("claim launch offer mapping", () => {
     expect(resolveClaimLaunchOffer(wrongPriceMarketing())).toBeNull();
     expect(resolveClaimLaunchOffer(unnamedPlanMarketing())).toBeNull();
     expect(resolveClaimLaunchOffer(blankEmailMarketing())).toBeNull();
+    expect(resolveClaimLaunchOffer(beautyMarketing)).toBeNull();
     expect(
       resolveClaimLaunchOffer(wrongPriceMarketing(restaurantMarketing)),
     ).toBeNull();
@@ -112,6 +114,7 @@ describe("claim launch offer mapping", () => {
     expect(claimPanel).toContain("plan: offer.planId");
     expect(claimPanel).toContain("offer.emailPlaceholder");
     expect(claimPanel).toContain('role="alert"');
+    expect(claimPanel).toContain('role="status"');
     expect(claimPanel).toContain('id={errorSummaryId}');
     expect(claimPanel).toContain("<form onSubmit={submit}");
     expect(claimPanel).toContain('type="submit"');
@@ -178,25 +181,34 @@ describe("claim page route state", () => {
 function wrongPriceMarketing(
   base: VerticalMarketing = foodRetailMarketing,
 ): VerticalMarketing {
-  const [plan] = base.pricing.plans;
+  const pricing = requirePricing(base);
+  const [plan] = pricing.plans;
   return {
     ...base,
     pricing: {
-      ...base.pricing,
+      ...pricing,
       plans: [{ ...plan, price: "$25" }],
     },
   };
 }
 
 function unnamedPlanMarketing(): VerticalMarketing {
-  const [plan] = localServiceMarketing.pricing.plans;
+  const pricing = requirePricing(localServiceMarketing);
+  const [plan] = pricing.plans;
   return {
     ...localServiceMarketing,
     pricing: {
-      ...localServiceMarketing.pricing,
+      ...pricing,
       plans: [{ ...plan, name: "Starter" }],
     },
   };
+}
+
+function requirePricing(marketing: VerticalMarketing) {
+  if (!marketing.pricing) {
+    throw new Error("expected a priced marketing fixture");
+  }
+  return marketing.pricing;
 }
 
 function blankEmailMarketing(): VerticalMarketing {

--- a/src/lib/claim-launch-offer.ts
+++ b/src/lib/claim-launch-offer.ts
@@ -69,7 +69,12 @@ export type ClaimPageState =
     };
 
 export function foundingOfferDisplay(
-  price: typeof FOUNDING_PRICE = FOUNDING_PRICE,
+  price: {
+    currency: string;
+    unitAmount: number;
+    interval: string;
+    intervalCount: number;
+  } = FOUNDING_PRICE,
 ): FoundingOfferDisplay | null {
   if (price.currency !== "usd") return null;
   if (price.intervalCount !== 1) return null;
@@ -78,7 +83,7 @@ export function foundingOfferDisplay(
   return {
     price: `$${majorUnits}`,
     cadence: `/${price.interval}`,
-    currency: price.currency,
+    currency: "usd",
   };
 }
 
@@ -87,9 +92,10 @@ export function resolveClaimLaunchOffer(
 ): ClaimLaunchOffer | null {
   const display = foundingOfferDisplay();
   const emailPlaceholder = marketing.signIn.emailPlaceholder.trim();
-  if (!display || emailPlaceholder.length === 0) return null;
+  const pricing = marketing.pricing;
+  if (!display || !pricing || emailPlaceholder.length === 0) return null;
 
-  const matches = marketing.pricing.plans.filter((plan) =>
+  const matches = pricing.plans.filter((plan) =>
     isValidFoundingPlan(plan, display),
   );
   const plan = matches.length === 1 ? matches[0] : undefined;

--- a/src/lib/claim-launch-offer.ts
+++ b/src/lib/claim-launch-offer.ts
@@ -1,0 +1,143 @@
+import {
+  FOUNDING_PLAN_ID,
+  FOUNDING_PRICE,
+  type BillingPlanId,
+} from "@/lib/billing-plans";
+import type { BrandIdentity } from "@/lib/brand";
+import type { SiteDraftView } from "@/lib/site-draft";
+import {
+  isVerticalClaimEnabled,
+  resolveVerticalConfig,
+} from "@/lib/verticals/registry";
+import type {
+  MarketingPlan,
+  VerticalId,
+  VerticalMarketing,
+} from "@/lib/verticals/types";
+
+/**
+ * Checkout's plan literal and the claim UI's displayed founding offer must
+ * resolve from this mapping. A vertical may print its own copy and features,
+ * but never a different price, cadence, or plan id than the Stripe contract.
+ */
+export const CLAIM_CHECKOUT_PLAN_ID = FOUNDING_PLAN_ID;
+
+export type FoundingOfferDisplay = {
+  price: string;
+  cadence: string;
+  currency: typeof FOUNDING_PRICE.currency;
+};
+
+export type ClaimLaunchOffer = {
+  planId: BillingPlanId;
+  name: string;
+  price: string;
+  cadence: string;
+  currency: typeof FOUNDING_PRICE.currency;
+  copy: string;
+  features: string[];
+  badge: string | null;
+  emailPlaceholder: string;
+};
+
+export type ClaimCheckoutReturn = {
+  sessionId: string;
+  claimInvitationId: string;
+};
+
+export type ClaimPanelProps = {
+  slug: string;
+  vertical: VerticalId;
+  fallbackDraft: SiteDraftView;
+  checkoutReturn: ClaimCheckoutReturn | null;
+  offer: ClaimLaunchOffer | null;
+};
+
+export type ClaimPageSite = {
+  vertical: VerticalId;
+  draft: SiteDraftView;
+};
+
+export type ClaimPageState =
+  | { kind: "not_found" }
+  | {
+      kind: "ready";
+      brand: BrandIdentity;
+      offer: ClaimLaunchOffer | null;
+      vertical: VerticalId;
+      draft: SiteDraftView;
+    };
+
+export function foundingOfferDisplay(
+  price: typeof FOUNDING_PRICE = FOUNDING_PRICE,
+): FoundingOfferDisplay | null {
+  if (price.currency !== "usd") return null;
+  if (price.intervalCount !== 1) return null;
+  const majorUnits = price.unitAmount / 100;
+  if (!Number.isInteger(majorUnits) || majorUnits <= 0) return null;
+  return {
+    price: `$${majorUnits}`,
+    cadence: `/${price.interval}`,
+    currency: price.currency,
+  };
+}
+
+export function resolveClaimLaunchOffer(
+  marketing: VerticalMarketing,
+): ClaimLaunchOffer | null {
+  const display = foundingOfferDisplay();
+  const emailPlaceholder = marketing.signIn.emailPlaceholder.trim();
+  if (!display || emailPlaceholder.length === 0) return null;
+
+  const matches = marketing.pricing.plans.filter((plan) =>
+    isValidFoundingPlan(plan, display),
+  );
+  const plan = matches.length === 1 ? matches[0] : undefined;
+  if (!plan) return null;
+
+  return {
+    planId: CLAIM_CHECKOUT_PLAN_ID,
+    name: plan.name,
+    price: plan.price,
+    cadence: plan.cadence,
+    currency: display.currency,
+    copy: plan.copy,
+    features: [...plan.features],
+    badge: plan.badge ?? null,
+    emailPlaceholder,
+  };
+}
+
+export function resolveClaimLaunchOfferForVertical(
+  id: VerticalId,
+): ClaimLaunchOffer | null {
+  return resolveClaimLaunchOffer(resolveVerticalConfig(id).marketing);
+}
+
+export function claimPageState(site: ClaimPageSite | null): ClaimPageState {
+  if (!site || !isVerticalClaimEnabled(site.vertical)) {
+    return { kind: "not_found" };
+  }
+  const config = resolveVerticalConfig(site.vertical);
+  return {
+    kind: "ready",
+    brand: config.marketing.brand,
+    offer: resolveClaimLaunchOffer(config.marketing),
+    vertical: site.vertical,
+    draft: site.draft,
+  };
+}
+
+function isValidFoundingPlan(
+  plan: MarketingPlan,
+  display: FoundingOfferDisplay,
+): boolean {
+  return (
+    plan.name.trim().toLowerCase() === CLAIM_CHECKOUT_PLAN_ID &&
+    plan.featured === true &&
+    plan.price === display.price &&
+    plan.cadence === display.cadence &&
+    plan.copy.trim().length > 0 &&
+    plan.features.length > 0
+  );
+}

--- a/src/lib/claim-page.test.tsx
+++ b/src/lib/claim-page.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ClaimPanel } from "@/app/claim/[slug]/claim-panel";
+import { Vertical } from "@/generated/prisma/enums";
+import { claimPageState } from "@/lib/claim-launch-offer";
+import { sampleSiteDraft } from "@/lib/restaurant";
+import type { SiteDraftView } from "@/lib/site-draft";
+import { sampleFoodRetailDraft } from "@/lib/verticals/food-retail/fixtures";
+import { sampleLocalServiceSiteDraft } from "@/lib/verticals/local-service/fixtures";
+import type { VerticalId } from "@/lib/verticals/types";
+
+describe("claim page route surface", () => {
+  it("renders restaurant brand and founding identity", () => {
+    const { brand, html } = renderClaimRoute(
+      Vertical.RESTAURANT,
+      sampleSiteDraft,
+    );
+    expect(brand).toBe("Restofrontapp");
+    expect(html).toContain("Claim Osteria Luna");
+    expect(html).toContain('placeholder="owner@restaurant.com"');
+    expect(html).toContain("Mobile-first website and menu");
+  });
+
+  it("renders food-retail brand and founding identity", () => {
+    const { brand, html } = renderClaimRoute(
+      Vertical.FOOD_RETAIL,
+      sampleFoodRetailDraft,
+    );
+    expect(brand).toBe("Shopfront Food");
+    expect(html).toContain("Claim Maison Levain");
+    expect(html).toContain('placeholder="owner@shop.com"');
+    expect(html).toContain("Mobile-first product ranges");
+    expect(html).not.toContain("owner@restaurant.com");
+    expect(html).not.toContain("Restofrontapp");
+  });
+
+  it("renders local-service brand and founding identity", () => {
+    const { brand, html } = renderClaimRoute(
+      Vertical.LOCAL_SERVICE,
+      sampleLocalServiceSiteDraft,
+    );
+    expect(brand).toBe("Tradefront");
+    expect(html).toContain("Claim Harbour Electrical");
+    expect(html).toContain('placeholder="owner@business.com"');
+    expect(html).toContain("Phone, WhatsApp and quote actions");
+    expect(html).not.toContain("owner@restaurant.com");
+    expect(html).not.toContain("Restofrontapp");
+  });
+
+  it("keeps beauty and missing sites behind the claim gate", () => {
+    expect(
+      claimPageState({
+        vertical: Vertical.BEAUTY,
+        draft: sampleSiteDraft,
+      }).kind,
+    ).toBe("not_found");
+    expect(claimPageState(null).kind).toBe("not_found");
+  });
+});
+
+function renderClaimRoute(vertical: VerticalId, draft: SiteDraftView) {
+  const state = claimPageState({ vertical, draft });
+  expect(state.kind).toBe("ready");
+  if (state.kind !== "ready") throw new Error("expected a claimable site");
+  return {
+    brand: state.brand.name,
+    html: renderToStaticMarkup(
+      <ClaimPanel
+        slug={draft.slug}
+        vertical={state.vertical}
+        fallbackDraft={state.draft}
+        offer={state.offer}
+        checkoutReturn={null}
+      />,
+    ),
+  };
+}

--- a/src/lib/claim-page.test.tsx
+++ b/src/lib/claim-page.test.tsx
@@ -9,7 +9,15 @@ import { sampleFoodRetailDraft } from "@/lib/verticals/food-retail/fixtures";
 import { sampleLocalServiceSiteDraft } from "@/lib/verticals/local-service/fixtures";
 import type { VerticalId } from "@/lib/verticals/types";
 
+const claimPageSource = await Bun.file(
+  new URL("../app/claim/[slug]/page.tsx", import.meta.url),
+).text();
+
 describe("claim page route surface", () => {
+  it("names the icon-only back control", () => {
+    expect(claimPageSource).toContain('aria-label="Back to create"');
+  });
+
   it("renders restaurant brand and founding identity", () => {
     const { brand, html } = renderClaimRoute(
       Vertical.RESTAURANT,

--- a/src/lib/claim-panel.test.tsx
+++ b/src/lib/claim-panel.test.tsx
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ClaimPanel } from "@/app/claim/[slug]/claim-panel";
+import { Vertical } from "@/generated/prisma/enums";
+import {
+  resolveClaimLaunchOffer,
+  type ClaimLaunchOffer,
+} from "@/lib/claim-launch-offer";
+import type { VerticalId } from "@/lib/verticals/types";
+import { sampleSiteDraft } from "@/lib/restaurant";
+import type { SiteDraftView } from "@/lib/site-draft";
+import { sampleFoodRetailDraft } from "@/lib/verticals/food-retail/fixtures";
+import { foodRetailMarketing } from "@/lib/verticals/food-retail/marketing";
+import { sampleLocalServiceSiteDraft } from "@/lib/verticals/local-service/fixtures";
+import { localServiceMarketing } from "@/lib/verticals/local-service/marketing";
+import { restaurantMarketing } from "@/lib/verticals/restaurant/marketing";
+
+describe("claim panel offer identity", () => {
+  it("renders the restaurant founding offer and email example", () => {
+    const html = renderPanel({
+      vertical: Vertical.RESTAURANT,
+      draft: sampleSiteDraft,
+      offer: requireOffer(restaurantMarketing),
+    });
+
+    expect(html).toContain("Claim Osteria Luna");
+    expect(html).toContain("Founding");
+    expect(html).toContain("$49");
+    expect(html).toContain("/month");
+    expect(html).toContain("mobile-first restaurant website");
+    expect(html).toContain('placeholder="owner@restaurant.com"');
+    expect(html).toContain("Mobile-first website and menu");
+    expect(html).not.toContain("owner@shop.com");
+    expectAccessibleClaimForm(html);
+  });
+
+  it("renders the food-retail founding offer instead of restaurant copy", () => {
+    const html = renderPanel({
+      vertical: Vertical.FOOD_RETAIL,
+      draft: sampleFoodRetailDraft,
+      offer: requireOffer(foodRetailMarketing),
+    });
+
+    expect(html).toContain("Claim Maison Levain");
+    expect(html).toContain("mobile-first food-retail website");
+    expect(html).toContain("Mobile-first product ranges");
+    expect(html).toContain('placeholder="owner@shop.com"');
+    expect(html).not.toContain("owner@restaurant.com");
+    expect(html).not.toContain("restaurant website");
+    expect(html).not.toContain("Existing booking and ordering links");
+    expectAccessibleClaimForm(html);
+  });
+
+  it("renders the local-service founding offer instead of restaurant copy", () => {
+    const html = renderPanel({
+      vertical: Vertical.LOCAL_SERVICE,
+      draft: sampleLocalServiceSiteDraft,
+      offer: requireOffer(localServiceMarketing),
+    });
+
+    expect(html).toContain("Claim Harbour Electrical");
+    expect(html).toContain("complete local-service website");
+    expect(html).toContain("Phone, WhatsApp and quote actions");
+    expect(html).toContain('placeholder="owner@business.com"');
+    expect(html).not.toContain("owner@restaurant.com");
+    expect(html).not.toContain("restaurant website");
+    expectAccessibleClaimForm(html);
+  });
+
+  it("fails closed with an actionable unavailable state when no launch offer exists", () => {
+    const html = renderPanel({
+      vertical: Vertical.FOOD_RETAIL,
+      draft: sampleFoodRetailDraft,
+      offer: null,
+    });
+
+    expect(html).toContain("Claiming is unavailable for Maison Levain.");
+    expect(html).toContain("role=\"status\"");
+    expect(html).toContain("launch offer for this site is not configured");
+    expect(html).not.toContain("Founding");
+    expect(html).not.toContain("$49");
+    expect(html).not.toContain("owner@restaurant.com");
+    expect(html).not.toContain("owner@shop.com");
+    expect(html).not.toContain("Verify ownership by email");
+    expect(html).not.toContain('id="claim-email"');
+    expect(html).not.toContain("<form");
+  });
+
+  it("keeps Stripe return reconciliation when the offer later becomes unavailable", () => {
+    const html = renderPanel({
+      vertical: Vertical.FOOD_RETAIL,
+      draft: sampleFoodRetailDraft,
+      offer: null,
+      checkoutReturn: {
+        sessionId: "cs_test_123",
+        claimInvitationId: "claim_123",
+      },
+    });
+
+    expect(html).toContain("Payment received. Finalizing the owner account");
+    expect(html).not.toContain("Claiming is unavailable");
+    expect(html).not.toContain("Verify ownership by email");
+  });
+});
+
+function renderPanel(input: {
+  vertical: VerticalId;
+  draft: SiteDraftView;
+  offer: ClaimLaunchOffer | null;
+  checkoutReturn?: {
+    sessionId: string;
+    claimInvitationId: string;
+  } | null;
+}) {
+  return renderToStaticMarkup(
+    <ClaimPanel
+      slug={input.draft.slug}
+      vertical={input.vertical}
+      fallbackDraft={input.draft}
+      offer={input.offer}
+      checkoutReturn={input.checkoutReturn ?? null}
+    />,
+  );
+}
+
+function requireOffer(
+  marketing: Parameters<typeof resolveClaimLaunchOffer>[0],
+): ClaimLaunchOffer {
+  const offer = resolveClaimLaunchOffer(marketing);
+  expect(offer).not.toBeNull();
+  return offer!;
+}
+
+function expectAccessibleClaimForm(html: string) {
+  expect(html).toContain("<form");
+  expect(html).toContain('type="submit"');
+  const email = associatedControl(html, "Business owner email", "input");
+  expect(email.id).toBe("claim-email");
+  expect(attribute(email.attributes, "type")).toBe("email");
+  expect(html).toContain(`id="${email.id}-description"`);
+  expect(html).toContain(`for="${email.id}"`);
+}
+
+function associatedControl(
+  html: string,
+  label: string,
+  tag: "input" | "select" | "textarea",
+) {
+  const labelMatch = html.match(
+    new RegExp(
+      `<label\\b[^>]*\\bfor="([^"]+)"[^>]*>${escapeRegex(label)}</label>`,
+    ),
+  );
+  expect(labelMatch, `Expected a visible label named “${label}”`).not.toBeNull();
+  const id = labelMatch![1];
+  const control = html.match(
+    new RegExp(`<${tag}\\b([^>]*\\bid="${escapeRegex(id)}"[^>]*)>`, "i"),
+  );
+  expect(control, `Expected <${tag} id="${id}">`).not.toBeNull();
+  return { id, attributes: control![1] };
+}
+
+function attribute(attributes: string, name: string) {
+  return attributes.match(new RegExp(`\\b${name}="([^"]*)"`))?.[1];
+}
+
+function escapeRegex(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/lib/claim-panel.test.tsx
+++ b/src/lib/claim-panel.test.tsx
@@ -98,6 +98,8 @@ describe("claim panel offer identity", () => {
     });
 
     expect(html).toContain("Payment received. Finalizing the owner account");
+    expect(html).toContain('role="status"');
+    expect(html).toContain('aria-live="polite"');
     expect(html).not.toContain("Claiming is unavailable");
     expect(html).not.toContain("Verify ownership by email");
   });

--- a/src/lib/dashboard-tabs-surface.test.ts
+++ b/src/lib/dashboard-tabs-surface.test.ts
@@ -28,6 +28,9 @@ const sitePublication = await Bun.file(
   new URL("./site-publication.ts", import.meta.url),
 ).text();
 const sites = await Bun.file(new URL("./sites.ts", import.meta.url)).text();
+const publicationCapability = await Bun.file(
+  new URL("./site-publication-capability.ts", import.meta.url),
+).text();
 const translationRegenerationRoute = await Bun.file(
   new URL(
     "../app/api/sites/[slug]/translations/[locale]/regenerate/route.ts",
@@ -90,6 +93,13 @@ describe("dashboard tab and settings surface", () => {
       ),
     ).toHaveLength(2);
     expect(sites).toContain("!isVerticalPublicationEnabled(version.vertical)");
+    expect(sites).not.toContain("isVerticalPublicationMutationEnabled");
+    expect(publicationCapability).toContain(
+      "isVerticalPublicationMutationEnabled",
+    );
+    expect(publicationCapability).not.toContain(
+      "isVerticalPublicationEnabled(vertical)",
+    );
   });
 
   it("carries the universal draft revision through auxiliary owner mutations", () => {

--- a/src/lib/food-retail-claim-gate.test.ts
+++ b/src/lib/food-retail-claim-gate.test.ts
@@ -32,9 +32,10 @@ describe("food retail factory claim gate", () => {
     expect(importStudio).toContain(
       "{isVerticalClaimEnabled(site.vertical) ? (",
     );
-    expect(claimPage).toContain("isVerticalClaimEnabled(site.vertical)");
+    expect(claimPage).toContain("claimPageState");
     expect(checkoutRoute).toContain(
       "isVerticalClaimEnabled(invitation.vertical)",
     );
+    expect(checkoutRoute).toContain("resolveClaimLaunchOfferForVertical");
   });
 });

--- a/src/lib/funnel-accessibility.test.tsx
+++ b/src/lib/funnel-accessibility.test.tsx
@@ -1,0 +1,304 @@
+import { describe, expect, it } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ImportStudio } from "@/app/create/import-studio";
+import { AuthShell } from "@/app/sign-in/auth-shell";
+import { SignInForm } from "@/app/sign-in/sign-in-form";
+import { ClaimPanel } from "@/app/claim/[slug]/claim-panel";
+import { BookingRequestForm } from "@/components/booking-request-form";
+import { Vertical } from "@/generated/prisma/enums";
+import { FACTORY_BRAND } from "@/lib/brand";
+import { resolveClaimLaunchOffer } from "@/lib/claim-launch-offer";
+import { sampleSiteDraft } from "@/lib/restaurant";
+import { signInErrorMessage, signInSurface } from "@/lib/sign-in-surface";
+import { restaurantMarketing } from "@/lib/verticals/restaurant/marketing";
+
+const importStudioSource = await Bun.file(
+  new URL("../app/create/import-studio.tsx", import.meta.url),
+).text();
+const signInFormSource = await Bun.file(
+  new URL("../app/sign-in/sign-in-form.tsx", import.meta.url),
+).text();
+const authShellSource = await Bun.file(
+  new URL("../app/sign-in/auth-shell.tsx", import.meta.url),
+).text();
+const claimPageSource = await Bun.file(
+  new URL("../app/claim/[slug]/page.tsx", import.meta.url),
+).text();
+const claimPanelSource = await Bun.file(
+  new URL("../app/claim/[slug]/claim-panel.tsx", import.meta.url),
+).text();
+const bookingFormSource = await Bun.file(
+  new URL("../components/booking-request-form.tsx", import.meta.url),
+).text();
+
+const factoryBrand = {
+  ...FACTORY_BRAND,
+  vertical: null,
+  homeUrl: "https://cornershop.dev",
+} as const;
+
+const bookingCopy = {
+  name: "Your name",
+  email: "Email",
+  phone: "Phone",
+  when: "Preferred time",
+  partySize: "Number of people",
+  notes: "Anything we should know?",
+  optional: "optional",
+  submit: "Send request",
+  sending: "Sending…",
+  success: "Thanks — we'll be in touch shortly.",
+  error: "Your request could not be sent. Try again.",
+  previewNotice: "This is a preview — requests are not sent.",
+};
+
+describe("create funnel accessibility", () => {
+  it("names the Import Studio source field from a visible label, not the placeholder", () => {
+    const html = renderToStaticMarkup(
+      <ImportStudio
+        initialSource=""
+        initialVertical={Vertical.RESTAURANT}
+        initialBrand={factoryBrand}
+      />,
+    );
+
+    const source = associatedControl(html, "Restaurant website or name", "input");
+    expect(source.id).toBe("import-source");
+    expect(attribute(source.attributes, "placeholder")).toBe(
+      "restaurant.com or restaurant name",
+    );
+    expect(attribute(source.attributes, "placeholder")).not.toBe(
+      "Restaurant website or name",
+    );
+    expect(html).toContain('type="submit"');
+    expect(html).toContain("Build preview");
+    expect(html).toContain('aria-label="Back to Cornershopdev"');
+    expect(html).toContain('aria-label="Mobile preview"');
+    expect(html).toContain('aria-label="Desktop preview"');
+    expect(html).toContain('aria-label="Kind of business"');
+  });
+
+  it("keeps Beauty source copy non-chargeable while still naming the control", () => {
+    const html = renderToStaticMarkup(
+      <ImportStudio
+        initialSource=""
+        initialVertical={Vertical.BEAUTY}
+        initialBrand={factoryBrand}
+      />,
+    );
+
+    const source = associatedControl(html, "Salon website or name", "input");
+    expect(attribute(source.attributes, "placeholder")).toBe(
+      "salon.com or salon name",
+    );
+    expect(html).toContain("The preview stays private and is not chargeable.");
+    expect(html).not.toContain("$49");
+    expect(html).not.toContain("founding plan");
+  });
+
+  it("announces import progress and asynchronous errors, and keeps busy names", () => {
+    expect(importStudioSource).toContain('role="status"');
+    expect(importStudioSource).toContain('aria-live="polite"');
+    expect(importStudioSource).toContain('role="alert"');
+    expect(importStudioSource).toContain('id="import-source-error"');
+    expect(importStudioSource).toContain("aria-busy={loading}");
+    expect(importStudioSource).toContain("Finishing the details");
+    expect(importStudioSource).toContain("Build preview");
+    expect(importStudioSource).toContain("<form");
+    expect(importStudioSource).toContain('type="submit"');
+    expect(importStudioSource).toContain('<Field');
+    expect(importStudioSource).toContain('label={copy.sourceLabel}');
+  });
+});
+
+describe("sign-in funnel accessibility", () => {
+  it("names the email field, associates help, and announces initial errors", () => {
+    const surface = signInSurface(null);
+    const error = signInErrorMessage("INVALID_TOKEN");
+    const html = renderToStaticMarkup(
+      <AuthShell surface={surface} backHref="/">
+        <SignInForm copy={surface.copy} inverse={surface.inverse} initialError={error} />
+      </AuthShell>,
+    );
+
+    const email = associatedControl(html, "Email", "input");
+    expect(email.id).toBe("sign-in-email");
+    expect(attribute(email.attributes, "placeholder")).toBe("you@business.com");
+    expect(attribute(email.attributes, "placeholder")).not.toBe("Email");
+    expect(attribute(email.attributes, "aria-invalid")).toBe("true");
+    expect(attribute(email.attributes, "aria-describedby")).toBe(
+      "sign-in-email-error",
+    );
+    expect(html).toContain('id="sign-in-email-error"');
+    expect(html).toContain('role="alert"');
+    expect(html).toContain(error!);
+    expect(html).toContain("Email me a secure link");
+    expect(html).toContain('type="submit"');
+    expect(html).toContain('aria-label="Back to Cornershopdev"');
+  });
+
+  it("keeps restaurant placeholders as examples on the same Email name", () => {
+    const surface = signInSurface(restaurantMarketing);
+    const html = renderToStaticMarkup(
+      <SignInForm
+        copy={surface.copy}
+        inverse={surface.inverse}
+        initialError={null}
+      />,
+    );
+
+    const email = associatedControl(html, "Email", "input");
+    expect(attribute(email.attributes, "placeholder")).toBe(
+      "owner@restaurant.com",
+    );
+    expect(html).not.toContain('role="alert"');
+  });
+
+  it("announces sent state, moves focus, and keeps a meaningful busy name", () => {
+    expect(signInFormSource).toContain("headingRef.current?.focus()");
+    expect(signInFormSource).toContain("tabIndex={sent ? -1 : undefined}");
+    expect(signInFormSource).toContain('role={sent ? "status" : undefined}');
+    expect(signInFormSource).toContain("aria-busy={loading}");
+    expect(signInFormSource).toContain("Email me a secure link");
+    expect(signInFormSource).toContain("<form onSubmit={submit}");
+    expect(signInFormSource).toContain('type="submit"');
+    expect(authShellSource).toContain("aria-label={`Back to ${surface.brand.name}`}");
+  });
+});
+
+describe("claim funnel accessibility", () => {
+  it("names the owner email field and keeps the founding example as a placeholder", () => {
+    const offer = resolveClaimLaunchOffer(restaurantMarketing);
+    expect(offer).not.toBeNull();
+    const html = renderToStaticMarkup(
+      <ClaimPanel
+        slug={sampleSiteDraft.slug}
+        vertical={Vertical.RESTAURANT}
+        fallbackDraft={sampleSiteDraft}
+        offer={offer}
+        checkoutReturn={null}
+      />,
+    );
+
+    const email = associatedControl(html, "Business owner email", "input");
+    expect(email.id).toBe("claim-email");
+    expect(attribute(email.attributes, "placeholder")).toBe(
+      "owner@restaurant.com",
+    );
+    expect(html).toContain(`id="${email.id}-description"`);
+    expect(html).toContain("Verify ownership by email");
+    expect(html).toContain('type="submit"');
+    expect(html).toContain("$49");
+  });
+
+  it("announces checkout processing through a live status region", () => {
+    const offer = resolveClaimLaunchOffer(restaurantMarketing);
+    const html = renderToStaticMarkup(
+      <ClaimPanel
+        slug={sampleSiteDraft.slug}
+        vertical={Vertical.RESTAURANT}
+        fallbackDraft={sampleSiteDraft}
+        offer={offer}
+        checkoutReturn={{
+          sessionId: "cs_test_123",
+          claimInvitationId: "claim_123",
+        }}
+      />,
+    );
+
+    expect(html).toContain("Payment received. Finalizing the owner account");
+    expect(html).toContain('role="status"');
+    expect(html).toContain('aria-live="polite"');
+    expect(html).toContain("Sending ownership link");
+    expect(html).toContain('aria-busy="true"');
+  });
+
+  it("gives the claim back icon a name and announces invitation, errors, and busy names", () => {
+    expect(claimPageSource).toContain('aria-label="Back to create"');
+    expect(claimPanelSource).toContain('role="alert"');
+    expect(claimPanelSource).toContain('role="status"');
+    expect(claimPanelSource).toContain('aria-live="polite"');
+    expect(claimPanelSource).toContain("aria-busy={loading}");
+    expect(claimPanelSource).toContain("Sending ownership link");
+    expect(claimPanelSource).toContain("Opening secure checkout");
+    expect(claimPanelSource).toContain("Verify ownership by email");
+    expect(claimPanelSource).toContain("<form onSubmit={submit}");
+    expect(claimPanelSource).toContain('type="submit"');
+  });
+});
+
+describe("booking funnel accessibility", () => {
+  it("names every booking control from a persistent label", () => {
+    const html = renderToStaticMarkup(
+      <BookingRequestForm slug="osteria-luna" copy={bookingCopy} />,
+    );
+
+    expect(associatedControl(html, "Your name", "input").id).toBe(
+      "booking-request-name",
+    );
+    expect(associatedControl(html, "Email", "input").id).toBe(
+      "booking-request-email",
+    );
+    expect(associatedControl(html, "Phone", "input").id).toBe(
+      "booking-request-phone",
+    );
+    expect(associatedControl(html, "Preferred time", "input").id).toBe(
+      "booking-request-when",
+    );
+    expect(associatedControl(html, "Number of people", "input").id).toBe(
+      "booking-request-party-size",
+    );
+    expect(html).toContain('for="booking-request-notes"');
+    expect(html).toContain('id="booking-request-notes"');
+    expect(html).toContain("Anything we should know?");
+    expect(html).toContain("Send request");
+    expect(html).toContain('type="submit"');
+    expect(html).not.toContain('role="alert"');
+  });
+
+  it("associates asynchronous errors and announces success with a focus move", () => {
+    expect(bookingFormSource).toContain('id={errorId}');
+    expect(bookingFormSource).toContain('role="alert"');
+    expect(bookingFormSource).toContain('aria-describedby={error ? errorId : undefined}');
+    expect(bookingFormSource).toContain('role="status"');
+    expect(bookingFormSource).toContain('aria-live="polite"');
+    expect(bookingFormSource).toContain("tabIndex={-1}");
+    expect(bookingFormSource).toContain("successRef.current?.focus()");
+    expect(bookingFormSource).toContain("aria-busy={sending}");
+    expect(bookingFormSource).toContain("{sending ? copy.sending : copy.submit}");
+    expect(bookingFormSource).toContain("<form");
+    expect(bookingFormSource).toContain('type="submit"');
+  });
+});
+
+function associatedControl(
+  html: string,
+  label: string,
+  tag: "input" | "select" | "textarea",
+) {
+  const labelMatch = html.match(
+    new RegExp(
+      `<label\\b[^>]*\\bfor="([^"]+)"[^>]*>${escapeRegex(label)}</label>`,
+    ),
+  );
+  expect(labelMatch, `Expected a visible label named “${label}”`).not.toBeNull();
+  const id = labelMatch![1];
+  const control = html.match(
+    new RegExp(`<${tag}\\b(?=[^>]*\\bid="${escapeRegex(id)}")[^>]*>`),
+  );
+  expect(
+    control,
+    `Expected ${tag}#${id} to be associated with “${label}”`,
+  ).not.toBeNull();
+  return { id, attributes: control![0] };
+}
+
+function attribute(attributes: string, name: string) {
+  return attributes.match(
+    new RegExp(`(?:^|\\s)${escapeRegex(name)}="([^"]*)"`),
+  )?.[1];
+}
+
+function escapeRegex(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/lib/owner-site-save.ts
+++ b/src/lib/owner-site-save.ts
@@ -4,7 +4,10 @@ import {
   DraftRevisionConflictError,
   updateSiteDraft,
 } from "@/lib/site-persistence";
-import { resolveVerticalConfig } from "@/lib/verticals/registry";
+import {
+  isVerticalOwnerReviewSupported,
+  resolveVerticalConfig,
+} from "@/lib/verticals/registry";
 
 type OwnerSiteSaveAccess = {
   site: { vertical: Vertical };
@@ -25,11 +28,11 @@ export async function saveAuthorizedSiteDraft(
   input: unknown,
   saveDraft: OwnerSiteDraftUpdater = updateSiteDraft,
 ) {
-  if (access.site.vertical === Vertical.BEAUTY) {
+  if (!isVerticalOwnerReviewSupported(access.site.vertical)) {
     return Response.json(
       {
         error:
-          "Owner editing for this vertical is not available yet. Use import and claim flows until the vertical editor ships.",
+          "Owner editing for this vertical is not available yet. Use the private preview until the vertical editor ships.",
       },
       { status: 409 },
     );

--- a/src/lib/sign-in-form-surface.test.ts
+++ b/src/lib/sign-in-form-surface.test.ts
@@ -13,7 +13,15 @@ const verifyRoute = await Bun.file(
 describe("magic-link sign-in form surface", () => {
   it("submits through the form handler instead of rendering a non-submit button", () => {
     expect(signInForm).toContain("<form onSubmit={submit}");
-    expect(signInForm).toContain('<Button type="submit"');
+    expect(signInForm).toContain('type="submit"');
+  });
+
+  it("names the email field and announces asynchronous errors", () => {
+    expect(signInForm).toContain('<Field label="Email" controlId="sign-in-email"');
+    expect(signInForm).toContain("error={error}");
+    expect(signInForm).toContain('placeholder={copy.emailPlaceholder}');
+    expect(signInForm).toContain("aria-busy={loading}");
+    expect(signInForm).toContain("Email me a secure link");
   });
 
   it("preserves token privacy while allowing the same-origin verification form", () => {

--- a/src/lib/sign-in-surface.test.ts
+++ b/src/lib/sign-in-surface.test.ts
@@ -38,7 +38,7 @@ describe("sign-in surface", () => {
       brand: beautyMarketing.brand,
       inverse: false,
       copy: {
-        title: "Open your salon.",
+        title: "Open your salon preview.",
         emailPlaceholder: "owner@salon.com",
         createHref: "/create?vertical=beauty",
       },

--- a/src/lib/site-owner-route.test.ts
+++ b/src/lib/site-owner-route.test.ts
@@ -119,6 +119,22 @@ describe("owner site save revision contract", () => {
     expect(updateSiteDraft).not.toHaveBeenCalled();
   });
 
+  it("rejects beauty owner saves without promising claim or checkout", async () => {
+    const response = await saveAuthorizedSiteDraft(
+      "atelier-coupe",
+      { ...access, site: { vertical: Vertical.BEAUTY } },
+      { expectedRevision: currentRevision },
+      updateSiteDraft,
+    );
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({
+      error:
+        "Owner editing for this vertical is not available yet. Use the private preview until the vertical editor ships.",
+    });
+    expect(updateSiteDraft).not.toHaveBeenCalled();
+  });
+
   it("persists a schema-valid local-service draft with optimistic concurrency", async () => {
     const response = await saveAuthorizedSiteDraft(
       sampleLocalServiceSiteDraft.slug,

--- a/src/lib/site-publication-capability.test.ts
+++ b/src/lib/site-publication-capability.test.ts
@@ -2,14 +2,37 @@ import { describe, expect, it } from "bun:test";
 import { Vertical } from "@/generated/prisma/enums";
 import {
   assertVerticalPublicationEnabled,
+  PUBLICATION_UNAVAILABLE_MESSAGE,
   publicationCapabilityFailureResponse,
+  SitePublicationCapabilityError,
 } from "@/lib/site-publication-capability";
 
+const ownerReviewVerticals = [
+  Vertical.RESTAURANT,
+  Vertical.FOOD_RETAIL,
+  Vertical.LOCAL_SERVICE,
+] as const;
+
 describe("site publication capability", () => {
-  it("allows reviewed publication for every registered SMB vertical", () => {
-    for (const vertical of Object.values(Vertical)) {
+  it("allows reviewed publication mutation for verticals with owner-review workflows", () => {
+    for (const vertical of ownerReviewVerticals) {
       expect(publicationCapabilityFailureResponse(vertical)).toBeNull();
       expect(() => assertVerticalPublicationEnabled(vertical)).not.toThrow();
     }
+  });
+
+  it("fails closed for beauty owner publication mutation", async () => {
+    const response = publicationCapabilityFailureResponse(Vertical.BEAUTY);
+    expect(response).not.toBeNull();
+    expect(response?.status).toBe(409);
+    expect(await response?.json()).toEqual({
+      error: PUBLICATION_UNAVAILABLE_MESSAGE,
+    });
+    expect(() => assertVerticalPublicationEnabled(Vertical.BEAUTY)).toThrow(
+      SitePublicationCapabilityError,
+    );
+    expect(() => assertVerticalPublicationEnabled(Vertical.BEAUTY)).toThrow(
+      PUBLICATION_UNAVAILABLE_MESSAGE,
+    );
   });
 });

--- a/src/lib/site-publication-capability.ts
+++ b/src/lib/site-publication-capability.ts
@@ -1,5 +1,5 @@
 import type { VerticalId } from "@/lib/verticals/types";
-import { isVerticalPublicationEnabled } from "@/lib/verticals/registry";
+import { isVerticalPublicationMutationEnabled } from "@/lib/verticals/registry";
 
 export const PUBLICATION_UNAVAILABLE_MESSAGE =
   "Publishing is not available for this vertical";
@@ -13,7 +13,7 @@ export class SitePublicationCapabilityError extends Error {
 
 /** Shared fail-closed assertion used by publish and rollback services. */
 export function assertVerticalPublicationEnabled(vertical: VerticalId): void {
-  if (!isVerticalPublicationEnabled(vertical)) {
+  if (!isVerticalPublicationMutationEnabled(vertical)) {
     throw new SitePublicationCapabilityError();
   }
 }
@@ -25,7 +25,7 @@ export function assertVerticalPublicationEnabled(vertical: VerticalId): void {
 export function publicationCapabilityFailureResponse(
   vertical: VerticalId,
 ): Response | null {
-  if (isVerticalPublicationEnabled(vertical)) return null;
+  if (isVerticalPublicationMutationEnabled(vertical)) return null;
   return Response.json(
     { error: PUBLICATION_UNAVAILABLE_MESSAGE },
     { status: 409 },

--- a/src/lib/verticals/beauty/config.ts
+++ b/src/lib/verticals/beauty/config.ts
@@ -79,6 +79,7 @@ export const beautyConfig = {
   marketing: beautyMarketing,
   claimMode: "disabled",
   publicationEnabled: true,
+  publicationMutationEnabled: false,
   integrationTypes: ["booking", "social"],
   attributesSchema: beautyAttributesSchema,
   attributeDefaults: {

--- a/src/lib/verticals/beauty/lifecycle.test.ts
+++ b/src/lib/verticals/beauty/lifecycle.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "bun:test";
+import { Vertical } from "@/generated/prisma/enums";
+import { beautyMarketing } from "@/lib/verticals/beauty/marketing";
+import { beautyConfig } from "@/lib/verticals/beauty/config";
+import {
+  isVerticalClaimEnabled,
+  isVerticalOwnerReviewSupported,
+  isVerticalPublicationEnabled,
+  isVerticalPublicationMutationEnabled,
+  resolveVerticalConfig,
+} from "@/lib/verticals/registry";
+
+const importStudio = await Bun.file(
+  new URL("../../../app/create/import-studio.tsx", import.meta.url),
+).text();
+const nichePage = await Bun.file(
+  new URL("../../../app/niche/[vertical]/page.tsx", import.meta.url),
+).text();
+const claimPage = await Bun.file(
+  new URL("../../../app/claim/[slug]/page.tsx", import.meta.url),
+).text();
+const checkoutRoute = await Bun.file(
+  new URL("../../../app/api/checkout/route.ts", import.meta.url),
+).text();
+const unsupportedDashboard = await Bun.file(
+  new URL(
+    "../../../app/dashboard/unsupported-vertical-dashboard.tsx",
+    import.meta.url,
+  ),
+).text();
+const dashboardPage = await Bun.file(
+  new URL("../../../app/dashboard/page.tsx", import.meta.url),
+).text();
+const ownerSiteSave = await Bun.file(
+  new URL("../../owner-site-save.ts", import.meta.url),
+).text();
+const claimInvitations = await Bun.file(
+  new URL("../../claim-invitations.ts", import.meta.url),
+).text();
+
+const forbiddenLifecyclePromise = new RegExp(
+  [
+    "\\$49",
+    "\\bclaim(?:s|ed|ing)?\\b",
+    "\\bpay(?:ment|ing)?\\b",
+    "\\bpaid\\b",
+    "checkout",
+    "custom[- ]domain",
+    "owner editing",
+    "\\bpublish(?:ing|ed)?\\b",
+    "publication",
+    "go live",
+    "monitor(?:ing)?",
+  ].join("|"),
+  "i",
+);
+
+function beautyCopyBlock(source: string): string {
+  const start = source.indexOf("[Vertical.BEAUTY]");
+  const next = source.indexOf("[Vertical.LOCAL_SERVICE]", start);
+  expect(start).toBeGreaterThan(-1);
+  expect(next).toBeGreaterThan(start);
+  return source.slice(start, next);
+}
+
+describe("beauty lifecycle contract", () => {
+  it("keeps public preview while disabling claim and owner publication mutation", () => {
+    expect(beautyConfig.claimMode).toBe("disabled");
+    expect(beautyConfig.marketing.publiclyAccessible).toBe(true);
+    expect(isVerticalClaimEnabled(Vertical.BEAUTY)).toBe(false);
+    expect(isVerticalPublicationEnabled(Vertical.BEAUTY)).toBe(true);
+    expect(isVerticalOwnerReviewSupported(Vertical.BEAUTY)).toBe(false);
+    expect(isVerticalPublicationMutationEnabled(Vertical.BEAUTY)).toBe(false);
+    expect(resolveVerticalConfig(Vertical.BEAUTY).marketing.pricing).toBeUndefined();
+  });
+
+  it("does not advertise claim, payment, domain, editing, publication or monitoring", () => {
+    const marketingBlob = JSON.stringify(beautyMarketing);
+    expect(marketingBlob).not.toMatch(forbiddenLifecyclePromise);
+    expect(beautyCopyBlock(importStudio)).not.toMatch(forbiddenLifecyclePromise);
+    expect(unsupportedDashboard).not.toMatch(forbiddenLifecyclePromise);
+    expect(ownerSiteSave).not.toMatch(/import and claim flows/i);
+    expect(ownerSiteSave).toContain(
+      "Use the private preview until the vertical editor ships.",
+    );
+  });
+
+  it("hides acquisition pricing on the public niche page while claiming is disabled", () => {
+    expect(nichePage).toContain("isVerticalClaimEnabled(id)");
+    expect(nichePage).toContain("acquisitionPricing");
+    expect(nichePage).toContain('href: "#pricing"');
+    expect(nichePage).toContain("<ImportForm");
+    expect(beautyMarketing.form.submitLabel).toBe("Show my preview");
+  });
+
+  it("keeps claim invitations and checkout fail-closed for beauty", () => {
+    expect(claimPage).toContain("isVerticalClaimEnabled(site.vertical)");
+    expect(checkoutRoute).toContain(
+      "isVerticalClaimEnabled(invitation.vertical)",
+    );
+    expect(claimInvitations).toContain(
+      "if (!isVerticalClaimEnabled(site.vertical)) throw notClaimable();",
+    );
+    expect(claimInvitations).toContain('"not_claimable"');
+    expect(importStudio).toContain(
+      "{isVerticalClaimEnabled(site.vertical) ? (",
+    );
+    expect(importStudio).toContain("Private pilot preview");
+  });
+
+  it("routes beauty to the unsupported dashboard instead of an owner-review workflow", () => {
+    expect(dashboardPage).toContain("UnsupportedVerticalDashboard");
+    expect(dashboardPage).toContain(
+      "access.site.vertical !== Vertical.RESTAURANT",
+    );
+    expect(dashboardPage).toContain("Vertical.FOOD_RETAIL");
+    expect(dashboardPage).toContain("Vertical.LOCAL_SERVICE");
+    expect(unsupportedDashboard).toContain("private, non-chargeable preview");
+  });
+});

--- a/src/lib/verticals/beauty/lifecycle.test.ts
+++ b/src/lib/verticals/beauty/lifecycle.test.ts
@@ -19,6 +19,9 @@ const nichePage = await Bun.file(
 const claimPage = await Bun.file(
   new URL("../../../app/claim/[slug]/page.tsx", import.meta.url),
 ).text();
+const claimLaunchOffer = await Bun.file(
+  new URL("../../claim-launch-offer.ts", import.meta.url),
+).text();
 const checkoutRoute = await Bun.file(
   new URL("../../../app/api/checkout/route.ts", import.meta.url),
 ).text();
@@ -94,7 +97,8 @@ describe("beauty lifecycle contract", () => {
   });
 
   it("keeps claim invitations and checkout fail-closed for beauty", () => {
-    expect(claimPage).toContain("isVerticalClaimEnabled(site.vertical)");
+    expect(claimPage).toContain("claimPageState");
+    expect(claimLaunchOffer).toContain("isVerticalClaimEnabled(site.vertical)");
     expect(checkoutRoute).toContain(
       "isVerticalClaimEnabled(invitation.vertical)",
     );

--- a/src/lib/verticals/beauty/marketing.ts
+++ b/src/lib/verticals/beauty/marketing.ts
@@ -1,9 +1,11 @@
 import type { VerticalMarketing } from "@/lib/verticals/types";
 
 /**
- * Built for public preview, but owner claim stays disabled until its dedicated
- * dashboard and evidence review are complete. It has no standalone domain —
- * hence no `hostnames` and a null `domain`.
+ * Built for public preview. Owner acquisition stays disabled until its
+ * dedicated dashboard and evidence review are complete. It has no standalone
+ * domain — hence no `hostnames` and a null `domain`. Pricing and founding-plan
+ * copy are omitted: this is an explicitly non-chargeable pilot, not a sellable
+ * niche.
  *
  * `heroVisual: "none"` because the restaurant transformation mock is a menu PDF
  * turning into a menu — dressing it up as a salon would be a lie about what the
@@ -18,14 +20,18 @@ export const beautyMarketing = {
   // record, a verified sender, and these two strings — in that order.
   email: null,
   audience: "salons and barbers",
-  tagline: "A service list and a booking button, always up to date.",
+  tagline: "A service list and a booking button, recovered from the source.",
   heroVisual: "none",
   hero: {
-    badge: "Your old site in. A finished one out.",
+    badge: "Your old site in. A finished preview out.",
     headline: "Every service, priced and bookable.",
     subheadline:
-      "Give us the salon. Get back a mobile-first website with the full service list, durations and prices already inside—and keep the booking system your clients already use.",
-    proofPoints: ["No setup call", "Private preview first", "$49/month"],
+      "Give us the salon. Get back a private mobile-first preview with the full service list, durations and prices already inside—keeping the booking system your clients already use.",
+    proofPoints: [
+      "No setup call",
+      "Private preview first",
+      "Non-chargeable pilot",
+    ],
   },
   form: {
     placeholder: "Salon website or name",
@@ -34,11 +40,11 @@ export const beautyMarketing = {
     pendingLabel: "Opening your salon",
   },
   signIn: {
-    title: "Open your salon.",
+    title: "Open your salon preview.",
     description:
-      "Enter the owner email used when the website was claimed. No password needed.",
+      "Enter the email used when this private preview was created. No password needed.",
     emailPlaceholder: "owner@salon.com",
-    emptyPrompt: "No site yet?",
+    emptyPrompt: "No preview yet?",
     createLabel: "Build a preview",
     createHref: "/create?vertical=beauty",
   },
@@ -55,8 +61,8 @@ export const beautyMarketing = {
     },
     {
       number: "03",
-      title: "Claim it and go live",
-      copy: "Claim the founding plan, connect the domain, and keep the booking system already taking appointments.",
+      title: "Keep it private for now",
+      copy: "This is a non-chargeable pilot. The preview stays private while Salonfront is still in preview.",
     },
   ],
   valueProps: {
@@ -81,8 +87,8 @@ export const beautyMarketing = {
       },
       {
         icon: "refresh",
-        title: "Always-current presence",
-        copy: "Prices, hours and integration checks become an ongoing service, not another redesign project.",
+        title: "A recovered snapshot of today",
+        copy: "Prices, hours and booking links come from the current source site, ready to inspect in the private preview.",
       },
     ],
   },
@@ -92,7 +98,7 @@ export const beautyMarketing = {
     imageAlt: "Salon interior photographed in natural light",
     eyebrow: "Credible imagery, not fantasy results",
     headline: "Fill the visual gaps without faking the work.",
-    copy: "Salonfront prioritises real source photography, then creates complementary editorial images for missing categories. Skin, hair and nail results are never regenerated, and every generated asset stays reviewable before publishing.",
+    copy: "Salonfront prioritises real source photography, then creates complementary editorial images for missing categories. Skin, hair and nail results are never regenerated.",
     assurances: [
       {
         icon: "shield",
@@ -100,34 +106,13 @@ export const beautyMarketing = {
       },
       {
         icon: "cursor",
-        copy: "One click to regenerate, replace or remove any image",
-      },
-    ],
-  },
-  pricing: {
-    eyebrow: "Simple ongoing care",
-    headline: "Less than one empty chair.",
-    copy: "Preview first. Pay only when the salon wants to claim and publish it. Local currency is shown at checkout.",
-    plans: [
-      {
-        name: "Founding",
-        price: "$49",
-        cadence: "/month",
-        copy: "One maintained, mobile-first salon website on the business's own domain.",
-        features: [
-          "Mobile-first website and service list",
-          "Existing booking links",
-          "Custom domain and SSL",
-          "Owner editing and source monitoring",
-        ],
-        featured: true,
-        badge: "Founding offer",
+        copy: "Every recovered image stays inspectable in the private preview",
       },
     ],
   },
   closing: {
     headline: "See the salon before asking it to change.",
-    copy: "Paste one website. Salonfront will do the first draft.",
+    copy: "Paste one website. Salonfront will do the first draft. Nothing is billed.",
   },
   footerTagline: "Every service, priced and bookable.",
 } satisfies VerticalMarketing;

--- a/src/lib/verticals/food-retail/config.ts
+++ b/src/lib/verticals/food-retail/config.ts
@@ -136,6 +136,7 @@ export const foodRetailConfig = {
   marketing: foodRetailMarketing,
   claimMode: "factory",
   publicationEnabled: true,
+  publicationMutationEnabled: true,
   integrationTypes: ["ordering", "delivery", "social"],
   attributesSchema: foodRetailAttributesSchema,
   attributeDefaults: {

--- a/src/lib/verticals/local-service/config.ts
+++ b/src/lib/verticals/local-service/config.ts
@@ -157,6 +157,7 @@ export const localServiceConfig = {
   marketing: localServiceMarketing,
   claimMode: "factory",
   publicationEnabled: true,
+  publicationMutationEnabled: true,
   draftGenerationStrategy: "deterministic-only",
   integrationTypes: ["quote", "contact", "booking", "social"],
   attributesSchema: localServiceAttributesSchema,

--- a/src/lib/verticals/registry.test.ts
+++ b/src/lib/verticals/registry.test.ts
@@ -12,7 +12,9 @@ import { localServiceConfig } from "@/lib/verticals/local-service/config";
 import {
   isVerticalClaimEnabled,
   isVerticalCatalogItemVisible,
+  isVerticalOwnerReviewSupported,
   isVerticalPublicationEnabled,
+  isVerticalPublicationMutationEnabled,
   isVerticalPubliclyAccessible,
   isVerticalPubliclyLaunched,
   listMarketingVerticals,
@@ -351,13 +353,44 @@ describe("niche routing", () => {
     expect(isVerticalClaimEnabled(Vertical.BEAUTY)).toBe(false);
     expect(isVerticalClaimEnabled(Vertical.LOCAL_SERVICE)).toBe(true);
     expect(isVerticalClaimEnabled(Vertical.FOOD_RETAIL)).toBe(true);
+    for (const id of listVerticalIds()) {
+      if (isVerticalClaimEnabled(id)) {
+        expect(resolveVerticalConfig(id).marketing.pricing).toBeDefined();
+      }
+    }
   });
 
-  it("enables reviewed publication for every registered SMB vertical", () => {
+  it("keeps existing published snapshots renderable independently of owner mutation", () => {
     expect(isVerticalPublicationEnabled(Vertical.RESTAURANT)).toBe(true);
     expect(isVerticalPublicationEnabled(Vertical.BEAUTY)).toBe(true);
     expect(isVerticalPublicationEnabled(Vertical.LOCAL_SERVICE)).toBe(true);
     expect(isVerticalPublicationEnabled(Vertical.FOOD_RETAIL)).toBe(true);
+  });
+
+  it("does not enable owner publication mutation without a supported owner-review workflow", () => {
+    expect(isVerticalOwnerReviewSupported(Vertical.RESTAURANT)).toBe(true);
+    expect(isVerticalOwnerReviewSupported(Vertical.FOOD_RETAIL)).toBe(true);
+    expect(isVerticalOwnerReviewSupported(Vertical.LOCAL_SERVICE)).toBe(true);
+    expect(isVerticalOwnerReviewSupported(Vertical.BEAUTY)).toBe(false);
+
+    expect(isVerticalPublicationMutationEnabled(Vertical.RESTAURANT)).toBe(true);
+    expect(isVerticalPublicationMutationEnabled(Vertical.FOOD_RETAIL)).toBe(
+      true,
+    );
+    expect(isVerticalPublicationMutationEnabled(Vertical.LOCAL_SERVICE)).toBe(
+      true,
+    );
+    expect(isVerticalPublicationMutationEnabled(Vertical.BEAUTY)).toBe(false);
+    expect(beautyConfig.publicationMutationEnabled).toBe(false);
+
+    for (const id of listVerticalIds()) {
+      if (resolveVerticalConfig(id).publicationMutationEnabled) {
+        expect(isVerticalOwnerReviewSupported(id)).toBe(true);
+      }
+      if (!isVerticalOwnerReviewSupported(id)) {
+        expect(isVerticalPublicationMutationEnabled(id)).toBe(false);
+      }
+    }
   });
 
   it("keeps local service gated until public access, domain, routing and sender are real", () => {

--- a/src/lib/verticals/registry.ts
+++ b/src/lib/verticals/registry.ts
@@ -191,12 +191,35 @@ export function isVerticalClaimEnabled(id: VerticalId): boolean {
 }
 
 /**
- * Publication is a separate capability from rendering, importing and claim.
- * Keeping it explicit prevents a private vertical from inheriting the shared
- * snapshot and rollback engine merely because its schema is registered.
+ * Dedicated owner-review dashboards currently exist for restaurant,
+ * food-retail and local-service. Beauty still uses UnsupportedVerticalDashboard.
+ */
+export function isVerticalOwnerReviewSupported(id: VerticalId): boolean {
+  return (
+    id === Vertical.RESTAURANT ||
+    id === Vertical.FOOD_RETAIL ||
+    id === Vertical.LOCAL_SERVICE
+  );
+}
+
+/**
+ * Whether an already-published snapshot may be rendered. Independent of
+ * whether owners may create or roll back snapshots.
  */
 export function isVerticalPublicationEnabled(id: VerticalId): boolean {
   return resolveVerticalConfig(id).publicationEnabled;
+}
+
+/**
+ * Owner publish/rollback. Fail closed unless the vertical both opts in and
+ * ships a supported owner-review workflow — otherwise a preview-only
+ * vertical could inherit mutation from a leftover config flag.
+ */
+export function isVerticalPublicationMutationEnabled(id: VerticalId): boolean {
+  const config = resolveVerticalConfig(id);
+  return (
+    config.publicationMutationEnabled && isVerticalOwnerReviewSupported(id)
+  );
 }
 
 /** Every vertical intentionally exposed by the shared public niche route. */

--- a/src/lib/verticals/restaurant/config.ts
+++ b/src/lib/verticals/restaurant/config.ts
@@ -113,6 +113,7 @@ export const restaurantConfig = {
   marketing: restaurantMarketing,
   claimMode: "niche",
   publicationEnabled: true,
+  publicationMutationEnabled: true,
   integrationTypes: ["booking", "ordering", "delivery", "social"],
   attributesSchema: restaurantAttributesSchema,
   attributeDefaults: {

--- a/src/lib/verticals/restaurant/marketing.test.ts
+++ b/src/lib/verticals/restaurant/marketing.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from "bun:test";
 import { readFile } from "node:fs/promises";
-import { beautyMarketing } from "@/lib/verticals/beauty/marketing";
+import { Vertical } from "@/generated/prisma/enums";
 import { foodRetailMarketing } from "@/lib/verticals/food-retail/marketing";
 import { localServiceMarketing } from "@/lib/verticals/local-service/marketing";
 import { restaurantMarketing } from "@/lib/verticals/restaurant/marketing";
+import {
+  isVerticalClaimEnabled,
+  listVerticalIds,
+  resolveVerticalConfig,
+} from "@/lib/verticals/registry";
 
 /**
  * GTM audit + first-customer runbook: launch is one $49/month founding plan.
@@ -39,18 +44,26 @@ describe("Restofront founding offer", () => {
     );
   });
 
-  it("shares one founding price while keeping vertical feature lists scoped", () => {
-    for (const marketing of [
-      restaurantMarketing,
-      beautyMarketing,
-      foodRetailMarketing,
-      localServiceMarketing,
-    ]) {
-      expect(marketing.pricing.plans).toHaveLength(1);
-      expect(marketing.pricing.plans[0]?.price).toBe("$49");
-      expect(marketing.pricing.copy).toContain("Local currency");
+  it("shares one founding price on claim-enabled verticals while keeping feature lists scoped", () => {
+    const claimEnabledMarketing = listVerticalIds()
+      .filter(isVerticalClaimEnabled)
+      .map((id) => resolveVerticalConfig(id).marketing);
+
+    expect(claimEnabledMarketing.map((marketing) => marketing.brand.name)).toEqual(
+      expect.arrayContaining([
+        restaurantMarketing.brand.name,
+        foodRetailMarketing.brand.name,
+        localServiceMarketing.brand.name,
+      ]),
+    );
+    expect(isVerticalClaimEnabled(Vertical.BEAUTY)).toBe(false);
+
+    for (const marketing of claimEnabledMarketing) {
+      expect(marketing.pricing?.plans).toHaveLength(1);
+      expect(marketing.pricing?.plans[0]?.price).toBe("$49");
+      expect(marketing.pricing?.copy).toContain("Local currency");
     }
-    expect(beautyMarketing.pricing.plans[0]?.features).not.toEqual(
+    expect(foodRetailMarketing.pricing.plans[0]?.features).not.toEqual(
       restaurantMarketing.pricing.plans[0]?.features,
     );
   });

--- a/src/lib/verticals/restaurant/marketing.test.ts
+++ b/src/lib/verticals/restaurant/marketing.test.ts
@@ -56,9 +56,13 @@ describe("Restofront founding offer", () => {
   });
 
   it("checks out the founding plan against the single STRIPE_PRICE_ID", async () => {
-    const [panel, checkoutRoute] = await Promise.all([
+    const [panel, mapping, checkoutRoute] = await Promise.all([
       readFile(
         new URL("../../../app/claim/[slug]/claim-panel.tsx", import.meta.url),
+        "utf8",
+      ),
+      readFile(
+        new URL("../../claim-launch-offer.ts", import.meta.url),
         "utf8",
       ),
       readFile(
@@ -66,11 +70,14 @@ describe("Restofront founding offer", () => {
         "utf8",
       ),
     ]);
-    expect(panel).toContain('CLAIM_CHECKOUT_PLAN_ID = "founding"');
-    expect(panel).toContain("restaurantMarketing.pricing.plans[0]");
+    expect(mapping).toContain("CLAIM_CHECKOUT_PLAN_ID = FOUNDING_PLAN_ID");
+    expect(mapping).toContain("foundingOfferDisplay");
+    expect(panel).toContain("plan: offer.planId");
+    expect(panel).not.toContain("restaurantMarketing");
     expect(panel).not.toContain("price: 25");
     expect(panel).not.toContain("price: 50");
     expect(panel).not.toContain("$25");
     expect(checkoutRoute).toContain("adaptive_pricing: { enabled: true }");
+    expect(checkoutRoute).toContain("resolveClaimLaunchOfferForVertical");
   });
 });

--- a/src/lib/verticals/types.ts
+++ b/src/lib/verticals/types.ts
@@ -236,7 +236,11 @@ export type VerticalMarketing = {
     copy: string;
     assurances: { icon: MarketingIconName; copy: string }[];
   };
-  pricing: {
+  /**
+   * Public founding offer. Omitted while claiming is disabled so a
+   * preview-only vertical cannot advertise a plan it cannot sell.
+   */
+  pricing?: {
     eyebrow: string;
     headline: string;
     copy: string;
@@ -267,11 +271,17 @@ export type VerticalConfig<
    */
   claimMode: "disabled" | "factory" | "niche";
   /**
-   * Whether owner-reviewed drafts may create or roll back public snapshots.
-   * This is explicit and server-enforced: a registered vertical can support
-   * private imports and previews without accidentally inheriting publication.
+   * Whether an already-published snapshot may be rendered on the public
+   * storefront. Independent of whether owners may create or roll back
+   * snapshots: flipping this off would hide existing live sites.
    */
   publicationEnabled: boolean;
+  /**
+   * Whether owners may create or roll back public snapshots. Requires a
+   * supported owner-review workflow; a vertical that only imports and
+   * previews must leave this off.
+   */
+  publicationMutationEnabled: boolean;
   /**
    * Model assistance is the compatibility default. Evidence-sensitive verticals
    * can opt into deterministic reconstruction and skip text generation entirely.


### PR DESCRIPTION
Depends on #168 and #172. Closes #155.

## Summary

Primary create, sign-in, claim, and booking funnels now have persistent programmatic names, named icon-only controls, associated errors/help, and announced processing/success transitions.

- Import Studio source input uses the shared `Field` pattern with a visible vertical-specific label; placeholders remain examples. Progress is a polite live status; import errors are alerts associated with the control. Beauty copy stays a non-chargeable private pilot.
- Sign-in email uses `Field` + a visible Email label. Asynchronous errors are `role="alert"`. Sent state announces via a live status and moves focus to the heading. The auth-shell back icon is named.
- Claim back icon is named. Checkout processing, invitation sent, and errors are live status/alert regions. Submit stays named while `aria-busy`.
- Booking fields use explicit `for`/`id` names (themed storefront controls, not dashboard Field chrome). Form-level errors are alerts associated with the controls. Success replaces the form with a focused live status.

Busy submit controls keep a meaningful accessible name (`Build preview` / `Finishing the details`, `Email me a secure link`, `Sending ownership link` / `Opening secure checkout`, `Send request` / `Sending…`).

Stacked on #168, with #172 merged so Import Studio Beauty copy stays truthful. Claim offer mapping fail-closes when `pricing` is omitted (Beauty) and the founding display fixture accepts a non-4900 amount only as a validator input — live price remains 4900 cents / $49.

## Files

- `src/app/create/import-studio.tsx`
- `src/app/sign-in/sign-in-form.tsx`, `src/app/sign-in/auth-shell.tsx`
- `src/app/claim/[slug]/page.tsx`, `src/app/claim/[slug]/claim-panel.tsx`
- `src/components/booking-request-form.tsx`
- `src/lib/claim-launch-offer.ts` and stacked TypeScript fixtures
- Tests: `src/lib/funnel-accessibility.test.tsx` plus sign-in/claim/beauty surface updates

## Verification

```
bun test src/lib/funnel-accessibility.test.tsx \
  src/lib/sign-in-form-surface.test.ts \
  src/lib/claim-panel.test.tsx \
  src/lib/claim-page.test.tsx \
  src/lib/claim-launch-offer.test.ts \
  src/lib/verticals/beauty/lifecycle.test.ts \
  src/lib/food-retail-claim-gate.test.ts \
  src/lib/editor-field-accessibility.test.tsx
# 44 pass

bun test
# 1101 pass, 110 skip, 0 fail

bun run lint
# pass

node node_modules/next/dist/bin/next typegen && bunx tsc --noEmit
# pass

git diff --check
# pass
```

`bun run build` TypeScript finished; local page collection still requires `BETTER_AUTH_SECRET` (set in CI).

## Residual risk

- Booking success/sign-in sent focus is covered by source contract plus SSR names; there is no jsdom runtime for the `useEffect` focus call.
- Playwright remains the first-customer journey only; keyboard coverage here is form `type="submit"` + labelled controls.
- Exact-head PR CI is the merge gate.
- Do not merge this stack before #168 and #172.