### PR TITLE
fix(dashboard): protect unsaved owner edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,49 @@
 Cornershopdev is a multi-vertical local-business website factory. Each
 configured niche supplies its own discovery queries, catalog/conversion
 signals, content schema, preview generator, storefront identity, and provider
-adapters. A business keeps the operational tools it already uses, reviews a
-private prefilled preview, claims it, subscribes, then connects its domain.
+adapters. A business keeps the operational tools it already uses and reviews a
+private prefilled preview. Claim, subscription, custom domains, monitoring,
+leads, and articles are per-vertical capabilities, not a universal lifecycle.
+
+## Vertical capabilities
+
+These axes are independent. Factory visibility is not a standalone niche
+launch. A claim mode is not owner publish. Rendering an already-published
+snapshot is not the same as creating one. Custom domains, source monitoring,
+leads, and articles are owner-operation flags resolved through
+`resolveOwnerOperations` and fail closed against claim and publication-mutation
+gates.
+
+| Vertical | Factory visibility | Standalone launch | Claim mode | Owner mutation | Platform publication | Custom domains | Monitoring | Leads | Articles |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Restaurant | public | launched | niche | enabled | enabled | enabled | enabled | enabled | enabled |
+| Beauty | public | unlaunched | disabled | unsupported | enabled | unsupported | unsupported | unsupported | unsupported |
+| Food Retail | private | unlaunched | factory | enabled | enabled | enabled | enabled | not-yet | not-yet |
+| Local Service | private | unlaunched | factory | enabled | enabled | enabled | enabled | not-yet | not-yet |
+
+- **Factory visibility** — `marketing.publiclyAccessible`: the shared
+  `/niche/[vertical]` route.
+- **Standalone launch** — `verticalLaunchReadiness`: public access, canonical
+  domain, matching routed hostname, and verified niche sender.
+- **Claim mode** — `disabled`, `factory` (Cornershopdev sender and
+  `<slug>.cornershop.dev`), or `niche` (the vertical's own domain and sender).
+- **Owner mutation** — publish and rollback. Requires
+  `publicationMutationEnabled` and a supported owner-review dashboard.
+- **Platform publication** — `publicationEnabled`: already-published snapshots
+  may still render when owners cannot create new ones.
+- **Custom domains / Monitoring / Leads / Articles** — owner-operation states
+  (`enabled`, `not-yet`, `gated`, `unsupported`).
+
+Restaurant, Food Retail, and Local Service also enable billing, publication
+history, workspace switching, and the reviewed photo library. Beauty leaves
+every paid owner operation unsupported. It is a non-chargeable factory
+preview, not a sellable niche.
 
 ## Product flow
 
-1. Paste a restaurant URL or name.
+Shared import path, used by every registered vertical:
+
+1. Paste a source URL or name into that vertical's intake.
 2. Import public website content with SSRF-safe fetching and bounded HTML reads.
 3. Deterministically recover structured business facts, hours, bounded catalog
    candidates, relevant navigation, authentic source assets, and field-level
@@ -16,20 +53,36 @@ private prefilled preview, claims it, subscribes, then connects its domain.
 4. Recover source logos/favicons and CSS/meta brand colours, repairing contrast
    where necessary before the palette reaches a renderer.
 5. Detect the source language and preserve it as canonical. When OpenRouter is
-   configured, generate a complete English translation in the structured pass.
-6. Preserve first-party photography and optionally enhance exposure, colour, crop, noise, and clarity without changing the food or venue.
+   configured, generate a complete English translation in the structured pass
+   unless the vertical is `deterministic-only`.
+6. Preserve first-party photography and optionally enhance exposure, colour,
+   crop, noise, and clarity without changing material scene content. Each
+   vertical lists its own forbidden elements.
 7. Save a private preview through a durable PostgreSQL-backed Workflow.
-8. Verify ownership through a one-time business-domain email invitation or a concierge-approved owner email.
-9. Claim the restaurant through invitation-bound Stripe Checkout; the completed checkout creates the prefilled owner account.
-10. Authorize the restaurant domain for on-demand TLS and show the exact DNS records.
-11. Monitor and maintain the menu, imagery, and external links from the dashboard.
+
+What happens after preview depends on the matrix above:
+
+- **Restaurant (`niche`)** — verify ownership through a one-time
+  business-domain email invitation or a concierge-approved owner email; claim
+  through invitation-bound Stripe Checkout; authorize a custom domain for
+  on-demand TLS; monitor the menu, imagery, and links; review first-party
+  booking leads; publish articles.
+- **Food Retail and Local Service (`factory`)** — an approved preview can
+  claim the shared $49 Cornershopdev plan and publish on
+  `<slug>.cornershop.dev`. Custom domains and source monitoring are enabled.
+  Owner analytics, lead inbox, and articles are not-yet.
+- **Beauty (`disabled`)** — the factory `/niche/beauty` preview stays
+  non-chargeable. Claim, owner mutation, billing, custom domains, monitoring,
+  leads, and articles are unsupported.
 
 ## Customer workspace and operator console
 
-Each claimed site has a tenant-scoped `/dashboard` workspace. Owners can edit
-their site, connect a domain, review first-party booking leads, and move each
-request from `NEW` to `CONTACTED` or `CLOSED`. Contact details are returned only
-after the session is revalidated against that site's organization membership.
+Each claimed site has a tenant-scoped `/dashboard` workspace. Owners only get
+the operations their vertical enables. Contact details are returned only after
+the session is revalidated against that site's organization membership.
+Restaurant can review first-party booking leads and move each request from
+`NEW` to `CONTACTED` or `CLOSED`. Food Retail and Local Service do not expose
+a lead inbox yet. Beauty has no owner-review dashboard.
 
 `/admin` is the platform operator console. It requires both a database
 `SUPERADMIN` role and an email listed in `SUPERADMIN_EMAILS`. It shows signups,
@@ -67,12 +120,14 @@ paths, query strings, provider URLs, names, email addresses, phone numbers, or
 booking notes. A one-minute Redis limiter may use a transient hash derived from
 the connection address; it is not written to PostgreSQL.
 
-Booking requests remain the authoritative lead count, so a dropped analytics
-beacon cannot lose a real lead. The corresponding `LEAD_CREATED` event is
-server-owned and best effort. Client and operator workspaces expose 7, 30, and
-90-day distinct-visit, CTA-visitor, booking-lead, and conversion metrics.
-Raw analytics events are retained for 120 days and pruned daily under a
-PostgreSQL advisory lock.
+Booking requests remain the authoritative lead count for verticals that enable
+the lead inbox, so a dropped analytics beacon cannot lose a real lead. The
+corresponding `LEAD_CREATED` event is server-owned and best effort. Restaurant
+owner workspaces and the operator console expose 7, 30, and 90-day
+distinct-visit, CTA-visitor, booking-lead, and conversion metrics. Food Retail
+and Local Service mark owner analytics as not-yet; Beauty has no owner
+analytics. Raw analytics events are retained for 120 days and pruned daily
+under a PostgreSQL advisory lock.
 
 ## Restaurant themes
 
@@ -101,6 +156,14 @@ Heritage and fine-dining templates default to a clean text-led menu; casual,
 fresh, coastal, and bold concepts default to a small highlights gallery. Owners
 can show or hide the gallery from the dashboard without deleting any images.
 
+## Beauty vertical
+
+`BEAUTY` is a non-chargeable factory preview. `/niche/beauty` is publicly
+accessible, but it has no standalone domain or sender, and `claimMode` is
+`disabled`. Already-published snapshots remain renderable. Owner mutation,
+billing, custom domains, monitoring, leads, articles, and the photo library
+are unsupported. There is no owner-review dashboard.
+
 ## Food retail vertical
 
 `FOOD_RETAIL` is a bounded vertical for bakeries, pâtisseries, butchers,
@@ -120,12 +183,12 @@ adapter restores business identity, contact details, hours, products, prices,
 ordering links and factual product attributes from deterministic crawl output.
 Unsupported model claims remain empty or null.
 
-The vertical is registered for private studio imports and owner dashboards but
-is not publicly launched: its marketing hostnames are empty, its domain and
-sender are null, and its server-side publication and rollback capability is
-disabled. Private preview and owner review remain available.
-The implementation contract, test fixture, structured-data mapping and required
-domain/sender/production-config evidence are documented in
+The vertical is factory-claimable but not publicly launched: marketing
+hostnames are empty, domain and sender are null, and `publiclyAccessible` is
+false. Claim mode is `factory`. Already-published snapshots render, and owners
+with the food-retail dashboard may publish and roll back. Custom domains,
+source monitoring, and the photo library are enabled. Owner analytics, lead
+inbox, and articles are not-yet. See the capability matrix above and
 [`docs/verticals/food-retail.md`](docs/verticals/food-retail.md).
 
 ## Local-service vertical
@@ -143,9 +206,11 @@ evidence. Missing emergency coverage, credentials, insurance, trust claims,
 projects, prices, or availability remain unstated rather than being inferred.
 
 The vertical is registered for private imports, previews, and revision-safe
-owner editing. Public niche access, claiming, publication, and rollback remain
-disabled until a real domain, exact routed hostname, and matching verified
-sender configuration satisfy the launch-readiness gate. See
+owner editing. Factory claim, publication, custom domains, source monitoring,
+and the photo library are enabled. Public niche access and standalone launch
+stay closed until a real domain, exact routed hostname, and matching verified
+sender satisfy `verticalLaunchReadiness`. Owner analytics, lead inbox, and
+articles are not-yet. See the capability matrix above and
 [`docs/verticals/local-service.md`](docs/verticals/local-service.md).
 
 ## Internationalization
@@ -153,8 +218,8 @@ sender configuration satisfy the launch-readiness gate. See
 Site data uses one canonical source locale plus structured translation
 overlays. Prices, currencies, images, addresses, provider names, and external
 booking or ordering URLs remain shared, so translating a site cannot fork its
-operational data. Menu sections, menu items, descriptions, dietary labels, and
-link labels keep the same order and count in every locale.
+operational data. Catalog sections, items, descriptions, vertical-specific
+labels, and link labels keep the same order and count in every locale.
 If an existing provider URL already exposes a `lang` parameter, the rendered
 link updates only that preference while preserving the same provider and flow.
 
@@ -166,13 +231,16 @@ The canonical site is available at `/preview/[slug]`; translations use
 
 ## Stack
 
+Package majors below match `package.json`. Runtime image pins live in the
+Dockerfile.
+
 - Next.js 16 App Router and React 19
-- Bun 1.3.14 for installs, Prisma/Workflow migrations, and operator tooling;
+- Bun 1.4.0 for installs, Prisma/Workflow migrations, and operator tooling;
   pinned Node.js 24.19.0 LTS for Next.js builds and the production standalone
   server
 - Tailwind CSS v4 and shadcn/ui
 - Prisma 7 with PostgreSQL and the `pg` driver adapter
-- Vercel AI SDK 6 with OpenRouter for structured text generation and optional
+- Vercel AI SDK 7 with OpenRouter for structured text generation and optional
   source-photo enhancement
 - Workflow DevKit with its self-hosted PostgreSQL World
 - Amazon S3 and CloudFront for persistent enhanced derivatives
@@ -230,7 +298,7 @@ fails closed when it is absent or invalid.
 
 ### AI generation
 
-Restaurant crawling, same-origin page discovery, SSRF checks, and source
+Source crawling, same-origin page discovery, SSRF checks, and source
 reconstruction run locally without a model. JSON-LD, metadata, explicit contact
 links, semantic address markup, source navigation, logos/favicons, and CSS/meta
 colours are recovered with bounded parsers. Every accepted fact keeps its source
@@ -303,9 +371,11 @@ reaches the live site only after the owner publishes again.
 
 Allowed edits are exposure, white balance, highlight and shadow recovery,
 denoising, sharpness, resolution, straightening, subtle cropping, and removal of
-transient non-material distractions such as sensor dust. Ingredients, garnishes,
-portions, plating, tableware, people, architecture, and material scene elements
-must not be added, removed, replaced, moved, or regenerated. Only approved
+transient non-material distractions such as sensor dust. Material scene
+elements must not be added, removed, replaced, moved, or regenerated. Each
+vertical lists its own forbidden subjects — food and plating for restaurants,
+product and packaging for food retail, skin/hair/nail and treatment results
+for beauty. Only approved
 originals enter a rate- and concurrency-limited batch. Originals remain active
 until the owner approves the before/after derivative, and every approve, reject,
 selection, restore, failure, and cost result is audited. See
@@ -392,7 +462,8 @@ bun run operator:preflight-outreach --environment production
 The application records the hostname and returns the production A or CNAME
 target. After DNS resolves, the owner verifies it in the dashboard. Caddy issues
 TLS only when its authorization callback confirms that the domain is verified
-and belongs to a restaurant.
+and belongs to a claimed site. Custom-domain owner operations stay closed for
+verticals whose `customDomain` capability is not enabled.
 
 ### Production routing
 
@@ -420,9 +491,10 @@ this same container, where the rewrite fires again — an infinite loop.
 - AI output is validated with Zod before it enters the product.
 - Existing booking and ordering links are extracted from source material and override model-generated links.
 - Stripe webhooks verify the raw body signature.
-- Restaurant claims require a hashed, expiring invitation bound to one site,
-  intended email, and Stripe Checkout session. Raw invitation tokens are kept
-  in URL fragments so embedded preview assets cannot receive them as referrers.
+- Claims require a hashed, expiring invitation bound to one site, intended
+  email, and Stripe Checkout session, and only for verticals whose claim mode
+  is enabled. Raw invitation tokens are kept in URL fragments so embedded
+  preview assets cannot receive them as referrers.
 - Self-serve claims require the exact imported business email or an address on
   the exact source hostname. Ambiguous ownership requires a dual-gated
   superadmin approval from the operator console.
@@ -431,17 +503,22 @@ this same container, where the rewrite fires again — an infinite loop.
   acceptance, and rejection events are recorded without tokens or contact data.
 - Better Auth owns revocable, database-backed dashboard sessions behind a
   signed HTTP-only, same-site cookie.
-- Restaurant mutations require a session matching the restaurant slug.
-- Image enhancement and domain management require that same restaurant-scoped session.
+- Site mutations require a session matching the site slug and current
+  organization membership. Routes are vertical-aware: publish/rollback, domain
+  management, photo library, source monitoring, analytics, articles, and the
+  lead inbox still fail closed when that vertical's owner operation is not
+  enabled.
+- Image enhancement and domain management require that same site-scoped session.
 - Public preview generation is rate limited and fails closed in production.
 - Enhanced derivatives are persisted to private S3 storage and served through CloudFront while authentic originals and provenance remain available.
-- Arbitrary restaurant images load directly in the browser instead of through the Next.js image proxy.
+- Arbitrary site images load directly in the browser instead of through the Next.js image proxy.
 
 ## Useful routes
 
 - `/` — marketing and URL intake
+- `/niche/[vertical]` — factory niche page for publicly accessible verticals
 - `/create` — import and preview studio
-- `/claim/[slug]` — pricing and claim checkout
+- `/claim/[slug]` — pricing and claim checkout, when that vertical's claim mode is enabled
 - `/dashboard` — authenticated vertical-aware owner management
 - `/dashboard?demo=1` — local demo dashboard
 - `/admin` — dual-gated superadmin operator console

--- a/docs/verticals/food-retail.md
+++ b/docs/verticals/food-retail.md
@@ -13,7 +13,8 @@ flowchart LR
   C --> D[(Shared Site and Catalog tables)]
   D --> E[Private preview]
   D --> F[Food retail owner dashboard]
-  F --> G[Private owner review]
+  F --> G[Factory claim]
+  G --> H[Publish on platform subdomain]
 ```
 
 ## Vertical boundary
@@ -89,6 +90,18 @@ carry the vertical data, so no existing rows are rewritten and the migration
 does not seed product facts. The owner PUT route parses FOOD_RETAIL drafts with
 the registered schema before the shared optimistic-revision persistence path.
 
+## Capability row
+
+Matches the README matrix and `resolveOwnerOperations(FOOD_RETAIL)`:
+
+| Vertical | Factory visibility | Standalone launch | Claim mode | Owner mutation | Platform publication | Custom domains | Monitoring | Leads | Articles |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Food Retail | private | unlaunched | factory | enabled | enabled | enabled | enabled | not-yet | not-yet |
+
+Owner photo library is enabled. Owner analytics, lead inbox, and articles stay
+`not-yet`. This vertical does not inherit restaurant reservations or booking
+leads.
+
 ## Factory claim and standalone launch gates
 
 Standalone niche marketing stays closed:
@@ -96,8 +109,10 @@ Standalone niche marketing stays closed:
 - `marketing.hostnames = []`
 - `marketing.domain = null`
 - `marketing.email = null`
+- `marketing.publiclyAccessible = false`
 - `claimMode = "factory"`
 - `publicationEnabled = true`
+- `publicationMutationEnabled = true`
 
 An approved private preview can claim the shared Cornershopdev $49 plan and
 publish at `<slug>.cornershop.dev`. That factory path requires:

--- a/docs/verticals/local-service.md
+++ b/docs/verticals/local-service.md
@@ -3,8 +3,9 @@
 `LOCAL_SERVICE` is the bounded local-trade implementation for plumbers,
 electricians, builders, repair businesses, and artisans. It is registered in
 the existing vertical registry and uses the shared crawler, import workflow,
-site tables, renderer, owner editing, analytics, domain routing, and
-source-monitoring engine. It does not fork the app and it
+site tables, renderer, owner editing, domain routing, and
+source-monitoring engine. Owner analytics, lead inbox, and articles are
+not-yet. It does not fork the app and it
 does not accept model-authored HTML, CSS, class names, or components.
 
 ## Data contract
@@ -90,13 +91,26 @@ use the shared billing, same-origin, optimistic-revision, immutable snapshot,
 and audit boundaries. The editor saves before publication and requires a
 3–280 character change summary plus explicit confirmation.
 
+## Capability row
+
+Matches the README matrix and `resolveOwnerOperations(LOCAL_SERVICE)`:
+
+| Vertical | Factory visibility | Standalone launch | Claim mode | Owner mutation | Platform publication | Custom domains | Monitoring | Leads | Articles |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Local Service | private | unlaunched | factory | enabled | enabled | enabled | enabled | not-yet | not-yet |
+
+Owner photo library is enabled. Owner analytics, lead inbox, and articles stay
+`not-yet`. The renderer disables the restaurant booking-request form.
+
 ## Launch gate
 
 Tradefront has no standalone niche storefront. Its marketing config therefore
 keeps hostname, domain, and niche sender empty, while `claimMode: "factory"`
 allows an approved private preview to use Cornershopdev's verified sender,
-shared $49 checkout, and `<slug>.cornershop.dev` public URL. A future standalone
-niche still must satisfy `verticalLaunchReadiness`:
+shared $49 checkout, and `<slug>.cornershop.dev` public URL.
+`publicationEnabled` and `publicationMutationEnabled` are both true for that
+factory path. A future standalone niche still must satisfy
+`verticalLaunchReadiness`:
 
 1. a configured public domain;
 2. that exact domain registered in the proxy hostname list;

--- a/src/app/dashboard/dashboard.tsx
+++ b/src/app/dashboard/dashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import Link from "next/link";
 import {
   ArrowUpRight,
@@ -92,6 +92,11 @@ import {
   validateRestaurantMenuDraft,
   type RestaurantMenuMutation,
 } from "@/lib/restaurant-menu-editor";
+import {
+  OwnerDraftDirtyGuard,
+  ownerDraftNavigationProps,
+  useOwnerDraftDirtyState,
+} from "@/lib/owner-draft-dirty-state";
 
 
 /**
@@ -130,24 +135,26 @@ export function Dashboard({
   platformUrl: string;
   ownerOperations?: VerticalOwnerOperations;
 }) {
-  const [draft, setDraftState] = useState(initialDraft);
-  const draftRef = useRef(initialDraft);
-  const [persistedDraft, setPersistedDraft] = useState(initialDraft);
-  function setDraft(
-    next:
-      | RestaurantDraft
-      | ((current: RestaurantDraft) => RestaurantDraft),
-  ) {
-    const resolved = typeof next === "function" ? next(draftRef.current) : next;
-    draftRef.current = resolved;
-    setDraftState(resolved);
-  }
+  const {
+    draft,
+    baseline,
+    revision: savedRevision,
+    dirty,
+    draftRef,
+    setDraft,
+    applyAuxiliary,
+    setRevision,
+    beginSave,
+    acknowledgeSave,
+    adoptServerDraft,
+  } = useOwnerDraftDirtyState(initialDraft, initialDraftRevision);
   const [saving, setSaving] = useState(false);
-  const [saved, setSaved] = useState(false);
-  const [savedRevision, setSavedRevision] = useState(initialDraftRevision);
-  const handlePhotoRevision = useCallback((revision: number) => {
-    setSavedRevision(revision);
-  }, []);
+  const handlePhotoRevision = useCallback(
+    (revision: number) => {
+      setRevision(revision);
+    },
+    [setRevision],
+  );
   const handlePhotoHeroChange = useCallback(
     (
       hero: {
@@ -156,14 +163,14 @@ export function Dashboard({
         provenance: "official" | "owner" | "permissioned-ugc";
       } | null,
     ) => {
-      setDraft((current) => ({
+      applyAuxiliary((current) => ({
         ...current,
         heroImageUrl: hero?.url ?? null,
         heroOriginalImageUrl: hero?.originalUrl ?? null,
         heroImageProvenance: hero?.provenance ?? null,
       }));
     },
-    [],
+    [applyAuxiliary],
   );
   const handlePhotoGalleryChange = useCallback(
     (
@@ -173,9 +180,9 @@ export function Dashboard({
         provenance: "official" | "owner" | "permissioned-ugc";
       }>,
     ) => {
-      setDraft((current) => ({ ...current, galleryImages }));
+      applyAuxiliary((current) => ({ ...current, galleryImages }));
     },
-    [],
+    [applyAuxiliary],
   );
   const handlePhotoCatalogChange = useCallback(
     (change: {
@@ -185,7 +192,7 @@ export function Dashboard({
       originalUrl: string | null;
       provenance: "official" | "owner" | "permissioned-ugc" | null;
     }) => {
-      setDraft((current) => ({
+      applyAuxiliary((current) => ({
         ...current,
         menuSections: current.menuSections.map((section, sectionIndex) =>
           sectionIndex !== change.sectionIndex
@@ -206,7 +213,7 @@ export function Dashboard({
         ),
       }));
     },
-    [],
+    [applyAuxiliary],
   );
   const [publishing, setPublishing] = useState(false);
   const [publishError, setPublishError] = useState<string | null>(null);
@@ -274,7 +281,8 @@ export function Dashboard({
   );
 
   async function save(): Promise<number | null> {
-    const requestedDraft = structuredClone(draftRef.current);
+    const submitted = beginSave();
+    const requestedDraft = structuredClone(submitted.submittedDraft);
     const validationIssues = validateRestaurantMenuDraft(requestedDraft);
     const integrationIssues = validateRestaurantIntegrations(requestedDraft);
     setMenuValidationIssues(validationIssues);
@@ -293,19 +301,18 @@ export function Dashboard({
       return null;
     }
     setSaving(true);
-    setSaved(false);
     setPublishError(null);
     setMenuSaveError(null);
     setIntegrationSaveError(null);
     try {
-      let persistedRevision = savedRevision;
+      let persistedRevision = submitted.expectedRevision;
       if (!demo) {
-        const response = await fetch(`/api/sites/${draft.slug}`, {
+        const response = await fetch(`/api/sites/${requestedDraft.slug}`, {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             ...requestedDraft,
-            expectedRevision: savedRevision,
+            expectedRevision: submitted.expectedRevision,
           }),
         });
         const result = (await response.json()) as {
@@ -319,22 +326,22 @@ export function Dashboard({
         if (!Number.isInteger(result.revision) || result.revision === undefined) {
           throw new Error("Save response did not include a draft revision");
         }
-        setSavedRevision(result.revision);
         persistedRevision = result.revision;
       }
-      setPersistedDraft(requestedDraft);
-      if (
-        JSON.stringify(draftRef.current) !== JSON.stringify(requestedDraft)
-      ) {
+      const acknowledged = acknowledgeSave({
+        submittedDraft: requestedDraft,
+        persistedDraft: requestedDraft,
+        submittedMutationVersion: submitted.submittedMutationVersion,
+        savedRevision: persistedRevision,
+      });
+      if (acknowledged.hadNewerEdits) {
         const message =
           "New edits were made while saving. Save them before publishing.";
-        setSaved(false);
         setPublishError(message);
         setMenuSaveError(message);
         setIntegrationSaveError(message);
         return null;
       }
-      setSaved(true);
       setThemeDirty(false);
       setMenuDirty(false);
       setIntegrationDirty(false);
@@ -441,7 +448,6 @@ export function Dashboard({
       themeId,
     );
     setDraft((current) => ({ ...current, themeSelection: selection }));
-    setSaved(false);
     setThemeDirty(true);
     markDraftUnpublished();
     setPublishError(null);
@@ -454,7 +460,6 @@ export function Dashboard({
         current.designProfile,
       ),
     }));
-    setSaved(false);
     setThemeDirty(true);
     markDraftUnpublished();
     setPublishError(null);
@@ -474,7 +479,6 @@ export function Dashboard({
       const next = applyRestaurantMenuMutation(draft, mutation);
       setDraft(next);
       setMenuDirty(true);
-      setSaved(false);
       setMenuSaveError(null);
       setMenuValidationIssues(validateRestaurantMenuDraft(next));
     } catch (error) {
@@ -491,7 +495,6 @@ export function Dashboard({
     const next = updateRestaurantTranslation(draft, locale, updater);
     setDraft(next);
     setMenuDirty(true);
-    setSaved(false);
     setMenuSaveError(null);
     setMenuValidationIssues(validateRestaurantMenuDraft(next));
   }
@@ -501,7 +504,6 @@ export function Dashboard({
       const next = markRestaurantTranslationReviewed(draft, locale);
       setDraft(next);
       setMenuDirty(true);
-      setSaved(false);
       setMenuSaveError(null);
       setMenuValidationIssues([]);
     } catch {
@@ -550,17 +552,17 @@ export function Dashboard({
         draftRef.current,
         regenerated,
       );
-      setPersistedDraft(structuredClone(regenerated));
-      setDraft(reconciled.draft);
-      setSavedRevision(result.revision);
+      adoptServerDraft({
+        draft: reconciled.draft,
+        baseline: regenerated,
+        revision: result.revision,
+      });
       if (reconciled.preservedClientEdits) {
-        setSaved(false);
         setMenuValidationIssues(validateRestaurantMenuDraft(reconciled.draft));
         setIntegrationValidationIssues(
           validateRestaurantIntegrations(reconciled.draft),
         );
       } else {
-        setSaved(true);
         setMenuDirty(false);
         setIntegrationDirty(false);
         setMenuValidationIssues([]);
@@ -583,7 +585,6 @@ export function Dashboard({
     setDraft(previous);
     setMenuUndoStack((current) => current.slice(0, -1));
     setMenuDirty(true);
-    setSaved(false);
     setMenuSaveError(null);
     setMenuValidationIssues([]);
   }
@@ -594,18 +595,23 @@ export function Dashboard({
   }) {
     const acceptedServerDraft = restaurantDraftSchema.parse(input.draft);
     const reconciled = reconcileAcceptedSourceMonitoringDraft(
-      persistedDraft,
+      baseline,
       draftRef.current,
       acceptedServerDraft,
     );
-    setPersistedDraft(acceptedServerDraft);
-    setDraft(reconciled.draft);
-    setSavedRevision(input.revision);
-    setSaved(!reconciled.preservedClientEdits);
+    adoptServerDraft({
+      draft: reconciled.draft,
+      baseline: acceptedServerDraft,
+      revision: input.revision,
+    });
     setMenuValidationIssues(validateRestaurantMenuDraft(reconciled.draft));
     setIntegrationValidationIssues(
       validateRestaurantIntegrations(reconciled.draft),
     );
+    if (!reconciled.preservedClientEdits) {
+      setMenuDirty(false);
+      setIntegrationDirty(false);
+    }
   }
 
   function mutateIntegration(
@@ -622,7 +628,6 @@ export function Dashboard({
       const next = applyRestaurantIntegrationMutation(draft, mutation);
       setDraft(next);
       setIntegrationDirty(true);
-      setSaved(false);
       setIntegrationSaveError(null);
       setIntegrationValidationIssues(
         validateRestaurantIntegrations(next),
@@ -650,7 +655,6 @@ export function Dashboard({
     );
     setDraft(next);
     setIntegrationDirty(true);
-    setSaved(false);
     setIntegrationSaveError(null);
     setIntegrationValidationIssues(
       validateRestaurantIntegrations(next),
@@ -662,7 +666,6 @@ export function Dashboard({
       const next = markRestaurantTranslationReviewed(draft, locale);
       setDraft(next);
       setIntegrationDirty(true);
-      setSaved(false);
       setIntegrationSaveError(null);
       setIntegrationValidationIssues([]);
     } catch {
@@ -678,13 +681,13 @@ export function Dashboard({
     setDraft(previous);
     setIntegrationUndoStack((current) => current.slice(0, -1));
     setIntegrationDirty(true);
-    setSaved(false);
     setIntegrationSaveError(null);
     setIntegrationValidationIssues([]);
   }
 
   return (
-    <main className="min-h-screen bg-[#f3f1eb]">
+    <OwnerDraftDirtyGuard dirty={dirty}>
+    <main className="min-h-screen bg-[#f3f1eb]" {...ownerDraftNavigationProps(dirty)}>
       <header className="sticky top-0 z-50 flex h-16 items-center justify-between border-b bg-background px-4 md:px-6">
         <div className="flex items-center gap-5">
           <Brand {...brand} />
@@ -724,7 +727,7 @@ export function Dashboard({
             disabled={saving || publishing}
           >
             {saving ? <LoaderCircle className="animate-spin" /> : <Save />}
-            {saved ? "Saved" : "Save"}
+            {dirty ? "Save" : "Saved"}
           </Button>
           <Button
             size="sm"
@@ -976,10 +979,7 @@ export function Dashboard({
                 initial={sourceMonitoring}
                 demo={demo}
                 draftRevision={savedRevision}
-                hasUnsavedChanges={
-                  JSON.stringify(draft) !==
-                  JSON.stringify(persistedDraft)
-                }
+                hasUnsavedChanges={dirty}
                 onAcceptedDraft={applyAcceptedSourceMonitoringDraft}
               />
             </TabsContent>
@@ -1340,6 +1340,7 @@ export function Dashboard({
         </div>
       </Tabs>
     </main>
+    </OwnerDraftDirtyGuard>
   );
 }
 

--- a/src/app/dashboard/food-retail-dashboard.tsx
+++ b/src/app/dashboard/food-retail-dashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import Link from "next/link";
 import {
   Check,
@@ -65,9 +65,13 @@ import {
   hasUnreviewedFoodRetailTranslations,
   markFoodRetailTranslationReviewed,
   markFoodRetailTranslationsStale,
-  reconcileFoodRetailDraftAfterSave,
   updateFoodRetailTranslation,
 } from "@/lib/verticals/food-retail/editor";
+import {
+  OwnerDraftDirtyGuard,
+  ownerDraftNavigationProps,
+  useOwnerDraftDirtyState,
+} from "@/lib/owner-draft-dirty-state";
 import {
   foodRetailSiteDraftSchema,
   type FoodRetailSiteDraft,
@@ -98,19 +102,18 @@ export function FoodRetailDashboard({
   publicationHistory?: ClientPublicationHistoryItem[];
   sourceMonitoring?: SourceMonitoringDashboardDto;
 }) {
-  const [draft, setDraftState] = useState(initialDraft);
-  const draftRef = useRef(initialDraft);
-  const [persistedDraft, setPersistedDraft] = useState(initialDraft);
-  function setDraft(
-    next:
-      | FoodRetailSiteDraft
-      | ((current: FoodRetailSiteDraft) => FoodRetailSiteDraft),
-  ) {
-    const resolved = typeof next === "function" ? next(draftRef.current) : next;
-    draftRef.current = resolved;
-    setDraftState(resolved);
-  }
-  const [revision, setRevision] = useState(initialRevision);
+  const {
+    draft,
+    revision,
+    dirty,
+    draftRef,
+    setDraft,
+    applyAuxiliary,
+    setRevision,
+    beginSave,
+    acknowledgeSave,
+    acknowledgeSnapshot,
+  } = useOwnerDraftDirtyState(initialDraft, initialRevision);
   const [saving, setSaving] = useState(false);
   const [publishing, setPublishing] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
@@ -129,9 +132,12 @@ export function FoodRetailDashboard({
     OwnerIntegrationIssue[]
   >([]);
 
-  const handlePhotoRevision = useCallback((nextRevision: number) => {
-    setRevision(nextRevision);
-  }, []);
+  const handlePhotoRevision = useCallback(
+    (nextRevision: number) => {
+      setRevision(nextRevision);
+    },
+    [setRevision],
+  );
   const handlePhotoHeroChange = useCallback(
     (
       hero: {
@@ -140,14 +146,14 @@ export function FoodRetailDashboard({
         provenance: "official" | "owner" | "permissioned-ugc";
       } | null,
     ) => {
-      setDraft((current) => ({
+      applyAuxiliary((current) => ({
         ...current,
         heroImageUrl: hero?.url ?? null,
         heroOriginalImageUrl: hero?.originalUrl ?? null,
         heroImageProvenance: hero?.provenance ?? null,
       }));
     },
-    [],
+    [applyAuxiliary],
   );
   const handlePhotoGalleryChange = useCallback(
     (
@@ -157,9 +163,9 @@ export function FoodRetailDashboard({
         provenance: "official" | "owner" | "permissioned-ugc";
       }>,
     ) => {
-      setDraft((current) => ({ ...current, galleryImages }));
+      applyAuxiliary((current) => ({ ...current, galleryImages }));
     },
-    [],
+    [applyAuxiliary],
   );
   const handlePhotoCatalogChange = useCallback(
     (change: {
@@ -169,7 +175,7 @@ export function FoodRetailDashboard({
       originalUrl: string | null;
       provenance: "official" | "owner" | "permissioned-ugc" | null;
     }) => {
-      setDraft((current) => ({
+      applyAuxiliary((current) => ({
         ...current,
         catalogSections: current.catalogSections.map((section, sectionIndex) =>
           sectionIndex !== change.sectionIndex
@@ -190,7 +196,7 @@ export function FoodRetailDashboard({
         ),
       }));
     },
-    [],
+    [applyAuxiliary],
   );
 
   function updateSection(
@@ -340,7 +346,8 @@ export function FoodRetailDashboard({
   }
 
   async function saveDraft(): Promise<number | null> {
-    const submittedDraft = draft;
+    const submitted = beginSave();
+    const submittedDraft = submitted.submittedDraft;
     const ownerIssues = validateOwnerIntegrations(submittedDraft.integrations);
     const parsed = foodRetailSiteDraftSchema.safeParse(submittedDraft);
     if (ownerIssues.length > 0 || !parsed.success) {
@@ -359,12 +366,12 @@ export function FoodRetailDashboard({
     setIntegrationIssues([]);
     setNotice(null);
     try {
-      const response = await fetch(`/api/sites/${draft.slug}`, {
+      const response = await fetch(`/api/sites/${submittedDraft.slug}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           ...parsed.data,
-          expectedRevision: revision,
+          expectedRevision: submitted.expectedRevision,
         }),
       });
       const result = (await response.json()) as {
@@ -378,13 +385,13 @@ export function FoodRetailDashboard({
       ) {
         throw new Error("Save response did not include a draft revision");
       }
-      const hadNewerEdits = draftRef.current !== submittedDraft;
-      setDraft((current) =>
-        reconcileFoodRetailDraftAfterSave(submittedDraft, parsed.data, current),
-      );
-      if (!hadNewerEdits) setPersistedDraft(parsed.data);
-      setRevision(result.revision);
-      if (hadNewerEdits) {
+      const acknowledged = acknowledgeSave({
+        submittedDraft,
+        persistedDraft: parsed.data,
+        submittedMutationVersion: submitted.submittedMutationVersion,
+        savedRevision: result.revision,
+      });
+      if (acknowledged.hadNewerEdits) {
         setError(
           "New edits were made while saving. Save them before leaving this private preview.",
         );
@@ -471,15 +478,17 @@ export function FoodRetailDashboard({
     draft: unknown;
   }) {
     const accepted = foodRetailSiteDraftSchema.parse(input.draft);
-    setDraft(accepted);
-    setPersistedDraft(accepted);
-    setRevision(input.revision);
+    acknowledgeSnapshot(accepted, input.revision);
     setNotice("Source suggestion saved to the private draft.");
     setError(null);
   }
 
   return (
-    <div className="min-h-screen bg-muted/35 text-foreground">
+    <OwnerDraftDirtyGuard dirty={dirty}>
+    <div
+      className="min-h-screen bg-muted/35 text-foreground"
+      {...ownerDraftNavigationProps(dirty)}
+    >
       <header className="border-b bg-background">
         <div className="mx-auto flex max-w-[1500px] items-center justify-between gap-4 px-5 py-4">
           <Brand {...brand} />
@@ -535,10 +544,10 @@ export function FoodRetailDashboard({
                 </Button>
                 <Button
                   variant="outline"
-                  disabled={saving || publishing}
+                  disabled={saving || publishing || !dirty}
                   onClick={() => void saveDraft()}
                 >
-                  <Save /> {saving ? "Saving…" : "Save"}
+                  <Save /> {saving ? "Saving…" : dirty ? "Save" : "Saved"}
                 </Button>
                 <Button
                   disabled={saving || publishing}
@@ -575,9 +584,7 @@ export function FoodRetailDashboard({
               siteSlug={draft.slug}
               initial={sourceMonitoring}
               draftRevision={revision}
-              hasUnsavedChanges={
-                JSON.stringify(draft) !== JSON.stringify(persistedDraft)
-              }
+              hasUnsavedChanges={dirty}
               onAcceptedDraft={applyAcceptedSourceMonitoringDraft}
             />
           ) : null}
@@ -1373,5 +1380,6 @@ export function FoodRetailDashboard({
         </div>
       </main>
     </div>
+    </OwnerDraftDirtyGuard>
   );
 }

--- a/src/app/dashboard/local-service-dashboard.tsx
+++ b/src/app/dashboard/local-service-dashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import Link from "next/link";
 import {
   ExternalLink,
@@ -59,6 +59,12 @@ import {
   type LocalServiceAttributes,
   type LocalServiceSiteDraft,
 } from "@/lib/verticals/local-service/schema";
+import {
+  OwnerDraftDirtyGuard,
+  acknowledgeOwnerDraftSave,
+  ownerDraftNavigationProps,
+  useOwnerDraftDirtyState,
+} from "@/lib/owner-draft-dirty-state";
 
 const tradeTypes: LocalServiceAttributes["tradeType"][] = [
   "plumber",
@@ -93,13 +99,26 @@ export function reconcileLocalServiceDraftAfterSave(input: {
   currentMutationVersion: number;
   savedRevision: number;
 }) {
-  const hadNewerEdits =
-    input.currentMutationVersion !== input.submittedMutationVersion;
+  const acknowledged = acknowledgeOwnerDraftSave(
+    {
+      draft: input.currentDraft,
+      baseline: input.submittedDraft,
+      revision: 0,
+      mutationVersion: input.currentMutationVersion,
+      dirty: true,
+    },
+    {
+      submittedDraft: input.submittedDraft,
+      persistedDraft: input.persistedDraft,
+      submittedMutationVersion: input.submittedMutationVersion,
+      savedRevision: input.savedRevision,
+    },
+  );
   return {
-    draft: hadNewerEdits ? input.currentDraft : input.persistedDraft,
-    revision: input.savedRevision,
-    dirty: hadNewerEdits,
-    hadNewerEdits,
+    draft: acknowledged.state.draft,
+    revision: acknowledged.state.revision,
+    dirty: acknowledged.state.dirty,
+    hadNewerEdits: acknowledged.hadNewerEdits,
   };
 }
 
@@ -128,13 +147,19 @@ export function LocalServiceDashboard({
   publicationHistory?: ClientPublicationHistoryItem[];
   sourceMonitoring?: SourceMonitoringDashboardDto;
 }) {
-  const [draft, setDraftState] = useState(initialDraft);
-  const draftRef = useRef(initialDraft);
-  const mutationVersionRef = useRef(0);
-  const [dirty, setDirty] = useState(false);
+  const {
+    draft,
+    revision: savedRevision,
+    dirty,
+    setDraft,
+    applyAuxiliary,
+    setRevision,
+    beginSave,
+    acknowledgeSave,
+    acknowledgeSnapshot,
+  } = useOwnerDraftDirtyState(initialDraft, initialRevision);
   const [saving, setSaving] = useState(false);
   const [publishing, setPublishing] = useState(false);
-  const [savedRevision, setSavedRevision] = useState(initialRevision);
   const paidOps = useOwnerPaidOperations({
     siteSlug: initialDraft.slug,
     platformUrl,
@@ -145,17 +170,18 @@ export function LocalServiceDashboard({
   });
   const publishedVersion = paidOps.publishedVersion;
   const published = initiallyPublished || paidOps.isPublished;
-  const savedRevisionRef = useRef(initialRevision);
   const [notice, setNotice] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [integrationIssues, setIntegrationIssues] = useState<
     OwnerIntegrationIssue[]
   >([]);
 
-  const handlePhotoRevision = useCallback((nextRevision: number) => {
-    savedRevisionRef.current = nextRevision;
-    setSavedRevision(nextRevision);
-  }, []);
+  const handlePhotoRevision = useCallback(
+    (nextRevision: number) => {
+      setRevision(nextRevision);
+    },
+    [setRevision],
+  );
   const handlePhotoHeroChange = useCallback(
     (
       hero: {
@@ -164,16 +190,14 @@ export function LocalServiceDashboard({
         provenance: "official" | "owner" | "permissioned-ugc";
       } | null,
     ) => {
-      const next = {
-        ...draftRef.current,
+      applyAuxiliary((current) => ({
+        ...current,
         heroImageUrl: hero?.url ?? null,
         heroOriginalImageUrl: hero?.originalUrl ?? null,
         heroImageProvenance: hero?.provenance ?? null,
-      };
-      draftRef.current = next;
-      setDraftState(next);
+      }));
     },
-    [],
+    [applyAuxiliary],
   );
   const handlePhotoGalleryChange = useCallback(
     (
@@ -183,8 +207,7 @@ export function LocalServiceDashboard({
         provenance: "official" | "owner" | "permissioned-ugc";
       }>,
     ) => {
-      const current = draftRef.current;
-      const next = {
+      applyAuxiliary((current) => ({
         ...current,
         galleryImages,
         attributes: {
@@ -200,11 +223,9 @@ export function LocalServiceDashboard({
             };
           }),
         },
-      };
-      draftRef.current = next;
-      setDraftState(next);
+      }));
     },
-    [],
+    [applyAuxiliary],
   );
   const handlePhotoCatalogChange = useCallback(
     (change: {
@@ -214,8 +235,7 @@ export function LocalServiceDashboard({
       originalUrl: string | null;
       provenance: "official" | "owner" | "permissioned-ugc" | null;
     }) => {
-      const current = draftRef.current;
-      const next = {
+      applyAuxiliary((current) => ({
         ...current,
         catalogSections: current.catalogSections.map((section, sectionIndex) =>
           sectionIndex !== change.sectionIndex
@@ -234,28 +254,25 @@ export function LocalServiceDashboard({
                 ),
               },
         ),
-      };
-      draftRef.current = next;
-      setDraftState(next);
+      }));
     },
-    [],
+    [applyAuxiliary],
   );
 
   function change(mutator: (next: LocalServiceSiteDraft) => void) {
-    const next = structuredClone(draftRef.current);
-    mutator(next);
-    draftRef.current = next;
-    mutationVersionRef.current += 1;
-    setDraftState(next);
-    setDirty(true);
+    setDraft((current) => {
+      const next = structuredClone(current);
+      mutator(next);
+      return next;
+    });
     setNotice(null);
     setError(null);
     setIntegrationIssues([]);
   }
 
   async function save(): Promise<number | null> {
-    const submittedDraft = draftRef.current;
-    const submittedMutationVersion = mutationVersionRef.current;
+    const submitted = beginSave();
+    const submittedDraft = submitted.submittedDraft;
     const ownerIssues = validateOwnerIntegrations(submittedDraft.integrations);
     const parsed = localServiceSiteDraftSchema.safeParse(submittedDraft);
     if (ownerIssues.length > 0 || !parsed.success) {
@@ -278,7 +295,7 @@ export function LocalServiceDashboard({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           ...parsed.data,
-          expectedRevision: savedRevisionRef.current,
+          expectedRevision: submitted.expectedRevision,
         }),
       });
       const result = (await response.json()) as {
@@ -292,25 +309,18 @@ export function LocalServiceDashboard({
       ) {
         throw new Error("Save succeeded without a draft revision");
       }
-      const reconciled = reconcileLocalServiceDraftAfterSave({
+      const reconciled = acknowledgeSave({
         submittedDraft,
         persistedDraft: parsed.data,
-        currentDraft: draftRef.current,
-        submittedMutationVersion,
-        currentMutationVersion: mutationVersionRef.current,
+        submittedMutationVersion: submitted.submittedMutationVersion,
         savedRevision: result.revision,
       });
-      draftRef.current = reconciled.draft;
-      savedRevisionRef.current = reconciled.revision;
-      setDraftState(reconciled.draft);
-      setSavedRevision(reconciled.revision);
-      setDirty(reconciled.dirty);
       setNotice(
         reconciled.hadNewerEdits
-          ? `Draft revision ${reconciled.revision} saved; newer edits remain unsaved`
+          ? `Draft revision ${reconciled.state.revision} saved; newer edits remain unsaved`
           : "Private draft saved",
       );
-      return reconciled.hadNewerEdits ? null : reconciled.revision;
+      return reconciled.hadNewerEdits ? null : reconciled.state.revision;
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : "Save failed");
       return null;
@@ -386,17 +396,17 @@ export function LocalServiceDashboard({
     draft: unknown;
   }) {
     const accepted = localServiceSiteDraftSchema.parse(input.draft);
-    draftRef.current = accepted;
-    savedRevisionRef.current = input.revision;
-    setDraftState(accepted);
-    setSavedRevision(input.revision);
-    setDirty(false);
+    acknowledgeSnapshot(accepted, input.revision);
     setNotice("Source suggestion saved to the private draft.");
     setError(null);
   }
 
   return (
-    <div className="min-h-screen bg-background text-foreground">
+    <OwnerDraftDirtyGuard dirty={dirty}>
+    <div
+      className="min-h-screen bg-background text-foreground"
+      {...ownerDraftNavigationProps(dirty)}
+    >
       <header className="border-b border-border/70">
         <div className="mx-auto flex max-w-7xl items-center justify-between gap-4 px-6 py-4">
           <Brand {...brand} />
@@ -1157,6 +1167,7 @@ export function LocalServiceDashboard({
         </EditorSection>
       </main>
     </div>
+    </OwnerDraftDirtyGuard>
   );
 }
 

--- a/src/components/account-actions.tsx
+++ b/src/components/account-actions.tsx
@@ -5,12 +5,18 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { LogOut } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  confirmDiscardUnsavedOwnerEdits,
+  useOwnerUnsavedEdits,
+} from "@/lib/owner-draft-dirty-state";
 
 export function AccountActions({ canSwitch }: { canSwitch: boolean }) {
   const router = useRouter();
+  const dirty = useOwnerUnsavedEdits();
   const [pending, setPending] = useState(false);
 
   async function logout() {
+    if (!confirmDiscardUnsavedOwnerEdits(dirty)) return;
     setPending(true);
     try {
       const response = await fetch("/api/auth/logout", { method: "POST" });
@@ -26,7 +32,16 @@ export function AccountActions({ canSwitch }: { canSwitch: boolean }) {
   return (
     <div className="flex items-center gap-2">
       {canSwitch ? (
-        <Button render={<Link href="/workspace/select" />} variant="outline" size="sm">
+        <Button
+          render={<Link href="/workspace/select" />}
+          variant="outline"
+          size="sm"
+          onClick={(event) => {
+            if (!confirmDiscardUnsavedOwnerEdits(dirty)) {
+              event.preventDefault();
+            }
+          }}
+        >
           Switch workspace
         </Button>
       ) : null}

--- a/src/lib/dashboard-tabs-surface.test.ts
+++ b/src/lib/dashboard-tabs-surface.test.ts
@@ -66,12 +66,18 @@ describe("dashboard tab and settings surface", () => {
       "initialDraftRevision={ownerDraft?.revision ?? 0}",
     );
     expect(dashboardPage).toContain("initialRevision={loaded.revision}");
-    expect(dashboard).toContain("useState(initialDraftRevision)");
-    expect(dashboard).toContain("expectedRevision: savedRevision");
+    expect(dashboard).toContain(
+      "useOwnerDraftDirtyState(initialDraft, initialDraftRevision)",
+    );
+    expect(dashboard).toContain(
+      "expectedRevision: submitted.expectedRevision",
+    );
     expect(restaurantSaveRoute).toContain("saveAuthorizedSiteDraft");
     expect(ownerSiteSave).toContain('code: "EXPECTED_REVISION_REQUIRED"');
     expect(dashboard).toContain("expectedRevision: revisionToPublish");
-    expect(foodRetailDashboard).toContain("expectedRevision: revision");
+    expect(foodRetailDashboard).toContain(
+      "expectedRevision: submitted.expectedRevision",
+    );
     expect(restaurantPublishRoute).toContain('code: "DRAFT_REVISION_CONFLICT"');
   });
 
@@ -109,7 +115,7 @@ describe("dashboard tab and settings surface", () => {
     expect(dashboard).toContain(
       "body: JSON.stringify({ expectedRevision: requestedRevision })",
     );
-    expect(dashboard).toContain("setSavedRevision(result.revision)");
+    expect(dashboard).toContain("adoptServerDraft({");
     expect(translationRegenerationRoute).toContain(
       "expectedRevision: requestBody.data.expectedRevision",
     );

--- a/src/lib/docs-capability-contract.test.ts
+++ b/src/lib/docs-capability-contract.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, it } from "bun:test";
+import {
+  isVerticalPublicationEnabled,
+  isVerticalPubliclyLaunched,
+  listVerticalIds,
+  resolveOwnerOperations,
+  resolveVerticalConfig,
+} from "@/lib/verticals/registry";
+import type { VerticalId } from "@/lib/verticals/types";
+
+const repoRoot = new URL("../..", import.meta.url);
+
+const CAPABILITY_HEADERS = [
+  "Vertical",
+  "Factory visibility",
+  "Standalone launch",
+  "Claim mode",
+  "Owner mutation",
+  "Platform publication",
+  "Custom domains",
+  "Monitoring",
+  "Leads",
+  "Articles",
+] as const;
+
+const STACK_MAJOR_PATTERNS = [
+  { packageName: "next", pattern: /Next\.js (\d+)/ },
+  { packageName: "react", pattern: /React (\d+)/ },
+  { packageName: "prisma", pattern: /Prisma (\d+)/ },
+  { packageName: "ai", pattern: /Vercel AI SDK (\d+)/ },
+  { packageName: "tailwindcss", pattern: /Tailwind CSS v(\d+)/ },
+] as const;
+
+const DOC_FILES = [
+  "README.md",
+  "docs/verticals/food-retail.md",
+  "docs/verticals/local-service.md",
+] as const;
+
+const GUIDE_VERTICAL: Record<
+  "docs/verticals/food-retail.md" | "docs/verticals/local-service.md",
+  VerticalId
+> = {
+  "docs/verticals/food-retail.md": "FOOD_RETAIL",
+  "docs/verticals/local-service.md": "LOCAL_SERVICE",
+};
+
+type PackageJson = {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  scripts?: Record<string, string>;
+};
+
+type MarkdownTable = {
+  headers: string[];
+  rows: string[][];
+};
+
+const [readme, foodRetailGuide, localServiceGuide, packageJson] =
+  await Promise.all([
+    readRepoFile("README.md"),
+    readRepoFile("docs/verticals/food-retail.md"),
+    readRepoFile("docs/verticals/local-service.md"),
+    readRepoJson("package.json"),
+  ]);
+
+const docsByPath = {
+  "README.md": readme,
+  "docs/verticals/food-retail.md": foodRetailGuide,
+  "docs/verticals/local-service.md": localServiceGuide,
+} as const;
+
+describe("documented vertical capabilities", () => {
+  it("keeps a README row for every registered vertical equal to the registry", () => {
+    const documented = capabilityRows(readme);
+    const expected = Object.fromEntries(
+      listVerticalIds().map((id) => [verticalLabel(id), expectedCapabilityRow(id)]),
+    );
+
+    expect(Object.keys(documented).sort()).toEqual(Object.keys(expected).sort());
+    expect(documented).toEqual(expected);
+  });
+
+  it("keeps Food Retail and Local Service guides on the same capability row", () => {
+    for (const relativePath of Object.keys(GUIDE_VERTICAL) as Array<
+      keyof typeof GUIDE_VERTICAL
+    >) {
+      const id = GUIDE_VERTICAL[relativePath];
+      expect(capabilityRows(docsByPath[relativePath])).toEqual({
+        [verticalLabel(id)]: expectedCapabilityRow(id),
+      });
+    }
+  });
+});
+
+describe("documented stack majors", () => {
+  it("matches package.json majors for every named stack package", () => {
+    for (const { packageName, pattern } of STACK_MAJOR_PATTERNS) {
+      const match = readme.match(pattern);
+      expect(match?.[1]).toBeDefined();
+      expect(Number(match?.[1])).toBe(packageMajor(packageName));
+    }
+
+    expect(packageMajor("prisma")).toBe(packageMajor("@prisma/client"));
+    expect(readme).not.toContain("Vercel AI SDK 6");
+  });
+});
+
+describe("documented links and commands", () => {
+  it("resolves internal documentation links and bun commands without network", async () => {
+    for (const relativePath of DOC_FILES) {
+      const source = docsByPath[relativePath];
+      const fileUrl = new URL(relativePath, repoRoot);
+
+      for (const target of markdownLinkTargets(source)) {
+        if (isExternalOrFragment(target)) continue;
+        const resolved = new URL(stripFragment(target), fileUrl);
+        expect(resolved.protocol).toBe("file:");
+        expect(await Bun.file(resolved).exists()).toBe(true);
+      }
+
+      for (const script of bunRunScripts(source)) {
+        expect(packageJson.scripts?.[script]).toBeDefined();
+      }
+
+      for (const binary of bunxBinaries(source)) {
+        expect(packageSpec(bunxPackageName(binary))).toBeDefined();
+      }
+    }
+  });
+});
+
+async function readRepoFile(relativePath: string): Promise<string> {
+  return Bun.file(new URL(relativePath, repoRoot)).text();
+}
+
+async function readRepoJson(relativePath: string): Promise<PackageJson> {
+  return Bun.file(new URL(relativePath, repoRoot)).json() as Promise<PackageJson>;
+}
+
+function verticalLabel(id: VerticalId): string {
+  return id
+    .toLowerCase()
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function expectedCapabilityRow(id: VerticalId): Record<string, string> {
+  const config = resolveVerticalConfig(id);
+  const operations = resolveOwnerOperations(id);
+  return {
+    Vertical: verticalLabel(id),
+    "Factory visibility": config.marketing.publiclyAccessible
+      ? "public"
+      : "private",
+    "Standalone launch": isVerticalPubliclyLaunched(id)
+      ? "launched"
+      : "unlaunched",
+    "Claim mode": config.claimMode,
+    "Owner mutation": operations.publicationMutation,
+    "Platform publication": isVerticalPublicationEnabled(id)
+      ? "enabled"
+      : "disabled",
+    "Custom domains": operations.customDomain,
+    Monitoring: operations.sourceMonitoring,
+    Leads: operations.bookingInbox,
+    Articles: operations.articles,
+  };
+}
+
+function capabilityRows(source: string): Record<string, Record<string, string>> {
+  const table = parseMarkdownTables(source).find((candidate) =>
+    headersMatch(candidate.headers, CAPABILITY_HEADERS),
+  );
+  expect(table).toBeDefined();
+  if (!table) return {};
+
+  const rows: Record<string, Record<string, string>> = {};
+  for (const cells of table.rows) {
+    expect(cells).toHaveLength(CAPABILITY_HEADERS.length);
+    const row = Object.fromEntries(
+      CAPABILITY_HEADERS.map((header, index) => [header, cells[index] ?? ""]),
+    );
+    const label = row.Vertical;
+    expect(label).toBeTruthy();
+    expect(rows[label]).toBeUndefined();
+    rows[label] = row;
+  }
+  return rows;
+}
+
+function parseMarkdownTables(source: string): MarkdownTable[] {
+  const tables: MarkdownTable[] = [];
+  const lines = source.split("\n");
+  for (let index = 0; index < lines.length - 1; index += 1) {
+    const headers = splitRow(lines[index] ?? "");
+    const divider = splitRow(lines[index + 1] ?? "");
+    if (!headers || !divider || !isDividerRow(divider)) continue;
+    if (headers.length !== divider.length) continue;
+
+    const rows: string[][] = [];
+    let cursor = index + 2;
+    while (cursor < lines.length) {
+      const cells = splitRow(lines[cursor] ?? "");
+      if (!cells || cells.length !== headers.length) break;
+      if (!isDividerRow(cells)) rows.push(cells);
+      cursor += 1;
+    }
+    tables.push({ headers, rows });
+  }
+  return tables;
+}
+
+function splitRow(line: string): string[] | null {
+  const trimmed = line.trim();
+  if (!trimmed.includes("|")) return null;
+  return trimmed
+    .replace(/^\|/, "")
+    .replace(/\|$/, "")
+    .split("|")
+    .map((cell) => cell.trim());
+}
+
+function isDividerRow(cells: string[]): boolean {
+  return cells.every((cell) => /^:?-{3,}:?$/.test(cell));
+}
+
+function headersMatch(
+  headers: string[],
+  expected: readonly string[],
+): boolean {
+  return (
+    headers.length === expected.length &&
+    expected.every((header, index) => headers[index] === header)
+  );
+}
+
+function packageSpec(name: string): string | undefined {
+  return packageJson.dependencies?.[name] ?? packageJson.devDependencies?.[name];
+}
+
+function packageMajor(name: string): number {
+  const spec = packageSpec(name);
+  const match = spec?.match(/\d+/);
+  if (!match) {
+    throw new Error(`Missing version for ${name}`);
+  }
+  return Number(match[0]);
+}
+
+function markdownLinkTargets(source: string): string[] {
+  return [...source.matchAll(/\[[^\]]*]\(([^)]+)\)/g)].map((match) => {
+    const raw = match[1]?.trim() ?? "";
+    const space = raw.search(/\s/);
+    return space === -1 ? raw : raw.slice(0, space);
+  });
+}
+
+function isExternalOrFragment(target: string): boolean {
+  return (
+    target.startsWith("#") ||
+    target.startsWith("http://") ||
+    target.startsWith("https://") ||
+    target.startsWith("mailto:")
+  );
+}
+
+function stripFragment(target: string): string {
+  const hash = target.indexOf("#");
+  return hash === -1 ? target : target.slice(0, hash);
+}
+
+function bunRunScripts(source: string): string[] {
+  return [...source.matchAll(/\bbun run ([a-zA-Z0-9:_-]+)/g)].map(
+    (match) => match[1] ?? "",
+  );
+}
+
+function bunxBinaries(source: string): string[] {
+  return [...source.matchAll(/\bbunx(?: --bun)? ([a-zA-Z0-9@/_-]+)/g)].map(
+    (match) => match[1] ?? "",
+  );
+}
+
+function bunxPackageName(binary: string): string {
+  if (binary === "tsc") return "typescript";
+  if (binary === "next") return "next";
+  return binary;
+}

--- a/src/lib/owner-draft-dirty-state.dashboard.test.tsx
+++ b/src/lib/owner-draft-dirty-state.dashboard.test.tsx
@@ -1,0 +1,149 @@
+import { describe, expect, it, mock } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+mock.module("next/navigation", () => ({
+  useRouter: () => ({
+    push: () => {},
+    replace: () => {},
+    refresh: () => {},
+    back: () => {},
+    prefetch: () => {},
+  }),
+  usePathname: () => "/dashboard",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+import { Dashboard } from "@/app/dashboard/dashboard";
+import { FoodRetailDashboard } from "@/app/dashboard/food-retail-dashboard";
+import { LocalServiceDashboard } from "@/app/dashboard/local-service-dashboard";
+import { AccountActions } from "@/components/account-actions";
+import { buildEmptyAnalyticsSummary } from "@/lib/analytics-contract";
+import { FACTORY_BRAND } from "@/lib/brand";
+import { sampleRestaurant } from "@/lib/restaurant";
+import { sampleFoodRetailDraft } from "@/lib/verticals/food-retail/fixtures";
+import { sampleLocalServiceSiteDraft } from "@/lib/verticals/local-service/fixtures";
+
+const dashboard = await Bun.file(
+  new URL("../app/dashboard/dashboard.tsx", import.meta.url),
+).text();
+const foodRetailDashboard = await Bun.file(
+  new URL("../app/dashboard/food-retail-dashboard.tsx", import.meta.url),
+).text();
+const localServiceDashboard = await Bun.file(
+  new URL("../app/dashboard/local-service-dashboard.tsx", import.meta.url),
+).text();
+const accountActions = await Bun.file(
+  new URL("../components/account-actions.tsx", import.meta.url),
+).text();
+const dirtyState = await Bun.file(
+  new URL("./owner-draft-dirty-state.ts", import.meta.url),
+).text();
+
+const dashboardSources = [
+  ["restaurant", dashboard],
+  ["food-retail", foodRetailDashboard],
+  ["local-service", localServiceDashboard],
+] as const;
+
+describe("vertical dashboards share one dirty-state contract", () => {
+  it("wires the shared hook, unload guard, and navigation intercept on every owner dashboard", () => {
+    expect(dirtyState).toContain("window.onbeforeunload");
+    expect(dirtyState).toContain("beforeunload");
+    expect(dirtyState).toContain("confirmDiscardUnsavedOwnerEdits");
+    expect(dirtyState).toContain("reconcileOwnerDraftAuxiliary");
+
+    for (const [, source] of dashboardSources) {
+      expect(source).toContain("useOwnerDraftDirtyState");
+      expect(source).toContain("OwnerDraftDirtyGuard");
+      expect(source).toContain("ownerDraftNavigationProps");
+      expect(source).toContain("applyAuxiliary");
+      expect(source).toContain("hasUnsavedChanges={dirty}");
+      expect(source).not.toContain("addEventListener(\"beforeunload\"");
+    }
+
+    expect(accountActions).toContain("useOwnerUnsavedEdits");
+    expect(accountActions).toContain("confirmDiscardUnsavedOwnerEdits");
+    expect(accountActions).toContain('href="/workspace/select"');
+    expect(accountActions).toContain("/api/auth/logout");
+  });
+
+  it("renders clean dashboards without an unsaved prompt surface", () => {
+    const restaurantHtml = renderToStaticMarkup(
+      <Dashboard
+        initialDraft={sampleRestaurant}
+        initialDraftRevision={4}
+        email="owner@example.com"
+        checkoutComplete={false}
+        demo
+        brand={FACTORY_BRAND}
+        analyticsSummary={buildEmptyAnalyticsSummary(
+          new Date("2026-08-23T00:00:00.000Z"),
+        )}
+        bookingInbox={{
+          requests: [],
+          total: 0,
+          awaitingContact: 0,
+          truncated: false,
+        }}
+        billingAccess={null}
+        publicationHistory={[]}
+        canSwitchWorkspace
+        sourceMonitoring={{
+          cadenceDays: null,
+          nextRunAt: null,
+          lastRunAt: null,
+          lastSuccessAt: null,
+          lastFailureAt: null,
+          lastFailureCode: null,
+          latestRun: null,
+          suggestions: [],
+        }}
+        platformUrl="https://osteria-luna.cornershop.dev"
+      />,
+    );
+    const foodRetailHtml = renderToStaticMarkup(
+      <FoodRetailDashboard
+        email="owner@example.com"
+        brand={FACTORY_BRAND}
+        initialDraft={sampleFoodRetailDraft}
+        initialRevision={7}
+        initiallyPublished={false}
+        canSwitchWorkspace
+        platformUrl="https://bakery.cornershop.dev"
+      />,
+    );
+    const localServiceHtml = renderToStaticMarkup(
+      <LocalServiceDashboard
+        initialDraft={sampleLocalServiceSiteDraft}
+        initialRevision={7}
+        email="owner@harbourelectrical.example"
+        brand={FACTORY_BRAND}
+        canSwitchWorkspace
+        initiallyPublished={false}
+        platformUrl="https://harbour-electrical.cornershop.dev"
+      />,
+    );
+
+    expect(restaurantHtml).toContain("Saved");
+    expect(foodRetailHtml).toContain("Saved");
+    expect(localServiceHtml).toContain("Saved");
+    expect(localServiceHtml).toContain("Draft revision 7");
+    expect(foodRetailHtml).toContain("Switch workspace");
+    expect(restaurantHtml).not.toContain("Unsaved changes");
+    expect(localServiceHtml).not.toContain("Unsaved changes");
+
+    const actions = renderToStaticMarkup(<AccountActions canSwitch />);
+    expect(actions).toContain("Switch workspace");
+    expect(actions).toContain("Sign out");
+    expect(actions).toContain("/workspace/select");
+  });
+
+  it("keeps restaurant settings and food-retail edits on the shared setDraft path", () => {
+    expect(dashboard).toContain('id="restaurant-name"');
+    expect(dashboard).toContain("setDraft((current) => ({");
+    expect(dashboard).toContain("showMenuImages: checked");
+    expect(foodRetailDashboard).toContain("setDraft({ ...draft, name:");
+    expect(localServiceDashboard).toContain("function change(");
+    expect(localServiceDashboard).toContain("setDraft((current) => {");
+  });
+});

--- a/src/lib/owner-draft-dirty-state.test.ts
+++ b/src/lib/owner-draft-dirty-state.test.ts
@@ -1,0 +1,336 @@
+import { describe, expect, it, mock } from "bun:test";
+import { sampleRestaurant } from "@/lib/restaurant";
+import { sampleFoodRetailDraft } from "@/lib/verticals/food-retail/fixtures";
+import { sampleLocalServiceSiteDraft } from "@/lib/verticals/local-service/fixtures";
+import {
+  OWNER_UNSAVED_EDITS_MESSAGE,
+  acknowledgeOwnerDraftSave,
+  acknowledgeOwnerDraftSnapshot,
+  applyOwnerDraftEdit,
+  beginOwnerDraftSave,
+  confirmDiscardUnsavedOwnerEdits,
+  createOwnerDraftDirtyState,
+  interceptOwnerNavigationClick,
+  ownerDraftBeforeUnloadHandler,
+  reconcileOwnerDraftAuxiliary,
+} from "@/lib/owner-draft-dirty-state";
+
+type Snapshot = {
+  name: string;
+  hero: string;
+};
+
+const verticalSamples = [
+  ["restaurant", sampleRestaurant],
+  ["food-retail", sampleFoodRetailDraft],
+  ["local-service", sampleLocalServiceSiteDraft],
+] as const;
+
+function snapshot(name = "Chez Léa", hero = "hero-1"): Snapshot {
+  return { name, hero };
+}
+
+function installWindow(confirmImpl: () => boolean = () => false) {
+  const confirm = mock(confirmImpl);
+  const previous = (globalThis as { window?: unknown }).window;
+  (globalThis as { window: unknown }).window = {
+    confirm,
+    location: {
+      href: "https://cornershop.dev/dashboard",
+      origin: "https://cornershop.dev",
+      pathname: "/dashboard",
+      search: "",
+    },
+  };
+  return {
+    confirm,
+    restore() {
+      if (previous === undefined) {
+        delete (globalThis as { window?: unknown }).window;
+      } else {
+        (globalThis as { window: unknown }).window = previous;
+      }
+    },
+  };
+}
+
+describe("owner draft dirty-state machine", () => {
+  it("starts clean and does not prompt", () => {
+    const api = installWindow(() => false);
+    const state = createOwnerDraftDirtyState(snapshot(), 4);
+
+    expect(state.dirty).toBe(false);
+    expect(state.revision).toBe(4);
+    expect(confirmDiscardUnsavedOwnerEdits(state.dirty)).toBe(true);
+    expect(api.confirm).not.toHaveBeenCalled();
+    api.restore();
+  });
+
+  it("marks every edit path dirty until the exact submitted snapshot is acknowledged", () => {
+    let state = createOwnerDraftDirtyState(snapshot(), 4);
+    state = applyOwnerDraftEdit(state, snapshot("Chez Léa edited"));
+    expect(state.dirty).toBe(true);
+    expect(state.mutationVersion).toBe(1);
+
+    const submitted = beginOwnerDraftSave(state);
+    const persisted = snapshot("Chez Léa edited");
+    const acknowledged = acknowledgeOwnerDraftSave(state, {
+      submittedDraft: submitted.submittedDraft,
+      persistedDraft: persisted,
+      submittedMutationVersion: submitted.submittedMutationVersion,
+      savedRevision: 5,
+    });
+
+    expect(acknowledged.hadNewerEdits).toBe(false);
+    expect(acknowledged.state.dirty).toBe(false);
+    expect(acknowledged.state.revision).toBe(5);
+    expect(acknowledged.state.draft).toEqual(persisted);
+  });
+
+  it("keeps in-flight edits and does not overwrite them when the save returns", () => {
+    let state = createOwnerDraftDirtyState(snapshot(), 4);
+    state = applyOwnerDraftEdit(state, snapshot("Submitted name"));
+    const submitted = beginOwnerDraftSave(state);
+    state = applyOwnerDraftEdit(state, snapshot("Typed while saving"));
+
+    const acknowledged = acknowledgeOwnerDraftSave(state, {
+      submittedDraft: submitted.submittedDraft,
+      persistedDraft: snapshot("Submitted name"),
+      submittedMutationVersion: submitted.submittedMutationVersion,
+      savedRevision: 5,
+    });
+
+    expect(acknowledged.hadNewerEdits).toBe(true);
+    expect(acknowledged.state.dirty).toBe(true);
+    expect(acknowledged.state.draft.name).toBe("Typed while saving");
+    expect(acknowledged.state.revision).toBe(5);
+    expect(acknowledged.state.baseline.name).toBe("Submitted name");
+  });
+
+  it("reconciles directly persisted photo-library patches without false dirty", () => {
+    for (const [vertical, sample] of verticalSamples) {
+      const state = createOwnerDraftDirtyState(sample, 7);
+      const patched = reconcileOwnerDraftAuxiliary(
+        state,
+        (draft) => ({
+          ...draft,
+          heroImageUrl: "https://photos.example/hero.webp",
+        }),
+        8,
+      );
+
+      expect(typeof vertical).toBe("string");
+      expect(patched.dirty).toBe(false);
+      expect(patched.revision).toBe(8);
+      expect(patched.draft.heroImageUrl).toBe(
+        "https://photos.example/hero.webp",
+      );
+      expect(patched.baseline.heroImageUrl).toBe(
+        "https://photos.example/hero.webp",
+      );
+      expect(confirmDiscardUnsavedOwnerEdits(patched.dirty)).toBe(true);
+    }
+  });
+
+  it("keeps owner edits dirty when a photo-library patch lands on the same snapshot", () => {
+    let state = createOwnerDraftDirtyState(snapshot(), 1);
+    state = applyOwnerDraftEdit(state, snapshot("Unsaved name"));
+    const patched = reconcileOwnerDraftAuxiliary(
+      state,
+      (draft) => ({ ...draft, hero: "hero-reviewed" }),
+      2,
+    );
+
+    expect(patched.dirty).toBe(true);
+    expect(patched.draft).toEqual({
+      name: "Unsaved name",
+      hero: "hero-reviewed",
+    });
+    expect(patched.baseline).toEqual({
+      name: "Chez Léa",
+      hero: "hero-reviewed",
+    });
+  });
+
+  it("does not let an exact save acknowledgement clobber a photo-library patch", () => {
+    let state = createOwnerDraftDirtyState(snapshot(), 1);
+    state = applyOwnerDraftEdit(state, snapshot("Saved name"));
+    const submitted = beginOwnerDraftSave(state);
+    state = reconcileOwnerDraftAuxiliary(
+      state,
+      (draft) => ({ ...draft, hero: "hero-reviewed" }),
+      3,
+    );
+
+    const acknowledged = acknowledgeOwnerDraftSave(state, {
+      submittedDraft: submitted.submittedDraft,
+      persistedDraft: snapshot("Saved name"),
+      submittedMutationVersion: submitted.submittedMutationVersion,
+      savedRevision: 4,
+    });
+
+    expect(acknowledged.hadNewerEdits).toBe(false);
+    expect(acknowledged.state.dirty).toBe(false);
+    expect(acknowledged.state.draft).toEqual({
+      name: "Saved name",
+      hero: "hero-reviewed",
+    });
+    expect(acknowledged.state.revision).toBe(4);
+  });
+
+  it("treats a source-monitoring accept as an acknowledged snapshot", () => {
+    let state = createOwnerDraftDirtyState(snapshot(), 2);
+    state = applyOwnerDraftEdit(state, snapshot("Should be replaced"));
+    const accepted = snapshot("Monitored name", "hero-2");
+    state = acknowledgeOwnerDraftSnapshot(state, accepted, 9);
+
+    expect(state.dirty).toBe(false);
+    expect(state.draft).toEqual(accepted);
+    expect(state.baseline).toEqual(accepted);
+    expect(state.revision).toBe(9);
+  });
+
+  it("clears dirty only for the submitted snapshot, not a later one", () => {
+    let state = createOwnerDraftDirtyState(snapshot(), 1);
+    state = applyOwnerDraftEdit(state, snapshot("First"));
+    const first = beginOwnerDraftSave(state);
+    state = applyOwnerDraftEdit(state, snapshot("Second"));
+    const second = beginOwnerDraftSave(state);
+
+    const firstAck = acknowledgeOwnerDraftSave(state, {
+      submittedDraft: first.submittedDraft,
+      persistedDraft: snapshot("First"),
+      submittedMutationVersion: first.submittedMutationVersion,
+      savedRevision: 2,
+    });
+    expect(firstAck.hadNewerEdits).toBe(true);
+    expect(firstAck.state.dirty).toBe(true);
+    expect(firstAck.state.draft.name).toBe("Second");
+
+    const secondAck = acknowledgeOwnerDraftSave(firstAck.state, {
+      submittedDraft: second.submittedDraft,
+      persistedDraft: snapshot("Second"),
+      submittedMutationVersion: second.submittedMutationVersion,
+      savedRevision: 3,
+    });
+    expect(secondAck.hadNewerEdits).toBe(false);
+    expect(secondAck.state.dirty).toBe(false);
+    expect(secondAck.state.draft.name).toBe("Second");
+  });
+});
+
+describe("owner draft navigation and unload guards", () => {
+  it("does not prompt on beforeunload or in-app navigation when clean", () => {
+    const api = installWindow(() => false);
+    let prevented = false;
+    const unload = {
+      preventDefault() {
+        prevented = true;
+      },
+      returnValue: "",
+    } as BeforeUnloadEvent;
+
+    expect(ownerDraftBeforeUnloadHandler(unload, false)).toBeUndefined();
+    expect(prevented).toBe(false);
+
+    interceptOwnerNavigationClick(
+      {
+        target: fakeAnchor("/workspace/select"),
+        preventDefault() {
+          prevented = true;
+        },
+        defaultPrevented: false,
+        metaKey: false,
+        ctrlKey: false,
+        shiftKey: false,
+        altKey: false,
+        button: 0,
+      },
+      false,
+    );
+
+    expect(prevented).toBe(false);
+    expect(api.confirm).not.toHaveBeenCalled();
+    api.restore();
+  });
+
+  it("warns on browser unload, in-app navigation, workspace switch, and sign-out when dirty", () => {
+    const api = installWindow(() => false);
+    let unloadPrevented = false;
+    const unload = {
+      preventDefault() {
+        unloadPrevented = true;
+      },
+      returnValue: "",
+    } as BeforeUnloadEvent;
+
+    expect(ownerDraftBeforeUnloadHandler(unload, true)).toBe(
+      OWNER_UNSAVED_EDITS_MESSAGE,
+    );
+    expect(unloadPrevented).toBe(true);
+    expect(unload.returnValue).toBe(OWNER_UNSAVED_EDITS_MESSAGE);
+
+    for (const href of ["/workspace/select", "/sign-in", "/create"]) {
+      api.confirm.mockClear();
+      let navigationPrevented = false;
+      interceptOwnerNavigationClick(
+        {
+          target: fakeAnchor(href),
+          preventDefault() {
+            navigationPrevented = true;
+          },
+          defaultPrevented: false,
+          metaKey: false,
+          ctrlKey: false,
+          shiftKey: false,
+          altKey: false,
+          button: 0,
+        },
+        true,
+      );
+      expect(api.confirm).toHaveBeenCalledWith(OWNER_UNSAVED_EDITS_MESSAGE);
+      expect(navigationPrevented).toBe(true);
+    }
+
+    api.confirm.mockClear();
+    expect(confirmDiscardUnsavedOwnerEdits(true)).toBe(false);
+    expect(api.confirm).toHaveBeenCalledWith(OWNER_UNSAVED_EDITS_MESSAGE);
+    api.restore();
+  });
+
+  it("does not intercept new-tab preview links", () => {
+    const api = installWindow(() => false);
+    let prevented = false;
+    interceptOwnerNavigationClick(
+      {
+        target: fakeAnchor("/preview/osteria-luna", "_blank"),
+        preventDefault() {
+          prevented = true;
+        },
+        defaultPrevented: false,
+        metaKey: false,
+        ctrlKey: false,
+        shiftKey: false,
+        altKey: false,
+        button: 0,
+      },
+      true,
+    );
+    expect(prevented).toBe(false);
+    expect(api.confirm).not.toHaveBeenCalled();
+    api.restore();
+  });
+});
+
+function fakeAnchor(href: string, target = "") {
+  return {
+    closest: (selector: string) =>
+      selector === "a"
+        ? {
+            target,
+            getAttribute: (name: string) => (name === "href" ? href : null),
+            hasAttribute: () => false,
+          }
+        : null,
+  };
+}

--- a/src/lib/owner-draft-dirty-state.ts
+++ b/src/lib/owner-draft-dirty-state.ts
@@ -1,0 +1,400 @@
+"use client";
+
+import {
+  createContext,
+  createElement,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+  type ReactNode,
+} from "react";
+
+export const OWNER_UNSAVED_EDITS_MESSAGE =
+  "You have unsaved changes. Leave this page and discard them?";
+
+export type OwnerDraftDirtyState<T> = {
+  draft: T;
+  baseline: T;
+  revision: number;
+  mutationVersion: number;
+  dirty: boolean;
+};
+
+export type OwnerDraftSaveAcknowledgement<T> = {
+  submittedDraft: T;
+  persistedDraft: T;
+  submittedMutationVersion: number;
+  savedRevision: number;
+};
+
+export function ownerDraftSnapshotsEqual(
+  left: unknown,
+  right: unknown,
+): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+export function createOwnerDraftDirtyState<T>(
+  draft: T,
+  revision: number,
+): OwnerDraftDirtyState<T> {
+  return {
+    draft,
+    baseline: structuredClone(draft),
+    revision,
+    mutationVersion: 0,
+    dirty: false,
+  };
+}
+
+export function applyOwnerDraftEdit<T>(
+  state: OwnerDraftDirtyState<T>,
+  nextDraft: T,
+): OwnerDraftDirtyState<T> {
+  return {
+    ...state,
+    draft: nextDraft,
+    mutationVersion: state.mutationVersion + 1,
+    dirty: !ownerDraftSnapshotsEqual(nextDraft, state.baseline),
+  };
+}
+
+export function beginOwnerDraftSave<T>(state: OwnerDraftDirtyState<T>): {
+  submittedDraft: T;
+  submittedMutationVersion: number;
+  expectedRevision: number;
+} {
+  return {
+    submittedDraft: state.draft,
+    submittedMutationVersion: state.mutationVersion,
+    expectedRevision: state.revision,
+  };
+}
+
+export function acknowledgeOwnerDraftSave<T>(
+  state: OwnerDraftDirtyState<T>,
+  acknowledgement: OwnerDraftSaveAcknowledgement<T>,
+): { state: OwnerDraftDirtyState<T>; hadNewerEdits: boolean } {
+  const hadNewerEdits =
+    state.mutationVersion !== acknowledgement.submittedMutationVersion;
+  if (hadNewerEdits) {
+    return {
+      state: {
+        ...state,
+        baseline: acknowledgement.persistedDraft,
+        revision: acknowledgement.savedRevision,
+        dirty: !ownerDraftSnapshotsEqual(
+          state.draft,
+          acknowledgement.persistedDraft,
+        ),
+      },
+      hadNewerEdits: true,
+    };
+  }
+
+  const nextDraft = ownerDraftSnapshotsEqual(
+    state.draft,
+    acknowledgement.submittedDraft,
+  )
+    ? acknowledgement.persistedDraft
+    : state.draft;
+  return {
+    state: {
+      ...state,
+      draft: nextDraft,
+      baseline: structuredClone(nextDraft),
+      revision: acknowledgement.savedRevision,
+      dirty: false,
+    },
+    hadNewerEdits: false,
+  };
+}
+
+export function reconcileOwnerDraftAuxiliary<T>(
+  state: OwnerDraftDirtyState<T>,
+  patch: (draft: T) => T,
+  revision: number = state.revision,
+): OwnerDraftDirtyState<T> {
+  const draft = patch(state.draft);
+  const baseline = patch(state.baseline);
+  return {
+    ...state,
+    draft,
+    baseline,
+    revision,
+    dirty: !ownerDraftSnapshotsEqual(draft, baseline),
+  };
+}
+
+export function acknowledgeOwnerDraftSnapshot<T>(
+  state: OwnerDraftDirtyState<T>,
+  snapshot: T,
+  revision: number,
+): OwnerDraftDirtyState<T> {
+  return {
+    ...state,
+    draft: snapshot,
+    baseline: structuredClone(snapshot),
+    revision,
+    dirty: false,
+  };
+}
+
+export function adoptOwnerDraftServerState<T>(
+  state: OwnerDraftDirtyState<T>,
+  input: { draft: T; baseline: T; revision: number },
+): OwnerDraftDirtyState<T> {
+  return {
+    ...state,
+    draft: input.draft,
+    baseline: input.baseline,
+    revision: input.revision,
+    dirty: !ownerDraftSnapshotsEqual(input.draft, input.baseline),
+  };
+}
+
+export function setOwnerDraftRevision<T>(
+  state: OwnerDraftDirtyState<T>,
+  revision: number,
+): OwnerDraftDirtyState<T> {
+  return { ...state, revision };
+}
+
+export function confirmDiscardUnsavedOwnerEdits(dirty: boolean): boolean {
+  if (!dirty) return true;
+  return window.confirm(OWNER_UNSAVED_EDITS_MESSAGE);
+}
+
+export function ownerDraftBeforeUnloadHandler(
+  event: BeforeUnloadEvent,
+  dirty: boolean,
+): string | undefined {
+  if (!dirty) return undefined;
+  event.preventDefault();
+  event.returnValue = OWNER_UNSAVED_EDITS_MESSAGE;
+  return OWNER_UNSAVED_EDITS_MESSAGE;
+}
+
+type OwnerNavigationClickEvent = {
+  target: unknown;
+  preventDefault: () => void;
+  defaultPrevented: boolean;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+  button: number;
+};
+
+function closestAnchor(target: unknown): {
+  target: string;
+  href: string | null;
+  download: boolean;
+} | null {
+  if (target === null || typeof target !== "object") return null;
+  const withClosest =
+    typeof (target as { closest?: unknown }).closest === "function"
+      ? target
+      : (target as { parentElement?: unknown }).parentElement;
+  if (withClosest === null || typeof withClosest !== "object") return null;
+  const element = withClosest as {
+    closest?: (selector: string) => unknown;
+  };
+  if (typeof element.closest !== "function") return null;
+  const anchor = element.closest("a") as {
+    target: string;
+    getAttribute?: (name: string) => string | null;
+    hasAttribute?: (name: string) => boolean;
+    href?: string;
+  } | null;
+  if (!anchor) return null;
+  return {
+    target: anchor.target ?? "",
+    href:
+      typeof anchor.getAttribute === "function"
+        ? anchor.getAttribute("href")
+        : (anchor.href ?? null),
+    download:
+      typeof anchor.hasAttribute === "function"
+        ? anchor.hasAttribute("download")
+        : false,
+  };
+}
+
+export function interceptOwnerNavigationClick(
+  event: OwnerNavigationClickEvent,
+  dirty: boolean,
+): void {
+  if (!dirty || event.defaultPrevented) return;
+  if (event.button !== 0) return;
+  if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+  const anchor = closestAnchor(event.target);
+  if (!anchor || anchor.download) return;
+  if (anchor.target === "_blank" || anchor.target === "_new") return;
+  const href = anchor.href;
+  if (!href || href.startsWith("#") || href.startsWith("javascript:")) return;
+  let destination: URL;
+  try {
+    destination = new URL(href, window.location.href);
+  } catch {
+    return;
+  }
+  if (destination.origin !== window.location.origin) return;
+  if (
+    destination.pathname === window.location.pathname &&
+    destination.search === window.location.search
+  ) {
+    return;
+  }
+  if (!confirmDiscardUnsavedOwnerEdits(true)) {
+    event.preventDefault();
+  }
+}
+
+const OwnerDraftDirtyContext = createContext(false);
+
+export function useOwnerUnsavedEdits(): boolean {
+  return useContext(OwnerDraftDirtyContext);
+}
+
+export function useOwnerDraftUnloadProtection(dirty: boolean) {
+  useEffect(() => {
+    if (!dirty) return;
+    const previous = window.onbeforeunload;
+    const handler = (event: BeforeUnloadEvent) =>
+      ownerDraftBeforeUnloadHandler(event, true);
+    window.onbeforeunload = handler;
+    return () => {
+      if (window.onbeforeunload === handler) {
+        window.onbeforeunload = previous;
+      }
+    };
+  }, [dirty]);
+}
+
+export function ownerDraftNavigationProps(dirty: boolean): {
+  onClickCapture: (event: ReactMouseEvent<HTMLElement>) => void;
+} {
+  return {
+    onClickCapture: (event: ReactMouseEvent<HTMLElement>) => {
+      interceptOwnerNavigationClick(event, dirty);
+    },
+  };
+}
+
+export function OwnerDraftDirtyGuard({
+  dirty,
+  children,
+}: {
+  dirty: boolean;
+  children: ReactNode;
+}) {
+  useOwnerDraftUnloadProtection(dirty);
+  return createElement(
+    OwnerDraftDirtyContext.Provider,
+    { value: dirty },
+    children,
+  );
+}
+
+export function useOwnerDraftDirtyState<T>(
+  initialDraft: T,
+  initialRevision: number,
+) {
+  const [state, setState] = useState(() =>
+    createOwnerDraftDirtyState(initialDraft, initialRevision),
+  );
+  const stateRef = useRef(state);
+  const draftRef = useRef(state.draft);
+
+  const commit = useCallback((next: OwnerDraftDirtyState<T>) => {
+    stateRef.current = next;
+    draftRef.current = next.draft;
+    setState(next);
+  }, []);
+
+  const setDraft = useCallback(
+    (next: T | ((current: T) => T)) => {
+      const current = stateRef.current;
+      const resolved =
+        typeof next === "function"
+          ? (next as (current: T) => T)(current.draft)
+          : next;
+      commit(applyOwnerDraftEdit(current, resolved));
+    },
+    [commit],
+  );
+
+  const applyAuxiliary = useCallback(
+    (patch: (draft: T) => T, revision?: number) => {
+      const current = stateRef.current;
+      commit(
+        reconcileOwnerDraftAuxiliary(
+          current,
+          patch,
+          revision ?? current.revision,
+        ),
+      );
+    },
+    [commit],
+  );
+
+  const setRevision = useCallback(
+    (revision: number) => {
+      commit(setOwnerDraftRevision(stateRef.current, revision));
+    },
+    [commit],
+  );
+
+  const beginSave = useCallback(
+    () => beginOwnerDraftSave(stateRef.current),
+    [],
+  );
+
+  const acknowledgeSave = useCallback(
+    (acknowledgement: OwnerDraftSaveAcknowledgement<T>) => {
+      const reconciled = acknowledgeOwnerDraftSave(
+        stateRef.current,
+        acknowledgement,
+      );
+      commit(reconciled.state);
+      return reconciled;
+    },
+    [commit],
+  );
+
+  const acknowledgeSnapshot = useCallback(
+    (snapshot: T, revision: number) => {
+      commit(
+        acknowledgeOwnerDraftSnapshot(stateRef.current, snapshot, revision),
+      );
+    },
+    [commit],
+  );
+
+  const adoptServerDraft = useCallback(
+    (input: { draft: T; baseline: T; revision: number }) => {
+      commit(adoptOwnerDraftServerState(stateRef.current, input));
+    },
+    [commit],
+  );
+
+  return {
+    draft: state.draft,
+    baseline: state.baseline,
+    revision: state.revision,
+    dirty: state.dirty,
+    mutationVersion: state.mutationVersion,
+    draftRef,
+    setDraft,
+    applyAuxiliary,
+    setRevision,
+    beginSave,
+    acknowledgeSave,
+    acknowledgeSnapshot,
+    adoptServerDraft,
+  };
+}


### PR DESCRIPTION
Depends on #176 / #158 (transitively #175, #174, #171, #172).

## Summary

Restaurant, Food Retail, and Local Service now share one persisted-snapshot / revision / dirty-state contract. Unsaved owner edits warn before browser unload, workspace switching, sign-out, and in-app navigation. Clean drafts never prompt.

- **Contract:** `useOwnerDraftDirtyState` marks every edit path dirty and clears only after acknowledgement of the exact submitted snapshot. Edits typed while a save is in flight stay dirty and are not overwritten.
- **Auxiliary mutations:** reviewed photo-library changes patch both the current draft and the persisted baseline, so they do not raise a false dirty prompt or clobber in-flight edits. Source-monitoring accepts are treated as acknowledged snapshots.
- **Guards:** `window.onbeforeunload` for tab close/reload; click capture plus `AccountActions` `window.confirm` for workspace switch, sign-out, and same-tab links. New-tab preview links are left alone. Publication still saves the intended revision before clearing state.

## Why

Unsaved owner edits could be lost, and dirty-state behavior differed by vertical: Restaurant settings did not invalidate Saved, Food Retail had no dirty contract, Local Service tracked dirty state without unload or navigation protection, and workspace switch / sign-out navigated immediately.

## Test plan

- [x] Hook/state-machine bun tests: dirty mark, exact-snapshot clear, in-flight edit preservation, photo-library reconcile, source-monitoring snapshot, no prompt when clean
- [x] Navigation/unload tests: beforeunload, workspace switch, sign-out, in-app links; new-tab preview links ignored
- [x] Component/source tests for all three dashboards plus AccountActions
- [x] Existing dashboard, menu, food-retail, local-service, and owner-integration suites
- [x] `bun run lint`
- [x] `next typegen` + `bunx tsc --noEmit`
- [x] `git diff --check`
- [ ] PR CI required checks

Closes #156