### PR TITLE
fix(monitoring): lossless review across owner verticals

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,49 @@
 Cornershopdev is a multi-vertical local-business website factory. Each
 configured niche supplies its own discovery queries, catalog/conversion
 signals, content schema, preview generator, storefront identity, and provider
-adapters. A business keeps the operational tools it already uses, reviews a
-private prefilled preview, claims it, subscribes, then connects its domain.
+adapters. A business keeps the operational tools it already uses and reviews a
+private prefilled preview. Claim, subscription, custom domains, monitoring,
+leads, and articles are per-vertical capabilities, not a universal lifecycle.
+
+## Vertical capabilities
+
+These axes are independent. Factory visibility is not a standalone niche
+launch. A claim mode is not owner publish. Rendering an already-published
+snapshot is not the same as creating one. Custom domains, source monitoring,
+leads, and articles are owner-operation flags resolved through
+`resolveOwnerOperations` and fail closed against claim and publication-mutation
+gates.
+
+| Vertical | Factory visibility | Standalone launch | Claim mode | Owner mutation | Platform publication | Custom domains | Monitoring | Leads | Articles |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Restaurant | public | launched | niche | enabled | enabled | enabled | enabled | enabled | enabled |
+| Beauty | public | unlaunched | disabled | unsupported | enabled | unsupported | unsupported | unsupported | unsupported |
+| Food Retail | private | unlaunched | factory | enabled | enabled | enabled | enabled | not-yet | not-yet |
+| Local Service | private | unlaunched | factory | enabled | enabled | enabled | enabled | not-yet | not-yet |
+
+- **Factory visibility** — `marketing.publiclyAccessible`: the shared
+  `/niche/[vertical]` route.
+- **Standalone launch** — `verticalLaunchReadiness`: public access, canonical
+  domain, matching routed hostname, and verified niche sender.
+- **Claim mode** — `disabled`, `factory` (Cornershopdev sender and
+  `<slug>.cornershop.dev`), or `niche` (the vertical's own domain and sender).
+- **Owner mutation** — publish and rollback. Requires
+  `publicationMutationEnabled` and a supported owner-review dashboard.
+- **Platform publication** — `publicationEnabled`: already-published snapshots
+  may still render when owners cannot create new ones.
+- **Custom domains / Monitoring / Leads / Articles** — owner-operation states
+  (`enabled`, `not-yet`, `gated`, `unsupported`).
+
+Restaurant, Food Retail, and Local Service also enable billing, publication
+history, workspace switching, and the reviewed photo library. Beauty leaves
+every paid owner operation unsupported. It is a non-chargeable factory
+preview, not a sellable niche.
 
 ## Product flow
 
-1. Paste a restaurant URL or name.
+Shared import path, used by every registered vertical:
+
+1. Paste a source URL or name into that vertical's intake.
 2. Import public website content with SSRF-safe fetching and bounded HTML reads.
 3. Deterministically recover structured business facts, hours, bounded catalog
    candidates, relevant navigation, authentic source assets, and field-level
@@ -16,20 +53,36 @@ private prefilled preview, claims it, subscribes, then connects its domain.
 4. Recover source logos/favicons and CSS/meta brand colours, repairing contrast
    where necessary before the palette reaches a renderer.
 5. Detect the source language and preserve it as canonical. When OpenRouter is
-   configured, generate a complete English translation in the structured pass.
-6. Preserve first-party photography and optionally enhance exposure, colour, crop, noise, and clarity without changing the food or venue.
+   configured, generate a complete English translation in the structured pass
+   unless the vertical is `deterministic-only`.
+6. Preserve first-party photography and optionally enhance exposure, colour,
+   crop, noise, and clarity without changing material scene content. Each
+   vertical lists its own forbidden elements.
 7. Save a private preview through a durable PostgreSQL-backed Workflow.
-8. Verify ownership through a one-time business-domain email invitation or a concierge-approved owner email.
-9. Claim the restaurant through invitation-bound Stripe Checkout; the completed checkout creates the prefilled owner account.
-10. Authorize the restaurant domain for on-demand TLS and show the exact DNS records.
-11. Monitor and maintain the menu, imagery, and external links from the dashboard.
+
+What happens after preview depends on the matrix above:
+
+- **Restaurant (`niche`)** — verify ownership through a one-time
+  business-domain email invitation or a concierge-approved owner email; claim
+  through invitation-bound Stripe Checkout; authorize a custom domain for
+  on-demand TLS; monitor the menu, imagery, and links; review first-party
+  booking leads; publish articles.
+- **Food Retail and Local Service (`factory`)** — an approved preview can
+  claim the shared $49 Cornershopdev plan and publish on
+  `<slug>.cornershop.dev`. Custom domains and source monitoring are enabled.
+  Owner analytics, lead inbox, and articles are not-yet.
+- **Beauty (`disabled`)** — the factory `/niche/beauty` preview stays
+  non-chargeable. Claim, owner mutation, billing, custom domains, monitoring,
+  leads, and articles are unsupported.
 
 ## Customer workspace and operator console
 
-Each claimed site has a tenant-scoped `/dashboard` workspace. Owners can edit
-their site, connect a domain, review first-party booking leads, and move each
-request from `NEW` to `CONTACTED` or `CLOSED`. Contact details are returned only
-after the session is revalidated against that site's organization membership.
+Each claimed site has a tenant-scoped `/dashboard` workspace. Owners only get
+the operations their vertical enables. Contact details are returned only after
+the session is revalidated against that site's organization membership.
+Restaurant can review first-party booking leads and move each request from
+`NEW` to `CONTACTED` or `CLOSED`. Food Retail and Local Service do not expose
+a lead inbox yet. Beauty has no owner-review dashboard.
 
 `/admin` is the platform operator console. It requires both a database
 `SUPERADMIN` role and an email listed in `SUPERADMIN_EMAILS`. It shows signups,
@@ -67,12 +120,14 @@ paths, query strings, provider URLs, names, email addresses, phone numbers, or
 booking notes. A one-minute Redis limiter may use a transient hash derived from
 the connection address; it is not written to PostgreSQL.
 
-Booking requests remain the authoritative lead count, so a dropped analytics
-beacon cannot lose a real lead. The corresponding `LEAD_CREATED` event is
-server-owned and best effort. Client and operator workspaces expose 7, 30, and
-90-day distinct-visit, CTA-visitor, booking-lead, and conversion metrics.
-Raw analytics events are retained for 120 days and pruned daily under a
-PostgreSQL advisory lock.
+Booking requests remain the authoritative lead count for verticals that enable
+the lead inbox, so a dropped analytics beacon cannot lose a real lead. The
+corresponding `LEAD_CREATED` event is server-owned and best effort. Restaurant
+owner workspaces and the operator console expose 7, 30, and 90-day
+distinct-visit, CTA-visitor, booking-lead, and conversion metrics. Food Retail
+and Local Service mark owner analytics as not-yet; Beauty has no owner
+analytics. Raw analytics events are retained for 120 days and pruned daily
+under a PostgreSQL advisory lock.
 
 ## Restaurant themes
 
@@ -101,6 +156,14 @@ Heritage and fine-dining templates default to a clean text-led menu; casual,
 fresh, coastal, and bold concepts default to a small highlights gallery. Owners
 can show or hide the gallery from the dashboard without deleting any images.
 
+## Beauty vertical
+
+`BEAUTY` is a non-chargeable factory preview. `/niche/beauty` is publicly
+accessible, but it has no standalone domain or sender, and `claimMode` is
+`disabled`. Already-published snapshots remain renderable. Owner mutation,
+billing, custom domains, monitoring, leads, articles, and the photo library
+are unsupported. There is no owner-review dashboard.
+
 ## Food retail vertical
 
 `FOOD_RETAIL` is a bounded vertical for bakeries, pâtisseries, butchers,
@@ -120,12 +183,12 @@ adapter restores business identity, contact details, hours, products, prices,
 ordering links and factual product attributes from deterministic crawl output.
 Unsupported model claims remain empty or null.
 
-The vertical is registered for private studio imports and owner dashboards but
-is not publicly launched: its marketing hostnames are empty, its domain and
-sender are null, and its server-side publication and rollback capability is
-disabled. Private preview and owner review remain available.
-The implementation contract, test fixture, structured-data mapping and required
-domain/sender/production-config evidence are documented in
+The vertical is factory-claimable but not publicly launched: marketing
+hostnames are empty, domain and sender are null, and `publiclyAccessible` is
+false. Claim mode is `factory`. Already-published snapshots render, and owners
+with the food-retail dashboard may publish and roll back. Custom domains,
+source monitoring, and the photo library are enabled. Owner analytics, lead
+inbox, and articles are not-yet. See the capability matrix above and
 [`docs/verticals/food-retail.md`](docs/verticals/food-retail.md).
 
 ## Local-service vertical
@@ -143,9 +206,11 @@ evidence. Missing emergency coverage, credentials, insurance, trust claims,
 projects, prices, or availability remain unstated rather than being inferred.
 
 The vertical is registered for private imports, previews, and revision-safe
-owner editing. Public niche access, claiming, publication, and rollback remain
-disabled until a real domain, exact routed hostname, and matching verified
-sender configuration satisfy the launch-readiness gate. See
+owner editing. Factory claim, publication, custom domains, source monitoring,
+and the photo library are enabled. Public niche access and standalone launch
+stay closed until a real domain, exact routed hostname, and matching verified
+sender satisfy `verticalLaunchReadiness`. Owner analytics, lead inbox, and
+articles are not-yet. See the capability matrix above and
 [`docs/verticals/local-service.md`](docs/verticals/local-service.md).
 
 ## Internationalization
@@ -153,8 +218,8 @@ sender configuration satisfy the launch-readiness gate. See
 Site data uses one canonical source locale plus structured translation
 overlays. Prices, currencies, images, addresses, provider names, and external
 booking or ordering URLs remain shared, so translating a site cannot fork its
-operational data. Menu sections, menu items, descriptions, dietary labels, and
-link labels keep the same order and count in every locale.
+operational data. Catalog sections, items, descriptions, vertical-specific
+labels, and link labels keep the same order and count in every locale.
 If an existing provider URL already exposes a `lang` parameter, the rendered
 link updates only that preference while preserving the same provider and flow.
 
@@ -166,13 +231,16 @@ The canonical site is available at `/preview/[slug]`; translations use
 
 ## Stack
 
+Package majors below match `package.json`. Runtime image pins live in the
+Dockerfile.
+
 - Next.js 16 App Router and React 19
-- Bun 1.3.14 for installs, Prisma/Workflow migrations, and operator tooling;
+- Bun 1.4.0 for installs, Prisma/Workflow migrations, and operator tooling;
   pinned Node.js 24.19.0 LTS for Next.js builds and the production standalone
   server
 - Tailwind CSS v4 and shadcn/ui
 - Prisma 7 with PostgreSQL and the `pg` driver adapter
-- Vercel AI SDK 6 with OpenRouter for structured text generation and optional
+- Vercel AI SDK 7 with OpenRouter for structured text generation and optional
   source-photo enhancement
 - Workflow DevKit with its self-hosted PostgreSQL World
 - Amazon S3 and CloudFront for persistent enhanced derivatives
@@ -230,7 +298,7 @@ fails closed when it is absent or invalid.
 
 ### AI generation
 
-Restaurant crawling, same-origin page discovery, SSRF checks, and source
+Source crawling, same-origin page discovery, SSRF checks, and source
 reconstruction run locally without a model. JSON-LD, metadata, explicit contact
 links, semantic address markup, source navigation, logos/favicons, and CSS/meta
 colours are recovered with bounded parsers. Every accepted fact keeps its source
@@ -303,9 +371,11 @@ reaches the live site only after the owner publishes again.
 
 Allowed edits are exposure, white balance, highlight and shadow recovery,
 denoising, sharpness, resolution, straightening, subtle cropping, and removal of
-transient non-material distractions such as sensor dust. Ingredients, garnishes,
-portions, plating, tableware, people, architecture, and material scene elements
-must not be added, removed, replaced, moved, or regenerated. Only approved
+transient non-material distractions such as sensor dust. Material scene
+elements must not be added, removed, replaced, moved, or regenerated. Each
+vertical lists its own forbidden subjects — food and plating for restaurants,
+product and packaging for food retail, skin/hair/nail and treatment results
+for beauty. Only approved
 originals enter a rate- and concurrency-limited batch. Originals remain active
 until the owner approves the before/after derivative, and every approve, reject,
 selection, restore, failure, and cost result is audited. See
@@ -392,7 +462,8 @@ bun run operator:preflight-outreach --environment production
 The application records the hostname and returns the production A or CNAME
 target. After DNS resolves, the owner verifies it in the dashboard. Caddy issues
 TLS only when its authorization callback confirms that the domain is verified
-and belongs to a restaurant.
+and belongs to a claimed site. Custom-domain owner operations stay closed for
+verticals whose `customDomain` capability is not enabled.
 
 ### Production routing
 
@@ -420,9 +491,10 @@ this same container, where the rewrite fires again — an infinite loop.
 - AI output is validated with Zod before it enters the product.
 - Existing booking and ordering links are extracted from source material and override model-generated links.
 - Stripe webhooks verify the raw body signature.
-- Restaurant claims require a hashed, expiring invitation bound to one site,
-  intended email, and Stripe Checkout session. Raw invitation tokens are kept
-  in URL fragments so embedded preview assets cannot receive them as referrers.
+- Claims require a hashed, expiring invitation bound to one site, intended
+  email, and Stripe Checkout session, and only for verticals whose claim mode
+  is enabled. Raw invitation tokens are kept in URL fragments so embedded
+  preview assets cannot receive them as referrers.
 - Self-serve claims require the exact imported business email or an address on
   the exact source hostname. Ambiguous ownership requires a dual-gated
   superadmin approval from the operator console.
@@ -431,17 +503,22 @@ this same container, where the rewrite fires again — an infinite loop.
   acceptance, and rejection events are recorded without tokens or contact data.
 - Better Auth owns revocable, database-backed dashboard sessions behind a
   signed HTTP-only, same-site cookie.
-- Restaurant mutations require a session matching the restaurant slug.
-- Image enhancement and domain management require that same restaurant-scoped session.
+- Site mutations require a session matching the site slug and current
+  organization membership. Routes are vertical-aware: publish/rollback, domain
+  management, photo library, source monitoring, analytics, articles, and the
+  lead inbox still fail closed when that vertical's owner operation is not
+  enabled.
+- Image enhancement and domain management require that same site-scoped session.
 - Public preview generation is rate limited and fails closed in production.
 - Enhanced derivatives are persisted to private S3 storage and served through CloudFront while authentic originals and provenance remain available.
-- Arbitrary restaurant images load directly in the browser instead of through the Next.js image proxy.
+- Arbitrary site images load directly in the browser instead of through the Next.js image proxy.
 
 ## Useful routes
 
 - `/` — marketing and URL intake
+- `/niche/[vertical]` — factory niche page for publicly accessible verticals
 - `/create` — import and preview studio
-- `/claim/[slug]` — pricing and claim checkout
+- `/claim/[slug]` — pricing and claim checkout, when that vertical's claim mode is enabled
 - `/dashboard` — authenticated vertical-aware owner management
 - `/dashboard?demo=1` — local demo dashboard
 - `/admin` — dual-gated superadmin operator console

--- a/docs/verticals/food-retail.md
+++ b/docs/verticals/food-retail.md
@@ -13,7 +13,8 @@ flowchart LR
   C --> D[(Shared Site and Catalog tables)]
   D --> E[Private preview]
   D --> F[Food retail owner dashboard]
-  F --> G[Private owner review]
+  F --> G[Factory claim]
+  G --> H[Publish on platform subdomain]
 ```
 
 ## Vertical boundary
@@ -89,6 +90,18 @@ carry the vertical data, so no existing rows are rewritten and the migration
 does not seed product facts. The owner PUT route parses FOOD_RETAIL drafts with
 the registered schema before the shared optimistic-revision persistence path.
 
+## Capability row
+
+Matches the README matrix and `resolveOwnerOperations(FOOD_RETAIL)`:
+
+| Vertical | Factory visibility | Standalone launch | Claim mode | Owner mutation | Platform publication | Custom domains | Monitoring | Leads | Articles |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Food Retail | private | unlaunched | factory | enabled | enabled | enabled | enabled | not-yet | not-yet |
+
+Owner photo library is enabled. Owner analytics, lead inbox, and articles stay
+`not-yet`. This vertical does not inherit restaurant reservations or booking
+leads.
+
 ## Factory claim and standalone launch gates
 
 Standalone niche marketing stays closed:
@@ -96,8 +109,10 @@ Standalone niche marketing stays closed:
 - `marketing.hostnames = []`
 - `marketing.domain = null`
 - `marketing.email = null`
+- `marketing.publiclyAccessible = false`
 - `claimMode = "factory"`
 - `publicationEnabled = true`
+- `publicationMutationEnabled = true`
 
 An approved private preview can claim the shared Cornershopdev $49 plan and
 publish at `<slug>.cornershop.dev`. That factory path requires:

--- a/docs/verticals/local-service.md
+++ b/docs/verticals/local-service.md
@@ -3,8 +3,9 @@
 `LOCAL_SERVICE` is the bounded local-trade implementation for plumbers,
 electricians, builders, repair businesses, and artisans. It is registered in
 the existing vertical registry and uses the shared crawler, import workflow,
-site tables, renderer, owner editing, analytics, domain routing, and
-source-monitoring engine. It does not fork the app and it
+site tables, renderer, owner editing, domain routing, and
+source-monitoring engine. Owner analytics, lead inbox, and articles are
+not-yet. It does not fork the app and it
 does not accept model-authored HTML, CSS, class names, or components.
 
 ## Data contract
@@ -90,13 +91,26 @@ use the shared billing, same-origin, optimistic-revision, immutable snapshot,
 and audit boundaries. The editor saves before publication and requires a
 3–280 character change summary plus explicit confirmation.
 
+## Capability row
+
+Matches the README matrix and `resolveOwnerOperations(LOCAL_SERVICE)`:
+
+| Vertical | Factory visibility | Standalone launch | Claim mode | Owner mutation | Platform publication | Custom domains | Monitoring | Leads | Articles |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Local Service | private | unlaunched | factory | enabled | enabled | enabled | enabled | not-yet | not-yet |
+
+Owner photo library is enabled. Owner analytics, lead inbox, and articles stay
+`not-yet`. The renderer disables the restaurant booking-request form.
+
 ## Launch gate
 
 Tradefront has no standalone niche storefront. Its marketing config therefore
 keeps hostname, domain, and niche sender empty, while `claimMode: "factory"`
 allows an approved private preview to use Cornershopdev's verified sender,
-shared $49 checkout, and `<slug>.cornershop.dev` public URL. A future standalone
-niche still must satisfy `verticalLaunchReadiness`:
+shared $49 checkout, and `<slug>.cornershop.dev` public URL.
+`publicationEnabled` and `publicationMutationEnabled` are both true for that
+factory path. A future standalone niche still must satisfy
+`verticalLaunchReadiness`:
 
 1. a configured public domain;
 2. that exact domain registered in the proxy hostname list;

--- a/src/app/api/sites/[slug]/source-monitoring/suggestions/[suggestionId]/route.ts
+++ b/src/app/api/sites/[slug]/source-monitoring/suggestions/[suggestionId]/route.ts
@@ -8,10 +8,12 @@ import {
 import {
   reviewSourceMonitoringSuggestion,
   SourceMonitoringConflictError,
+  SourceMonitoringUnsupportedSuggestionError,
 } from "@/lib/source-monitoring";
 import { getSourceMonitoringAccess } from "@/lib/source-monitoring-access";
 import { isSameOriginMutation } from "@/lib/request-origin";
 import { DraftRevisionConflictError } from "@/lib/site-persistence";
+import { resolveVerticalConfig } from "@/lib/verticals/registry";
 
 const reviewSchema = z.discriminatedUnion("action", [
   z.object({
@@ -53,9 +55,8 @@ export async function PATCH(
       ...parsed.data,
     });
     const ownerDraft =
-      result.status === "ACCEPTED" &&
-      result.vertical === Vertical.RESTAURANT
-        ? toRestaurantDraft(restaurantSiteDraftSchema.parse(result.draft))
+      result.status === "ACCEPTED" && result.vertical && result.draft !== undefined
+        ? toOwnerReviewDraft(result.vertical, result.draft)
         : undefined;
     return Response.json({
       status: result.status,
@@ -76,9 +77,18 @@ export async function PATCH(
     if (error instanceof SourceMonitoringConflictError) {
       return Response.json({ error: error.message }, { status: 409 });
     }
+    if (error instanceof SourceMonitoringUnsupportedSuggestionError) {
+      return Response.json(
+        { error: error.message, code: "UNSUPPORTED_SUGGESTION" },
+        { status: 422 },
+      );
+    }
     if (error instanceof z.ZodError) {
       return Response.json(
-        { error: "The edited suggestion is not valid for this site" },
+        {
+          error:
+            "This suggestion is not valid for this workspace. Nothing was saved to the private draft.",
+        },
         { status: 422 },
       );
     }
@@ -92,4 +102,11 @@ export async function PATCH(
       { status: 500 },
     );
   }
+}
+
+function toOwnerReviewDraft(vertical: Vertical, draft: unknown) {
+  if (vertical === Vertical.RESTAURANT) {
+    return toRestaurantDraft(restaurantSiteDraftSchema.parse(draft));
+  }
+  return resolveVerticalConfig(vertical).draftSchema.parse(draft);
 }

--- a/src/app/dashboard/dashboard.tsx
+++ b/src/app/dashboard/dashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import Link from "next/link";
 import {
   ArrowUpRight,
@@ -92,6 +92,11 @@ import {
   validateRestaurantMenuDraft,
   type RestaurantMenuMutation,
 } from "@/lib/restaurant-menu-editor";
+import {
+  OwnerDraftDirtyGuard,
+  ownerDraftNavigationProps,
+  useOwnerDraftDirtyState,
+} from "@/lib/owner-draft-dirty-state";
 
 
 /**
@@ -130,24 +135,26 @@ export function Dashboard({
   platformUrl: string;
   ownerOperations?: VerticalOwnerOperations;
 }) {
-  const [draft, setDraftState] = useState(initialDraft);
-  const draftRef = useRef(initialDraft);
-  const [persistedDraft, setPersistedDraft] = useState(initialDraft);
-  function setDraft(
-    next:
-      | RestaurantDraft
-      | ((current: RestaurantDraft) => RestaurantDraft),
-  ) {
-    const resolved = typeof next === "function" ? next(draftRef.current) : next;
-    draftRef.current = resolved;
-    setDraftState(resolved);
-  }
+  const {
+    draft,
+    baseline,
+    revision: savedRevision,
+    dirty,
+    draftRef,
+    setDraft,
+    applyAuxiliary,
+    setRevision,
+    beginSave,
+    acknowledgeSave,
+    adoptServerDraft,
+  } = useOwnerDraftDirtyState(initialDraft, initialDraftRevision);
   const [saving, setSaving] = useState(false);
-  const [saved, setSaved] = useState(false);
-  const [savedRevision, setSavedRevision] = useState(initialDraftRevision);
-  const handlePhotoRevision = useCallback((revision: number) => {
-    setSavedRevision(revision);
-  }, []);
+  const handlePhotoRevision = useCallback(
+    (revision: number) => {
+      setRevision(revision);
+    },
+    [setRevision],
+  );
   const handlePhotoHeroChange = useCallback(
     (
       hero: {
@@ -156,14 +163,14 @@ export function Dashboard({
         provenance: "official" | "owner" | "permissioned-ugc";
       } | null,
     ) => {
-      setDraft((current) => ({
+      applyAuxiliary((current) => ({
         ...current,
         heroImageUrl: hero?.url ?? null,
         heroOriginalImageUrl: hero?.originalUrl ?? null,
         heroImageProvenance: hero?.provenance ?? null,
       }));
     },
-    [],
+    [applyAuxiliary],
   );
   const handlePhotoGalleryChange = useCallback(
     (
@@ -173,9 +180,9 @@ export function Dashboard({
         provenance: "official" | "owner" | "permissioned-ugc";
       }>,
     ) => {
-      setDraft((current) => ({ ...current, galleryImages }));
+      applyAuxiliary((current) => ({ ...current, galleryImages }));
     },
-    [],
+    [applyAuxiliary],
   );
   const handlePhotoCatalogChange = useCallback(
     (change: {
@@ -185,7 +192,7 @@ export function Dashboard({
       originalUrl: string | null;
       provenance: "official" | "owner" | "permissioned-ugc" | null;
     }) => {
-      setDraft((current) => ({
+      applyAuxiliary((current) => ({
         ...current,
         menuSections: current.menuSections.map((section, sectionIndex) =>
           sectionIndex !== change.sectionIndex
@@ -206,7 +213,7 @@ export function Dashboard({
         ),
       }));
     },
-    [],
+    [applyAuxiliary],
   );
   const [publishing, setPublishing] = useState(false);
   const [publishError, setPublishError] = useState<string | null>(null);
@@ -274,7 +281,8 @@ export function Dashboard({
   );
 
   async function save(): Promise<number | null> {
-    const requestedDraft = structuredClone(draftRef.current);
+    const submitted = beginSave();
+    const requestedDraft = structuredClone(submitted.submittedDraft);
     const validationIssues = validateRestaurantMenuDraft(requestedDraft);
     const integrationIssues = validateRestaurantIntegrations(requestedDraft);
     setMenuValidationIssues(validationIssues);
@@ -293,19 +301,18 @@ export function Dashboard({
       return null;
     }
     setSaving(true);
-    setSaved(false);
     setPublishError(null);
     setMenuSaveError(null);
     setIntegrationSaveError(null);
     try {
-      let persistedRevision = savedRevision;
+      let persistedRevision = submitted.expectedRevision;
       if (!demo) {
-        const response = await fetch(`/api/sites/${draft.slug}`, {
+        const response = await fetch(`/api/sites/${requestedDraft.slug}`, {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             ...requestedDraft,
-            expectedRevision: savedRevision,
+            expectedRevision: submitted.expectedRevision,
           }),
         });
         const result = (await response.json()) as {
@@ -319,22 +326,22 @@ export function Dashboard({
         if (!Number.isInteger(result.revision) || result.revision === undefined) {
           throw new Error("Save response did not include a draft revision");
         }
-        setSavedRevision(result.revision);
         persistedRevision = result.revision;
       }
-      setPersistedDraft(requestedDraft);
-      if (
-        JSON.stringify(draftRef.current) !== JSON.stringify(requestedDraft)
-      ) {
+      const acknowledged = acknowledgeSave({
+        submittedDraft: requestedDraft,
+        persistedDraft: requestedDraft,
+        submittedMutationVersion: submitted.submittedMutationVersion,
+        savedRevision: persistedRevision,
+      });
+      if (acknowledged.hadNewerEdits) {
         const message =
           "New edits were made while saving. Save them before publishing.";
-        setSaved(false);
         setPublishError(message);
         setMenuSaveError(message);
         setIntegrationSaveError(message);
         return null;
       }
-      setSaved(true);
       setThemeDirty(false);
       setMenuDirty(false);
       setIntegrationDirty(false);
@@ -441,7 +448,6 @@ export function Dashboard({
       themeId,
     );
     setDraft((current) => ({ ...current, themeSelection: selection }));
-    setSaved(false);
     setThemeDirty(true);
     markDraftUnpublished();
     setPublishError(null);
@@ -454,7 +460,6 @@ export function Dashboard({
         current.designProfile,
       ),
     }));
-    setSaved(false);
     setThemeDirty(true);
     markDraftUnpublished();
     setPublishError(null);
@@ -474,7 +479,6 @@ export function Dashboard({
       const next = applyRestaurantMenuMutation(draft, mutation);
       setDraft(next);
       setMenuDirty(true);
-      setSaved(false);
       setMenuSaveError(null);
       setMenuValidationIssues(validateRestaurantMenuDraft(next));
     } catch (error) {
@@ -491,7 +495,6 @@ export function Dashboard({
     const next = updateRestaurantTranslation(draft, locale, updater);
     setDraft(next);
     setMenuDirty(true);
-    setSaved(false);
     setMenuSaveError(null);
     setMenuValidationIssues(validateRestaurantMenuDraft(next));
   }
@@ -501,7 +504,6 @@ export function Dashboard({
       const next = markRestaurantTranslationReviewed(draft, locale);
       setDraft(next);
       setMenuDirty(true);
-      setSaved(false);
       setMenuSaveError(null);
       setMenuValidationIssues([]);
     } catch {
@@ -550,17 +552,17 @@ export function Dashboard({
         draftRef.current,
         regenerated,
       );
-      setPersistedDraft(structuredClone(regenerated));
-      setDraft(reconciled.draft);
-      setSavedRevision(result.revision);
+      adoptServerDraft({
+        draft: reconciled.draft,
+        baseline: regenerated,
+        revision: result.revision,
+      });
       if (reconciled.preservedClientEdits) {
-        setSaved(false);
         setMenuValidationIssues(validateRestaurantMenuDraft(reconciled.draft));
         setIntegrationValidationIssues(
           validateRestaurantIntegrations(reconciled.draft),
         );
       } else {
-        setSaved(true);
         setMenuDirty(false);
         setIntegrationDirty(false);
         setMenuValidationIssues([]);
@@ -583,7 +585,6 @@ export function Dashboard({
     setDraft(previous);
     setMenuUndoStack((current) => current.slice(0, -1));
     setMenuDirty(true);
-    setSaved(false);
     setMenuSaveError(null);
     setMenuValidationIssues([]);
   }
@@ -594,18 +595,23 @@ export function Dashboard({
   }) {
     const acceptedServerDraft = restaurantDraftSchema.parse(input.draft);
     const reconciled = reconcileAcceptedSourceMonitoringDraft(
-      persistedDraft,
+      baseline,
       draftRef.current,
       acceptedServerDraft,
     );
-    setPersistedDraft(acceptedServerDraft);
-    setDraft(reconciled.draft);
-    setSavedRevision(input.revision);
-    setSaved(!reconciled.preservedClientEdits);
+    adoptServerDraft({
+      draft: reconciled.draft,
+      baseline: acceptedServerDraft,
+      revision: input.revision,
+    });
     setMenuValidationIssues(validateRestaurantMenuDraft(reconciled.draft));
     setIntegrationValidationIssues(
       validateRestaurantIntegrations(reconciled.draft),
     );
+    if (!reconciled.preservedClientEdits) {
+      setMenuDirty(false);
+      setIntegrationDirty(false);
+    }
   }
 
   function mutateIntegration(
@@ -622,7 +628,6 @@ export function Dashboard({
       const next = applyRestaurantIntegrationMutation(draft, mutation);
       setDraft(next);
       setIntegrationDirty(true);
-      setSaved(false);
       setIntegrationSaveError(null);
       setIntegrationValidationIssues(
         validateRestaurantIntegrations(next),
@@ -650,7 +655,6 @@ export function Dashboard({
     );
     setDraft(next);
     setIntegrationDirty(true);
-    setSaved(false);
     setIntegrationSaveError(null);
     setIntegrationValidationIssues(
       validateRestaurantIntegrations(next),
@@ -662,7 +666,6 @@ export function Dashboard({
       const next = markRestaurantTranslationReviewed(draft, locale);
       setDraft(next);
       setIntegrationDirty(true);
-      setSaved(false);
       setIntegrationSaveError(null);
       setIntegrationValidationIssues([]);
     } catch {
@@ -678,13 +681,13 @@ export function Dashboard({
     setDraft(previous);
     setIntegrationUndoStack((current) => current.slice(0, -1));
     setIntegrationDirty(true);
-    setSaved(false);
     setIntegrationSaveError(null);
     setIntegrationValidationIssues([]);
   }
 
   return (
-    <main className="min-h-screen bg-[#f3f1eb]">
+    <OwnerDraftDirtyGuard dirty={dirty}>
+    <main className="min-h-screen bg-[#f3f1eb]" {...ownerDraftNavigationProps(dirty)}>
       <header className="sticky top-0 z-50 flex h-16 items-center justify-between border-b bg-background px-4 md:px-6">
         <div className="flex items-center gap-5">
           <Brand {...brand} />
@@ -724,7 +727,7 @@ export function Dashboard({
             disabled={saving || publishing}
           >
             {saving ? <LoaderCircle className="animate-spin" /> : <Save />}
-            {saved ? "Saved" : "Save"}
+            {dirty ? "Save" : "Saved"}
           </Button>
           <Button
             size="sm"
@@ -976,10 +979,7 @@ export function Dashboard({
                 initial={sourceMonitoring}
                 demo={demo}
                 draftRevision={savedRevision}
-                hasUnsavedChanges={
-                  JSON.stringify(draft) !==
-                  JSON.stringify(persistedDraft)
-                }
+                hasUnsavedChanges={dirty}
                 onAcceptedDraft={applyAcceptedSourceMonitoringDraft}
               />
             </TabsContent>
@@ -1340,6 +1340,7 @@ export function Dashboard({
         </div>
       </Tabs>
     </main>
+    </OwnerDraftDirtyGuard>
   );
 }
 

--- a/src/app/dashboard/dashboard.tsx
+++ b/src/app/dashboard/dashboard.tsx
@@ -66,7 +66,7 @@ import {
 } from "@/lib/owner-operations";
 import type { VerticalOwnerOperations } from "@/lib/verticals/types";
 import { listRestaurantThemeManifests } from "@/lib/site-themes/restaurant/registry";
-import type { SourceMonitoringDashboardDto } from "@/lib/source-monitoring";
+import type { SourceMonitoringDashboardDto } from "@/lib/source-monitoring-diff";
 import {
   parseRestaurantThemeSelection,
   restoreAutomaticRestaurantTheme,

--- a/src/app/dashboard/food-retail-dashboard.tsx
+++ b/src/app/dashboard/food-retail-dashboard.tsx
@@ -20,6 +20,7 @@ import {
   OwnerPaidOperationsSection,
   useOwnerPaidOperations,
 } from "@/components/owner-paid-operations";
+import { SourceMonitoringPanel } from "@/components/source-monitoring-panel";
 import { SiteRenderer } from "@/components/site-renderer";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -37,6 +38,10 @@ import {
   ownerOperationUnavailableMessage,
   type ClientPublicationHistoryItem,
 } from "@/lib/owner-operations";
+import {
+  EMPTY_SOURCE_MONITORING_DASHBOARD,
+  type SourceMonitoringDashboardDto,
+} from "@/lib/source-monitoring-diff";
 import type { VerticalOwnerOperations } from "@/lib/verticals/types";
 import {
   canEnableOwnerIntegration,
@@ -78,6 +83,7 @@ export function FoodRetailDashboard({
   ownerOperations = foodRetailOwnerOperations,
   billingAccess = null,
   publicationHistory = [],
+  sourceMonitoring = EMPTY_SOURCE_MONITORING_DASHBOARD,
 }: {
   email: string;
   brand: BrandIdentity;
@@ -89,9 +95,11 @@ export function FoodRetailDashboard({
   ownerOperations?: VerticalOwnerOperations;
   billingAccess?: BillingAccess | null;
   publicationHistory?: ClientPublicationHistoryItem[];
+  sourceMonitoring?: SourceMonitoringDashboardDto;
 }) {
   const [draft, setDraftState] = useState(initialDraft);
   const draftRef = useRef(initialDraft);
+  const [persistedDraft, setPersistedDraft] = useState(initialDraft);
   function setDraft(
     next:
       | FoodRetailSiteDraft
@@ -309,6 +317,7 @@ export function FoodRetailDashboard({
       setDraft((current) =>
         reconcileFoodRetailDraftAfterSave(submittedDraft, parsed.data, current),
       );
+      if (!hadNewerEdits) setPersistedDraft(parsed.data);
       setRevision(result.revision);
       if (hadNewerEdits) {
         setError(
@@ -390,6 +399,18 @@ export function FoodRetailDashboard({
     } finally {
       setPublishing(false);
     }
+  }
+
+  function applyAcceptedSourceMonitoringDraft(input: {
+    revision: number;
+    draft: unknown;
+  }) {
+    const accepted = foodRetailSiteDraftSchema.parse(input.draft);
+    setDraft(accepted);
+    setPersistedDraft(accepted);
+    setRevision(input.revision);
+    setNotice("Source suggestion saved to the private draft.");
+    setError(null);
   }
 
   return (
@@ -484,6 +505,17 @@ export function FoodRetailDashboard({
           </Card>
 
           <OwnerPaidOperationsSection paid={paidOps} />
+          {isOwnerOperationEnabled(ownerOperations.sourceMonitoring) ? (
+            <SourceMonitoringPanel
+              siteSlug={draft.slug}
+              initial={sourceMonitoring}
+              draftRevision={revision}
+              hasUnsavedChanges={
+                JSON.stringify(draft) !== JSON.stringify(persistedDraft)
+              }
+              onAcceptedDraft={applyAcceptedSourceMonitoringDraft}
+            />
+          ) : null}
 
           <Card>
             <CardHeader>

--- a/src/app/dashboard/food-retail-dashboard.tsx
+++ b/src/app/dashboard/food-retail-dashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import Link from "next/link";
 import {
   Check,
@@ -20,6 +20,7 @@ import {
   OwnerPaidOperationsSection,
   useOwnerPaidOperations,
 } from "@/components/owner-paid-operations";
+import { PhotoLibraryPanel } from "@/components/photo-library-panel";
 import { SourceMonitoringPanel } from "@/components/source-monitoring-panel";
 import { SiteRenderer } from "@/components/site-renderer";
 import { Button } from "@/components/ui/button";
@@ -64,9 +65,13 @@ import {
   hasUnreviewedFoodRetailTranslations,
   markFoodRetailTranslationReviewed,
   markFoodRetailTranslationsStale,
-  reconcileFoodRetailDraftAfterSave,
   updateFoodRetailTranslation,
 } from "@/lib/verticals/food-retail/editor";
+import {
+  OwnerDraftDirtyGuard,
+  ownerDraftNavigationProps,
+  useOwnerDraftDirtyState,
+} from "@/lib/owner-draft-dirty-state";
 import {
   foodRetailSiteDraftSchema,
   type FoodRetailSiteDraft,
@@ -97,19 +102,18 @@ export function FoodRetailDashboard({
   publicationHistory?: ClientPublicationHistoryItem[];
   sourceMonitoring?: SourceMonitoringDashboardDto;
 }) {
-  const [draft, setDraftState] = useState(initialDraft);
-  const draftRef = useRef(initialDraft);
-  const [persistedDraft, setPersistedDraft] = useState(initialDraft);
-  function setDraft(
-    next:
-      | FoodRetailSiteDraft
-      | ((current: FoodRetailSiteDraft) => FoodRetailSiteDraft),
-  ) {
-    const resolved = typeof next === "function" ? next(draftRef.current) : next;
-    draftRef.current = resolved;
-    setDraftState(resolved);
-  }
-  const [revision, setRevision] = useState(initialRevision);
+  const {
+    draft,
+    revision,
+    dirty,
+    draftRef,
+    setDraft,
+    applyAuxiliary,
+    setRevision,
+    beginSave,
+    acknowledgeSave,
+    acknowledgeSnapshot,
+  } = useOwnerDraftDirtyState(initialDraft, initialRevision);
   const [saving, setSaving] = useState(false);
   const [publishing, setPublishing] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
@@ -127,6 +131,73 @@ export function FoodRetailDashboard({
   const [integrationIssues, setIntegrationIssues] = useState<
     OwnerIntegrationIssue[]
   >([]);
+
+  const handlePhotoRevision = useCallback(
+    (nextRevision: number) => {
+      setRevision(nextRevision);
+    },
+    [setRevision],
+  );
+  const handlePhotoHeroChange = useCallback(
+    (
+      hero: {
+        url: string;
+        originalUrl: string;
+        provenance: "official" | "owner" | "permissioned-ugc";
+      } | null,
+    ) => {
+      applyAuxiliary((current) => ({
+        ...current,
+        heroImageUrl: hero?.url ?? null,
+        heroOriginalImageUrl: hero?.originalUrl ?? null,
+        heroImageProvenance: hero?.provenance ?? null,
+      }));
+    },
+    [applyAuxiliary],
+  );
+  const handlePhotoGalleryChange = useCallback(
+    (
+      galleryImages: Array<{
+        url: string;
+        originalUrl: string;
+        provenance: "official" | "owner" | "permissioned-ugc";
+      }>,
+    ) => {
+      applyAuxiliary((current) => ({ ...current, galleryImages }));
+    },
+    [applyAuxiliary],
+  );
+  const handlePhotoCatalogChange = useCallback(
+    (change: {
+      sectionIndex: number;
+      itemIndex: number;
+      url: string | null;
+      originalUrl: string | null;
+      provenance: "official" | "owner" | "permissioned-ugc" | null;
+    }) => {
+      applyAuxiliary((current) => ({
+        ...current,
+        catalogSections: current.catalogSections.map((section, sectionIndex) =>
+          sectionIndex !== change.sectionIndex
+            ? section
+            : {
+                ...section,
+                items: section.items.map((item, itemIndex) =>
+                  itemIndex !== change.itemIndex
+                    ? item
+                    : {
+                        ...item,
+                        imageUrl: change.url,
+                        originalImageUrl: change.originalUrl,
+                        imageProvenance: change.provenance,
+                      },
+                ),
+              },
+        ),
+      }));
+    },
+    [applyAuxiliary],
+  );
 
   function updateSection(
     sectionIndex: number,
@@ -275,7 +346,8 @@ export function FoodRetailDashboard({
   }
 
   async function saveDraft(): Promise<number | null> {
-    const submittedDraft = draft;
+    const submitted = beginSave();
+    const submittedDraft = submitted.submittedDraft;
     const ownerIssues = validateOwnerIntegrations(submittedDraft.integrations);
     const parsed = foodRetailSiteDraftSchema.safeParse(submittedDraft);
     if (ownerIssues.length > 0 || !parsed.success) {
@@ -294,12 +366,12 @@ export function FoodRetailDashboard({
     setIntegrationIssues([]);
     setNotice(null);
     try {
-      const response = await fetch(`/api/sites/${draft.slug}`, {
+      const response = await fetch(`/api/sites/${submittedDraft.slug}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           ...parsed.data,
-          expectedRevision: revision,
+          expectedRevision: submitted.expectedRevision,
         }),
       });
       const result = (await response.json()) as {
@@ -313,13 +385,13 @@ export function FoodRetailDashboard({
       ) {
         throw new Error("Save response did not include a draft revision");
       }
-      const hadNewerEdits = draftRef.current !== submittedDraft;
-      setDraft((current) =>
-        reconcileFoodRetailDraftAfterSave(submittedDraft, parsed.data, current),
-      );
-      if (!hadNewerEdits) setPersistedDraft(parsed.data);
-      setRevision(result.revision);
-      if (hadNewerEdits) {
+      const acknowledged = acknowledgeSave({
+        submittedDraft,
+        persistedDraft: parsed.data,
+        submittedMutationVersion: submitted.submittedMutationVersion,
+        savedRevision: result.revision,
+      });
+      if (acknowledged.hadNewerEdits) {
         setError(
           "New edits were made while saving. Save them before leaving this private preview.",
         );
@@ -406,15 +478,17 @@ export function FoodRetailDashboard({
     draft: unknown;
   }) {
     const accepted = foodRetailSiteDraftSchema.parse(input.draft);
-    setDraft(accepted);
-    setPersistedDraft(accepted);
-    setRevision(input.revision);
+    acknowledgeSnapshot(accepted, input.revision);
     setNotice("Source suggestion saved to the private draft.");
     setError(null);
   }
 
   return (
-    <div className="min-h-screen bg-muted/35 text-foreground">
+    <OwnerDraftDirtyGuard dirty={dirty}>
+    <div
+      className="min-h-screen bg-muted/35 text-foreground"
+      {...ownerDraftNavigationProps(dirty)}
+    >
       <header className="border-b bg-background">
         <div className="mx-auto flex max-w-[1500px] items-center justify-between gap-4 px-5 py-4">
           <Brand {...brand} />
@@ -470,10 +544,10 @@ export function FoodRetailDashboard({
                 </Button>
                 <Button
                   variant="outline"
-                  disabled={saving || publishing}
+                  disabled={saving || publishing || !dirty}
                   onClick={() => void saveDraft()}
                 >
-                  <Save /> {saving ? "Saving…" : "Save"}
+                  <Save /> {saving ? "Saving…" : dirty ? "Save" : "Saved"}
                 </Button>
                 <Button
                   disabled={saving || publishing}
@@ -510,10 +584,17 @@ export function FoodRetailDashboard({
               siteSlug={draft.slug}
               initial={sourceMonitoring}
               draftRevision={revision}
-              hasUnsavedChanges={
-                JSON.stringify(draft) !== JSON.stringify(persistedDraft)
-              }
+              hasUnsavedChanges={dirty}
               onAcceptedDraft={applyAcceptedSourceMonitoringDraft}
+            />
+          ) : null}
+          {isOwnerOperationEnabled(ownerOperations.photoLibrary) ? (
+            <PhotoLibraryPanel
+              siteSlug={draft.slug}
+              onRevision={handlePhotoRevision}
+              onHeroChange={handlePhotoHeroChange}
+              onGalleryChange={handlePhotoGalleryChange}
+              onCatalogChange={handlePhotoCatalogChange}
             />
           ) : null}
 
@@ -924,39 +1005,21 @@ export function FoodRetailDashboard({
                         }
                       />
                     </div>
-                    <div className="grid gap-3 sm:grid-cols-[1fr_180px]">
-                      <Input
-                        aria-label={`Product ${itemIndex + 1} image`}
-                        type="url"
-                        placeholder="Approved product image URL"
-                        value={item.imageUrl ?? ""}
-                        onChange={(event) =>
-                          updateItem(sectionIndex, itemIndex, (next) => {
-                            next.imageUrl = event.target.value || null;
-                            if (!next.imageUrl) next.imageProvenance = null;
-                          })
-                        }
-                      />
-                      <select
-                        aria-label={`Product ${itemIndex + 1} image provenance`}
-                        className="h-9 rounded-lg border bg-background px-2 text-sm"
-                        value={item.imageProvenance ?? ""}
-                        onChange={(event) =>
-                          updateItem(sectionIndex, itemIndex, (next) => {
-                            next.imageProvenance = (event.target.value ||
-                              null) as
-                              "official" | "owner" | "permissioned-ugc" | null;
-                          })
-                        }
-                      >
-                        <option value="">Choose image source</option>
-                        <option value="official">Official source</option>
-                        <option value="owner">Owner supplied</option>
-                        <option value="permissioned-ugc">
-                          Permissioned UGC
-                        </option>
-                      </select>
-                    </div>
+                    {item.imageUrl ? (
+                      <p className="text-xs text-muted-foreground">
+                        Product image is selected from the reviewed photo
+                        library
+                        {item.imageProvenance
+                          ? ` · ${item.imageProvenance.replaceAll("-", " ")}`
+                          : ""}
+                        .
+                      </p>
+                    ) : (
+                      <p className="text-xs text-muted-foreground">
+                        Choose an approved photo for this product in the photo
+                        library.
+                      </p>
+                    )}
                   </div>
                 ))}
                 <Button
@@ -1317,5 +1380,6 @@ export function FoodRetailDashboard({
         </div>
       </main>
     </div>
+    </OwnerDraftDirtyGuard>
   );
 }

--- a/src/app/dashboard/local-service-dashboard.tsx
+++ b/src/app/dashboard/local-service-dashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import Link from "next/link";
 import {
   ExternalLink,
@@ -18,6 +18,7 @@ import {
   OwnerPaidOperationsSection,
   useOwnerPaidOperations,
 } from "@/components/owner-paid-operations";
+import { PhotoLibraryPanel } from "@/components/photo-library-panel";
 import { SourceMonitoringPanel } from "@/components/source-monitoring-panel";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -58,6 +59,12 @@ import {
   type LocalServiceAttributes,
   type LocalServiceSiteDraft,
 } from "@/lib/verticals/local-service/schema";
+import {
+  OwnerDraftDirtyGuard,
+  acknowledgeOwnerDraftSave,
+  ownerDraftNavigationProps,
+  useOwnerDraftDirtyState,
+} from "@/lib/owner-draft-dirty-state";
 
 const tradeTypes: LocalServiceAttributes["tradeType"][] = [
   "plumber",
@@ -92,13 +99,26 @@ export function reconcileLocalServiceDraftAfterSave(input: {
   currentMutationVersion: number;
   savedRevision: number;
 }) {
-  const hadNewerEdits =
-    input.currentMutationVersion !== input.submittedMutationVersion;
+  const acknowledged = acknowledgeOwnerDraftSave(
+    {
+      draft: input.currentDraft,
+      baseline: input.submittedDraft,
+      revision: 0,
+      mutationVersion: input.currentMutationVersion,
+      dirty: true,
+    },
+    {
+      submittedDraft: input.submittedDraft,
+      persistedDraft: input.persistedDraft,
+      submittedMutationVersion: input.submittedMutationVersion,
+      savedRevision: input.savedRevision,
+    },
+  );
   return {
-    draft: hadNewerEdits ? input.currentDraft : input.persistedDraft,
-    revision: input.savedRevision,
-    dirty: hadNewerEdits,
-    hadNewerEdits,
+    draft: acknowledged.state.draft,
+    revision: acknowledged.state.revision,
+    dirty: acknowledged.state.dirty,
+    hadNewerEdits: acknowledged.hadNewerEdits,
   };
 }
 
@@ -127,13 +147,19 @@ export function LocalServiceDashboard({
   publicationHistory?: ClientPublicationHistoryItem[];
   sourceMonitoring?: SourceMonitoringDashboardDto;
 }) {
-  const [draft, setDraftState] = useState(initialDraft);
-  const draftRef = useRef(initialDraft);
-  const mutationVersionRef = useRef(0);
-  const [dirty, setDirty] = useState(false);
+  const {
+    draft,
+    revision: savedRevision,
+    dirty,
+    setDraft,
+    applyAuxiliary,
+    setRevision,
+    beginSave,
+    acknowledgeSave,
+    acknowledgeSnapshot,
+  } = useOwnerDraftDirtyState(initialDraft, initialRevision);
   const [saving, setSaving] = useState(false);
   const [publishing, setPublishing] = useState(false);
-  const [savedRevision, setSavedRevision] = useState(initialRevision);
   const paidOps = useOwnerPaidOperations({
     siteSlug: initialDraft.slug,
     platformUrl,
@@ -144,28 +170,109 @@ export function LocalServiceDashboard({
   });
   const publishedVersion = paidOps.publishedVersion;
   const published = initiallyPublished || paidOps.isPublished;
-  const savedRevisionRef = useRef(initialRevision);
   const [notice, setNotice] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [integrationIssues, setIntegrationIssues] = useState<
     OwnerIntegrationIssue[]
   >([]);
 
+  const handlePhotoRevision = useCallback(
+    (nextRevision: number) => {
+      setRevision(nextRevision);
+    },
+    [setRevision],
+  );
+  const handlePhotoHeroChange = useCallback(
+    (
+      hero: {
+        url: string;
+        originalUrl: string;
+        provenance: "official" | "owner" | "permissioned-ugc";
+      } | null,
+    ) => {
+      applyAuxiliary((current) => ({
+        ...current,
+        heroImageUrl: hero?.url ?? null,
+        heroOriginalImageUrl: hero?.originalUrl ?? null,
+        heroImageProvenance: hero?.provenance ?? null,
+      }));
+    },
+    [applyAuxiliary],
+  );
+  const handlePhotoGalleryChange = useCallback(
+    (
+      galleryImages: Array<{
+        url: string;
+        originalUrl: string;
+        provenance: "official" | "owner" | "permissioned-ugc";
+      }>,
+    ) => {
+      applyAuxiliary((current) => ({
+        ...current,
+        galleryImages,
+        attributes: {
+          ...current.attributes,
+          projects: current.attributes.projects.map((project, index) => {
+            const selected = galleryImages[index];
+            if (!selected) return project;
+            return {
+              ...project,
+              imageUrl: selected.url,
+              originalImageUrl: selected.originalUrl,
+              imageProvenance: selected.provenance,
+            };
+          }),
+        },
+      }));
+    },
+    [applyAuxiliary],
+  );
+  const handlePhotoCatalogChange = useCallback(
+    (change: {
+      sectionIndex: number;
+      itemIndex: number;
+      url: string | null;
+      originalUrl: string | null;
+      provenance: "official" | "owner" | "permissioned-ugc" | null;
+    }) => {
+      applyAuxiliary((current) => ({
+        ...current,
+        catalogSections: current.catalogSections.map((section, sectionIndex) =>
+          sectionIndex !== change.sectionIndex
+            ? section
+            : {
+                ...section,
+                items: section.items.map((item, itemIndex) =>
+                  itemIndex !== change.itemIndex
+                    ? item
+                    : {
+                        ...item,
+                        imageUrl: change.url,
+                        originalImageUrl: change.originalUrl,
+                        imageProvenance: change.provenance,
+                      },
+                ),
+              },
+        ),
+      }));
+    },
+    [applyAuxiliary],
+  );
+
   function change(mutator: (next: LocalServiceSiteDraft) => void) {
-    const next = structuredClone(draftRef.current);
-    mutator(next);
-    draftRef.current = next;
-    mutationVersionRef.current += 1;
-    setDraftState(next);
-    setDirty(true);
+    setDraft((current) => {
+      const next = structuredClone(current);
+      mutator(next);
+      return next;
+    });
     setNotice(null);
     setError(null);
     setIntegrationIssues([]);
   }
 
   async function save(): Promise<number | null> {
-    const submittedDraft = draftRef.current;
-    const submittedMutationVersion = mutationVersionRef.current;
+    const submitted = beginSave();
+    const submittedDraft = submitted.submittedDraft;
     const ownerIssues = validateOwnerIntegrations(submittedDraft.integrations);
     const parsed = localServiceSiteDraftSchema.safeParse(submittedDraft);
     if (ownerIssues.length > 0 || !parsed.success) {
@@ -188,7 +295,7 @@ export function LocalServiceDashboard({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           ...parsed.data,
-          expectedRevision: savedRevisionRef.current,
+          expectedRevision: submitted.expectedRevision,
         }),
       });
       const result = (await response.json()) as {
@@ -202,25 +309,18 @@ export function LocalServiceDashboard({
       ) {
         throw new Error("Save succeeded without a draft revision");
       }
-      const reconciled = reconcileLocalServiceDraftAfterSave({
+      const reconciled = acknowledgeSave({
         submittedDraft,
         persistedDraft: parsed.data,
-        currentDraft: draftRef.current,
-        submittedMutationVersion,
-        currentMutationVersion: mutationVersionRef.current,
+        submittedMutationVersion: submitted.submittedMutationVersion,
         savedRevision: result.revision,
       });
-      draftRef.current = reconciled.draft;
-      savedRevisionRef.current = reconciled.revision;
-      setDraftState(reconciled.draft);
-      setSavedRevision(reconciled.revision);
-      setDirty(reconciled.dirty);
       setNotice(
         reconciled.hadNewerEdits
-          ? `Draft revision ${reconciled.revision} saved; newer edits remain unsaved`
+          ? `Draft revision ${reconciled.state.revision} saved; newer edits remain unsaved`
           : "Private draft saved",
       );
-      return reconciled.hadNewerEdits ? null : reconciled.revision;
+      return reconciled.hadNewerEdits ? null : reconciled.state.revision;
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : "Save failed");
       return null;
@@ -296,17 +396,17 @@ export function LocalServiceDashboard({
     draft: unknown;
   }) {
     const accepted = localServiceSiteDraftSchema.parse(input.draft);
-    draftRef.current = accepted;
-    savedRevisionRef.current = input.revision;
-    setDraftState(accepted);
-    setSavedRevision(input.revision);
-    setDirty(false);
+    acknowledgeSnapshot(accepted, input.revision);
     setNotice("Source suggestion saved to the private draft.");
     setError(null);
   }
 
   return (
-    <div className="min-h-screen bg-background text-foreground">
+    <OwnerDraftDirtyGuard dirty={dirty}>
+    <div
+      className="min-h-screen bg-background text-foreground"
+      {...ownerDraftNavigationProps(dirty)}
+    >
       <header className="border-b border-border/70">
         <div className="mx-auto flex max-w-7xl items-center justify-between gap-4 px-6 py-4">
           <Brand {...brand} />
@@ -412,6 +512,17 @@ export function LocalServiceDashboard({
               draftRevision={savedRevision}
               hasUnsavedChanges={dirty}
               onAcceptedDraft={applyAcceptedSourceMonitoringDraft}
+            />
+          </div>
+        ) : null}
+        {isOwnerOperationEnabled(ownerOperations.photoLibrary) ? (
+          <div className="mt-8">
+            <PhotoLibraryPanel
+              siteSlug={draft.slug}
+              onRevision={handlePhotoRevision}
+              onHeroChange={handlePhotoHeroChange}
+              onGalleryChange={handlePhotoGalleryChange}
+              onCatalogChange={handlePhotoCatalogChange}
             />
           </div>
         ) : null}
@@ -919,17 +1030,20 @@ export function LocalServiceDashboard({
                       })
                     }
                   />
-                  <Input
-                    aria-label="Project image URL"
-                    value={project.imageUrl ?? ""}
-                    placeholder="https://…"
-                    onChange={(event) =>
-                      change((next) => {
-                        next.attributes.projects[index].imageUrl =
-                          event.target.value || null;
-                      })
-                    }
-                  />
+                  {project.imageUrl ? (
+                    <p className="text-xs text-muted-foreground">
+                      Project image is selected from the reviewed photo library
+                      {project.imageProvenance
+                        ? ` · ${project.imageProvenance.replaceAll("-", " ")}`
+                        : ""}
+                      .
+                    </p>
+                  ) : (
+                    <p className="text-xs text-muted-foreground">
+                      Choose an approved gallery photo for this project in the
+                      photo library.
+                    </p>
+                  )}
                   <Button
                     variant="destructive"
                     size="sm"
@@ -1053,6 +1167,7 @@ export function LocalServiceDashboard({
         </EditorSection>
       </main>
     </div>
+    </OwnerDraftDirtyGuard>
   );
 }
 

--- a/src/app/dashboard/local-service-dashboard.tsx
+++ b/src/app/dashboard/local-service-dashboard.tsx
@@ -18,6 +18,7 @@ import {
   OwnerPaidOperationsSection,
   useOwnerPaidOperations,
 } from "@/components/owner-paid-operations";
+import { SourceMonitoringPanel } from "@/components/source-monitoring-panel";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -34,6 +35,10 @@ import {
   ownerOperationUnavailableMessage,
   type ClientPublicationHistoryItem,
 } from "@/lib/owner-operations";
+import {
+  EMPTY_SOURCE_MONITORING_DASHBOARD,
+  type SourceMonitoringDashboardDto,
+} from "@/lib/source-monitoring-diff";
 import type { VerticalOwnerOperations } from "@/lib/verticals/types";
 import {
   canEnableOwnerIntegration,
@@ -108,6 +113,7 @@ export function LocalServiceDashboard({
   ownerOperations = localServiceOwnerOperations,
   billingAccess = null,
   publicationHistory = [],
+  sourceMonitoring = EMPTY_SOURCE_MONITORING_DASHBOARD,
 }: {
   initialDraft: LocalServiceSiteDraft;
   initialRevision: number;
@@ -119,6 +125,7 @@ export function LocalServiceDashboard({
   ownerOperations?: VerticalOwnerOperations;
   billingAccess?: BillingAccess | null;
   publicationHistory?: ClientPublicationHistoryItem[];
+  sourceMonitoring?: SourceMonitoringDashboardDto;
 }) {
   const [draft, setDraftState] = useState(initialDraft);
   const draftRef = useRef(initialDraft);
@@ -284,6 +291,20 @@ export function LocalServiceDashboard({
     }
   }
 
+  function applyAcceptedSourceMonitoringDraft(input: {
+    revision: number;
+    draft: unknown;
+  }) {
+    const accepted = localServiceSiteDraftSchema.parse(input.draft);
+    draftRef.current = accepted;
+    savedRevisionRef.current = input.revision;
+    setDraftState(accepted);
+    setSavedRevision(input.revision);
+    setDirty(false);
+    setNotice("Source suggestion saved to the private draft.");
+    setError(null);
+  }
+
   return (
     <div className="min-h-screen bg-background text-foreground">
       <header className="border-b border-border/70">
@@ -383,6 +404,17 @@ export function LocalServiceDashboard({
         <div className="mt-8">
           <OwnerPaidOperationsSection paid={paidOps} />
         </div>
+        {isOwnerOperationEnabled(ownerOperations.sourceMonitoring) ? (
+          <div className="mt-8">
+            <SourceMonitoringPanel
+              siteSlug={draft.slug}
+              initial={sourceMonitoring}
+              draftRevision={savedRevision}
+              hasUnsavedChanges={dirty}
+              onAcceptedDraft={applyAcceptedSourceMonitoringDraft}
+            />
+          </div>
+        ) : null}
 
         <div className="mt-8 grid gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
           <Card>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -12,7 +12,10 @@ import { isOwnerOperationEnabled } from "@/lib/owner-operations";
 import { loadOwnerPaidWorkspace } from "@/lib/owner-workspace";
 import { getRestaurantOwnerDraft } from "@/lib/restaurants";
 import { sampleRestaurant } from "@/lib/restaurant";
-import { getSourceMonitoringDashboard } from "@/lib/source-monitoring";
+import {
+  EMPTY_SOURCE_MONITORING_DASHBOARD,
+  getSourceMonitoringDashboard,
+} from "@/lib/source-monitoring";
 import { resolveRequestBrand } from "@/lib/verticals/request-site";
 import { resolveOwnerOperations } from "@/lib/verticals/registry";
 import { UnsupportedVerticalDashboard } from "@/app/dashboard/unsupported-vertical-dashboard";
@@ -49,9 +52,13 @@ export default async function DashboardPage({
   if (session && (!access || !access.ok)) redirect("/sign-in");
 
   if (access?.ok && access.site.vertical === Vertical.FOOD_RETAIL) {
-    const [loaded, paid] = await Promise.all([
+    const capabilities = resolveOwnerOperations(access.site.vertical);
+    const [loaded, paid, sourceMonitoring] = await Promise.all([
       findSiteDraft(access.site.slug),
       loadOwnerPaidWorkspace(access),
+      isOwnerOperationEnabled(capabilities.sourceMonitoring)
+        ? getSourceMonitoringDashboard(access.site.id)
+        : EMPTY_SOURCE_MONITORING_DASHBOARD,
     ]);
     if (!loaded || loaded.vertical !== Vertical.FOOD_RETAIL)
       redirect("/sign-in");
@@ -71,15 +78,20 @@ export default async function DashboardPage({
           ownerOperations={paid.capabilities}
           billingAccess={paid.billingAccess}
           publicationHistory={paid.publicationHistory}
+          sourceMonitoring={sourceMonitoring}
         />
       </EditorialFontScope>
     );
   }
 
   if (access?.ok && access.site.vertical === Vertical.LOCAL_SERVICE) {
-    const [loaded, paid] = await Promise.all([
+    const capabilities = resolveOwnerOperations(access.site.vertical);
+    const [loaded, paid, sourceMonitoring] = await Promise.all([
       findSiteDraft(access.site.slug),
       loadOwnerPaidWorkspace(access),
+      isOwnerOperationEnabled(capabilities.sourceMonitoring)
+        ? getSourceMonitoringDashboard(access.site.id)
+        : EMPTY_SOURCE_MONITORING_DASHBOARD,
     ]);
     if (!loaded || loaded.vertical !== Vertical.LOCAL_SERVICE) {
       redirect("/sign-in");
@@ -100,6 +112,7 @@ export default async function DashboardPage({
           ownerOperations={paid.capabilities}
           billingAccess={paid.billingAccess}
           publicationHistory={paid.publicationHistory}
+          sourceMonitoring={sourceMonitoring}
         />
       </EditorialFontScope>
     );
@@ -124,16 +137,6 @@ export default async function DashboardPage({
     awaitingContact: 0,
     truncated: false,
   };
-  const emptySourceMonitoring = {
-    cadenceDays: null,
-    nextRunAt: null,
-    lastRunAt: null,
-    lastSuccessAt: null,
-    lastFailureAt: null,
-    lastFailureCode: null,
-    latestRun: null,
-    suggestions: [],
-  };
   const restaurantCapabilities = access?.ok
     ? resolveOwnerOperations(access.site.vertical)
     : resolveOwnerOperations(Vertical.RESTAURANT);
@@ -155,7 +158,7 @@ export default async function DashboardPage({
         loadOwnerPaidWorkspace(access),
         isOwnerOperationEnabled(restaurantCapabilities.sourceMonitoring)
           ? getSourceMonitoringDashboard(access.site.id)
-          : emptySourceMonitoring,
+          : EMPTY_SOURCE_MONITORING_DASHBOARD,
       ])
     : [
         { draft: sampleRestaurant, revision: 0 },
@@ -168,7 +171,7 @@ export default async function DashboardPage({
           workspaces: [],
           canSwitchWorkspace: false,
         },
-        emptySourceMonitoring,
+        EMPTY_SOURCE_MONITORING_DASHBOARD,
       ];
 
   // A claimed restaurant without a loadable draft is a data integrity problem,

--- a/src/components/account-actions.tsx
+++ b/src/components/account-actions.tsx
@@ -5,12 +5,18 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { LogOut } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  confirmDiscardUnsavedOwnerEdits,
+  useOwnerUnsavedEdits,
+} from "@/lib/owner-draft-dirty-state";
 
 export function AccountActions({ canSwitch }: { canSwitch: boolean }) {
   const router = useRouter();
+  const dirty = useOwnerUnsavedEdits();
   const [pending, setPending] = useState(false);
 
   async function logout() {
+    if (!confirmDiscardUnsavedOwnerEdits(dirty)) return;
     setPending(true);
     try {
       const response = await fetch("/api/auth/logout", { method: "POST" });
@@ -26,7 +32,16 @@ export function AccountActions({ canSwitch }: { canSwitch: boolean }) {
   return (
     <div className="flex items-center gap-2">
       {canSwitch ? (
-        <Button render={<Link href="/workspace/select" />} variant="outline" size="sm">
+        <Button
+          render={<Link href="/workspace/select" />}
+          variant="outline"
+          size="sm"
+          onClick={(event) => {
+            if (!confirmDiscardUnsavedOwnerEdits(dirty)) {
+              event.preventDefault();
+            }
+          }}
+        >
           Switch workspace
         </Button>
       ) : null}

--- a/src/components/source-monitoring-panel.tsx
+++ b/src/components/source-monitoring-panel.tsx
@@ -12,7 +12,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Textarea } from "@/components/ui/textarea";
-import type { SourceMonitoringDashboardDto } from "@/lib/source-monitoring";
+import type { SourceMonitoringDashboardDto } from "@/lib/source-monitoring-diff";
 
 export function SourceMonitoringPanel({
   siteSlug,
@@ -297,10 +297,10 @@ function formatDateTime(value: string | null) {
 function fieldLabel(value: string) {
   return (
     {
-      MENU: "Menu changes",
+      MENU: "Catalog changes",
       CONTACT: "Contact details",
       HOURS: "Business hours",
-      LINKS: "Booking and ordering links",
+      LINKS: "External links",
     }[value] ?? value
   );
 }

--- a/src/lib/dashboard-tabs-surface.test.ts
+++ b/src/lib/dashboard-tabs-surface.test.ts
@@ -123,6 +123,12 @@ describe("dashboard tab and settings surface", () => {
     expect(dashboard).toContain(
       "onAcceptedDraft={applyAcceptedSourceMonitoringDraft}",
     );
+    expect(foodRetailDashboard).toContain(
+      "onAcceptedDraft={applyAcceptedSourceMonitoringDraft}",
+    );
+    expect(localServiceDashboard).toContain(
+      "onAcceptedDraft={applyAcceptedSourceMonitoringDraft}",
+    );
     expect(sourceMonitoringPanel).toContain(
       "onAcceptedDraft({ revision: acceptedRevision, draft: result.draft })",
     );

--- a/src/lib/dashboard-tabs-surface.test.ts
+++ b/src/lib/dashboard-tabs-surface.test.ts
@@ -66,12 +66,18 @@ describe("dashboard tab and settings surface", () => {
       "initialDraftRevision={ownerDraft?.revision ?? 0}",
     );
     expect(dashboardPage).toContain("initialRevision={loaded.revision}");
-    expect(dashboard).toContain("useState(initialDraftRevision)");
-    expect(dashboard).toContain("expectedRevision: savedRevision");
+    expect(dashboard).toContain(
+      "useOwnerDraftDirtyState(initialDraft, initialDraftRevision)",
+    );
+    expect(dashboard).toContain(
+      "expectedRevision: submitted.expectedRevision",
+    );
     expect(restaurantSaveRoute).toContain("saveAuthorizedSiteDraft");
     expect(ownerSiteSave).toContain('code: "EXPECTED_REVISION_REQUIRED"');
     expect(dashboard).toContain("expectedRevision: revisionToPublish");
-    expect(foodRetailDashboard).toContain("expectedRevision: revision");
+    expect(foodRetailDashboard).toContain(
+      "expectedRevision: submitted.expectedRevision",
+    );
     expect(restaurantPublishRoute).toContain('code: "DRAFT_REVISION_CONFLICT"');
   });
 
@@ -109,7 +115,7 @@ describe("dashboard tab and settings surface", () => {
     expect(dashboard).toContain(
       "body: JSON.stringify({ expectedRevision: requestedRevision })",
     );
-    expect(dashboard).toContain("setSavedRevision(result.revision)");
+    expect(dashboard).toContain("adoptServerDraft({");
     expect(translationRegenerationRoute).toContain(
       "expectedRevision: requestBody.data.expectedRevision",
     );
@@ -129,6 +135,14 @@ describe("dashboard tab and settings surface", () => {
     expect(localServiceDashboard).toContain(
       "onAcceptedDraft={applyAcceptedSourceMonitoringDraft}",
     );
+    expect(foodRetailDashboard).toContain("<PhotoLibraryPanel");
+    expect(localServiceDashboard).toContain("<PhotoLibraryPanel");
+    expect(foodRetailDashboard).toContain("onCatalogChange={handlePhotoCatalogChange}");
+    expect(localServiceDashboard).toContain(
+      "onCatalogChange={handlePhotoCatalogChange}",
+    );
+    expect(foodRetailDashboard).not.toContain("Approved product image URL");
+    expect(localServiceDashboard).not.toContain("Project image URL");
     expect(sourceMonitoringPanel).toContain(
       "onAcceptedDraft({ revision: acceptedRevision, draft: result.draft })",
     );

--- a/src/lib/docs-capability-contract.test.ts
+++ b/src/lib/docs-capability-contract.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, it } from "bun:test";
+import {
+  isVerticalPublicationEnabled,
+  isVerticalPubliclyLaunched,
+  listVerticalIds,
+  resolveOwnerOperations,
+  resolveVerticalConfig,
+} from "@/lib/verticals/registry";
+import type { VerticalId } from "@/lib/verticals/types";
+
+const repoRoot = new URL("../..", import.meta.url);
+
+const CAPABILITY_HEADERS = [
+  "Vertical",
+  "Factory visibility",
+  "Standalone launch",
+  "Claim mode",
+  "Owner mutation",
+  "Platform publication",
+  "Custom domains",
+  "Monitoring",
+  "Leads",
+  "Articles",
+] as const;
+
+const STACK_MAJOR_PATTERNS = [
+  { packageName: "next", pattern: /Next\.js (\d+)/ },
+  { packageName: "react", pattern: /React (\d+)/ },
+  { packageName: "prisma", pattern: /Prisma (\d+)/ },
+  { packageName: "ai", pattern: /Vercel AI SDK (\d+)/ },
+  { packageName: "tailwindcss", pattern: /Tailwind CSS v(\d+)/ },
+] as const;
+
+const DOC_FILES = [
+  "README.md",
+  "docs/verticals/food-retail.md",
+  "docs/verticals/local-service.md",
+] as const;
+
+const GUIDE_VERTICAL: Record<
+  "docs/verticals/food-retail.md" | "docs/verticals/local-service.md",
+  VerticalId
+> = {
+  "docs/verticals/food-retail.md": "FOOD_RETAIL",
+  "docs/verticals/local-service.md": "LOCAL_SERVICE",
+};
+
+type PackageJson = {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  scripts?: Record<string, string>;
+};
+
+type MarkdownTable = {
+  headers: string[];
+  rows: string[][];
+};
+
+const [readme, foodRetailGuide, localServiceGuide, packageJson] =
+  await Promise.all([
+    readRepoFile("README.md"),
+    readRepoFile("docs/verticals/food-retail.md"),
+    readRepoFile("docs/verticals/local-service.md"),
+    readRepoJson("package.json"),
+  ]);
+
+const docsByPath = {
+  "README.md": readme,
+  "docs/verticals/food-retail.md": foodRetailGuide,
+  "docs/verticals/local-service.md": localServiceGuide,
+} as const;
+
+describe("documented vertical capabilities", () => {
+  it("keeps a README row for every registered vertical equal to the registry", () => {
+    const documented = capabilityRows(readme);
+    const expected = Object.fromEntries(
+      listVerticalIds().map((id) => [verticalLabel(id), expectedCapabilityRow(id)]),
+    );
+
+    expect(Object.keys(documented).sort()).toEqual(Object.keys(expected).sort());
+    expect(documented).toEqual(expected);
+  });
+
+  it("keeps Food Retail and Local Service guides on the same capability row", () => {
+    for (const relativePath of Object.keys(GUIDE_VERTICAL) as Array<
+      keyof typeof GUIDE_VERTICAL
+    >) {
+      const id = GUIDE_VERTICAL[relativePath];
+      expect(capabilityRows(docsByPath[relativePath])).toEqual({
+        [verticalLabel(id)]: expectedCapabilityRow(id),
+      });
+    }
+  });
+});
+
+describe("documented stack majors", () => {
+  it("matches package.json majors for every named stack package", () => {
+    for (const { packageName, pattern } of STACK_MAJOR_PATTERNS) {
+      const match = readme.match(pattern);
+      expect(match?.[1]).toBeDefined();
+      expect(Number(match?.[1])).toBe(packageMajor(packageName));
+    }
+
+    expect(packageMajor("prisma")).toBe(packageMajor("@prisma/client"));
+    expect(readme).not.toContain("Vercel AI SDK 6");
+  });
+});
+
+describe("documented links and commands", () => {
+  it("resolves internal documentation links and bun commands without network", async () => {
+    for (const relativePath of DOC_FILES) {
+      const source = docsByPath[relativePath];
+      const fileUrl = new URL(relativePath, repoRoot);
+
+      for (const target of markdownLinkTargets(source)) {
+        if (isExternalOrFragment(target)) continue;
+        const resolved = new URL(stripFragment(target), fileUrl);
+        expect(resolved.protocol).toBe("file:");
+        expect(await Bun.file(resolved).exists()).toBe(true);
+      }
+
+      for (const script of bunRunScripts(source)) {
+        expect(packageJson.scripts?.[script]).toBeDefined();
+      }
+
+      for (const binary of bunxBinaries(source)) {
+        expect(packageSpec(bunxPackageName(binary))).toBeDefined();
+      }
+    }
+  });
+});
+
+async function readRepoFile(relativePath: string): Promise<string> {
+  return Bun.file(new URL(relativePath, repoRoot)).text();
+}
+
+async function readRepoJson(relativePath: string): Promise<PackageJson> {
+  return Bun.file(new URL(relativePath, repoRoot)).json() as Promise<PackageJson>;
+}
+
+function verticalLabel(id: VerticalId): string {
+  return id
+    .toLowerCase()
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function expectedCapabilityRow(id: VerticalId): Record<string, string> {
+  const config = resolveVerticalConfig(id);
+  const operations = resolveOwnerOperations(id);
+  return {
+    Vertical: verticalLabel(id),
+    "Factory visibility": config.marketing.publiclyAccessible
+      ? "public"
+      : "private",
+    "Standalone launch": isVerticalPubliclyLaunched(id)
+      ? "launched"
+      : "unlaunched",
+    "Claim mode": config.claimMode,
+    "Owner mutation": operations.publicationMutation,
+    "Platform publication": isVerticalPublicationEnabled(id)
+      ? "enabled"
+      : "disabled",
+    "Custom domains": operations.customDomain,
+    Monitoring: operations.sourceMonitoring,
+    Leads: operations.bookingInbox,
+    Articles: operations.articles,
+  };
+}
+
+function capabilityRows(source: string): Record<string, Record<string, string>> {
+  const table = parseMarkdownTables(source).find((candidate) =>
+    headersMatch(candidate.headers, CAPABILITY_HEADERS),
+  );
+  expect(table).toBeDefined();
+  if (!table) return {};
+
+  const rows: Record<string, Record<string, string>> = {};
+  for (const cells of table.rows) {
+    expect(cells).toHaveLength(CAPABILITY_HEADERS.length);
+    const row = Object.fromEntries(
+      CAPABILITY_HEADERS.map((header, index) => [header, cells[index] ?? ""]),
+    );
+    const label = row.Vertical;
+    expect(label).toBeTruthy();
+    expect(rows[label]).toBeUndefined();
+    rows[label] = row;
+  }
+  return rows;
+}
+
+function parseMarkdownTables(source: string): MarkdownTable[] {
+  const tables: MarkdownTable[] = [];
+  const lines = source.split("\n");
+  for (let index = 0; index < lines.length - 1; index += 1) {
+    const headers = splitRow(lines[index] ?? "");
+    const divider = splitRow(lines[index + 1] ?? "");
+    if (!headers || !divider || !isDividerRow(divider)) continue;
+    if (headers.length !== divider.length) continue;
+
+    const rows: string[][] = [];
+    let cursor = index + 2;
+    while (cursor < lines.length) {
+      const cells = splitRow(lines[cursor] ?? "");
+      if (!cells || cells.length !== headers.length) break;
+      if (!isDividerRow(cells)) rows.push(cells);
+      cursor += 1;
+    }
+    tables.push({ headers, rows });
+  }
+  return tables;
+}
+
+function splitRow(line: string): string[] | null {
+  const trimmed = line.trim();
+  if (!trimmed.includes("|")) return null;
+  return trimmed
+    .replace(/^\|/, "")
+    .replace(/\|$/, "")
+    .split("|")
+    .map((cell) => cell.trim());
+}
+
+function isDividerRow(cells: string[]): boolean {
+  return cells.every((cell) => /^:?-{3,}:?$/.test(cell));
+}
+
+function headersMatch(
+  headers: string[],
+  expected: readonly string[],
+): boolean {
+  return (
+    headers.length === expected.length &&
+    expected.every((header, index) => headers[index] === header)
+  );
+}
+
+function packageSpec(name: string): string | undefined {
+  return packageJson.dependencies?.[name] ?? packageJson.devDependencies?.[name];
+}
+
+function packageMajor(name: string): number {
+  const spec = packageSpec(name);
+  const match = spec?.match(/\d+/);
+  if (!match) {
+    throw new Error(`Missing version for ${name}`);
+  }
+  return Number(match[0]);
+}
+
+function markdownLinkTargets(source: string): string[] {
+  return [...source.matchAll(/\[[^\]]*]\(([^)]+)\)/g)].map((match) => {
+    const raw = match[1]?.trim() ?? "";
+    const space = raw.search(/\s/);
+    return space === -1 ? raw : raw.slice(0, space);
+  });
+}
+
+function isExternalOrFragment(target: string): boolean {
+  return (
+    target.startsWith("#") ||
+    target.startsWith("http://") ||
+    target.startsWith("https://") ||
+    target.startsWith("mailto:")
+  );
+}
+
+function stripFragment(target: string): string {
+  const hash = target.indexOf("#");
+  return hash === -1 ? target : target.slice(0, hash);
+}
+
+function bunRunScripts(source: string): string[] {
+  return [...source.matchAll(/\bbun run ([a-zA-Z0-9:_-]+)/g)].map(
+    (match) => match[1] ?? "",
+  );
+}
+
+function bunxBinaries(source: string): string[] {
+  return [...source.matchAll(/\bbunx(?: --bun)? ([a-zA-Z0-9@/_-]+)/g)].map(
+    (match) => match[1] ?? "",
+  );
+}
+
+function bunxPackageName(binary: string): string {
+  if (binary === "tsc") return "typescript";
+  if (binary === "next") return "next";
+  return binary;
+}

--- a/src/lib/owner-draft-dirty-state.dashboard.test.tsx
+++ b/src/lib/owner-draft-dirty-state.dashboard.test.tsx
@@ -1,0 +1,149 @@
+import { describe, expect, it, mock } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+mock.module("next/navigation", () => ({
+  useRouter: () => ({
+    push: () => {},
+    replace: () => {},
+    refresh: () => {},
+    back: () => {},
+    prefetch: () => {},
+  }),
+  usePathname: () => "/dashboard",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+import { Dashboard } from "@/app/dashboard/dashboard";
+import { FoodRetailDashboard } from "@/app/dashboard/food-retail-dashboard";
+import { LocalServiceDashboard } from "@/app/dashboard/local-service-dashboard";
+import { AccountActions } from "@/components/account-actions";
+import { buildEmptyAnalyticsSummary } from "@/lib/analytics-contract";
+import { FACTORY_BRAND } from "@/lib/brand";
+import { sampleRestaurant } from "@/lib/restaurant";
+import { sampleFoodRetailDraft } from "@/lib/verticals/food-retail/fixtures";
+import { sampleLocalServiceSiteDraft } from "@/lib/verticals/local-service/fixtures";
+
+const dashboard = await Bun.file(
+  new URL("../app/dashboard/dashboard.tsx", import.meta.url),
+).text();
+const foodRetailDashboard = await Bun.file(
+  new URL("../app/dashboard/food-retail-dashboard.tsx", import.meta.url),
+).text();
+const localServiceDashboard = await Bun.file(
+  new URL("../app/dashboard/local-service-dashboard.tsx", import.meta.url),
+).text();
+const accountActions = await Bun.file(
+  new URL("../components/account-actions.tsx", import.meta.url),
+).text();
+const dirtyState = await Bun.file(
+  new URL("./owner-draft-dirty-state.ts", import.meta.url),
+).text();
+
+const dashboardSources = [
+  ["restaurant", dashboard],
+  ["food-retail", foodRetailDashboard],
+  ["local-service", localServiceDashboard],
+] as const;
+
+describe("vertical dashboards share one dirty-state contract", () => {
+  it("wires the shared hook, unload guard, and navigation intercept on every owner dashboard", () => {
+    expect(dirtyState).toContain("window.onbeforeunload");
+    expect(dirtyState).toContain("beforeunload");
+    expect(dirtyState).toContain("confirmDiscardUnsavedOwnerEdits");
+    expect(dirtyState).toContain("reconcileOwnerDraftAuxiliary");
+
+    for (const [, source] of dashboardSources) {
+      expect(source).toContain("useOwnerDraftDirtyState");
+      expect(source).toContain("OwnerDraftDirtyGuard");
+      expect(source).toContain("ownerDraftNavigationProps");
+      expect(source).toContain("applyAuxiliary");
+      expect(source).toContain("hasUnsavedChanges={dirty}");
+      expect(source).not.toContain("addEventListener(\"beforeunload\"");
+    }
+
+    expect(accountActions).toContain("useOwnerUnsavedEdits");
+    expect(accountActions).toContain("confirmDiscardUnsavedOwnerEdits");
+    expect(accountActions).toContain('href="/workspace/select"');
+    expect(accountActions).toContain("/api/auth/logout");
+  });
+
+  it("renders clean dashboards without an unsaved prompt surface", () => {
+    const restaurantHtml = renderToStaticMarkup(
+      <Dashboard
+        initialDraft={sampleRestaurant}
+        initialDraftRevision={4}
+        email="owner@example.com"
+        checkoutComplete={false}
+        demo
+        brand={FACTORY_BRAND}
+        analyticsSummary={buildEmptyAnalyticsSummary(
+          new Date("2026-08-23T00:00:00.000Z"),
+        )}
+        bookingInbox={{
+          requests: [],
+          total: 0,
+          awaitingContact: 0,
+          truncated: false,
+        }}
+        billingAccess={null}
+        publicationHistory={[]}
+        canSwitchWorkspace
+        sourceMonitoring={{
+          cadenceDays: null,
+          nextRunAt: null,
+          lastRunAt: null,
+          lastSuccessAt: null,
+          lastFailureAt: null,
+          lastFailureCode: null,
+          latestRun: null,
+          suggestions: [],
+        }}
+        platformUrl="https://osteria-luna.cornershop.dev"
+      />,
+    );
+    const foodRetailHtml = renderToStaticMarkup(
+      <FoodRetailDashboard
+        email="owner@example.com"
+        brand={FACTORY_BRAND}
+        initialDraft={sampleFoodRetailDraft}
+        initialRevision={7}
+        initiallyPublished={false}
+        canSwitchWorkspace
+        platformUrl="https://bakery.cornershop.dev"
+      />,
+    );
+    const localServiceHtml = renderToStaticMarkup(
+      <LocalServiceDashboard
+        initialDraft={sampleLocalServiceSiteDraft}
+        initialRevision={7}
+        email="owner@harbourelectrical.example"
+        brand={FACTORY_BRAND}
+        canSwitchWorkspace
+        initiallyPublished={false}
+        platformUrl="https://harbour-electrical.cornershop.dev"
+      />,
+    );
+
+    expect(restaurantHtml).toContain("Saved");
+    expect(foodRetailHtml).toContain("Saved");
+    expect(localServiceHtml).toContain("Saved");
+    expect(localServiceHtml).toContain("Draft revision 7");
+    expect(foodRetailHtml).toContain("Switch workspace");
+    expect(restaurantHtml).not.toContain("Unsaved changes");
+    expect(localServiceHtml).not.toContain("Unsaved changes");
+
+    const actions = renderToStaticMarkup(<AccountActions canSwitch />);
+    expect(actions).toContain("Switch workspace");
+    expect(actions).toContain("Sign out");
+    expect(actions).toContain("/workspace/select");
+  });
+
+  it("keeps restaurant settings and food-retail edits on the shared setDraft path", () => {
+    expect(dashboard).toContain('id="restaurant-name"');
+    expect(dashboard).toContain("setDraft((current) => ({");
+    expect(dashboard).toContain("showMenuImages: checked");
+    expect(foodRetailDashboard).toContain("setDraft({ ...draft, name:");
+    expect(localServiceDashboard).toContain("function change(");
+    expect(localServiceDashboard).toContain("setDraft((current) => {");
+  });
+});

--- a/src/lib/owner-draft-dirty-state.test.ts
+++ b/src/lib/owner-draft-dirty-state.test.ts
@@ -1,0 +1,336 @@
+import { describe, expect, it, mock } from "bun:test";
+import { sampleRestaurant } from "@/lib/restaurant";
+import { sampleFoodRetailDraft } from "@/lib/verticals/food-retail/fixtures";
+import { sampleLocalServiceSiteDraft } from "@/lib/verticals/local-service/fixtures";
+import {
+  OWNER_UNSAVED_EDITS_MESSAGE,
+  acknowledgeOwnerDraftSave,
+  acknowledgeOwnerDraftSnapshot,
+  applyOwnerDraftEdit,
+  beginOwnerDraftSave,
+  confirmDiscardUnsavedOwnerEdits,
+  createOwnerDraftDirtyState,
+  interceptOwnerNavigationClick,
+  ownerDraftBeforeUnloadHandler,
+  reconcileOwnerDraftAuxiliary,
+} from "@/lib/owner-draft-dirty-state";
+
+type Snapshot = {
+  name: string;
+  hero: string;
+};
+
+const verticalSamples = [
+  ["restaurant", sampleRestaurant],
+  ["food-retail", sampleFoodRetailDraft],
+  ["local-service", sampleLocalServiceSiteDraft],
+] as const;
+
+function snapshot(name = "Chez Léa", hero = "hero-1"): Snapshot {
+  return { name, hero };
+}
+
+function installWindow(confirmImpl: () => boolean = () => false) {
+  const confirm = mock(confirmImpl);
+  const previous = (globalThis as { window?: unknown }).window;
+  (globalThis as { window: unknown }).window = {
+    confirm,
+    location: {
+      href: "https://cornershop.dev/dashboard",
+      origin: "https://cornershop.dev",
+      pathname: "/dashboard",
+      search: "",
+    },
+  };
+  return {
+    confirm,
+    restore() {
+      if (previous === undefined) {
+        delete (globalThis as { window?: unknown }).window;
+      } else {
+        (globalThis as { window: unknown }).window = previous;
+      }
+    },
+  };
+}
+
+describe("owner draft dirty-state machine", () => {
+  it("starts clean and does not prompt", () => {
+    const api = installWindow(() => false);
+    const state = createOwnerDraftDirtyState(snapshot(), 4);
+
+    expect(state.dirty).toBe(false);
+    expect(state.revision).toBe(4);
+    expect(confirmDiscardUnsavedOwnerEdits(state.dirty)).toBe(true);
+    expect(api.confirm).not.toHaveBeenCalled();
+    api.restore();
+  });
+
+  it("marks every edit path dirty until the exact submitted snapshot is acknowledged", () => {
+    let state = createOwnerDraftDirtyState(snapshot(), 4);
+    state = applyOwnerDraftEdit(state, snapshot("Chez Léa edited"));
+    expect(state.dirty).toBe(true);
+    expect(state.mutationVersion).toBe(1);
+
+    const submitted = beginOwnerDraftSave(state);
+    const persisted = snapshot("Chez Léa edited");
+    const acknowledged = acknowledgeOwnerDraftSave(state, {
+      submittedDraft: submitted.submittedDraft,
+      persistedDraft: persisted,
+      submittedMutationVersion: submitted.submittedMutationVersion,
+      savedRevision: 5,
+    });
+
+    expect(acknowledged.hadNewerEdits).toBe(false);
+    expect(acknowledged.state.dirty).toBe(false);
+    expect(acknowledged.state.revision).toBe(5);
+    expect(acknowledged.state.draft).toEqual(persisted);
+  });
+
+  it("keeps in-flight edits and does not overwrite them when the save returns", () => {
+    let state = createOwnerDraftDirtyState(snapshot(), 4);
+    state = applyOwnerDraftEdit(state, snapshot("Submitted name"));
+    const submitted = beginOwnerDraftSave(state);
+    state = applyOwnerDraftEdit(state, snapshot("Typed while saving"));
+
+    const acknowledged = acknowledgeOwnerDraftSave(state, {
+      submittedDraft: submitted.submittedDraft,
+      persistedDraft: snapshot("Submitted name"),
+      submittedMutationVersion: submitted.submittedMutationVersion,
+      savedRevision: 5,
+    });
+
+    expect(acknowledged.hadNewerEdits).toBe(true);
+    expect(acknowledged.state.dirty).toBe(true);
+    expect(acknowledged.state.draft.name).toBe("Typed while saving");
+    expect(acknowledged.state.revision).toBe(5);
+    expect(acknowledged.state.baseline.name).toBe("Submitted name");
+  });
+
+  it("reconciles directly persisted photo-library patches without false dirty", () => {
+    for (const [vertical, sample] of verticalSamples) {
+      const state = createOwnerDraftDirtyState(sample, 7);
+      const patched = reconcileOwnerDraftAuxiliary(
+        state,
+        (draft) => ({
+          ...draft,
+          heroImageUrl: "https://photos.example/hero.webp",
+        }),
+        8,
+      );
+
+      expect(typeof vertical).toBe("string");
+      expect(patched.dirty).toBe(false);
+      expect(patched.revision).toBe(8);
+      expect(patched.draft.heroImageUrl).toBe(
+        "https://photos.example/hero.webp",
+      );
+      expect(patched.baseline.heroImageUrl).toBe(
+        "https://photos.example/hero.webp",
+      );
+      expect(confirmDiscardUnsavedOwnerEdits(patched.dirty)).toBe(true);
+    }
+  });
+
+  it("keeps owner edits dirty when a photo-library patch lands on the same snapshot", () => {
+    let state = createOwnerDraftDirtyState(snapshot(), 1);
+    state = applyOwnerDraftEdit(state, snapshot("Unsaved name"));
+    const patched = reconcileOwnerDraftAuxiliary(
+      state,
+      (draft) => ({ ...draft, hero: "hero-reviewed" }),
+      2,
+    );
+
+    expect(patched.dirty).toBe(true);
+    expect(patched.draft).toEqual({
+      name: "Unsaved name",
+      hero: "hero-reviewed",
+    });
+    expect(patched.baseline).toEqual({
+      name: "Chez Léa",
+      hero: "hero-reviewed",
+    });
+  });
+
+  it("does not let an exact save acknowledgement clobber a photo-library patch", () => {
+    let state = createOwnerDraftDirtyState(snapshot(), 1);
+    state = applyOwnerDraftEdit(state, snapshot("Saved name"));
+    const submitted = beginOwnerDraftSave(state);
+    state = reconcileOwnerDraftAuxiliary(
+      state,
+      (draft) => ({ ...draft, hero: "hero-reviewed" }),
+      3,
+    );
+
+    const acknowledged = acknowledgeOwnerDraftSave(state, {
+      submittedDraft: submitted.submittedDraft,
+      persistedDraft: snapshot("Saved name"),
+      submittedMutationVersion: submitted.submittedMutationVersion,
+      savedRevision: 4,
+    });
+
+    expect(acknowledged.hadNewerEdits).toBe(false);
+    expect(acknowledged.state.dirty).toBe(false);
+    expect(acknowledged.state.draft).toEqual({
+      name: "Saved name",
+      hero: "hero-reviewed",
+    });
+    expect(acknowledged.state.revision).toBe(4);
+  });
+
+  it("treats a source-monitoring accept as an acknowledged snapshot", () => {
+    let state = createOwnerDraftDirtyState(snapshot(), 2);
+    state = applyOwnerDraftEdit(state, snapshot("Should be replaced"));
+    const accepted = snapshot("Monitored name", "hero-2");
+    state = acknowledgeOwnerDraftSnapshot(state, accepted, 9);
+
+    expect(state.dirty).toBe(false);
+    expect(state.draft).toEqual(accepted);
+    expect(state.baseline).toEqual(accepted);
+    expect(state.revision).toBe(9);
+  });
+
+  it("clears dirty only for the submitted snapshot, not a later one", () => {
+    let state = createOwnerDraftDirtyState(snapshot(), 1);
+    state = applyOwnerDraftEdit(state, snapshot("First"));
+    const first = beginOwnerDraftSave(state);
+    state = applyOwnerDraftEdit(state, snapshot("Second"));
+    const second = beginOwnerDraftSave(state);
+
+    const firstAck = acknowledgeOwnerDraftSave(state, {
+      submittedDraft: first.submittedDraft,
+      persistedDraft: snapshot("First"),
+      submittedMutationVersion: first.submittedMutationVersion,
+      savedRevision: 2,
+    });
+    expect(firstAck.hadNewerEdits).toBe(true);
+    expect(firstAck.state.dirty).toBe(true);
+    expect(firstAck.state.draft.name).toBe("Second");
+
+    const secondAck = acknowledgeOwnerDraftSave(firstAck.state, {
+      submittedDraft: second.submittedDraft,
+      persistedDraft: snapshot("Second"),
+      submittedMutationVersion: second.submittedMutationVersion,
+      savedRevision: 3,
+    });
+    expect(secondAck.hadNewerEdits).toBe(false);
+    expect(secondAck.state.dirty).toBe(false);
+    expect(secondAck.state.draft.name).toBe("Second");
+  });
+});
+
+describe("owner draft navigation and unload guards", () => {
+  it("does not prompt on beforeunload or in-app navigation when clean", () => {
+    const api = installWindow(() => false);
+    let prevented = false;
+    const unload = {
+      preventDefault() {
+        prevented = true;
+      },
+      returnValue: "",
+    } as BeforeUnloadEvent;
+
+    expect(ownerDraftBeforeUnloadHandler(unload, false)).toBeUndefined();
+    expect(prevented).toBe(false);
+
+    interceptOwnerNavigationClick(
+      {
+        target: fakeAnchor("/workspace/select"),
+        preventDefault() {
+          prevented = true;
+        },
+        defaultPrevented: false,
+        metaKey: false,
+        ctrlKey: false,
+        shiftKey: false,
+        altKey: false,
+        button: 0,
+      },
+      false,
+    );
+
+    expect(prevented).toBe(false);
+    expect(api.confirm).not.toHaveBeenCalled();
+    api.restore();
+  });
+
+  it("warns on browser unload, in-app navigation, workspace switch, and sign-out when dirty", () => {
+    const api = installWindow(() => false);
+    let unloadPrevented = false;
+    const unload = {
+      preventDefault() {
+        unloadPrevented = true;
+      },
+      returnValue: "",
+    } as BeforeUnloadEvent;
+
+    expect(ownerDraftBeforeUnloadHandler(unload, true)).toBe(
+      OWNER_UNSAVED_EDITS_MESSAGE,
+    );
+    expect(unloadPrevented).toBe(true);
+    expect(unload.returnValue).toBe(OWNER_UNSAVED_EDITS_MESSAGE);
+
+    for (const href of ["/workspace/select", "/sign-in", "/create"]) {
+      api.confirm.mockClear();
+      let navigationPrevented = false;
+      interceptOwnerNavigationClick(
+        {
+          target: fakeAnchor(href),
+          preventDefault() {
+            navigationPrevented = true;
+          },
+          defaultPrevented: false,
+          metaKey: false,
+          ctrlKey: false,
+          shiftKey: false,
+          altKey: false,
+          button: 0,
+        },
+        true,
+      );
+      expect(api.confirm).toHaveBeenCalledWith(OWNER_UNSAVED_EDITS_MESSAGE);
+      expect(navigationPrevented).toBe(true);
+    }
+
+    api.confirm.mockClear();
+    expect(confirmDiscardUnsavedOwnerEdits(true)).toBe(false);
+    expect(api.confirm).toHaveBeenCalledWith(OWNER_UNSAVED_EDITS_MESSAGE);
+    api.restore();
+  });
+
+  it("does not intercept new-tab preview links", () => {
+    const api = installWindow(() => false);
+    let prevented = false;
+    interceptOwnerNavigationClick(
+      {
+        target: fakeAnchor("/preview/osteria-luna", "_blank"),
+        preventDefault() {
+          prevented = true;
+        },
+        defaultPrevented: false,
+        metaKey: false,
+        ctrlKey: false,
+        shiftKey: false,
+        altKey: false,
+        button: 0,
+      },
+      true,
+    );
+    expect(prevented).toBe(false);
+    expect(api.confirm).not.toHaveBeenCalled();
+    api.restore();
+  });
+});
+
+function fakeAnchor(href: string, target = "") {
+  return {
+    closest: (selector: string) =>
+      selector === "a"
+        ? {
+            target,
+            getAttribute: (name: string) => (name === "href" ? href : null),
+            hasAttribute: () => false,
+          }
+        : null,
+  };
+}

--- a/src/lib/owner-draft-dirty-state.ts
+++ b/src/lib/owner-draft-dirty-state.ts
@@ -1,0 +1,400 @@
+"use client";
+
+import {
+  createContext,
+  createElement,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+  type ReactNode,
+} from "react";
+
+export const OWNER_UNSAVED_EDITS_MESSAGE =
+  "You have unsaved changes. Leave this page and discard them?";
+
+export type OwnerDraftDirtyState<T> = {
+  draft: T;
+  baseline: T;
+  revision: number;
+  mutationVersion: number;
+  dirty: boolean;
+};
+
+export type OwnerDraftSaveAcknowledgement<T> = {
+  submittedDraft: T;
+  persistedDraft: T;
+  submittedMutationVersion: number;
+  savedRevision: number;
+};
+
+export function ownerDraftSnapshotsEqual(
+  left: unknown,
+  right: unknown,
+): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+export function createOwnerDraftDirtyState<T>(
+  draft: T,
+  revision: number,
+): OwnerDraftDirtyState<T> {
+  return {
+    draft,
+    baseline: structuredClone(draft),
+    revision,
+    mutationVersion: 0,
+    dirty: false,
+  };
+}
+
+export function applyOwnerDraftEdit<T>(
+  state: OwnerDraftDirtyState<T>,
+  nextDraft: T,
+): OwnerDraftDirtyState<T> {
+  return {
+    ...state,
+    draft: nextDraft,
+    mutationVersion: state.mutationVersion + 1,
+    dirty: !ownerDraftSnapshotsEqual(nextDraft, state.baseline),
+  };
+}
+
+export function beginOwnerDraftSave<T>(state: OwnerDraftDirtyState<T>): {
+  submittedDraft: T;
+  submittedMutationVersion: number;
+  expectedRevision: number;
+} {
+  return {
+    submittedDraft: state.draft,
+    submittedMutationVersion: state.mutationVersion,
+    expectedRevision: state.revision,
+  };
+}
+
+export function acknowledgeOwnerDraftSave<T>(
+  state: OwnerDraftDirtyState<T>,
+  acknowledgement: OwnerDraftSaveAcknowledgement<T>,
+): { state: OwnerDraftDirtyState<T>; hadNewerEdits: boolean } {
+  const hadNewerEdits =
+    state.mutationVersion !== acknowledgement.submittedMutationVersion;
+  if (hadNewerEdits) {
+    return {
+      state: {
+        ...state,
+        baseline: acknowledgement.persistedDraft,
+        revision: acknowledgement.savedRevision,
+        dirty: !ownerDraftSnapshotsEqual(
+          state.draft,
+          acknowledgement.persistedDraft,
+        ),
+      },
+      hadNewerEdits: true,
+    };
+  }
+
+  const nextDraft = ownerDraftSnapshotsEqual(
+    state.draft,
+    acknowledgement.submittedDraft,
+  )
+    ? acknowledgement.persistedDraft
+    : state.draft;
+  return {
+    state: {
+      ...state,
+      draft: nextDraft,
+      baseline: structuredClone(nextDraft),
+      revision: acknowledgement.savedRevision,
+      dirty: false,
+    },
+    hadNewerEdits: false,
+  };
+}
+
+export function reconcileOwnerDraftAuxiliary<T>(
+  state: OwnerDraftDirtyState<T>,
+  patch: (draft: T) => T,
+  revision: number = state.revision,
+): OwnerDraftDirtyState<T> {
+  const draft = patch(state.draft);
+  const baseline = patch(state.baseline);
+  return {
+    ...state,
+    draft,
+    baseline,
+    revision,
+    dirty: !ownerDraftSnapshotsEqual(draft, baseline),
+  };
+}
+
+export function acknowledgeOwnerDraftSnapshot<T>(
+  state: OwnerDraftDirtyState<T>,
+  snapshot: T,
+  revision: number,
+): OwnerDraftDirtyState<T> {
+  return {
+    ...state,
+    draft: snapshot,
+    baseline: structuredClone(snapshot),
+    revision,
+    dirty: false,
+  };
+}
+
+export function adoptOwnerDraftServerState<T>(
+  state: OwnerDraftDirtyState<T>,
+  input: { draft: T; baseline: T; revision: number },
+): OwnerDraftDirtyState<T> {
+  return {
+    ...state,
+    draft: input.draft,
+    baseline: input.baseline,
+    revision: input.revision,
+    dirty: !ownerDraftSnapshotsEqual(input.draft, input.baseline),
+  };
+}
+
+export function setOwnerDraftRevision<T>(
+  state: OwnerDraftDirtyState<T>,
+  revision: number,
+): OwnerDraftDirtyState<T> {
+  return { ...state, revision };
+}
+
+export function confirmDiscardUnsavedOwnerEdits(dirty: boolean): boolean {
+  if (!dirty) return true;
+  return window.confirm(OWNER_UNSAVED_EDITS_MESSAGE);
+}
+
+export function ownerDraftBeforeUnloadHandler(
+  event: BeforeUnloadEvent,
+  dirty: boolean,
+): string | undefined {
+  if (!dirty) return undefined;
+  event.preventDefault();
+  event.returnValue = OWNER_UNSAVED_EDITS_MESSAGE;
+  return OWNER_UNSAVED_EDITS_MESSAGE;
+}
+
+type OwnerNavigationClickEvent = {
+  target: unknown;
+  preventDefault: () => void;
+  defaultPrevented: boolean;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+  button: number;
+};
+
+function closestAnchor(target: unknown): {
+  target: string;
+  href: string | null;
+  download: boolean;
+} | null {
+  if (target === null || typeof target !== "object") return null;
+  const withClosest =
+    typeof (target as { closest?: unknown }).closest === "function"
+      ? target
+      : (target as { parentElement?: unknown }).parentElement;
+  if (withClosest === null || typeof withClosest !== "object") return null;
+  const element = withClosest as {
+    closest?: (selector: string) => unknown;
+  };
+  if (typeof element.closest !== "function") return null;
+  const anchor = element.closest("a") as {
+    target: string;
+    getAttribute?: (name: string) => string | null;
+    hasAttribute?: (name: string) => boolean;
+    href?: string;
+  } | null;
+  if (!anchor) return null;
+  return {
+    target: anchor.target ?? "",
+    href:
+      typeof anchor.getAttribute === "function"
+        ? anchor.getAttribute("href")
+        : (anchor.href ?? null),
+    download:
+      typeof anchor.hasAttribute === "function"
+        ? anchor.hasAttribute("download")
+        : false,
+  };
+}
+
+export function interceptOwnerNavigationClick(
+  event: OwnerNavigationClickEvent,
+  dirty: boolean,
+): void {
+  if (!dirty || event.defaultPrevented) return;
+  if (event.button !== 0) return;
+  if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+  const anchor = closestAnchor(event.target);
+  if (!anchor || anchor.download) return;
+  if (anchor.target === "_blank" || anchor.target === "_new") return;
+  const href = anchor.href;
+  if (!href || href.startsWith("#") || href.startsWith("javascript:")) return;
+  let destination: URL;
+  try {
+    destination = new URL(href, window.location.href);
+  } catch {
+    return;
+  }
+  if (destination.origin !== window.location.origin) return;
+  if (
+    destination.pathname === window.location.pathname &&
+    destination.search === window.location.search
+  ) {
+    return;
+  }
+  if (!confirmDiscardUnsavedOwnerEdits(true)) {
+    event.preventDefault();
+  }
+}
+
+const OwnerDraftDirtyContext = createContext(false);
+
+export function useOwnerUnsavedEdits(): boolean {
+  return useContext(OwnerDraftDirtyContext);
+}
+
+export function useOwnerDraftUnloadProtection(dirty: boolean) {
+  useEffect(() => {
+    if (!dirty) return;
+    const previous = window.onbeforeunload;
+    const handler = (event: BeforeUnloadEvent) =>
+      ownerDraftBeforeUnloadHandler(event, true);
+    window.onbeforeunload = handler;
+    return () => {
+      if (window.onbeforeunload === handler) {
+        window.onbeforeunload = previous;
+      }
+    };
+  }, [dirty]);
+}
+
+export function ownerDraftNavigationProps(dirty: boolean): {
+  onClickCapture: (event: ReactMouseEvent<HTMLElement>) => void;
+} {
+  return {
+    onClickCapture: (event: ReactMouseEvent<HTMLElement>) => {
+      interceptOwnerNavigationClick(event, dirty);
+    },
+  };
+}
+
+export function OwnerDraftDirtyGuard({
+  dirty,
+  children,
+}: {
+  dirty: boolean;
+  children: ReactNode;
+}) {
+  useOwnerDraftUnloadProtection(dirty);
+  return createElement(
+    OwnerDraftDirtyContext.Provider,
+    { value: dirty },
+    children,
+  );
+}
+
+export function useOwnerDraftDirtyState<T>(
+  initialDraft: T,
+  initialRevision: number,
+) {
+  const [state, setState] = useState(() =>
+    createOwnerDraftDirtyState(initialDraft, initialRevision),
+  );
+  const stateRef = useRef(state);
+  const draftRef = useRef(state.draft);
+
+  const commit = useCallback((next: OwnerDraftDirtyState<T>) => {
+    stateRef.current = next;
+    draftRef.current = next.draft;
+    setState(next);
+  }, []);
+
+  const setDraft = useCallback(
+    (next: T | ((current: T) => T)) => {
+      const current = stateRef.current;
+      const resolved =
+        typeof next === "function"
+          ? (next as (current: T) => T)(current.draft)
+          : next;
+      commit(applyOwnerDraftEdit(current, resolved));
+    },
+    [commit],
+  );
+
+  const applyAuxiliary = useCallback(
+    (patch: (draft: T) => T, revision?: number) => {
+      const current = stateRef.current;
+      commit(
+        reconcileOwnerDraftAuxiliary(
+          current,
+          patch,
+          revision ?? current.revision,
+        ),
+      );
+    },
+    [commit],
+  );
+
+  const setRevision = useCallback(
+    (revision: number) => {
+      commit(setOwnerDraftRevision(stateRef.current, revision));
+    },
+    [commit],
+  );
+
+  const beginSave = useCallback(
+    () => beginOwnerDraftSave(stateRef.current),
+    [],
+  );
+
+  const acknowledgeSave = useCallback(
+    (acknowledgement: OwnerDraftSaveAcknowledgement<T>) => {
+      const reconciled = acknowledgeOwnerDraftSave(
+        stateRef.current,
+        acknowledgement,
+      );
+      commit(reconciled.state);
+      return reconciled;
+    },
+    [commit],
+  );
+
+  const acknowledgeSnapshot = useCallback(
+    (snapshot: T, revision: number) => {
+      commit(
+        acknowledgeOwnerDraftSnapshot(stateRef.current, snapshot, revision),
+      );
+    },
+    [commit],
+  );
+
+  const adoptServerDraft = useCallback(
+    (input: { draft: T; baseline: T; revision: number }) => {
+      commit(adoptOwnerDraftServerState(stateRef.current, input));
+    },
+    [commit],
+  );
+
+  return {
+    draft: state.draft,
+    baseline: state.baseline,
+    revision: state.revision,
+    dirty: state.dirty,
+    mutationVersion: state.mutationVersion,
+    draftRef,
+    setDraft,
+    applyAuxiliary,
+    setRevision,
+    beginSave,
+    acknowledgeSave,
+    acknowledgeSnapshot,
+    adoptServerDraft,
+  };
+}

--- a/src/lib/owner-operations.test.ts
+++ b/src/lib/owner-operations.test.ts
@@ -61,6 +61,9 @@ describe("owner operations capability model", () => {
     expect(localServiceDashboard).toContain("useOwnerPaidOperations");
     expect(foodRetailDashboard).toContain("OwnerPaidOperationsSection");
     expect(localServiceDashboard).toContain("OwnerPaidOperationsSection");
+    expect(dashboardPage).toContain("getSourceMonitoringDashboard(access.site.id)");
+    expect(foodRetailDashboard).toContain("SourceMonitoringPanel");
+    expect(localServiceDashboard).toContain("SourceMonitoringPanel");
   });
 
   it("enables billing, publication, domain, and workspace switching for owner-review verticals", () => {
@@ -78,20 +81,23 @@ describe("owner operations capability model", () => {
     }
   });
 
-  it("keeps food-retail and local-service monitoring, articles, and photos explicit not-yet states", () => {
+  it("enables source monitoring for owner-review verticals and keeps later surfaces explicit not-yet", () => {
+    for (const id of [
+      Vertical.RESTAURANT,
+      Vertical.FOOD_RETAIL,
+      Vertical.LOCAL_SERVICE,
+    ] as const) {
+      expect(resolveOwnerOperations(id).sourceMonitoring).toBe("enabled");
+    }
     for (const ops of [
       resolveOwnerOperations(Vertical.FOOD_RETAIL),
       resolveOwnerOperations(Vertical.LOCAL_SERVICE),
     ]) {
-      expect(ops.sourceMonitoring).toBe("not-yet");
       expect(ops.articles).toBe("not-yet");
       expect(ops.photoLibrary).toBe("not-yet");
       expect(ops.analytics).toBe("not-yet");
       expect(ops.bookingInbox).toBe("not-yet");
     }
-    expect(resolveOwnerOperations(Vertical.RESTAURANT).sourceMonitoring).toBe(
-      "enabled",
-    );
   });
 
   it("fails closed for beauty paid operations even if a leftover enabled flag is present", () => {

--- a/src/lib/owner-operations.test.ts
+++ b/src/lib/owner-operations.test.ts
@@ -64,6 +64,8 @@ describe("owner operations capability model", () => {
     expect(dashboardPage).toContain("getSourceMonitoringDashboard(access.site.id)");
     expect(foodRetailDashboard).toContain("SourceMonitoringPanel");
     expect(localServiceDashboard).toContain("SourceMonitoringPanel");
+    expect(foodRetailDashboard).toContain("PhotoLibraryPanel");
+    expect(localServiceDashboard).toContain("PhotoLibraryPanel");
   });
 
   it("enables billing, publication, domain, and workspace switching for owner-review verticals", () => {
@@ -81,20 +83,20 @@ describe("owner operations capability model", () => {
     }
   });
 
-  it("enables source monitoring for owner-review verticals and keeps later surfaces explicit not-yet", () => {
+  it("enables source monitoring and the photo library for owner-review verticals", () => {
     for (const id of [
       Vertical.RESTAURANT,
       Vertical.FOOD_RETAIL,
       Vertical.LOCAL_SERVICE,
     ] as const) {
       expect(resolveOwnerOperations(id).sourceMonitoring).toBe("enabled");
+      expect(resolveOwnerOperations(id).photoLibrary).toBe("enabled");
     }
     for (const ops of [
       resolveOwnerOperations(Vertical.FOOD_RETAIL),
       resolveOwnerOperations(Vertical.LOCAL_SERVICE),
     ]) {
       expect(ops.articles).toBe("not-yet");
-      expect(ops.photoLibrary).toBe("not-yet");
       expect(ops.analytics).toBe("not-yet");
       expect(ops.bookingInbox).toBe("not-yet");
     }

--- a/src/lib/owner-operations.test.tsx
+++ b/src/lib/owner-operations.test.tsx
@@ -138,7 +138,10 @@ describe("shared owner paid operations surface", () => {
       expect(html).toContain("Version 3");
       expect(html).toContain("Rollback");
       expect(html).toContain("Use your own domain (optional)");
-      expect(html).toContain("Source monitoring is not ready for this workspace yet.");
+      expect(html).toContain("Changes wait for your approval.");
+      expect(html).not.toContain(
+        "Source monitoring is not ready for this workspace yet.",
+      );
       expect(html).toContain("The photo library is not ready for this workspace yet.");
       expect(html).not.toContain("Restofront");
       expect(html).not.toContain("restaurant.com");
@@ -172,5 +175,29 @@ describe("shared owner paid operations surface", () => {
     );
     expect(html).not.toContain("Last source check");
     expect(restaurantOwnerOperations.sourceMonitoring).toBe("enabled");
+  });
+
+  it("keeps the shared monitoring panel fail-closed when the registry disables it", () => {
+    const html = renderToStaticMarkup(
+      <FoodRetailDashboard
+        email="owner@example.com"
+        brand={FACTORY_BRAND}
+        initialDraft={sampleFoodRetailDraft}
+        initialRevision={7}
+        initiallyPublished
+        canSwitchWorkspace={false}
+        platformUrl="https://bakery.cornershop.dev"
+        billingAccess={activeBilling}
+        publicationHistory={history}
+        ownerOperations={{
+          ...foodRetailOwnerOperations,
+          sourceMonitoring: "not-yet",
+        }}
+      />,
+    );
+    expect(html).toContain(
+      "Source monitoring is not ready for this workspace yet.",
+    );
+    expect(html).not.toContain("Changes wait for your approval.");
   });
 });

--- a/src/lib/owner-operations.test.tsx
+++ b/src/lib/owner-operations.test.tsx
@@ -142,7 +142,13 @@ describe("shared owner paid operations surface", () => {
       expect(html).not.toContain(
         "Source monitoring is not ready for this workspace yet.",
       );
-      expect(html).toContain("The photo library is not ready for this workspace yet.");
+      expect(html).not.toContain(
+        "The photo library is not ready for this workspace yet.",
+      );
+      expect(html).toContain("Approved-source intake");
+      expect(html).not.toContain("Approved product image URL");
+      expect(html).not.toContain("Project image URL");
+      expect(html).not.toContain("Choose image source");
       expect(html).not.toContain("Restofront");
       expect(html).not.toContain("restaurant.com");
     }
@@ -199,5 +205,29 @@ describe("shared owner paid operations surface", () => {
       "Source monitoring is not ready for this workspace yet.",
     );
     expect(html).not.toContain("Changes wait for your approval.");
+  });
+
+  it("keeps the shared photo library fail-closed when the registry disables it", () => {
+    const html = renderToStaticMarkup(
+      <FoodRetailDashboard
+        email="owner@example.com"
+        brand={FACTORY_BRAND}
+        initialDraft={sampleFoodRetailDraft}
+        initialRevision={7}
+        initiallyPublished
+        canSwitchWorkspace={false}
+        platformUrl="https://bakery.cornershop.dev"
+        billingAccess={activeBilling}
+        publicationHistory={history}
+        ownerOperations={{
+          ...foodRetailOwnerOperations,
+          photoLibrary: "not-yet",
+        }}
+      />,
+    );
+    expect(html).toContain(
+      "The photo library is not ready for this workspace yet.",
+    );
+    expect(html).not.toContain("Approved-source intake");
   });
 });

--- a/src/lib/owner-operations.ts
+++ b/src/lib/owner-operations.ts
@@ -132,15 +132,16 @@ export const restaurantOwnerOperations = {
 } as const satisfies VerticalOwnerOperations;
 
 /**
- * Food-retail and local-service share billing, publication, domain, and
- * workspace switching. Monitoring, articles, and the photo library stay
- * explicit not-yet states until those issues ship.
+ * Food-retail and local-service share billing, publication, domain,
+ * workspace switching, and source-monitoring review. Articles, analytics,
+ * leads, and the photo library stay explicit not-yet states until those
+ * issues ship.
  */
 export const foodRetailOwnerOperations = {
   ...paidOwnerReviewOperations,
   analytics: "not-yet",
   bookingInbox: "not-yet",
-  sourceMonitoring: "not-yet",
+  sourceMonitoring: "enabled",
   articles: "not-yet",
   photoLibrary: "not-yet",
 } as const satisfies VerticalOwnerOperations;

--- a/src/lib/owner-operations.ts
+++ b/src/lib/owner-operations.ts
@@ -133,9 +133,8 @@ export const restaurantOwnerOperations = {
 
 /**
  * Food-retail and local-service share billing, publication, domain,
- * workspace switching, and source-monitoring review. Articles, analytics,
- * leads, and the photo library stay explicit not-yet states until those
- * issues ship.
+ * workspace switching, source-monitoring review, and the reviewed photo
+ * library. Articles, analytics, and leads stay explicit not-yet states.
  */
 export const foodRetailOwnerOperations = {
   ...paidOwnerReviewOperations,
@@ -143,7 +142,7 @@ export const foodRetailOwnerOperations = {
   bookingInbox: "not-yet",
   sourceMonitoring: "enabled",
   articles: "not-yet",
-  photoLibrary: "not-yet",
+  photoLibrary: "enabled",
 } as const satisfies VerticalOwnerOperations;
 
 export const localServiceOwnerOperations = foodRetailOwnerOperations;

--- a/src/lib/photo-access.test.ts
+++ b/src/lib/photo-access.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+import { Vertical } from "@/generated/prisma/enums";
+
+let mode: "owner" | "operator" | "denied" = "denied";
+let vertical: Vertical = Vertical.RESTAURANT;
+mock.module("@/lib/authorization", () => ({
+  getSiteAccess: async (slug: string) =>
+    mode === "owner"
+      ? {
+          ok: true,
+          site: { id: "site_1", slug, vertical },
+          user: { id: "user_1", email: "owner@example.com" },
+        }
+      : { ok: false, status: 403, message: "Forbidden" },
+  getSuperadminAccess: async () =>
+    mode === "operator"
+      ? { id: "operator_1", email: "ops@example.com" }
+      : null,
+}));
+mock.module("@/lib/db", () => ({
+  getDb: () => ({
+    site: {
+      findUnique: async () => ({
+        id: "site_1",
+        slug: "example",
+        vertical,
+      }),
+    },
+  }),
+}));
+
+const { getPhotoLibraryAccess } = await import("@/lib/photo-access");
+
+describe("photo library authorization", () => {
+  beforeEach(() => {
+    mode = "denied";
+    vertical = Vertical.RESTAURANT;
+  });
+
+  it("allows the owning site member", async () => {
+    mode = "owner";
+    expect(await getPhotoLibraryAccess("example")).toMatchObject({
+      ok: true,
+      actor: { id: "user_1", role: "owner" },
+      site: { id: "site_1" },
+    });
+  });
+
+  it("allows a dual-gated platform operator", async () => {
+    mode = "operator";
+    expect(await getPhotoLibraryAccess("example")).toMatchObject({
+      ok: true,
+      actor: { id: "operator_1", role: "operator" },
+      site: { id: "site_1" },
+    });
+  });
+
+  it("rejects everyone else", async () => {
+    expect(await getPhotoLibraryAccess("example")).toEqual({
+      ok: false,
+      status: 403,
+      message: "Forbidden",
+    });
+  });
+
+  it("allows food-retail and local-service owners when the photo library is enabled", async () => {
+    mode = "owner";
+    vertical = Vertical.FOOD_RETAIL;
+    expect(await getPhotoLibraryAccess("bakery")).toMatchObject({
+      ok: true,
+      actor: { role: "owner" },
+    });
+    vertical = Vertical.LOCAL_SERVICE;
+    expect(await getPhotoLibraryAccess("trades")).toMatchObject({
+      ok: true,
+      actor: { role: "owner" },
+    });
+  });
+
+  it("fails closed when the vertical registry disables the photo library", async () => {
+    mode = "owner";
+    vertical = Vertical.BEAUTY;
+    expect(await getPhotoLibraryAccess("salon")).toEqual({
+      ok: false,
+      status: 403,
+      message: "The photo library is not available for this vertical.",
+    });
+    mode = "operator";
+    expect(await getPhotoLibraryAccess("salon")).toEqual({
+      ok: false,
+      status: 403,
+      message: "The photo library is not available for this vertical.",
+    });
+  });
+});

--- a/src/lib/photo-access.ts
+++ b/src/lib/photo-access.ts
@@ -6,6 +6,9 @@ import {
 } from "@/lib/authorization";
 import type { Vertical } from "@/generated/prisma/enums";
 import { getDb } from "@/lib/db";
+import { ownerOperationUnavailableMessage } from "@/lib/owner-operations";
+import { resolveOwnerOperations } from "@/lib/verticals/registry";
+import type { VerticalId } from "@/lib/verticals/types";
 
 export type PhotoLibraryAccess =
   | {
@@ -20,6 +23,8 @@ export async function getPhotoLibraryAccess(
 ): Promise<PhotoLibraryAccess> {
   const owner = await getSiteAccess(siteSlug);
   if (owner.ok) {
+    const denied = photoLibraryUnavailable(owner.site.vertical);
+    if (denied) return denied;
     return {
       ok: true,
       site: {
@@ -37,9 +42,23 @@ export async function getPhotoLibraryAccess(
     select: { id: true, slug: true, vertical: true },
   });
   if (!site) return owner;
+  const denied = photoLibraryUnavailable(site.vertical);
+  if (denied) return denied;
   return {
     ok: true,
     site,
     actor: { id: operator.id, role: "operator" },
+  };
+}
+
+function photoLibraryUnavailable(
+  vertical: VerticalId,
+): AccessFailure | null {
+  const state = resolveOwnerOperations(vertical).photoLibrary;
+  if (state === "enabled") return null;
+  return {
+    ok: false,
+    status: 403,
+    message: ownerOperationUnavailableMessage("photoLibrary", state),
   };
 }

--- a/src/lib/photo-library.postgres.test.ts
+++ b/src/lib/photo-library.postgres.test.ts
@@ -618,3 +618,436 @@ describe.skipIf(!enabled)("photo library PostgreSQL persistence", () => {
     });
   });
 });
+
+const foodSiteId = `photo-food-${randomUUID()}`;
+const foodSlug = `photo-food-${randomUUID()}`;
+const localSiteId = `photo-local-${randomUUID()}`;
+const localSlug = `photo-local-${randomUUID()}`;
+const otherSiteId = `photo-other-${randomUUID()}`;
+const otherSlug = `photo-other-${randomUUID()}`;
+
+describe.skipIf(!enabled)("vertical photo library PostgreSQL persistence", () => {
+  let sampleFoodRetailDraft: typeof import("@/lib/verticals/food-retail/fixtures").sampleFoodRetailDraft;
+  let sampleLocalServiceDraft: typeof import("@/lib/verticals/local-service/fixtures").sampleLocalServiceSiteDraft;
+  let Vertical: typeof import("@/generated/prisma/enums").Vertical;
+  let foodProductPhotoId: string;
+  let foodHeroPhotoId: string;
+  let localGalleryPhotoId: string;
+
+  beforeAll(async () => {
+    const foodRetail = await import("@/lib/verticals/food-retail/fixtures");
+    const localService = await import("@/lib/verticals/local-service/fixtures");
+    const enums = await import("@/generated/prisma/enums");
+    sampleFoodRetailDraft = foodRetail.sampleFoodRetailDraft;
+    sampleLocalServiceDraft = localService.sampleLocalServiceSiteDraft;
+    Vertical = enums.Vertical;
+
+    await db.site.create({
+      data: {
+        id: foodSiteId,
+        slug: foodSlug,
+        name: sampleFoodRetailDraft.name,
+        description: sampleFoodRetailDraft.description,
+        sourceUrl: sampleFoodRetailDraft.sourceUrl,
+        vertical: Vertical.FOOD_RETAIL,
+        status: "CLAIMED",
+        attributes: sampleFoodRetailDraft.attributes,
+        catalogSections: {
+          create: {
+            name: sampleFoodRetailDraft.catalogSections[0]!.name,
+            position: 0,
+            items: {
+              create: {
+                name: sampleFoodRetailDraft.catalogSections[0]!.items[0]!.name,
+                position: 0,
+              },
+            },
+          },
+        },
+      },
+    });
+    foodHeroPhotoId = (
+      await db.photoAsset.create({
+        data: {
+          siteId: foodSiteId,
+          sourceUrl: "https://photo-food.example/counter.jpg",
+          provenance: "OFFICIAL",
+          sourceKind: "FIRST_PARTY",
+          contentSha256: "1".repeat(64),
+          originalStorageKey: `test/${"1".repeat(64)}.jpg`,
+          originalUrl: "https://assets.example/food-counter.jpg",
+          mediaType: "image/jpeg",
+          byteLength: 1_024,
+          candidateUsages: ["HERO"],
+          reviewStatus: "APPROVED",
+          reviewedAt: new Date(),
+          reviewedBy: `owner:${actor.id}`,
+        },
+      })
+    ).id;
+    foodProductPhotoId = (
+      await db.photoAsset.create({
+        data: {
+          siteId: foodSiteId,
+          sourceUrl: "owner-upload:test:loaf.jpg",
+          provenance: "OWNER",
+          sourceKind: "OWNER_UPLOAD",
+          contentSha256: "2".repeat(64),
+          originalStorageKey: `test/${"2".repeat(64)}.jpg`,
+          originalUrl: "https://assets.example/food-loaf.jpg",
+          mediaType: "image/jpeg",
+          byteLength: 1_024,
+          candidateUsages: ["CATALOG"],
+          reviewStatus: "APPROVED",
+          reviewedAt: new Date(),
+          reviewedBy: `owner:${actor.id}`,
+        },
+      })
+    ).id;
+
+    await db.site.create({
+      data: {
+        id: localSiteId,
+        slug: localSlug,
+        name: sampleLocalServiceDraft.name,
+        description: sampleLocalServiceDraft.description,
+        sourceUrl: sampleLocalServiceDraft.sourceUrl,
+        vertical: Vertical.LOCAL_SERVICE,
+        status: "CLAIMED",
+        attributes: sampleLocalServiceDraft.attributes,
+        catalogSections: {
+          create: {
+            name: sampleLocalServiceDraft.catalogSections[0]!.name,
+            position: 0,
+            items: {
+              create: {
+                name: sampleLocalServiceDraft.catalogSections[0]!.items[0]!.name,
+                position: 0,
+              },
+            },
+          },
+        },
+      },
+    });
+    localGalleryPhotoId = (
+      await db.photoAsset.create({
+        data: {
+          siteId: localSiteId,
+          sourceUrl: "https://photo-local.example/rewire.jpg",
+          provenance: "OFFICIAL",
+          sourceKind: "FIRST_PARTY",
+          contentSha256: "3".repeat(64),
+          originalStorageKey: `test/${"3".repeat(64)}.jpg`,
+          originalUrl: "https://assets.example/local-rewire.jpg",
+          mediaType: "image/jpeg",
+          byteLength: 1_024,
+          candidateUsages: ["GALLERY"],
+          reviewStatus: "APPROVED",
+          reviewedAt: new Date(),
+          reviewedBy: `owner:${actor.id}`,
+        },
+      })
+    ).id;
+
+    await db.site.create({
+      data: {
+        id: otherSiteId,
+        slug: otherSlug,
+        name: "Other bakery",
+        description: "A second tenant used only to prove photo isolation.",
+        sourceUrl: "https://other-bakery.example/",
+        vertical: Vertical.FOOD_RETAIL,
+        status: "CLAIMED",
+        attributes: sampleFoodRetailDraft.attributes,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await db.site.deleteMany({
+      where: { id: { in: [foodSiteId, localSiteId, otherSiteId] } },
+    });
+  });
+
+  test("does not save arbitrary food-retail URLs or caller-authored provenance", async () => {
+    const draft = structuredClone(sampleFoodRetailDraft);
+    draft.slug = foodSlug;
+    draft.heroImageUrl = "https://example.com/invented-hero.jpg";
+    draft.heroOriginalImageUrl = "https://example.com/invented-hero.jpg";
+    draft.heroImageProvenance = "permissioned-ugc";
+    draft.catalogSections[0]!.items[0]!.imageUrl =
+      "https://example.com/invented-loaf.jpg";
+    draft.catalogSections[0]!.items[0]!.originalImageUrl =
+      "https://example.com/invented-loaf.jpg";
+    draft.catalogSections[0]!.items[0]!.imageProvenance = "owner";
+
+    await updateSiteDraft(foodSlug, draft, Vertical.FOOD_RETAIL, {
+      expectedRevision: 0,
+      actor: { id: actor.id, email: "photo-owner@example.test" },
+    });
+    expect(
+      await db.site.findUniqueOrThrow({
+        where: { id: foodSiteId },
+        select: {
+          heroImageUrl: true,
+          heroOriginalImageUrl: true,
+          heroImageProvenance: true,
+        },
+      }),
+    ).toEqual({
+      heroImageUrl: null,
+      heroOriginalImageUrl: null,
+      heroImageProvenance: null,
+    });
+    expect(
+      await db.catalogItem.findFirstOrThrow({
+        where: {
+          section: { siteId: foodSiteId },
+          name: sampleFoodRetailDraft.catalogSections[0]!.items[0]!.name,
+        },
+        select: {
+          imageUrl: true,
+          originalImageUrl: true,
+          imageProvenance: true,
+        },
+      }),
+    ).toEqual({
+      imageUrl: null,
+      originalImageUrl: null,
+      imageProvenance: null,
+    });
+  });
+
+  test("maps approved food-retail media onto hero and product slots with tenant isolation", async () => {
+    const library = await getPhotoLibrary(foodSiteId);
+    const productItem = library.catalogItems.find(
+      (item) =>
+        item.name === sampleFoodRetailDraft.catalogSections[0]!.items[0]!.name,
+    );
+    expect(productItem).toBeDefined();
+    await reviewPhoto({
+      siteId: foodSiteId,
+      photoId: foodHeroPhotoId,
+      expectedRevision: library.draftRevision,
+      actor,
+      review: { action: "select_hero" },
+    });
+    await reviewPhoto({
+      siteId: foodSiteId,
+      photoId: foodProductPhotoId,
+      actor,
+      review: { action: "select_catalog", catalogItemId: productItem!.id },
+    });
+
+    const otherLibrary = await getPhotoLibrary(otherSiteId);
+    expect(otherLibrary.photos).toEqual([]);
+
+    expect(
+      await db.site.findUniqueOrThrow({
+        where: { id: foodSiteId },
+        select: {
+          heroImageUrl: true,
+          heroOriginalImageUrl: true,
+          heroImageProvenance: true,
+        },
+      }),
+    ).toEqual({
+      heroImageUrl: "https://assets.example/food-counter.jpg",
+      heroOriginalImageUrl: "https://assets.example/food-counter.jpg",
+      heroImageProvenance: "OFFICIAL",
+    });
+    expect(
+      await db.catalogItem.findFirstOrThrow({
+        where: {
+          section: { siteId: foodSiteId },
+          name: sampleFoodRetailDraft.catalogSections[0]!.items[0]!.name,
+        },
+        select: {
+          imageUrl: true,
+          originalImageUrl: true,
+          imageProvenance: true,
+        },
+      }),
+    ).toEqual({
+      imageUrl: "https://assets.example/food-loaf.jpg",
+      originalImageUrl: "https://assets.example/food-loaf.jpg",
+      imageProvenance: "OWNER",
+    });
+
+    const overwrite = structuredClone(sampleFoodRetailDraft);
+    overwrite.slug = foodSlug;
+    overwrite.heroImageUrl = "https://example.com/invented-hero.jpg";
+    overwrite.heroOriginalImageUrl = "https://example.com/invented-hero.jpg";
+    overwrite.heroImageProvenance = "permissioned-ugc";
+    overwrite.catalogSections[0]!.items[0]!.imageUrl =
+      "https://example.com/invented-loaf.jpg";
+    overwrite.catalogSections[0]!.items[0]!.imageProvenance = "owner";
+    await updateSiteDraft(foodSlug, overwrite, Vertical.FOOD_RETAIL, {
+      expectedRevision: (await getPhotoLibrary(foodSiteId)).draftRevision,
+    });
+    expect(
+      await db.site.findUniqueOrThrow({
+        where: { id: foodSiteId },
+        select: { heroImageUrl: true },
+      }),
+    ).toEqual({ heroImageUrl: "https://assets.example/food-counter.jpg" });
+    expect(
+      await db.catalogItem.findFirstOrThrow({
+        where: {
+          section: { siteId: foodSiteId },
+          name: sampleFoodRetailDraft.catalogSections[0]!.items[0]!.name,
+        },
+        select: { imageUrl: true },
+      }),
+    ).toEqual({ imageUrl: "https://assets.example/food-loaf.jpg" });
+
+    const smuggled = structuredClone(sampleFoodRetailDraft);
+    smuggled.slug = otherSlug;
+    smuggled.heroImageUrl = "https://assets.example/food-counter.jpg";
+    smuggled.heroOriginalImageUrl = "https://assets.example/food-counter.jpg";
+    smuggled.heroImageProvenance = "official";
+    await updateSiteDraft(otherSlug, smuggled, Vertical.FOOD_RETAIL, {
+      expectedRevision: 0,
+    });
+    expect((await findSiteView(otherSlug))?.draft.heroImageUrl).toBeNull();
+  });
+
+  test("maps local-service gallery photos onto project slots and survives save, publish, and rollback", async () => {
+    const before = await getPhotoLibrary(localSiteId);
+    await reviewPhoto({
+      siteId: localSiteId,
+      photoId: localGalleryPhotoId,
+      expectedRevision: before.draftRevision,
+      actor,
+      review: { action: "select_gallery" },
+    });
+    await expect(
+      reviewPhoto({
+        siteId: localSiteId,
+        photoId: localGalleryPhotoId,
+        expectedRevision: before.draftRevision,
+        actor,
+        review: { action: "unselect" },
+      }),
+    ).rejects.toMatchObject({ code: "DRAFT_REVISION_CONFLICT", status: 409 });
+
+    const draft = structuredClone(sampleLocalServiceDraft);
+    draft.slug = localSlug;
+    draft.attributes.projects[0]!.imageUrl =
+      "https://example.com/invented-project.jpg";
+    draft.attributes.projects[0]!.imageProvenance = "owner";
+    const saved = await updateSiteDraft(localSlug, draft, Vertical.LOCAL_SERVICE, {
+      expectedRevision: (await getPhotoLibrary(localSiteId)).draftRevision,
+      actor: { id: actor.id, email: "photo-owner@example.test" },
+    });
+    const privateView = await findSiteView(localSlug);
+    expect(privateView?.draft.galleryImages).toEqual([
+      {
+        url: "https://assets.example/local-rewire.jpg",
+        originalUrl: "https://assets.example/local-rewire.jpg",
+        provenance: "official",
+      },
+    ]);
+    const privateProjects = (
+      privateView?.draft.attributes as {
+        projects: Array<Record<string, unknown>>;
+      }
+    ).projects;
+    expect(privateProjects[0]).toMatchObject({
+      title: "Townhouse rewire",
+      imageUrl: "https://assets.example/local-rewire.jpg",
+      originalImageUrl: "https://assets.example/local-rewire.jpg",
+      imageProvenance: "official",
+    });
+
+    await publishSiteDraft({
+      siteId: localSiteId,
+      slug: localSlug,
+      vertical: "LOCAL_SERVICE",
+      actor: { id: actor.id, email: "photo-owner@example.test" },
+      expectedRevision: saved.revision,
+      changeSummary: "Publish reviewed project gallery",
+    });
+    const live = await findPublishedSiteView(localSlug);
+    expect(live?.draft.galleryImages[0]?.url).toBe(
+      "https://assets.example/local-rewire.jpg",
+    );
+    const liveProjects = (
+      live?.draft.attributes as {
+        projects: Array<Record<string, unknown>>;
+      }
+    ).projects;
+    expect(liveProjects[0]).toMatchObject({
+      imageUrl: "https://assets.example/local-rewire.jpg",
+      imageProvenance: "official",
+    });
+
+    const firstVersion = await db.siteVersion.findFirstOrThrow({
+      where: { siteId: localSiteId },
+      orderBy: { version: "asc" },
+      select: { id: true },
+    });
+    const publication = await import("@/lib/site-publication");
+    await publication.rollbackPublishedSiteVersion({
+      siteId: localSiteId,
+      slug: localSlug,
+      vertical: "LOCAL_SERVICE",
+      targetSiteVersionId: firstVersion.id,
+      actor: { id: actor.id, email: "photo-owner@example.test" },
+    });
+    expect(
+      (await findPublishedSiteView(localSlug))?.draft.galleryImages[0],
+    ).toEqual({
+      url: "https://assets.example/local-rewire.jpg",
+      originalUrl: "https://assets.example/local-rewire.jpg",
+      provenance: "official",
+    });
+    expect((await findSiteView(localSlug))?.draft.galleryImages[0]?.url).toBe(
+      "https://assets.example/local-rewire.jpg",
+    );
+  });
+
+  test("keeps a valid imported local path readable until it is adopted", async () => {
+    const library = await getPhotoLibrary(foodSiteId);
+    const selectedProduct = library.photos.find(
+      (entry) => entry.id === foodProductPhotoId,
+    );
+    if (selectedProduct?.selectedUsage === "CATALOG") {
+      await reviewPhoto({
+        siteId: foodSiteId,
+        photoId: foodProductPhotoId,
+        expectedRevision: library.draftRevision,
+        actor,
+        review: { action: "unselect" },
+      });
+    }
+    const draft = structuredClone(sampleFoodRetailDraft);
+    draft.slug = foodSlug;
+    draft.heroImageUrl = null;
+    draft.heroOriginalImageUrl = null;
+    draft.heroImageProvenance = null;
+    draft.catalogSections[0]!.items[0]!.imageUrl = "/approved/loaf.webp";
+    draft.catalogSections[0]!.items[0]!.originalImageUrl = "/approved/loaf.webp";
+    draft.catalogSections[0]!.items[0]!.imageProvenance = "owner";
+    await updateSiteDraft(foodSlug, draft, Vertical.FOOD_RETAIL, {
+      expectedRevision: (await getPhotoLibrary(foodSiteId)).draftRevision,
+    });
+    expect(
+      await db.catalogItem.findFirstOrThrow({
+        where: {
+          section: { siteId: foodSiteId },
+          name: sampleFoodRetailDraft.catalogSections[0]!.items[0]!.name,
+        },
+        select: {
+          imageUrl: true,
+          originalImageUrl: true,
+          imageProvenance: true,
+        },
+      }),
+    ).toEqual({
+      imageUrl: "/approved/loaf.webp",
+      originalImageUrl: "/approved/loaf.webp",
+      imageProvenance: "OWNER",
+    });
+  });
+});

--- a/src/lib/reviewed-photo-projection.test.ts
+++ b/src/lib/reviewed-photo-projection.test.ts
@@ -1,0 +1,326 @@
+import { describe, expect, it } from "bun:test";
+import type { LibraryPhotoProjection } from "@/lib/reviewed-photo-projection";
+import {
+  bindImageSlot,
+  bindOwnerDraftImagesToLibrary,
+  catalogItemHasUnselectedRemoteImage,
+  gallerySlotsFromLibrary,
+  isArbitraryRemoteImageUrl,
+  isInventedOwnerImageUrl,
+  isPreservedImportedImageUrl,
+  projectHasUnselectedRemoteImage,
+  slotFromLibraryPhoto,
+} from "@/lib/reviewed-photo-projection";
+
+function photo(
+  overrides: Partial<LibraryPhotoProjection> &
+    Pick<LibraryPhotoProjection, "originalUrl">,
+): LibraryPhotoProjection {
+  return {
+    enhancedUrl: null,
+    provenance: "OFFICIAL",
+    reviewStatus: "APPROVED",
+    selectedUsage: null,
+    selectedCatalogItemId: null,
+    activeVariant: "ORIGINAL",
+    enhancedReviewStatus: null,
+    ...overrides,
+  };
+}
+
+const originalHero = "https://assets.example/original-hero.jpg";
+const enhancedHero = "https://assets.example/enhanced-hero.webp";
+const productOriginal = "https://assets.example/original-loaf.jpg";
+const projectOriginal = "https://assets.example/original-rewire.jpg";
+const arbitrary = "https://example.com/invented-product.jpg";
+const importedFixture =
+  "https://images.unsplash.com/photo-1552566626-52f8b828add9?auto=format&fit=crop&w=1800&q=88";
+
+describe("reviewed photo slot mapping", () => {
+  it("rejects arbitrary remote URLs that are not in the tenant library", () => {
+    expect(isArbitraryRemoteImageUrl(arbitrary, [])).toBe(true);
+    expect(
+      isArbitraryRemoteImageUrl(arbitrary, [photo({ originalUrl: originalHero })]),
+    ).toBe(true);
+    expect(
+      isArbitraryRemoteImageUrl(originalHero, [
+        photo({ originalUrl: originalHero }),
+      ]),
+    ).toBe(false);
+    expect(isArbitraryRemoteImageUrl("/approved/loaf.webp", [])).toBe(false);
+    expect(isArbitraryRemoteImageUrl(importedFixture, [])).toBe(false);
+    expect(isArbitraryRemoteImageUrl(originalHero, [])).toBe(true);
+    expect(isInventedOwnerImageUrl(arbitrary)).toBe(true);
+    expect(isInventedOwnerImageUrl(originalHero)).toBe(true);
+    expect(isInventedOwnerImageUrl(importedFixture)).toBe(false);
+    expect(isInventedOwnerImageUrl("/themes/restaurant/counter-service.webp")).toBe(
+      false,
+    );
+    expect(isPreservedImportedImageUrl(importedFixture)).toBe(true);
+    expect(isPreservedImportedImageUrl("/approved/loaf.webp")).toBe(true);
+    expect(isPreservedImportedImageUrl(originalHero)).toBe(false);
+  });
+
+  it("maps approved originals and derivatives onto hero, catalog, gallery, and project slots", () => {
+    const hero = photo({
+      originalUrl: originalHero,
+      enhancedUrl: enhancedHero,
+      selectedUsage: "HERO",
+      activeVariant: "ENHANCED",
+      enhancedReviewStatus: "APPROVED",
+      provenance: "OWNER",
+    });
+    const product = photo({
+      originalUrl: productOriginal,
+      selectedUsage: "CATALOG",
+      selectedCatalogItemId: "item_bread",
+      provenance: "OFFICIAL",
+    });
+    const gallery = photo({
+      originalUrl: projectOriginal,
+      selectedUsage: "GALLERY",
+      provenance: "PERMISSIONED_UGC",
+    });
+    const bound = bindOwnerDraftImagesToLibrary(
+      {
+        heroImageUrl: arbitrary,
+        heroOriginalImageUrl: arbitrary,
+        heroImageProvenance: "owner",
+        galleryImages: [
+          {
+            url: arbitrary,
+            originalUrl: arbitrary,
+            provenance: "owner",
+          },
+        ],
+        catalogSections: [
+          {
+            name: "Breads",
+            items: [
+              {
+                name: "Country loaf",
+                imageUrl: arbitrary,
+                originalImageUrl: arbitrary,
+                imageProvenance: "owner",
+              },
+            ],
+          },
+        ],
+        attributes: {
+          projects: [
+            {
+              title: "Townhouse rewire",
+              imageUrl: arbitrary,
+              originalImageUrl: arbitrary,
+              imageProvenance: "owner",
+              location: "Valletta",
+            },
+          ],
+        },
+      },
+      [hero, product, gallery],
+    );
+
+    expect(bound.heroImageUrl).toBe(enhancedHero);
+    expect(bound.heroOriginalImageUrl).toBe(originalHero);
+    expect(bound.heroImageProvenance).toBe("owner");
+    expect(bound.galleryImages).toMatchObject([
+      {
+        url: projectOriginal,
+        originalUrl: projectOriginal,
+        provenance: "permissioned-ugc",
+      },
+    ]);
+    expect(bound.catalogSections[0]?.items[0]).toMatchObject({
+      imageUrl: null,
+      originalImageUrl: null,
+      imageProvenance: null,
+    });
+    expect(bound.attributes.projects).toMatchObject([
+      {
+        title: "Townhouse rewire",
+        imageUrl: projectOriginal,
+        originalImageUrl: projectOriginal,
+        imageProvenance: "permissioned-ugc",
+        location: "Valletta",
+      },
+    ]);
+    expect(gallerySlotsFromLibrary([hero, product, gallery])).toEqual([
+      {
+        url: projectOriginal,
+        originalUrl: projectOriginal,
+        provenance: "permissioned-ugc",
+      },
+    ]);
+  });
+
+  it("adopts an approved library original without rewriting its stored URL or provenance", () => {
+    const loaf = photo({
+      originalUrl: productOriginal,
+      provenance: "OFFICIAL",
+    });
+    expect(
+      bindImageSlot(
+        {
+          url: productOriginal,
+          originalUrl: arbitrary,
+          provenance: "owner",
+        },
+        [loaf],
+      ),
+    ).toEqual(slotFromLibraryPhoto(loaf));
+  });
+
+  it("keeps existing valid local imported images readable", () => {
+    expect(
+      bindImageSlot(
+        {
+          url: "/approved/loaf.webp",
+          originalUrl: "/approved/loaf.webp",
+          provenance: "owner",
+        },
+        [],
+      ),
+    ).toEqual({
+      url: "/approved/loaf.webp",
+      originalUrl: "/approved/loaf.webp",
+      provenance: "owner",
+    });
+  });
+
+  it("keeps restaurant fixture photography readable without rewriting it onto a selected library photo", () => {
+    expect(
+      bindImageSlot(
+        {
+          url: importedFixture,
+          originalUrl: importedFixture,
+          provenance: "owner",
+        },
+        [],
+      ),
+    ).toEqual({
+      url: importedFixture,
+      originalUrl: importedFixture,
+      provenance: "owner",
+    });
+    expect(
+      bindImageSlot(
+        {
+          url: importedFixture,
+          originalUrl: importedFixture,
+          provenance: "owner",
+        },
+        [
+          photo({
+            originalUrl: originalHero,
+            selectedUsage: "HERO",
+            provenance: "OWNER",
+          }),
+        ],
+        photo({
+          originalUrl: originalHero,
+          selectedUsage: "HERO",
+          provenance: "OWNER",
+        }),
+      ),
+    ).toEqual({
+      url: importedFixture,
+      originalUrl: importedFixture,
+      provenance: "owner",
+    });
+  });
+
+  it("does not persist caller-authored provenance for a remote URL outside the library", () => {
+    expect(
+      bindImageSlot(
+        {
+          url: arbitrary,
+          originalUrl: arbitrary,
+          provenance: "permissioned-ugc",
+        },
+        [photo({ originalUrl: originalHero })],
+      ),
+    ).toEqual({
+      url: null,
+      originalUrl: null,
+      provenance: null,
+    });
+    expect(
+      bindImageSlot(
+        {
+          url: "https://assets.example/food-counter.jpg",
+          originalUrl: "https://assets.example/food-counter.jpg",
+          provenance: "official",
+        },
+        [],
+      ),
+    ).toEqual({
+      url: null,
+      originalUrl: null,
+      provenance: null,
+    });
+  });
+
+  it("flags unselected remote catalog and project images as unpublished", () => {
+    const selected = photo({
+      originalUrl: productOriginal,
+      selectedUsage: "CATALOG",
+      selectedCatalogItemId: "item_bread",
+    });
+    expect(
+      catalogItemHasUnselectedRemoteImage({
+        imageUrl: productOriginal,
+        originalImageUrl: productOriginal,
+        imageProvenance: "official",
+        selected,
+      }),
+    ).toBe(false);
+    expect(
+      catalogItemHasUnselectedRemoteImage({
+        imageUrl: arbitrary,
+        originalImageUrl: arbitrary,
+        imageProvenance: "owner",
+        selected: null,
+      }),
+    ).toBe(true);
+    expect(
+      catalogItemHasUnselectedRemoteImage({
+        imageUrl: "/approved/loaf.webp",
+        selected: null,
+      }),
+    ).toBe(false);
+    expect(
+      catalogItemHasUnselectedRemoteImage({
+        imageUrl: importedFixture,
+        originalImageUrl: importedFixture,
+        imageProvenance: "owner",
+        selected: null,
+      }),
+    ).toBe(false);
+    expect(
+      catalogItemHasUnselectedRemoteImage({
+        imageUrl: originalHero,
+        originalImageUrl: originalHero,
+        imageProvenance: "official",
+        selected: null,
+      }),
+    ).toBe(true);
+    expect(
+      projectHasUnselectedRemoteImage({
+        imageUrl: projectOriginal,
+        originalImageUrl: projectOriginal,
+        imageProvenance: "official",
+        selected: photo({
+          originalUrl: projectOriginal,
+          selectedUsage: "GALLERY",
+        }),
+      }),
+    ).toBe(false);
+    expect(
+      projectHasUnselectedRemoteImage({
+        imageUrl: arbitrary,
+        selected: null,
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/lib/reviewed-photo-projection.ts
+++ b/src/lib/reviewed-photo-projection.ts
@@ -1,0 +1,347 @@
+import type { ImageProvenance, PhotoUsage } from "@/generated/prisma/enums";
+
+export type LibraryPhotoProjection = {
+  originalUrl: string;
+  enhancedUrl: string | null;
+  provenance: ImageProvenance;
+  reviewStatus: "PENDING" | "APPROVED" | "REJECTED";
+  selectedUsage: PhotoUsage | null;
+  selectedCatalogItemId: string | null;
+  activeVariant: "ORIGINAL" | "ENHANCED";
+  enhancedReviewStatus: "PENDING" | "APPROVED" | "REJECTED" | null;
+};
+
+export type ClientImageSlot = {
+  url: string | null;
+  originalUrl: string | null;
+  provenance: "official" | "owner" | "permissioned-ugc" | null;
+};
+
+export type PhotoBindableDraft = {
+  heroImageUrl: string | null;
+  heroOriginalImageUrl?: string | null;
+  heroImageProvenance?: "official" | "owner" | "permissioned-ugc" | null;
+  galleryImages?: Array<{
+    url: string;
+    originalUrl: string;
+    provenance: "official" | "owner" | "permissioned-ugc";
+  }>;
+  catalogSections: Array<{
+    name: string;
+    items: Array<{
+      name: string;
+      imageUrl: string | null;
+      originalImageUrl?: string | null;
+      imageProvenance?: "official" | "owner" | "permissioned-ugc" | null;
+    }>;
+  }>;
+  attributes: Record<string, unknown>;
+};
+
+const emptySlot: ClientImageSlot = {
+  url: null,
+  originalUrl: null,
+  provenance: null,
+};
+
+export function clientImageProvenance(
+  value: ImageProvenance | string,
+): "official" | "owner" | "permissioned-ugc" {
+  return value.toLowerCase().replaceAll("_", "-") as
+    | "official"
+    | "owner"
+    | "permissioned-ugc";
+}
+
+export function isLocalImportedImageUrl(
+  value: string | null | undefined,
+): boolean {
+  return typeof value === "string" && /^\/(?!\/)[a-zA-Z0-9/_\-.]+$/.test(value);
+}
+
+export function libraryPhotoMatchesUrl(
+  photo: Pick<LibraryPhotoProjection, "originalUrl" | "enhancedUrl">,
+  url: string | null | undefined,
+): boolean {
+  return Boolean(url) && (photo.originalUrl === url || photo.enhancedUrl === url);
+}
+
+/**
+ * Restaurant publication fixtures that may appear on a draft without a
+ * PhotoAsset row: local `/approved` and `/themes` paths, plus Unsplash
+ * photography on the sample restaurant catalog. Everything else remote is
+ * owner-typed and must be an approved tenant library asset.
+ */
+const PRESERVED_IMPORTED_IMAGE_HOSTS = new Set(["images.unsplash.com"]);
+
+export function isPreservedImportedImageUrl(
+  value: string | null | undefined,
+): boolean {
+  if (isLocalImportedImageUrl(value)) return true;
+  if (typeof value !== "string") return false;
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol === "https:" &&
+      PRESERVED_IMPORTED_IMAGE_HOSTS.has(url.hostname.toLowerCase())
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function isInventedOwnerImageUrl(
+  value: string | null | undefined,
+): boolean {
+  if (!value || isPreservedImportedImageUrl(value)) return false;
+  return true;
+}
+
+export function isArbitraryRemoteImageUrl(
+  value: string | null | undefined,
+  library: readonly Pick<
+    LibraryPhotoProjection,
+    "originalUrl" | "enhancedUrl"
+  >[],
+): boolean {
+  if (!value || isPreservedImportedImageUrl(value)) return false;
+  if (library.some((photo) => libraryPhotoMatchesUrl(photo, value))) {
+    return false;
+  }
+  return true;
+}
+
+export function activeReviewedPhotoUrl(
+  photo: Pick<
+    LibraryPhotoProjection,
+    | "activeVariant"
+    | "enhancedReviewStatus"
+    | "enhancedUrl"
+    | "originalUrl"
+  >,
+): string {
+  return photo.activeVariant === "ENHANCED" &&
+    photo.enhancedReviewStatus === "APPROVED" &&
+    photo.enhancedUrl
+    ? photo.enhancedUrl
+    : photo.originalUrl;
+}
+
+export function slotFromLibraryPhoto(
+  photo: LibraryPhotoProjection,
+): ClientImageSlot {
+  return {
+    url: activeReviewedPhotoUrl(photo),
+    originalUrl: photo.originalUrl,
+    provenance: clientImageProvenance(photo.provenance),
+  };
+}
+
+export function approvedSelectedPhotos(
+  library: readonly LibraryPhotoProjection[],
+  usage: PhotoUsage,
+): LibraryPhotoProjection[] {
+  return library.filter(
+    (photo) =>
+      photo.selectedUsage === usage && photo.reviewStatus === "APPROVED",
+  );
+}
+
+function keepImportedImageSlot(submitted: ClientImageSlot): ClientImageSlot {
+  const url = submitted.url;
+  if (!url) return emptySlot;
+  return {
+    url,
+    originalUrl:
+      submitted.originalUrl &&
+      isPreservedImportedImageUrl(submitted.originalUrl)
+        ? submitted.originalUrl
+        : url,
+    provenance: submitted.provenance,
+  };
+}
+
+/**
+ * Library selections win over empty slots and invented owner-typed URLs.
+ * Existing valid imported images stay readable so they can be adopted
+ * without rewriting stored originals.
+ */
+export function bindImageSlot(
+  submitted: ClientImageSlot,
+  library: readonly LibraryPhotoProjection[],
+  selected: LibraryPhotoProjection | null = null,
+): ClientImageSlot {
+  const url = submitted.url;
+  if (selected?.reviewStatus === "APPROVED") {
+    if (
+      !url ||
+      isInventedOwnerImageUrl(url) ||
+      libraryPhotoMatchesUrl(selected, url)
+    ) {
+      return slotFromLibraryPhoto(selected);
+    }
+    return keepImportedImageSlot(submitted);
+  }
+  if (!url) return emptySlot;
+  const adopted = library.find(
+    (photo) =>
+      photo.reviewStatus === "APPROVED" && libraryPhotoMatchesUrl(photo, url),
+  );
+  if (adopted) return slotFromLibraryPhoto(adopted);
+  if (isPreservedImportedImageUrl(url)) {
+    return keepImportedImageSlot(submitted);
+  }
+  return emptySlot;
+}
+
+export function gallerySlotsFromLibrary(
+  library: readonly LibraryPhotoProjection[],
+): Array<{
+  url: string;
+  originalUrl: string;
+  provenance: "official" | "owner" | "permissioned-ugc";
+}> {
+  return approvedSelectedPhotos(library, "GALLERY").flatMap((photo) => {
+    const slot = slotFromLibraryPhoto(photo);
+    return slot.url && slot.originalUrl && slot.provenance
+      ? [
+          {
+            url: slot.url,
+            originalUrl: slot.originalUrl,
+            provenance: slot.provenance,
+          },
+        ]
+      : [];
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function projectImageSlot(project: Record<string, unknown>): ClientImageSlot {
+  return {
+    url: typeof project.imageUrl === "string" ? project.imageUrl : null,
+    originalUrl:
+      typeof project.originalImageUrl === "string"
+        ? project.originalImageUrl
+        : null,
+    provenance:
+      project.imageProvenance === "official" ||
+      project.imageProvenance === "owner" ||
+      project.imageProvenance === "permissioned-ugc"
+        ? project.imageProvenance
+        : null,
+  };
+}
+
+export function bindProjectImagesFromLibrary(
+  attributes: Record<string, unknown>,
+  library: readonly LibraryPhotoProjection[],
+): Record<string, unknown> {
+  if (!Array.isArray(attributes.projects)) return attributes;
+  const gallery = approvedSelectedPhotos(library, "GALLERY");
+  return {
+    ...attributes,
+    projects: attributes.projects.map((value, index) => {
+      if (!isRecord(value)) return value;
+      const slot = bindImageSlot(
+        projectImageSlot(value),
+        library,
+        gallery[index] ?? null,
+      );
+      return {
+        ...value,
+        imageUrl: slot.url,
+        originalImageUrl: slot.originalUrl,
+        imageProvenance: slot.provenance,
+      };
+    }),
+  };
+}
+
+/**
+ * Replaces caller-authored hero, gallery, catalog, and project image fields
+ * with the tenant photo-library projection before an owner save.
+ */
+export function bindOwnerDraftImagesToLibrary<TDraft extends PhotoBindableDraft>(
+  draft: TDraft,
+  library: readonly LibraryPhotoProjection[],
+): TDraft {
+  const hero = bindImageSlot(
+    {
+      url: draft.heroImageUrl,
+      originalUrl: draft.heroOriginalImageUrl ?? null,
+      provenance: draft.heroImageProvenance ?? null,
+    },
+    library,
+    approvedSelectedPhotos(library, "HERO")[0] ?? null,
+  );
+  return {
+    ...draft,
+    heroImageUrl: hero.url,
+    heroOriginalImageUrl: hero.originalUrl,
+    heroImageProvenance: hero.provenance,
+    galleryImages: gallerySlotsFromLibrary(library),
+    catalogSections: draft.catalogSections.map((section) => ({
+      ...section,
+      items: section.items.map((item) => {
+        const slot = bindImageSlot(
+          {
+            url: item.imageUrl,
+            originalUrl: item.originalImageUrl ?? null,
+            provenance: item.imageProvenance ?? null,
+          },
+          library,
+        );
+        return {
+          ...item,
+          imageUrl: slot.url,
+          originalImageUrl: slot.originalUrl,
+          imageProvenance: slot.provenance,
+        };
+      }),
+    })),
+    attributes: bindProjectImagesFromLibrary(draft.attributes, library),
+  };
+}
+
+export function catalogItemHasUnselectedRemoteImage(input: {
+  imageUrl: string | null;
+  originalImageUrl?: string | null;
+  imageProvenance?: string | null;
+  selected: LibraryPhotoProjection | null;
+}): boolean {
+  const url = input.imageUrl;
+  if (!url || isLocalImportedImageUrl(url)) return false;
+  const selected = input.selected;
+  if (selected?.reviewStatus === "APPROVED") {
+    const slot = slotFromLibraryPhoto(selected);
+    return (
+      input.imageUrl !== slot.url ||
+      (input.originalImageUrl ?? null) !== slot.originalUrl ||
+      (input.imageProvenance ?? null) !== slot.provenance
+    );
+  }
+  return isInventedOwnerImageUrl(url);
+}
+
+export function projectHasUnselectedRemoteImage(input: {
+  imageUrl: unknown;
+  originalImageUrl?: unknown;
+  imageProvenance?: unknown;
+  selected: LibraryPhotoProjection | null;
+}): boolean {
+  if (typeof input.imageUrl !== "string" || !input.imageUrl) return false;
+  if (isLocalImportedImageUrl(input.imageUrl)) return false;
+  return catalogItemHasUnselectedRemoteImage({
+    imageUrl: input.imageUrl,
+    originalImageUrl:
+      typeof input.originalImageUrl === "string"
+        ? input.originalImageUrl
+        : null,
+    imageProvenance:
+      typeof input.imageProvenance === "string" ? input.imageProvenance : null,
+    selected: input.selected,
+  });
+}

--- a/src/lib/site-persistence.ts
+++ b/src/lib/site-persistence.ts
@@ -2,6 +2,7 @@ import { Prisma } from "@/generated/prisma/client";
 import { catalogPhotoReplacementPosition } from "@/lib/catalog-photo-reconciliation";
 import { Vertical } from "@/generated/prisma/enums";
 import { getDb } from "@/lib/db";
+import { bindOwnerDraftImagesToLibrary } from "@/lib/reviewed-photo-projection";
 import { evidenceDigest, integrationUrlDigest } from "@/lib/evidence-digests";
 import { LEGACY_THEME_VERSION, slugify } from "@/lib/site-draft";
 import { restaurantSiteTheme } from "@/lib/site-themes/restaurant/configuration";
@@ -695,15 +696,8 @@ export async function updateSiteDraft(
           ) {
             throw new DraftRevisionConflictError(current.draftRevision);
           }
-          // Catalog rows are replaced on a full owner save. Preserve a managed
-          // photo only when section + item names identify one unique replacement;
-          // position alone can silently move a real product photo to another item.
-          const catalogPhotoSelections = await tx.photoAsset.findMany({
-            where: {
-              siteId: current.id,
-              selectedUsage: "CATALOG",
-              selectedCatalogItemId: { not: null },
-            },
+          const libraryPhotos = await tx.photoAsset.findMany({
+            where: { siteId: current.id },
             select: {
               id: true,
               originalUrl: true,
@@ -711,6 +705,9 @@ export async function updateSiteDraft(
               enhancedReviewStatus: true,
               activeVariant: true,
               provenance: true,
+              reviewStatus: true,
+              selectedUsage: true,
+              selectedCatalogItemId: true,
               selectedCatalogItem: {
                 select: {
                   name: true,
@@ -719,86 +716,40 @@ export async function updateSiteDraft(
               },
             },
           });
-          const catalogPhotoTargets = catalogPhotoSelections.map((selection) => ({
-            selection,
-            position: selection.selectedCatalogItem
-              ? catalogPhotoReplacementPosition({
-                  previousSectionName: selection.selectedCatalogItem.section.name,
-                  previousItemName: selection.selectedCatalogItem.name,
-                  replacementCatalog: parsed.catalogSections,
-                })
-              : null,
-          }));
+          const bound = bindOwnerDraftImagesToLibrary(parsed, libraryPhotos);
+          // Catalog rows are replaced on a full owner save. Preserve a managed
+          // photo only when section + item names identify one unique replacement;
+          // position alone can silently move a real product photo to another item.
+          const catalogPhotoTargets = libraryPhotos.flatMap((selection) =>
+            selection.selectedUsage === "CATALOG" &&
+            selection.selectedCatalogItem
+              ? [
+                  {
+                    selection,
+                    position: catalogPhotoReplacementPosition({
+                      previousSectionName:
+                        selection.selectedCatalogItem.section.name,
+                      previousItemName: selection.selectedCatalogItem.name,
+                      replacementCatalog: bound.catalogSections,
+                    }),
+                  },
+                ]
+              : [],
+          );
           const updated = await tx.site.update({
             where: { id: current.id },
             data: {
-              ...siteDraftScalarData(parsed, vertical),
-              ...siteRelationReplaceData(parsed, vertical),
+              ...siteDraftScalarData(bound, vertical),
+              ...siteRelationReplaceData(bound, vertical),
               draftRevision: { increment: 1 },
             },
             select: { id: true, draftRevision: true },
           });
-          if (catalogPhotoSelections.length > 0) {
-            const replacementItems = await tx.catalogItem.findMany({
-              where: { section: { siteId: current.id } },
-              select: {
-                id: true,
-                position: true,
-                section: { select: { position: true } },
-              },
-            });
-            for (const { selection, position } of catalogPhotoTargets) {
-              const replacement = position
-                ? replacementItems.find(
-                    (item) =>
-                      item.position === position.itemIndex &&
-                      item.section.position === position.sectionIndex,
-                  )
-                : null;
-              const managedUrls = [selection.originalUrl, selection.enhancedUrl]
-                .filter((url): url is string => Boolean(url));
-              await tx.catalogItem.updateMany({
-                where: {
-                  section: { siteId: current.id },
-                  ...(replacement ? { id: { not: replacement.id } } : {}),
-                  OR: [
-                    { imageUrl: { in: managedUrls } },
-                    { originalImageUrl: { in: managedUrls } },
-                  ],
-                },
-                data: {
-                  imageUrl: null,
-                  originalImageUrl: null,
-                  imageProvenance: null,
-                },
-              });
-              if (replacement) {
-                const imageUrl =
-                  selection.activeVariant === "ENHANCED" &&
-                  selection.enhancedReviewStatus === "APPROVED" &&
-                  selection.enhancedUrl
-                    ? selection.enhancedUrl
-                    : selection.originalUrl;
-                await tx.catalogItem.update({
-                  where: { id: replacement.id },
-                  data: {
-                    imageUrl,
-                    originalImageUrl: selection.originalUrl,
-                    imageProvenance: selection.provenance,
-                  },
-                });
-              }
-              await tx.photoAsset.update({
-                where: { id: selection.id },
-                data: replacement
-                  ? {
-                      selectedCatalogItemId: replacement.id,
-                      selectedUsage: "CATALOG",
-                    }
-                  : { selectedCatalogItemId: null, selectedUsage: null },
-              });
-            }
-          }
+          await rebindSelectedCatalogPhotos(
+            tx,
+            current.id,
+            catalogPhotoTargets,
+          );
           if (options.actor) {
             await tx.auditEvent.create({
               data: {
@@ -840,6 +791,86 @@ function requireImportDatabase() {
     throw new ImportDatabaseUnavailableError();
   }
   return getDb();
+}
+
+type CatalogPhotoSelectionRow = {
+  id: string;
+  originalUrl: string;
+  enhancedUrl: string | null;
+  enhancedReviewStatus: "PENDING" | "APPROVED" | "REJECTED" | null;
+  activeVariant: "ORIGINAL" | "ENHANCED";
+  provenance: "OFFICIAL" | "OWNER" | "PERMISSIONED_UGC";
+};
+
+export async function rebindSelectedCatalogPhotos(
+  tx: Prisma.TransactionClient,
+  siteId: string,
+  catalogPhotoTargets: Array<{
+    selection: CatalogPhotoSelectionRow;
+    position: { sectionIndex: number; itemIndex: number } | null;
+  }>,
+): Promise<void> {
+  if (catalogPhotoTargets.length === 0) return;
+  const replacementItems = await tx.catalogItem.findMany({
+    where: { section: { siteId } },
+    select: {
+      id: true,
+      position: true,
+      section: { select: { position: true } },
+    },
+  });
+  for (const { selection, position } of catalogPhotoTargets) {
+    const replacement = position
+      ? replacementItems.find(
+          (item) =>
+            item.position === position.itemIndex &&
+            item.section.position === position.sectionIndex,
+        )
+      : null;
+    const managedUrls = [selection.originalUrl, selection.enhancedUrl].filter(
+      (url): url is string => Boolean(url),
+    );
+    await tx.catalogItem.updateMany({
+      where: {
+        section: { siteId },
+        ...(replacement ? { id: { not: replacement.id } } : {}),
+        OR: [
+          { imageUrl: { in: managedUrls } },
+          { originalImageUrl: { in: managedUrls } },
+        ],
+      },
+      data: {
+        imageUrl: null,
+        originalImageUrl: null,
+        imageProvenance: null,
+      },
+    });
+    if (replacement) {
+      const imageUrl =
+        selection.activeVariant === "ENHANCED" &&
+        selection.enhancedReviewStatus === "APPROVED" &&
+        selection.enhancedUrl
+          ? selection.enhancedUrl
+          : selection.originalUrl;
+      await tx.catalogItem.update({
+        where: { id: replacement.id },
+        data: {
+          imageUrl,
+          originalImageUrl: selection.originalUrl,
+          imageProvenance: selection.provenance,
+        },
+      });
+    }
+    await tx.photoAsset.update({
+      where: { id: selection.id },
+      data: replacement
+        ? {
+            selectedCatalogItemId: replacement.id,
+            selectedUsage: "CATALOG",
+          }
+        : { selectedCatalogItemId: null, selectedUsage: null },
+    });
+  }
 }
 
 function siteRelationReplaceData(
@@ -966,8 +997,8 @@ function toDatabaseIntegrationType(
 
 function toDatabaseImageProvenance(
   value: PersistableSiteDraft["heroImageProvenance"],
-): "OFFICIAL" | "OWNER" | "PERMISSIONED_UGC" | undefined {
-  if (!value) return undefined;
+): "OFFICIAL" | "OWNER" | "PERMISSIONED_UGC" | null {
+  if (!value) return null;
   if (value === "permissioned-ugc") return "PERMISSIONED_UGC";
   return value.toUpperCase() as "OFFICIAL" | "OWNER";
 }

--- a/src/lib/site-publication.ts
+++ b/src/lib/site-publication.ts
@@ -17,6 +17,10 @@ import {
   SitePublicationCapabilityError,
 } from "@/lib/site-publication-capability";
 import {
+  catalogItemHasUnselectedRemoteImage,
+  projectHasUnselectedRemoteImage,
+} from "@/lib/reviewed-photo-projection";
+import {
   projectPublishedSiteVersion,
   projectSiteDraft,
   siteDraftRelations,
@@ -307,6 +311,55 @@ function assertPublishablePhotoProjection(
     )
   ) {
     throw new SitePublicationPhotoError();
+  }
+
+  const catalogItems = site.catalogSections.flatMap((section) => section.items);
+  for (const item of catalogItems) {
+    const selected = selectedPhotos.find(
+      (photo) =>
+        photo.selectedUsage === "CATALOG" &&
+        photo.selectedCatalogItemId === item.id,
+    );
+    if (
+      catalogItemHasUnselectedRemoteImage({
+        imageUrl: item.imageUrl,
+        originalImageUrl: item.originalImageUrl,
+        imageProvenance: item.imageProvenance
+          ? item.imageProvenance.toLowerCase().replace("_", "-")
+          : null,
+        selected: selected ?? null,
+      })
+    ) {
+      throw new SitePublicationPhotoError();
+    }
+    if (selected && !isStoredAndApproved(selected)) {
+      throw new SitePublicationPhotoError();
+    }
+  }
+
+  const projects = Array.isArray(
+    (site.attributes as { projects?: unknown }).projects,
+  )
+    ? ((site.attributes as { projects: unknown[] }).projects)
+    : [];
+  const gallery = selectedPhotos.filter(
+    (photo) => photo.selectedUsage === "GALLERY",
+  );
+  for (const [index, project] of projects.entries()) {
+    const record =
+      typeof project === "object" && project !== null
+        ? (project as Record<string, unknown>)
+        : {};
+    if (
+      projectHasUnselectedRemoteImage({
+        imageUrl: record.imageUrl,
+        originalImageUrl: record.originalImageUrl,
+        imageProvenance: record.imageProvenance,
+        selected: gallery[index] ?? null,
+      })
+    ) {
+      throw new SitePublicationPhotoError();
+    }
   }
 }
 

--- a/src/lib/source-monitoring-access.test.ts
+++ b/src/lib/source-monitoring-access.test.ts
@@ -2,13 +2,16 @@ import { beforeEach, describe, expect, it, mock } from "bun:test";
 
 mock.module("server-only", () => ({}));
 
+import { Vertical } from "@/generated/prisma/enums";
+
 let mode: "owner" | "operator" | "denied" = "denied";
+let vertical: Vertical = Vertical.RESTAURANT;
 mock.module("@/lib/authorization", () => ({
   getSiteAccess: async (slug: string) =>
     mode === "owner"
       ? {
           ok: true,
-          site: { id: "site_1", slug },
+          site: { id: "site_1", slug, vertical },
           user: { id: "user_1", email: "owner@example.com" },
         }
       : { ok: false, status: 403, message: "Forbidden" },
@@ -20,7 +23,11 @@ mock.module("@/lib/authorization", () => ({
 mock.module("@/lib/db", () => ({
   getDb: () => ({
     site: {
-      findUnique: async () => ({ id: "site_1", slug: "example" }),
+      findUnique: async () => ({
+        id: "site_1",
+        slug: "example",
+        vertical,
+      }),
     },
   }),
 }));
@@ -32,6 +39,7 @@ const { getSourceMonitoringAccess } = await import(
 describe("source monitoring review authorization", () => {
   beforeEach(() => {
     mode = "denied";
+    vertical = Vertical.RESTAURANT;
   });
 
   it("allows the owning site member", async () => {
@@ -57,6 +65,36 @@ describe("source monitoring review authorization", () => {
       ok: false,
       status: 403,
       message: "Forbidden",
+    });
+  });
+
+  it("allows food-retail and local-service owners when monitoring is enabled", async () => {
+    mode = "owner";
+    vertical = Vertical.FOOD_RETAIL;
+    expect(await getSourceMonitoringAccess("bakery")).toMatchObject({
+      ok: true,
+      actor: { role: "owner" },
+    });
+    vertical = Vertical.LOCAL_SERVICE;
+    expect(await getSourceMonitoringAccess("trades")).toMatchObject({
+      ok: true,
+      actor: { role: "owner" },
+    });
+  });
+
+  it("fails closed when the vertical registry disables monitoring", async () => {
+    mode = "owner";
+    vertical = Vertical.BEAUTY;
+    expect(await getSourceMonitoringAccess("salon")).toEqual({
+      ok: false,
+      status: 403,
+      message: "Source monitoring is not available for this vertical.",
+    });
+    mode = "operator";
+    expect(await getSourceMonitoringAccess("salon")).toEqual({
+      ok: false,
+      status: 403,
+      message: "Source monitoring is not available for this vertical.",
     });
   });
 });

--- a/src/lib/source-monitoring-access.ts
+++ b/src/lib/source-monitoring-access.ts
@@ -5,6 +5,9 @@ import {
   type AccessFailure,
 } from "@/lib/authorization";
 import { getDb } from "@/lib/db";
+import { ownerOperationUnavailableMessage } from "@/lib/owner-operations";
+import { resolveOwnerOperations } from "@/lib/verticals/registry";
+import type { VerticalId } from "@/lib/verticals/types";
 
 export type SourceMonitoringAccess =
   | {
@@ -23,6 +26,8 @@ export async function getSourceMonitoringAccess(
 ): Promise<SourceMonitoringAccess> {
   const owner = await getSiteAccess(siteSlug);
   if (owner.ok) {
+    const denied = sourceMonitoringUnavailable(owner.site.vertical);
+    if (denied) return denied;
     return {
       ok: true,
       site: { id: owner.site.id, slug: owner.site.slug },
@@ -38,7 +43,7 @@ export async function getSourceMonitoringAccess(
   if (!operator) return owner;
   const site = await getDb().site.findUnique({
     where: { slug: siteSlug },
-    select: { id: true, slug: true },
+    select: { id: true, slug: true, vertical: true },
   });
   if (!site) {
     return {
@@ -47,13 +52,27 @@ export async function getSourceMonitoringAccess(
       message: "Site access is required",
     };
   }
+  const denied = sourceMonitoringUnavailable(site.vertical);
+  if (denied) return denied;
   return {
     ok: true,
-    site,
+    site: { id: site.id, slug: site.slug },
     actor: {
       id: operator.id,
       email: operator.email,
       role: "operator",
     },
+  };
+}
+
+function sourceMonitoringUnavailable(
+  vertical: VerticalId,
+): AccessFailure | null {
+  const state = resolveOwnerOperations(vertical).sourceMonitoring;
+  if (state === "enabled") return null;
+  return {
+    ok: false,
+    status: 403,
+    message: ownerOperationUnavailableMessage("sourceMonitoring", state),
   };
 }

--- a/src/lib/source-monitoring-diff.test.ts
+++ b/src/lib/source-monitoring-diff.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "bun:test";
-import { buildSourceMonitoringDiff } from "@/lib/source-monitoring-diff";
+import { Vertical } from "@/generated/prisma/enums";
+import {
+  buildSourceMonitoringDiff,
+  parseSourceMonitoringSuggestionValue,
+  SourceMonitoringUnsupportedSuggestionError,
+} from "@/lib/source-monitoring-diff";
+import { sampleSiteDraft } from "@/lib/restaurant";
+import { sampleFoodRetailDraft } from "@/lib/verticals/food-retail/fixtures";
+import { sampleLocalServiceSiteDraft } from "@/lib/verticals/local-service/fixtures";
 
 describe("evidence-backed source diffs", () => {
   it("emits menu, contact, hours and link suggestions with evidence", () => {
@@ -60,6 +68,17 @@ describe("evidence-backed source diffs", () => {
       "MENU",
     ]);
     expect(result.every((entry) => entry.evidence.length > 0)).toBe(true);
+    const links = result.find((entry) => entry.field === "LINKS");
+    expect(links?.suggestedValue).toMatchObject({
+      integrations: [
+        {
+          label: "Book",
+          url: "https://book.example.com/",
+          enabled: false,
+          venueId: null,
+        },
+      ],
+    });
   });
 
   it("drops AI-proposed facts that are absent from source evidence", () => {
@@ -107,6 +126,422 @@ describe("evidence-backed source diffs", () => {
     expect(result).toEqual([]);
   });
 });
+
+describe("lossless source-monitoring diffs", () => {
+  it("does not implicitly enable newly discovered links", () => {
+    const current = structuredClone(sampleSiteDraft);
+    current.integrations = [
+      {
+        type: "booking",
+        label: "Reserve",
+        provider: "OpenTable",
+        url: "https://www.opentable.com/r/osteria-luna",
+        enabled: false,
+        venueId: "rid-123",
+      },
+    ];
+    const result = buildSourceMonitoringDiff({
+      current,
+      proposed: current,
+      extracted: extractedSite({
+        pageText: "Reserve at OpenTable or book with CoverManager.",
+        links: [
+          {
+            type: "booking",
+            label: "CoverManager",
+            provider: "CoverManager",
+            url: "https://book.covermanager.test/osteria",
+          },
+        ],
+      }),
+      checkedLinks: [
+        {
+          originalUrl: "https://www.opentable.com/r/osteria-luna",
+          finalUrl: "https://www.opentable.com/r/osteria-luna-valletta",
+          status: 200,
+        },
+      ],
+      capturedAt: new Date("2026-08-25T00:00:00.000Z"),
+    });
+    const links = result.find((entry) => entry.field === "LINKS");
+    expect(links?.suggestedValue).toEqual({
+      integrations: [
+        {
+          type: "booking",
+          label: "Reserve",
+          provider: "OpenTable",
+          url: "https://www.opentable.com/r/osteria-luna-valletta",
+          enabled: false,
+          venueId: "rid-123",
+        },
+        {
+          type: "booking",
+          label: "CoverManager",
+          provider: "CoverManager",
+          url: "https://book.covermanager.test/osteria",
+          enabled: false,
+          venueId: null,
+        },
+      ],
+      translations: current.translations,
+    });
+  });
+
+  it("preserves restaurant availability, dietary attributes, and translation structure", () => {
+    const current = structuredClone(sampleSiteDraft);
+    current.catalogSections = [
+      {
+        ...current.catalogSections[0],
+        items: [current.catalogSections[0].items[0]],
+      },
+    ];
+    const proposed = structuredClone(current);
+    proposed.catalogSections[0].items[0] = {
+      ...proposed.catalogSections[0].items[0],
+      description: "Rosemary, sea salt, cultured butter, extra virgin oil",
+      available: false,
+      attributes: { dietaryLabels: ["vegan"] },
+      imageUrl: null,
+    };
+    proposed.catalogSections[0].items.push({
+      name: "Olives",
+      description: "House marinated",
+      price: 5,
+      currency: "EUR",
+      available: true,
+      attributes: { dietaryLabels: [] },
+      imageUrl: null,
+    });
+    const result = buildSourceMonitoringDiff({
+      current,
+      proposed,
+      extracted: extractedSite({
+        pageText:
+          "To begin House focaccia Rosemary, sea salt, cultured butter, extra virgin oil. Olives House marinated.",
+      }),
+      checkedLinks: [],
+      capturedAt: new Date("2026-08-25T00:00:00.000Z"),
+    });
+    const menu = result.find((entry) => entry.field === "MENU");
+    const suggested = menu?.suggestedValue as {
+      catalogSections: typeof current.catalogSections;
+    };
+    expect(suggested.catalogSections[0].items[0]).toMatchObject({
+      name: "House focaccia",
+      description: "Rosemary, sea salt, cultured butter, extra virgin oil",
+      available: current.catalogSections[0].items[0].available,
+      attributes: current.catalogSections[0].items[0].attributes,
+    });
+    expect(suggested.catalogSections[0].items.at(-1)).toMatchObject({
+      name: "Olives",
+      available: true,
+    });
+  });
+
+  it("preserves food-retail tri-state stock and item attributes across catalog suggestions", () => {
+    const current = structuredClone(sampleFoodRetailDraft);
+    const proposed = structuredClone(current);
+    proposed.catalogSections[0].items[0] = {
+      ...proposed.catalogSections[0].items[0],
+      description: "Natural starter, wheat flour and a longer ferment.",
+      available: false,
+      attributes: {
+        ...proposed.catalogSections[0].items[0].attributes,
+        visible: false,
+        stockSourceUrl: null,
+        allergens: [],
+        allergenSourceUrl: null,
+      },
+    };
+    proposed.catalogSections[1].items[0] = {
+      ...proposed.catalogSections[1].items[0],
+      available: true,
+      attributes: {
+        ...proposed.catalogSections[1].items[0].attributes,
+        seasonalAvailability: "invented",
+      },
+    };
+    const result = buildSourceMonitoringDiff({
+      current,
+      proposed,
+      extracted: extractedSite({
+        pageText:
+          "Daily breads Country sourdough Natural starter, wheat flour and a longer ferment. Weekend counter Apricot tart Available during apricot season.",
+      }),
+      checkedLinks: [],
+      capturedAt: new Date("2026-08-25T00:00:00.000Z"),
+    });
+    const menu = result.find((entry) => entry.field === "MENU");
+    const suggested = menu?.suggestedValue as {
+      catalogSections: typeof current.catalogSections;
+      translations: typeof current.translations;
+    };
+    expect(suggested.catalogSections[0].items[0]).toMatchObject({
+      description: "Natural starter, wheat flour and a longer ferment.",
+      available: true,
+      attributes: current.catalogSections[0].items[0].attributes,
+    });
+    expect(suggested.catalogSections[1].items[0]).toMatchObject({
+      available: null,
+      attributes: current.catalogSections[1].items[0].attributes,
+    });
+    expect(suggested.translations[0]?.catalogSections).toHaveLength(
+      current.translations[0].catalogSections.length,
+    );
+  });
+
+  it("preserves local-service pricing attributes and does not invent public quote links", () => {
+    const current = structuredClone(sampleLocalServiceSiteDraft);
+    const proposed = structuredClone(current);
+    proposed.catalogSections[0].items[0] = {
+      ...proposed.catalogSections[0].items[0],
+      description: "Diagnosis and repair for tripping circuits and failed sockets.",
+      attributes: {
+        pricingModel: "hourly",
+        priceUnit: "per hour",
+        emergencyEligible: false,
+      },
+    };
+    const result = buildSourceMonitoringDiff({
+      current,
+      proposed,
+      extracted: extractedSite({
+        pageText:
+          "Electrical work Fault finding and repairs Diagnosis and repair for tripping circuits and failed sockets. Rewires and upgrades.",
+        links: [
+          {
+            type: "quote",
+            label: "New quote form",
+            provider: "Harbour quotes",
+            url: "https://harbour-electrical.example/new-quote",
+          },
+        ],
+      }),
+      checkedLinks: [],
+      capturedAt: new Date("2026-08-25T00:00:00.000Z"),
+    });
+    const menu = result.find((entry) => entry.field === "MENU");
+    const suggestedMenu = menu?.suggestedValue as {
+      catalogSections: typeof current.catalogSections;
+    };
+    expect(suggestedMenu.catalogSections[0].items[0]).toMatchObject({
+      description:
+        "Diagnosis and repair for tripping circuits and failed sockets.",
+      available: true,
+      attributes: {
+        pricingModel: "quote",
+        priceUnit: "",
+        emergencyEligible: true,
+      },
+    });
+    const links = result.find((entry) => entry.field === "LINKS");
+    const suggestedLinks = links?.suggestedValue as {
+      integrations: typeof current.integrations;
+    };
+    expect(
+      suggestedLinks.integrations.map((link) => ({
+        url: link.url,
+        enabled: link.enabled,
+        provider: link.provider,
+      })),
+    ).toEqual([
+      {
+        url: "https://wa.me/35679991122",
+        enabled: true,
+        provider: "WhatsApp",
+      },
+      {
+        url: "https://harbour-electrical.example/quote",
+        enabled: true,
+        provider: "Existing quote form",
+      },
+      {
+        url: "https://harbour-electrical.example/new-quote",
+        enabled: false,
+        provider: "Harbour quotes",
+      },
+    ]);
+  });
+});
+
+describe("unsupported source-monitoring suggestion shapes", () => {
+  it("fails closed when a discovered link omits the visibility decision", () => {
+    expect(() =>
+      parseSourceMonitoringSuggestionValue(
+        "LINKS",
+        {
+          integrations: [
+            {
+              type: "booking",
+              label: "Book",
+              provider: "CoverManager",
+              url: "https://book.covermanager.test/osteria",
+              venueId: null,
+            },
+          ],
+          translations: [],
+        },
+        sampleSiteDraft,
+        Vertical.RESTAURANT,
+      ),
+    ).toThrow(SourceMonitoringUnsupportedSuggestionError);
+  });
+
+  it("fails closed when food-retail is given a restaurant booking link", () => {
+    expect(() =>
+      parseSourceMonitoringSuggestionValue(
+        "LINKS",
+        {
+          integrations: [
+            {
+              type: "booking",
+              label: "Book a table",
+              provider: "OpenTable",
+              url: "https://www.opentable.com/r/bakery",
+              enabled: false,
+              venueId: null,
+            },
+          ],
+          translations: sampleFoodRetailDraft.translations.map(
+            (translation) => ({
+              ...translation,
+              integrationLabels: ["Book a table"],
+            }),
+          ),
+        },
+        sampleFoodRetailDraft,
+        Vertical.FOOD_RETAIL,
+      ),
+    ).toThrow(SourceMonitoringUnsupportedSuggestionError);
+  });
+
+  it("fails closed when food-retail stock is claimed without source evidence", () => {
+    const invalid = structuredClone(sampleFoodRetailDraft);
+    invalid.catalogSections[1].items[0].available = true;
+    expect(() =>
+      parseSourceMonitoringSuggestionValue(
+        "MENU",
+        {
+          catalogSections: invalid.catalogSections,
+          translations: invalid.translations,
+        },
+        sampleFoodRetailDraft,
+        Vertical.FOOD_RETAIL,
+      ),
+    ).toThrow(SourceMonitoringUnsupportedSuggestionError);
+  });
+
+  it("fails closed on extra suggestion keys instead of dropping them", () => {
+    expect(() =>
+      parseSourceMonitoringSuggestionValue(
+        "CONTACT",
+        {
+          address: "1 Harbour Street",
+          phone: "+356 7999 1122",
+          published: true,
+        },
+        sampleLocalServiceSiteDraft,
+        Vertical.LOCAL_SERVICE,
+      ),
+    ).toThrow(/Nothing was saved to the private draft/);
+  });
+
+  it("accepts an explicit disabled discovered link for each owner-review vertical", () => {
+    expect(
+      parseSourceMonitoringSuggestionValue(
+        "LINKS",
+        {
+          integrations: [
+            ...sampleSiteDraft.integrations,
+            {
+              type: "social",
+              label: "Instagram",
+              provider: "Instagram",
+              url: "https://www.instagram.com/osterialuna/",
+              enabled: false,
+              venueId: null,
+            },
+          ],
+          translations: sampleSiteDraft.translations,
+        },
+        sampleSiteDraft,
+        Vertical.RESTAURANT,
+      ),
+    ).toMatchObject({
+      integrations: expect.arrayContaining([
+        expect.objectContaining({
+          url: "https://www.instagram.com/osterialuna/",
+          enabled: false,
+        }),
+      ]),
+    });
+    expect(
+      parseSourceMonitoringSuggestionValue(
+        "LINKS",
+        {
+          integrations: [
+            ...sampleFoodRetailDraft.integrations,
+            {
+              type: "delivery",
+              label: "Delivery",
+              provider: "Existing delivery",
+              url: "https://maison-levain.example/delivery",
+              enabled: false,
+              venueId: null,
+            },
+          ],
+          translations: sampleFoodRetailDraft.translations.map(
+            (translation) => ({
+              ...translation,
+              integrationLabels: [
+                ...translation.integrationLabels,
+                "Delivery",
+              ],
+            }),
+          ),
+        },
+        sampleFoodRetailDraft,
+        Vertical.FOOD_RETAIL,
+      ),
+    ).toMatchObject({
+      integrations: expect.arrayContaining([
+        expect.objectContaining({ enabled: false, type: "delivery" }),
+      ]),
+    });
+    expect(
+      parseSourceMonitoringSuggestionValue(
+        "CONTACT",
+        { address: "Valletta waterfront", phone: "+356 7999 1122" },
+        sampleLocalServiceSiteDraft,
+        Vertical.LOCAL_SERVICE,
+      ),
+    ).toEqual({ address: "Valletta waterfront", phone: "+356 7999 1122" });
+  });
+});
+
+function extractedSite(input: {
+  pageText: string;
+  links?: Array<{
+    type: "booking" | "ordering" | "delivery" | "social" | "quote" | "contact";
+    label: string;
+    provider: string | null;
+    url: string;
+  }>;
+}) {
+  return {
+    source: "source.test",
+    sourceUrl: "https://source.test/",
+    sourceLocale: "en",
+    name: "Source",
+    description: "",
+    address: "",
+    phone: "",
+    heroImageUrl: null,
+    photos: [],
+    pageText: input.pageText,
+    links: input.links ?? [],
+  };
+}
 
 function draft() {
   return {

--- a/src/lib/source-monitoring-diff.test.ts
+++ b/src/lib/source-monitoring-diff.test.ts
@@ -192,7 +192,14 @@ describe("lossless source-monitoring diffs", () => {
     current.catalogSections = [
       {
         ...current.catalogSections[0],
-        items: [current.catalogSections[0].items[0]],
+        items: [
+          {
+            ...current.catalogSections[0].items[0],
+            imageUrl: "https://assets.example/original-focaccia.jpg",
+            originalImageUrl: "https://assets.example/original-focaccia.jpg",
+            imageProvenance: "official",
+          },
+        ],
       },
     ];
     const proposed = structuredClone(current);
@@ -201,7 +208,9 @@ describe("lossless source-monitoring diffs", () => {
       description: "Rosemary, sea salt, cultured butter, extra virgin oil",
       available: false,
       attributes: { dietaryLabels: ["vegan"] },
-      imageUrl: null,
+      imageUrl: "https://example.com/invented-focaccia.jpg",
+      originalImageUrl: "https://example.com/invented-focaccia.jpg",
+      imageProvenance: "owner",
     };
     proposed.catalogSections[0].items.push({
       name: "Olives",
@@ -231,6 +240,9 @@ describe("lossless source-monitoring diffs", () => {
       description: "Rosemary, sea salt, cultured butter, extra virgin oil",
       available: current.catalogSections[0].items[0].available,
       attributes: current.catalogSections[0].items[0].attributes,
+      imageUrl: "https://assets.example/original-focaccia.jpg",
+      originalImageUrl: "https://assets.example/original-focaccia.jpg",
+      imageProvenance: "official",
     });
     expect(suggested.catalogSections[0].items.at(-1)).toMatchObject({
       name: "Olives",

--- a/src/lib/source-monitoring-diff.ts
+++ b/src/lib/source-monitoring-diff.ts
@@ -1,7 +1,16 @@
 import { createHash } from "node:crypto";
+import { z } from "zod";
 import type { Prisma } from "@/generated/prisma/client";
+import type { Vertical } from "@/generated/prisma/enums";
 import type { ExtractedSite } from "@/lib/importer";
 import type { PersistableSiteDraft } from "@/lib/site-persistence";
+import { resolveVerticalConfig } from "@/lib/verticals/registry";
+import {
+  businessHoursSchema,
+  catalogItemSchema,
+  catalogSectionSchema,
+  integrationSchema,
+} from "@/lib/verticals/schema";
 
 export type MonitoringField = "MENU" | "CONTACT" | "HOURS" | "LINKS";
 
@@ -20,6 +29,97 @@ export type MonitoringSuggestionInput = {
   suggestedValue: Prisma.InputJsonValue;
   evidence: SourceEvidence[];
 };
+
+export type SourceMonitoringDashboardDto = {
+  cadenceDays: number | null;
+  nextRunAt: string | null;
+  lastRunAt: string | null;
+  lastSuccessAt: string | null;
+  lastFailureAt: string | null;
+  lastFailureCode: string | null;
+  latestRun: {
+    id: string;
+    status: string;
+    scheduledFor: string;
+    completedAt: string | null;
+    suggestionCount: number;
+    checkedSourceCount: number;
+    failedSourceCount: number;
+    notificationFailureCode: string | null;
+  } | null;
+  suggestions: Array<{
+    id: string;
+    field: MonitoringField;
+    path: string;
+    currentValue: unknown;
+    suggestedValue: unknown;
+    editedValue: unknown;
+    evidence: SourceEvidence[];
+    status: string;
+    createdAt: string;
+  }>;
+};
+
+export const EMPTY_SOURCE_MONITORING_DASHBOARD: SourceMonitoringDashboardDto = {
+  cadenceDays: null,
+  nextRunAt: null,
+  lastRunAt: null,
+  lastSuccessAt: null,
+  lastFailureAt: null,
+  lastFailureCode: null,
+  latestRun: null,
+  suggestions: [],
+};
+
+export class SourceMonitoringUnsupportedSuggestionError extends Error {
+  readonly issues: string[];
+
+  constructor(error?: z.ZodError) {
+    const issues = error?.issues.map((issue) => {
+      const path = issue.path.length > 0 ? issue.path.join(".") : "suggestion";
+      return `${path}: ${issue.message}`;
+    }) ?? ["Unsupported suggestion shape"];
+    super(
+      `Unsupported suggestion (${issues[0]}). Nothing was saved to the private draft.`,
+    );
+    this.name = "SourceMonitoringUnsupportedSuggestionError";
+    this.issues = issues;
+  }
+}
+
+const contactSchema = z
+  .object({
+    address: z.string().max(220),
+    phone: z.string().max(40),
+  })
+  .strict();
+
+const monitoringCatalogItemSchema = catalogItemSchema.extend({
+  available: z.boolean().nullable(),
+});
+
+const monitoringCatalogSectionSchema = catalogSectionSchema.extend({
+  items: z.array(monitoringCatalogItemSchema).max(40),
+});
+
+const monitoringLinkSchema = integrationSchema.extend({
+  enabled: z.boolean(),
+  venueId: z.string().max(120).nullable(),
+});
+
+export const menuSuggestionSchema = z
+  .object({
+    catalogSections: z.array(monitoringCatalogSectionSchema).min(1).max(16),
+    translations: z.array(z.unknown()).max(8),
+  })
+  .strict();
+
+export const linksSuggestionSchema = z
+  .object({
+    integrations: z.array(monitoringLinkSchema).max(12),
+    translations: z.array(z.unknown()).max(8),
+  })
+  .strict();
 
 export function buildSourceMonitoringDiff(input: {
   current: PersistableSiteDraft;
@@ -82,11 +182,15 @@ export function buildSourceMonitoringDiff(input: {
     );
   }
 
-  const proposedItemNames = input.proposed.catalogSections.flatMap((section) =>
+  const proposedCatalog = losslessCatalogSections(
+    input.current.catalogSections,
+    input.proposed.catalogSections,
+  );
+  const proposedItemNames = proposedCatalog.flatMap((section) =>
     section.items.map((item) => item.name),
   );
   if (
-    !same(input.current.catalogSections, input.proposed.catalogSections) &&
+    !same(input.current.catalogSections, proposedCatalog) &&
     proposedItemNames.length > 0 &&
     hasEvidenceForEveryValue(input.extracted.pageText, proposedItemNames)
   ) {
@@ -99,10 +203,10 @@ export function buildSourceMonitoringDiff(input: {
           translations: input.current.translations,
         },
         {
-          catalogSections: input.proposed.catalogSections,
+          catalogSections: proposedCatalog,
           translations: structurallyCompatibleTranslations(
             input.current.translations,
-            input.proposed.catalogSections,
+            proposedCatalog,
           ),
         },
         evidenceForValues(
@@ -193,6 +297,34 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function losslessCatalogSections(
+  current: PersistableSiteDraft["catalogSections"],
+  proposed: PersistableSiteDraft["catalogSections"],
+): PersistableSiteDraft["catalogSections"] {
+  return proposed.map((proposedSection) => {
+    const currentSection = current.find(
+      (section) => section.name === proposedSection.name,
+    );
+    return {
+      ...proposedSection,
+      items: proposedSection.items.map((proposedItem) => {
+        const currentItem = currentSection?.items.find(
+          (item) => item.name === proposedItem.name,
+        );
+        if (!currentItem) return proposedItem;
+        return {
+          ...proposedItem,
+          available: currentItem.available,
+          attributes: currentItem.attributes,
+          imageUrl: currentItem.imageUrl,
+          originalImageUrl: currentItem.originalImageUrl,
+          imageProvenance: currentItem.imageProvenance,
+        };
+      }),
+    };
+  });
+}
+
 function mergeLinks(
   current: PersistableSiteDraft["integrations"],
   extracted: ExtractedSite["links"],
@@ -213,10 +345,70 @@ function mergeLinks(
           (link.provider && candidate.provider === link.provider),
       )
     ) {
-      merged.push({ ...link, enabled: true, venueId: null });
+      merged.push({
+        type: link.type,
+        label: link.label,
+        provider: link.provider,
+        url: link.url,
+        enabled: false,
+        venueId: null,
+      });
     }
   }
   return merged;
+}
+
+export function monitoringFieldValue(
+  draft: PersistableSiteDraft,
+  field: MonitoringField | "MENU" | "CONTACT" | "HOURS" | "LINKS",
+) {
+  if (field === "CONTACT") {
+    return { address: draft.address, phone: draft.phone };
+  }
+  if (field === "HOURS") return draft.businessHours;
+  if (field === "MENU") {
+    return {
+      catalogSections: draft.catalogSections,
+      translations: draft.translations,
+    };
+  }
+  return {
+    integrations: draft.integrations,
+    translations: draft.translations,
+  };
+}
+
+export function parseSourceMonitoringSuggestionValue(
+  field: MonitoringField | "MENU" | "CONTACT" | "HOURS" | "LINKS",
+  value: unknown,
+  current: PersistableSiteDraft,
+  vertical: Vertical,
+) {
+  try {
+    const parsed =
+      field === "CONTACT"
+        ? contactSchema.parse(value)
+        : field === "HOURS"
+          ? businessHoursSchema.parse(value)
+          : field === "MENU"
+            ? menuSuggestionSchema.parse(value)
+            : linksSuggestionSchema.parse(value);
+    resolveVerticalConfig(vertical).draftSchema.parse({
+      ...current,
+      ...(field === "CONTACT" ? parsed : {}),
+      ...(field === "HOURS" ? { businessHours: parsed } : {}),
+      ...(field === "MENU" ? parsed : {}),
+      ...(field === "LINKS" ? parsed : {}),
+    });
+    return parsed;
+  } catch (error) {
+    if (error instanceof SourceMonitoringUnsupportedSuggestionError) {
+      throw error;
+    }
+    throw new SourceMonitoringUnsupportedSuggestionError(
+      error instanceof z.ZodError ? error : undefined,
+    );
+  }
 }
 
 function suggestion(

--- a/src/lib/source-monitoring.postgres.test.ts
+++ b/src/lib/source-monitoring.postgres.test.ts
@@ -7,20 +7,36 @@ import {
   mock,
   test,
 } from "bun:test";
+import { Vertical } from "@/generated/prisma/enums";
+import {
+  restaurantSiteDraftSchema,
+  sampleSiteDraft,
+} from "@/lib/restaurant";
+import { updateSiteDraft } from "@/lib/site-persistence";
+import { findSiteDraft } from "@/lib/sites";
+import { sampleFoodRetailDraft } from "@/lib/verticals/food-retail/fixtures";
+import { foodRetailSiteDraftSchema } from "@/lib/verticals/food-retail/schema";
+import { sampleLocalServiceSiteDraft } from "@/lib/verticals/local-service/fixtures";
+import { localServiceSiteDraftSchema } from "@/lib/verticals/local-service/schema";
 
 mock.module("server-only", () => ({}));
 
 const enabled = process.env.SOURCE_MONITORING_POSTGRES_TEST === "1";
 const siteId = `monitor-site-${randomUUID()}`;
+const foodSiteId = `monitor-food-${randomUUID()}`;
+const localSiteId = `monitor-local-${randomUUID()}`;
 const organizationId = `monitor-org-${randomUUID()}`;
 const userId = `monitor-user-${randomUUID()}`;
 const slug = `monitor-${randomUUID()}`;
+const foodSlug = `monitor-food-${randomUUID()}`;
+const localSlug = `monitor-local-${randomUUID()}`;
 const previousPrice = process.env.STRIPE_PRICE_ID;
 
 let db: ReturnType<typeof import("@/lib/db").getDb>;
 let dispatchDueSourceMonitoring: typeof import("@/lib/source-monitoring").dispatchDueSourceMonitoring;
 let reviewSourceMonitoringSuggestion: typeof import("@/lib/source-monitoring").reviewSourceMonitoringSuggestion;
 let SourceMonitoringConflictError: typeof import("@/lib/source-monitoring").SourceMonitoringConflictError;
+let SourceMonitoringUnsupportedSuggestionError: typeof import("@/lib/source-monitoring").SourceMonitoringUnsupportedSuggestionError;
 
 describe.skipIf(!enabled)("source monitoring PostgreSQL persistence", () => {
   beforeAll(async () => {
@@ -32,6 +48,8 @@ describe.skipIf(!enabled)("source monitoring PostgreSQL persistence", () => {
     reviewSourceMonitoringSuggestion =
       monitoring.reviewSourceMonitoringSuggestion;
     SourceMonitoringConflictError = monitoring.SourceMonitoringConflictError;
+    SourceMonitoringUnsupportedSuggestionError =
+      monitoring.SourceMonitoringUnsupportedSuggestionError;
 
     await db.user.create({
       data: {
@@ -86,10 +104,34 @@ describe.skipIf(!enabled)("source monitoring PostgreSQL persistence", () => {
         },
       },
     });
+    await createOwnedSite({
+      id: foodSiteId,
+      slug: foodSlug,
+      vertical: Vertical.FOOD_RETAIL,
+      name: "Monitoring Bakery",
+    });
+    await createOwnedSite({
+      id: localSiteId,
+      slug: localSlug,
+      vertical: Vertical.LOCAL_SERVICE,
+      name: "Monitoring Electrical",
+    });
+    await updateSiteDraft(
+      foodSlug,
+      { ...sampleFoodRetailDraft, slug: foodSlug },
+      Vertical.FOOD_RETAIL,
+    );
+    await updateSiteDraft(
+      localSlug,
+      { ...sampleLocalServiceSiteDraft, slug: localSlug },
+      Vertical.LOCAL_SERVICE,
+    );
   });
 
   afterAll(async () => {
-    await db.site.deleteMany({ where: { id: siteId } });
+    await db.site.deleteMany({
+      where: { id: { in: [siteId, foodSiteId, localSiteId] } },
+    });
     await db.organization.deleteMany({ where: { id: organizationId } });
     await db.user.deleteMany({ where: { id: userId } });
     restoreEnvironment(
@@ -276,15 +318,486 @@ describe.skipIf(!enabled)("source monitoring PostgreSQL persistence", () => {
       }),
     ).toEqual({ status: "PENDING" });
   });
+
+  test("accepts restaurant, food-retail, and local-service catalog suggestions without publishing", async () => {
+    await updateSiteDraft(
+      slug,
+      { ...sampleSiteDraft, slug },
+      Vertical.RESTAURANT,
+    );
+    const restaurantBefore = restaurantSiteDraftSchema.parse(
+      (await findSiteDraft(slug))?.draft,
+    );
+    const restaurantRevision = (await findSiteDraft(slug))?.revision;
+    if (restaurantRevision === undefined) throw new Error("Restaurant draft missing");
+    const restaurantMenu = {
+      catalogSections: restaurantBefore.catalogSections.map(
+        (section, sectionIndex) => ({
+          ...section,
+          items: section.items.map((item, itemIndex) =>
+            sectionIndex === 0 && itemIndex === 0
+              ? { ...item, description: "Reviewed focaccia description" }
+              : item,
+          ),
+        }),
+      ),
+      translations: restaurantBefore.translations,
+    };
+    const restaurantAccepted = await acceptSuggestion({
+      siteId,
+      field: "MENU",
+      path: "catalogSections",
+      currentValue: {
+        catalogSections: restaurantBefore.catalogSections,
+        translations: restaurantBefore.translations,
+      },
+      suggestedValue: restaurantMenu,
+      expectedRevision: restaurantRevision,
+    });
+    expect(restaurantAccepted).toMatchObject({
+      status: "ACCEPTED",
+      vertical: "RESTAURANT",
+    });
+    const restaurantAfter = restaurantSiteDraftSchema.parse(
+      (await findSiteDraft(slug))?.draft,
+    );
+    expect(restaurantAfter.catalogSections[0].items[0]).toMatchObject({
+      description: "Reviewed focaccia description",
+      available: restaurantBefore.catalogSections[0].items[0].available,
+      attributes: restaurantBefore.catalogSections[0].items[0].attributes,
+    });
+    expect(await unpublished(siteId)).toBe(true);
+
+    const foodLoaded = await findSiteDraft(foodSlug);
+    const foodBefore = foodRetailSiteDraftSchema.parse(foodLoaded?.draft);
+    if (foodLoaded?.revision === undefined) {
+      throw new Error("Food-retail draft missing");
+    }
+    const foodMenu = {
+      catalogSections: foodBefore.catalogSections.map(
+        (section, sectionIndex) => ({
+          ...section,
+          items: section.items.map((item, itemIndex) =>
+            sectionIndex === 0 && itemIndex === 0
+              ? {
+                  ...item,
+                  description: "Natural starter with a longer ferment.",
+                }
+              : item,
+          ),
+        }),
+      ),
+      translations: foodBefore.translations,
+    };
+    await acceptSuggestion({
+      siteId: foodSiteId,
+      field: "MENU",
+      path: "catalogSections",
+      currentValue: {
+        catalogSections: foodBefore.catalogSections,
+        translations: foodBefore.translations,
+      },
+      suggestedValue: foodMenu,
+      expectedRevision: foodLoaded.revision,
+    });
+    const foodAfter = foodRetailSiteDraftSchema.parse(
+      (await findSiteDraft(foodSlug))?.draft,
+    );
+    expect(foodAfter.catalogSections[0].items[0]).toMatchObject({
+      description: "Natural starter with a longer ferment.",
+      available: true,
+      attributes: {
+        visible: true,
+        stockSourceUrl: "https://example.com/maison-levain/daily-breads",
+        allergens: ["gluten"],
+      },
+    });
+    expect(foodAfter.catalogSections[1].items[0]).toMatchObject({
+      available: null,
+      attributes: { visible: true, stockSourceUrl: null },
+    });
+    expect(await unpublished(foodSiteId)).toBe(true);
+
+    const localLoaded = await findSiteDraft(localSlug);
+    const localBefore = localServiceSiteDraftSchema.parse(localLoaded?.draft);
+    if (localLoaded?.revision === undefined) {
+      throw new Error("Local-service draft missing");
+    }
+    const localMenu = {
+      catalogSections: localBefore.catalogSections.map((section) => ({
+        ...section,
+        items: section.items.map((item, itemIndex) =>
+          itemIndex === 0
+            ? {
+                ...item,
+                description: "Diagnosis and repair, reviewed from source.",
+              }
+            : item,
+        ),
+      })),
+      translations: localBefore.translations,
+    };
+    await acceptSuggestion({
+      siteId: localSiteId,
+      field: "MENU",
+      path: "catalogSections",
+      currentValue: {
+        catalogSections: localBefore.catalogSections,
+        translations: localBefore.translations,
+      },
+      suggestedValue: localMenu,
+      expectedRevision: localLoaded.revision,
+    });
+    const localAfter = localServiceSiteDraftSchema.parse(
+      (await findSiteDraft(localSlug))?.draft,
+    );
+    expect(localAfter.catalogSections[0].items[0]).toMatchObject({
+      description: "Diagnosis and repair, reviewed from source.",
+      available: true,
+      attributes: {
+        pricingModel: "quote",
+        emergencyEligible: true,
+      },
+    });
+    expect(localAfter.attributes).toMatchObject({
+      credentials: localBefore.attributes.credentials,
+      projects: localBefore.attributes.projects,
+    });
+    expect(await unpublished(localSiteId)).toBe(true);
+  });
+
+  test("persists newly discovered links as disabled reviewable visibility decisions", async () => {
+    const foodLoaded = await findSiteDraft(foodSlug);
+    const foodBefore = foodRetailSiteDraftSchema.parse(foodLoaded?.draft);
+    if (foodLoaded?.revision === undefined) {
+      throw new Error("Food-retail draft missing");
+    }
+    const discovered = {
+      type: "delivery" as const,
+      label: "Delivery",
+      provider: "Existing delivery",
+      url: "https://maison-levain.example/delivery",
+      enabled: false,
+      venueId: null,
+    };
+    const suggested = {
+      integrations: [...foodBefore.integrations, discovered],
+      translations: foodBefore.translations.map((translation) => ({
+        ...translation,
+        integrationLabels: [...translation.integrationLabels, discovered.label],
+      })),
+    };
+    await acceptSuggestion({
+      siteId: foodSiteId,
+      field: "LINKS",
+      path: "integrations",
+      currentValue: {
+        integrations: foodBefore.integrations,
+        translations: foodBefore.translations,
+      },
+      suggestedValue: suggested,
+      expectedRevision: foodLoaded.revision,
+    });
+    const foodAfter = foodRetailSiteDraftSchema.parse(
+      (await findSiteDraft(foodSlug))?.draft,
+    );
+    expect(foodAfter.integrations).toEqual(suggested.integrations);
+    expect(
+      await db.integration.findMany({
+        where: { siteId: foodSiteId },
+        orderBy: { position: "asc" },
+        select: { url: true, enabled: true, provider: true },
+      }),
+    ).toEqual([
+      {
+        url: "https://maison-levain.example/order",
+        enabled: true,
+        provider: "Existing ordering",
+      },
+      {
+        url: "https://maison-levain.example/delivery",
+        enabled: false,
+        provider: "Existing delivery",
+      },
+    ]);
+    expect(await unpublished(foodSiteId)).toBe(true);
+  });
+
+  test("rejects a local-service suggestion without changing the private draft", async () => {
+    const localLoaded = await findSiteDraft(localSlug);
+    const localBefore = localServiceSiteDraftSchema.parse(localLoaded?.draft);
+    if (localLoaded?.revision === undefined) {
+      throw new Error("Local-service draft missing");
+    }
+    const run = await db.sourceMonitorRun.create({
+      data: {
+        siteId: localSiteId,
+        idempotencyKey: `${localSiteId}:reject`,
+        scheduledFor: new Date(),
+        status: "SUCCEEDED",
+        completedAt: new Date(),
+        suggestionCount: 1,
+      },
+    });
+    const suggestion = await db.sourceMonitorSuggestion.create({
+      data: {
+        siteId: localSiteId,
+        runId: run.id,
+        fingerprint: randomUUID(),
+        field: "CONTACT",
+        path: "contact",
+        currentValue: {
+          address: localBefore.address,
+          phone: localBefore.phone,
+        },
+        suggestedValue: {
+          address: "Rejected address",
+          phone: localBefore.phone,
+        },
+        evidence: [],
+      },
+    });
+    await expect(
+      reviewSourceMonitoringSuggestion({
+        siteId: localSiteId,
+        suggestionId: suggestion.id,
+        actor: ownerActor(),
+        action: "reject",
+      }),
+    ).resolves.toEqual({ status: "REJECTED" });
+    expect(
+      localServiceSiteDraftSchema.parse((await findSiteDraft(localSlug))?.draft)
+        .address,
+    ).toBe(localBefore.address);
+    expect((await findSiteDraft(localSlug))?.revision).toBe(
+      localLoaded.revision,
+    );
+    expect(await unpublished(localSiteId)).toBe(true);
+  });
+
+  test("rejects unsupported suggestion shapes without mutating the draft", async () => {
+    const localLoaded = await findSiteDraft(localSlug);
+    const localBefore = localServiceSiteDraftSchema.parse(localLoaded?.draft);
+    if (localLoaded?.revision === undefined) {
+      throw new Error("Local-service draft missing");
+    }
+    const run = await db.sourceMonitorRun.create({
+      data: {
+        siteId: localSiteId,
+        idempotencyKey: `${localSiteId}:unsupported-shape`,
+        scheduledFor: new Date(),
+        status: "SUCCEEDED",
+        completedAt: new Date(),
+        suggestionCount: 1,
+      },
+    });
+    const suggestion = await db.sourceMonitorSuggestion.create({
+      data: {
+        siteId: localSiteId,
+        runId: run.id,
+        fingerprint: randomUUID(),
+        field: "LINKS",
+        path: "integrations",
+        currentValue: {
+          integrations: localBefore.integrations,
+          translations: localBefore.translations,
+        },
+        suggestedValue: {
+          integrations: [
+            {
+              type: "quote",
+              label: "Broken",
+              provider: "Harbour quotes",
+              url: "https://harbour-electrical.example/broken",
+              venueId: null,
+            },
+          ],
+          translations: localBefore.translations,
+        },
+        evidence: [],
+      },
+    });
+    await expect(
+      reviewSourceMonitoringSuggestion({
+        siteId: localSiteId,
+        suggestionId: suggestion.id,
+        actor: ownerActor(),
+        action: "accept",
+        expectedRevision: localLoaded.revision,
+      }),
+    ).rejects.toBeInstanceOf(SourceMonitoringUnsupportedSuggestionError);
+    expect(
+      await db.sourceMonitorSuggestion.findUniqueOrThrow({
+        where: { id: suggestion.id },
+        select: { status: true },
+      }),
+    ).toEqual({ status: "PENDING" });
+    expect((await findSiteDraft(localSlug))?.revision).toBe(
+      localLoaded.revision,
+    );
+    expect(await unpublished(localSiteId)).toBe(true);
+  });
+
+  test("rejects a stale food-retail revision without applying the suggestion", async () => {
+    const foodLoaded = await findSiteDraft(foodSlug);
+    const foodBefore = foodRetailSiteDraftSchema.parse(foodLoaded?.draft);
+    if (foodLoaded?.revision === undefined) {
+      throw new Error("Food-retail draft missing");
+    }
+    const run = await db.sourceMonitorRun.create({
+      data: {
+        siteId: foodSiteId,
+        idempotencyKey: `${foodSiteId}:stale-revision`,
+        scheduledFor: new Date(),
+        status: "SUCCEEDED",
+        completedAt: new Date(),
+        suggestionCount: 1,
+      },
+    });
+    const suggestion = await db.sourceMonitorSuggestion.create({
+      data: {
+        siteId: foodSiteId,
+        runId: run.id,
+        fingerprint: randomUUID(),
+        field: "CONTACT",
+        path: "contact",
+        currentValue: {
+          address: foodBefore.address,
+          phone: foodBefore.phone,
+        },
+        suggestedValue: {
+          address: "Stale bakery address",
+          phone: foodBefore.phone,
+        },
+        evidence: [],
+      },
+    });
+    await expect(
+      reviewSourceMonitoringSuggestion({
+        siteId: foodSiteId,
+        suggestionId: suggestion.id,
+        actor: ownerActor(),
+        action: "accept",
+        expectedRevision: foodLoaded.revision - 1,
+      }),
+    ).rejects.toMatchObject({
+      name: "DraftRevisionConflictError",
+      currentRevision: foodLoaded.revision,
+    });
+    expect(
+      foodRetailSiteDraftSchema.parse((await findSiteDraft(foodSlug))?.draft)
+        .address,
+    ).toBe(foodBefore.address);
+    expect(
+      await db.sourceMonitorSuggestion.findUniqueOrThrow({
+        where: { id: suggestion.id },
+        select: { status: true },
+      }),
+    ).toEqual({ status: "PENDING" });
+  });
 });
 
-async function currentRevision(): Promise<number> {
+async function currentRevision(id = siteId): Promise<number> {
   return (
     await db.site.findUniqueOrThrow({
-      where: { id: siteId },
+      where: { id },
       select: { draftRevision: true },
     })
   ).draftRevision;
+}
+
+function ownerActor() {
+  return {
+    id: userId,
+    email: `${userId}@example.test`,
+    role: "owner" as const,
+  };
+}
+
+async function unpublished(id: string) {
+  const site = await db.site.findUniqueOrThrow({
+    where: { id },
+    select: {
+      publishedSiteVersionId: true,
+      _count: { select: { siteVersions: true } },
+    },
+  });
+  return site.publishedSiteVersionId === null && site._count.siteVersions === 0;
+}
+
+async function acceptSuggestion(input: {
+  siteId: string;
+  field: "MENU" | "CONTACT" | "HOURS" | "LINKS";
+  path: string;
+  currentValue: unknown;
+  suggestedValue: unknown;
+  expectedRevision: number;
+}) {
+  const run = await db.sourceMonitorRun.create({
+    data: {
+      siteId: input.siteId,
+      idempotencyKey: `${input.siteId}:${randomUUID()}`,
+      scheduledFor: new Date(),
+      status: "SUCCEEDED",
+      completedAt: new Date(),
+      suggestionCount: 1,
+    },
+  });
+  const suggestion = await db.sourceMonitorSuggestion.create({
+    data: {
+      siteId: input.siteId,
+      runId: run.id,
+      fingerprint: randomUUID(),
+      field: input.field,
+      path: input.path,
+      currentValue: input.currentValue as never,
+      suggestedValue: input.suggestedValue as never,
+      evidence: [],
+    },
+  });
+  return reviewSourceMonitoringSuggestion({
+    siteId: input.siteId,
+    suggestionId: suggestion.id,
+    actor: ownerActor(),
+    action: "accept",
+    expectedRevision: input.expectedRevision,
+  });
+}
+
+async function createOwnedSite(input: {
+  id: string;
+  slug: string;
+  vertical: Vertical;
+  name: string;
+}) {
+  await db.site.create({
+    data: {
+      id: input.id,
+      slug: input.slug,
+      name: input.name,
+      eyebrow: "Workspace",
+      description: "A sufficiently long monitoring integration fixture.",
+      address: "Old address",
+      phone: "1111",
+      sourceUrl: "https://source.test/",
+      draftPalette: {
+        background: "#ffffff",
+        foreground: "#111111",
+        accent: "#aa0000",
+      },
+      attributes: {},
+      status: "CLAIMED",
+      vertical: input.vertical,
+      organizationId,
+      catalogSections: {
+        create: {
+          name: "Catalog",
+          description: "",
+          position: 0,
+        },
+      },
+    },
+  });
 }
 
 function restoreEnvironment(name: string, value: string | undefined) {

--- a/src/lib/source-monitoring.ts
+++ b/src/lib/source-monitoring.ts
@@ -29,8 +29,10 @@ import {
   monitoringIdempotencyKey,
   nextMonitoringTime,
 } from "@/lib/source-monitoring-plan";
+import { catalogPhotoReplacementPosition } from "@/lib/catalog-photo-reconciliation";
 import {
   DraftRevisionConflictError,
+  rebindSelectedCatalogPhotos,
   type PersistableSiteDraft,
 } from "@/lib/site-persistence";
 import { projectSiteDraft, siteDraftRelations } from "@/lib/sites";
@@ -700,6 +702,37 @@ async function applySuggestionValue(
   const config = resolveVerticalConfig(vertical);
   const { catalogSections: sections, translations } =
     menuSuggestionSchema.parse(value);
+  const catalogPhotoSelections = await transaction.photoAsset.findMany({
+    where: {
+      siteId,
+      selectedUsage: "CATALOG",
+      selectedCatalogItemId: { not: null },
+    },
+    select: {
+      id: true,
+      originalUrl: true,
+      enhancedUrl: true,
+      enhancedReviewStatus: true,
+      activeVariant: true,
+      provenance: true,
+      selectedCatalogItem: {
+        select: {
+          name: true,
+          section: { select: { name: true } },
+        },
+      },
+    },
+  });
+  const catalogPhotoTargets = catalogPhotoSelections.map((selection) => ({
+    selection,
+    position: selection.selectedCatalogItem
+      ? catalogPhotoReplacementPosition({
+          previousSectionName: selection.selectedCatalogItem.section.name,
+          previousItemName: selection.selectedCatalogItem.name,
+          replacementCatalog: sections,
+        })
+      : null,
+  }));
   const updated = await transaction.site.update({
     where: { id: siteId },
     data: {
@@ -735,6 +768,7 @@ async function applySuggestionValue(
       },
     });
   }
+  await rebindSelectedCatalogPhotos(transaction, siteId, catalogPhotoTargets);
   return updated.draftRevision;
 }
 

--- a/src/lib/source-monitoring.ts
+++ b/src/lib/source-monitoring.ts
@@ -14,8 +14,15 @@ import { emailReplyTo, emailSender } from "@/lib/email-identity";
 import { getResend } from "@/lib/resend";
 import {
   buildSourceMonitoringDiff,
+  EMPTY_SOURCE_MONITORING_DASHBOARD,
+  linksSuggestionSchema,
+  menuSuggestionSchema,
+  monitoringFieldValue,
+  parseSourceMonitoringSuggestionValue,
+  SourceMonitoringUnsupportedSuggestionError,
   type MonitoringSuggestionInput,
   type SourceEvidence,
+  type SourceMonitoringDashboardDto,
 } from "@/lib/source-monitoring-diff";
 import {
   monitoringEntitlement,
@@ -28,29 +35,21 @@ import {
 } from "@/lib/site-persistence";
 import { projectSiteDraft, siteDraftRelations } from "@/lib/sites";
 import { crawlSiteSource, generateDraftForVertical } from "@/lib/site-pipeline";
-import {
-  businessHoursSchema,
-  catalogSectionSchema,
-  integrationSchema,
-} from "@/lib/verticals/schema";
+import { businessHoursSchema } from "@/lib/verticals/schema";
 import { resolveVerticalConfig } from "@/lib/verticals/registry";
 import type { VerticalId } from "@/lib/verticals/types";
+
+export {
+  EMPTY_SOURCE_MONITORING_DASHBOARD,
+  SourceMonitoringUnsupportedSuggestionError,
+  type SourceMonitoringDashboardDto,
+};
 
 const DAY_MS = 24 * 60 * 60_000;
 const MAX_DISPATCH = 200;
 const contactSchema = z.object({
   address: z.string().max(220),
   phone: z.string().max(40),
-});
-const menuSchema = z.array(catalogSectionSchema).min(1).max(12);
-const linksSchema = z.array(integrationSchema).max(12);
-const menuSuggestionSchema = z.object({
-  catalogSections: menuSchema,
-  translations: z.array(z.unknown()).max(8),
-});
-const linksSuggestionSchema = z.object({
-  integrations: linksSchema,
-  translations: z.array(z.unknown()).max(8),
 });
 
 export class SourceMonitoringConflictError extends Error {
@@ -59,36 +58,6 @@ export class SourceMonitoringConflictError extends Error {
     this.name = "SourceMonitoringConflictError";
   }
 }
-
-export type SourceMonitoringDashboardDto = {
-  cadenceDays: number | null;
-  nextRunAt: string | null;
-  lastRunAt: string | null;
-  lastSuccessAt: string | null;
-  lastFailureAt: string | null;
-  lastFailureCode: string | null;
-  latestRun: {
-    id: string;
-    status: string;
-    scheduledFor: string;
-    completedAt: string | null;
-    suggestionCount: number;
-    checkedSourceCount: number;
-    failedSourceCount: number;
-    notificationFailureCode: string | null;
-  } | null;
-  suggestions: Array<{
-    id: string;
-    field: SourceMonitorSuggestionField;
-    path: string;
-    currentValue: unknown;
-    suggestedValue: unknown;
-    editedValue: unknown;
-    evidence: SourceEvidence[];
-    status: string;
-    createdAt: string;
-  }>;
-};
 
 export async function dispatchDueSourceMonitoring(
   now = new Date(),
@@ -567,7 +536,7 @@ export async function reviewSourceMonitoringSuggestion(input: {
       if (!sameJsonValue(currentValue, suggestion.currentValue)) {
         throw new SourceMonitoringConflictError();
       }
-      const proposedValue = parseSuggestionValue(
+      const proposedValue = parseSourceMonitoringSuggestionValue(
         suggestion.field,
         input.editedValue ?? suggestion.suggestedValue,
         currentDraft,
@@ -672,51 +641,6 @@ async function persistSuccessfulRun(
   );
 }
 
-function monitoringFieldValue(
-  draft: PersistableSiteDraft,
-  field: SourceMonitorSuggestionField,
-) {
-  if (field === "CONTACT") {
-    return { address: draft.address, phone: draft.phone };
-  }
-  if (field === "HOURS") return draft.businessHours;
-  if (field === "MENU") {
-    return {
-      catalogSections: draft.catalogSections,
-      translations: draft.translations,
-    };
-  }
-  return {
-    integrations: draft.integrations,
-    translations: draft.translations,
-  };
-}
-
-function parseSuggestionValue(
-  field: SourceMonitorSuggestionField,
-  value: unknown,
-  current: PersistableSiteDraft,
-  vertical: Vertical,
-) {
-  const parsed =
-    field === "CONTACT"
-      ? contactSchema.parse(value)
-      : field === "HOURS"
-        ? businessHoursSchema.parse(value)
-        : field === "MENU"
-          ? menuSuggestionSchema.parse(value)
-          : linksSuggestionSchema.parse(value);
-  const config = resolveVerticalConfig(vertical);
-  config.draftSchema.parse({
-    ...current,
-    ...(field === "CONTACT" ? parsed : {}),
-    ...(field === "HOURS" ? { businessHours: parsed } : {}),
-    ...(field === "MENU" ? parsed : {}),
-    ...(field === "LINKS" ? parsed : {}),
-  });
-  return parsed;
-}
-
 async function applySuggestionValue(
   transaction: Prisma.TransactionClient,
   siteId: string,
@@ -765,6 +689,7 @@ async function applySuggestionValue(
         label: link.label,
         provider: link.provider,
         url: link.url,
+        enabled: link.enabled,
         venueId: link.venueId,
         position,
       })),
@@ -797,6 +722,7 @@ async function applySuggestionValue(
             description: item.description,
             price: item.price,
             currency: item.currency,
+            available: item.available,
             attributes: config.itemAttributesSchema.parse(
               item.attributes,
             ) as Prisma.InputJsonValue,

--- a/src/lib/verticals/local-service/local-service.test.ts
+++ b/src/lib/verticals/local-service/local-service.test.ts
@@ -41,6 +41,17 @@ describe("local-service vertical", () => {
         projects: [{ title: "Claimed project", imageUrl: "javascript:alert(1)" }],
       }).success,
     ).toBe(false);
+    expect(
+      localServiceAttributesSchema.safeParse({
+        ...localServiceConfig.attributeDefaults,
+        projects: [
+          {
+            title: "Claimed project",
+            imageUrl: "https://assets.example/rewire.jpg",
+          },
+        ],
+      }).success,
+    ).toBe(false);
   });
 
   it("keeps availability, insurance and price posture unstated by default", () => {

--- a/src/lib/verticals/local-service/schema.ts
+++ b/src/lib/verticals/local-service/schema.ts
@@ -5,6 +5,7 @@ import {
   baseSiteTranslationSchema,
   catalogItemSchema,
   catalogSectionSchema,
+  imageProvenanceSchema,
   integrationSchema,
   siteImageUrlSchema,
   translatedCatalogItemSchema,
@@ -40,18 +41,31 @@ export const localServiceTrustSignalSchema = z.object({
   detail: z.string().trim().max(140).default(""),
 });
 
-export const localServiceProjectSchema = z.object({
-  title: z.string().trim().min(1).max(100),
-  description: z.string().trim().max(320).default(""),
-  imageUrl: siteImageUrlSchema
-    .refine(
-      (value) => value.startsWith("/") || new URL(value).protocol === "https:",
-      "Project images must use HTTPS or a local asset path",
-    )
-    .nullable()
-    .default(null),
-  location: z.string().trim().max(100).default(""),
-});
+export const localServiceProjectSchema = z
+  .object({
+    title: z.string().trim().min(1).max(100),
+    description: z.string().trim().max(320).default(""),
+    imageUrl: siteImageUrlSchema
+      .refine(
+        (value) =>
+          value.startsWith("/") || new URL(value).protocol === "https:",
+        "Project images must use HTTPS or a local asset path",
+      )
+      .nullable()
+      .default(null),
+    originalImageUrl: siteImageUrlSchema.nullable().optional(),
+    imageProvenance: imageProvenanceSchema.nullable().optional(),
+    location: z.string().trim().max(100).default(""),
+  })
+  .superRefine((project, context) => {
+    if (project.imageUrl && !project.imageProvenance) {
+      context.addIssue({
+        code: "custom",
+        path: ["imageProvenance"],
+        message: "A project image requires recorded provenance",
+      });
+    }
+  });
 
 export const localServiceAttributesSchema = z.object({
   tradeType: localServiceTradeTypeSchema.default("general-trades"),


### PR DESCRIPTION
Depends on #174 / #151 (and transitively #171, #172).

## Summary

Source-monitoring review is no longer restaurant-only. Food-retail and local-service owner dashboards load tenant-scoped cadence, last result, failures, evidence, and accept/reject actions through the shared panel when `ownerOperations.sourceMonitoring` is enabled. Beauty and any registry-disabled vertical stay fail-closed.

- **Capability:** food-retail and local-service enable source monitoring; articles, photos, analytics, and leads stay explicit not-yet.
- **Visibility:** newly discovered links are suggested with `enabled: false` / `venueId: null`. Existing provider identity, enabled state, and venue ids are preserved. Accepting never publishes.
- **Lossless catalog:** matching items keep tri-state `available`, vertical attributes (stock, allergens, pricing/emergency), images, translations, and ordering unless the evidence-backed suggestion changes them. Persistence now writes `available` and `enabled`.
- **Fail closed:** unsupported suggestion shapes (missing visibility, extra keys, vertical-illegal link types, stock without evidence) return an actionable 422 and do not mutate the private draft. Stale revisions still 409.

## Why

#151 already showed an explicit not-yet monitoring card on food-retail/local-service. The product copy promised monitoring the restaurant dashboard already had, and the shared diff path was laundering discovered links to `enabled: true` plus dropping catalog availability on accept.

## Test plan

- [x] Unit tests for lossless restaurant / food-retail / local-service diffs and implicit-enable regression
- [x] Unit tests for unsupported suggestion shapes and capability fail-closed access
- [x] Postgres suite skip-safe without `SOURCE_MONITORING_POSTGRES_TEST=1`; covers accept/reject, stale revision, and all three verticals when enabled
- [x] `bun run lint`
- [x] `next typegen` + `bunx tsc --noEmit`
- [x] `git diff --check`
- [ ] PR CI required checks

Closes #150