### PR TITLE
docs: align capability and stack claims with runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,49 @@
 Cornershopdev is a multi-vertical local-business website factory. Each
 configured niche supplies its own discovery queries, catalog/conversion
 signals, content schema, preview generator, storefront identity, and provider
-adapters. A business keeps the operational tools it already uses, reviews a
-private prefilled preview, claims it, subscribes, then connects its domain.
+adapters. A business keeps the operational tools it already uses and reviews a
+private prefilled preview. Claim, subscription, custom domains, monitoring,
+leads, and articles are per-vertical capabilities, not a universal lifecycle.
+
+## Vertical capabilities
+
+These axes are independent. Factory visibility is not a standalone niche
+launch. A claim mode is not owner publish. Rendering an already-published
+snapshot is not the same as creating one. Custom domains, source monitoring,
+leads, and articles are owner-operation flags resolved through
+`resolveOwnerOperations` and fail closed against claim and publication-mutation
+gates.
+
+| Vertical | Factory visibility | Standalone launch | Claim mode | Owner mutation | Platform publication | Custom domains | Monitoring | Leads | Articles |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Restaurant | public | launched | niche | enabled | enabled | enabled | enabled | enabled | enabled |
+| Beauty | public | unlaunched | disabled | unsupported | enabled | unsupported | unsupported | unsupported | unsupported |
+| Food Retail | private | unlaunched | factory | enabled | enabled | enabled | enabled | not-yet | not-yet |
+| Local Service | private | unlaunched | factory | enabled | enabled | enabled | enabled | not-yet | not-yet |
+
+- **Factory visibility** — `marketing.publiclyAccessible`: the shared
+  `/niche/[vertical]` route.
+- **Standalone launch** — `verticalLaunchReadiness`: public access, canonical
+  domain, matching routed hostname, and verified niche sender.
+- **Claim mode** — `disabled`, `factory` (Cornershopdev sender and
+  `<slug>.cornershop.dev`), or `niche` (the vertical's own domain and sender).
+- **Owner mutation** — publish and rollback. Requires
+  `publicationMutationEnabled` and a supported owner-review dashboard.
+- **Platform publication** — `publicationEnabled`: already-published snapshots
+  may still render when owners cannot create new ones.
+- **Custom domains / Monitoring / Leads / Articles** — owner-operation states
+  (`enabled`, `not-yet`, `gated`, `unsupported`).
+
+Restaurant, Food Retail, and Local Service also enable billing, publication
+history, workspace switching, and the reviewed photo library. Beauty leaves
+every paid owner operation unsupported. It is a non-chargeable factory
+preview, not a sellable niche.
 
 ## Product flow
 
-1. Paste a restaurant URL or name.
+Shared import path, used by every registered vertical:
+
+1. Paste a source URL or name into that vertical's intake.
 2. Import public website content with SSRF-safe fetching and bounded HTML reads.
 3. Deterministically recover structured business facts, hours, bounded catalog
    candidates, relevant navigation, authentic source assets, and field-level
@@ -16,20 +53,36 @@ private prefilled preview, claims it, subscribes, then connects its domain.
 4. Recover source logos/favicons and CSS/meta brand colours, repairing contrast
    where necessary before the palette reaches a renderer.
 5. Detect the source language and preserve it as canonical. When OpenRouter is
-   configured, generate a complete English translation in the structured pass.
-6. Preserve first-party photography and optionally enhance exposure, colour, crop, noise, and clarity without changing the food or venue.
+   configured, generate a complete English translation in the structured pass
+   unless the vertical is `deterministic-only`.
+6. Preserve first-party photography and optionally enhance exposure, colour,
+   crop, noise, and clarity without changing material scene content. Each
+   vertical lists its own forbidden elements.
 7. Save a private preview through a durable PostgreSQL-backed Workflow.
-8. Verify ownership through a one-time business-domain email invitation or a concierge-approved owner email.
-9. Claim the restaurant through invitation-bound Stripe Checkout; the completed checkout creates the prefilled owner account.
-10. Authorize the restaurant domain for on-demand TLS and show the exact DNS records.
-11. Monitor and maintain the menu, imagery, and external links from the dashboard.
+
+What happens after preview depends on the matrix above:
+
+- **Restaurant (`niche`)** — verify ownership through a one-time
+  business-domain email invitation or a concierge-approved owner email; claim
+  through invitation-bound Stripe Checkout; authorize a custom domain for
+  on-demand TLS; monitor the menu, imagery, and links; review first-party
+  booking leads; publish articles.
+- **Food Retail and Local Service (`factory`)** — an approved preview can
+  claim the shared $49 Cornershopdev plan and publish on
+  `<slug>.cornershop.dev`. Custom domains and source monitoring are enabled.
+  Owner analytics, lead inbox, and articles are not-yet.
+- **Beauty (`disabled`)** — the factory `/niche/beauty` preview stays
+  non-chargeable. Claim, owner mutation, billing, custom domains, monitoring,
+  leads, and articles are unsupported.
 
 ## Customer workspace and operator console
 
-Each claimed site has a tenant-scoped `/dashboard` workspace. Owners can edit
-their site, connect a domain, review first-party booking leads, and move each
-request from `NEW` to `CONTACTED` or `CLOSED`. Contact details are returned only
-after the session is revalidated against that site's organization membership.
+Each claimed site has a tenant-scoped `/dashboard` workspace. Owners only get
+the operations their vertical enables. Contact details are returned only after
+the session is revalidated against that site's organization membership.
+Restaurant can review first-party booking leads and move each request from
+`NEW` to `CONTACTED` or `CLOSED`. Food Retail and Local Service do not expose
+a lead inbox yet. Beauty has no owner-review dashboard.
 
 `/admin` is the platform operator console. It requires both a database
 `SUPERADMIN` role and an email listed in `SUPERADMIN_EMAILS`. It shows signups,
@@ -67,12 +120,14 @@ paths, query strings, provider URLs, names, email addresses, phone numbers, or
 booking notes. A one-minute Redis limiter may use a transient hash derived from
 the connection address; it is not written to PostgreSQL.
 
-Booking requests remain the authoritative lead count, so a dropped analytics
-beacon cannot lose a real lead. The corresponding `LEAD_CREATED` event is
-server-owned and best effort. Client and operator workspaces expose 7, 30, and
-90-day distinct-visit, CTA-visitor, booking-lead, and conversion metrics.
-Raw analytics events are retained for 120 days and pruned daily under a
-PostgreSQL advisory lock.
+Booking requests remain the authoritative lead count for verticals that enable
+the lead inbox, so a dropped analytics beacon cannot lose a real lead. The
+corresponding `LEAD_CREATED` event is server-owned and best effort. Restaurant
+owner workspaces and the operator console expose 7, 30, and 90-day
+distinct-visit, CTA-visitor, booking-lead, and conversion metrics. Food Retail
+and Local Service mark owner analytics as not-yet; Beauty has no owner
+analytics. Raw analytics events are retained for 120 days and pruned daily
+under a PostgreSQL advisory lock.
 
 ## Restaurant themes
 
@@ -101,6 +156,14 @@ Heritage and fine-dining templates default to a clean text-led menu; casual,
 fresh, coastal, and bold concepts default to a small highlights gallery. Owners
 can show or hide the gallery from the dashboard without deleting any images.
 
+## Beauty vertical
+
+`BEAUTY` is a non-chargeable factory preview. `/niche/beauty` is publicly
+accessible, but it has no standalone domain or sender, and `claimMode` is
+`disabled`. Already-published snapshots remain renderable. Owner mutation,
+billing, custom domains, monitoring, leads, articles, and the photo library
+are unsupported. There is no owner-review dashboard.
+
 ## Food retail vertical
 
 `FOOD_RETAIL` is a bounded vertical for bakeries, pâtisseries, butchers,
@@ -120,12 +183,12 @@ adapter restores business identity, contact details, hours, products, prices,
 ordering links and factual product attributes from deterministic crawl output.
 Unsupported model claims remain empty or null.
 
-The vertical is registered for private studio imports and owner dashboards but
-is not publicly launched: its marketing hostnames are empty, its domain and
-sender are null, and its server-side publication and rollback capability is
-disabled. Private preview and owner review remain available.
-The implementation contract, test fixture, structured-data mapping and required
-domain/sender/production-config evidence are documented in
+The vertical is factory-claimable but not publicly launched: marketing
+hostnames are empty, domain and sender are null, and `publiclyAccessible` is
+false. Claim mode is `factory`. Already-published snapshots render, and owners
+with the food-retail dashboard may publish and roll back. Custom domains,
+source monitoring, and the photo library are enabled. Owner analytics, lead
+inbox, and articles are not-yet. See the capability matrix above and
 [`docs/verticals/food-retail.md`](docs/verticals/food-retail.md).
 
 ## Local-service vertical
@@ -143,9 +206,11 @@ evidence. Missing emergency coverage, credentials, insurance, trust claims,
 projects, prices, or availability remain unstated rather than being inferred.
 
 The vertical is registered for private imports, previews, and revision-safe
-owner editing. Public niche access, claiming, publication, and rollback remain
-disabled until a real domain, exact routed hostname, and matching verified
-sender configuration satisfy the launch-readiness gate. See
+owner editing. Factory claim, publication, custom domains, source monitoring,
+and the photo library are enabled. Public niche access and standalone launch
+stay closed until a real domain, exact routed hostname, and matching verified
+sender satisfy `verticalLaunchReadiness`. Owner analytics, lead inbox, and
+articles are not-yet. See the capability matrix above and
 [`docs/verticals/local-service.md`](docs/verticals/local-service.md).
 
 ## Internationalization
@@ -153,8 +218,8 @@ sender configuration satisfy the launch-readiness gate. See
 Site data uses one canonical source locale plus structured translation
 overlays. Prices, currencies, images, addresses, provider names, and external
 booking or ordering URLs remain shared, so translating a site cannot fork its
-operational data. Menu sections, menu items, descriptions, dietary labels, and
-link labels keep the same order and count in every locale.
+operational data. Catalog sections, items, descriptions, vertical-specific
+labels, and link labels keep the same order and count in every locale.
 If an existing provider URL already exposes a `lang` parameter, the rendered
 link updates only that preference while preserving the same provider and flow.
 
@@ -166,13 +231,16 @@ The canonical site is available at `/preview/[slug]`; translations use
 
 ## Stack
 
+Package majors below match `package.json`. Runtime image pins live in the
+Dockerfile.
+
 - Next.js 16 App Router and React 19
-- Bun 1.3.14 for installs, Prisma/Workflow migrations, and operator tooling;
+- Bun 1.4.0 for installs, Prisma/Workflow migrations, and operator tooling;
   pinned Node.js 24.19.0 LTS for Next.js builds and the production standalone
   server
 - Tailwind CSS v4 and shadcn/ui
 - Prisma 7 with PostgreSQL and the `pg` driver adapter
-- Vercel AI SDK 6 with OpenRouter for structured text generation and optional
+- Vercel AI SDK 7 with OpenRouter for structured text generation and optional
   source-photo enhancement
 - Workflow DevKit with its self-hosted PostgreSQL World
 - Amazon S3 and CloudFront for persistent enhanced derivatives
@@ -230,7 +298,7 @@ fails closed when it is absent or invalid.
 
 ### AI generation
 
-Restaurant crawling, same-origin page discovery, SSRF checks, and source
+Source crawling, same-origin page discovery, SSRF checks, and source
 reconstruction run locally without a model. JSON-LD, metadata, explicit contact
 links, semantic address markup, source navigation, logos/favicons, and CSS/meta
 colours are recovered with bounded parsers. Every accepted fact keeps its source
@@ -303,9 +371,11 @@ reaches the live site only after the owner publishes again.
 
 Allowed edits are exposure, white balance, highlight and shadow recovery,
 denoising, sharpness, resolution, straightening, subtle cropping, and removal of
-transient non-material distractions such as sensor dust. Ingredients, garnishes,
-portions, plating, tableware, people, architecture, and material scene elements
-must not be added, removed, replaced, moved, or regenerated. Only approved
+transient non-material distractions such as sensor dust. Material scene
+elements must not be added, removed, replaced, moved, or regenerated. Each
+vertical lists its own forbidden subjects — food and plating for restaurants,
+product and packaging for food retail, skin/hair/nail and treatment results
+for beauty. Only approved
 originals enter a rate- and concurrency-limited batch. Originals remain active
 until the owner approves the before/after derivative, and every approve, reject,
 selection, restore, failure, and cost result is audited. See
@@ -392,7 +462,8 @@ bun run operator:preflight-outreach --environment production
 The application records the hostname and returns the production A or CNAME
 target. After DNS resolves, the owner verifies it in the dashboard. Caddy issues
 TLS only when its authorization callback confirms that the domain is verified
-and belongs to a restaurant.
+and belongs to a claimed site. Custom-domain owner operations stay closed for
+verticals whose `customDomain` capability is not enabled.
 
 ### Production routing
 
@@ -420,9 +491,10 @@ this same container, where the rewrite fires again — an infinite loop.
 - AI output is validated with Zod before it enters the product.
 - Existing booking and ordering links are extracted from source material and override model-generated links.
 - Stripe webhooks verify the raw body signature.
-- Restaurant claims require a hashed, expiring invitation bound to one site,
-  intended email, and Stripe Checkout session. Raw invitation tokens are kept
-  in URL fragments so embedded preview assets cannot receive them as referrers.
+- Claims require a hashed, expiring invitation bound to one site, intended
+  email, and Stripe Checkout session, and only for verticals whose claim mode
+  is enabled. Raw invitation tokens are kept in URL fragments so embedded
+  preview assets cannot receive them as referrers.
 - Self-serve claims require the exact imported business email or an address on
   the exact source hostname. Ambiguous ownership requires a dual-gated
   superadmin approval from the operator console.
@@ -431,17 +503,22 @@ this same container, where the rewrite fires again — an infinite loop.
   acceptance, and rejection events are recorded without tokens or contact data.
 - Better Auth owns revocable, database-backed dashboard sessions behind a
   signed HTTP-only, same-site cookie.
-- Restaurant mutations require a session matching the restaurant slug.
-- Image enhancement and domain management require that same restaurant-scoped session.
+- Site mutations require a session matching the site slug and current
+  organization membership. Routes are vertical-aware: publish/rollback, domain
+  management, photo library, source monitoring, analytics, articles, and the
+  lead inbox still fail closed when that vertical's owner operation is not
+  enabled.
+- Image enhancement and domain management require that same site-scoped session.
 - Public preview generation is rate limited and fails closed in production.
 - Enhanced derivatives are persisted to private S3 storage and served through CloudFront while authentic originals and provenance remain available.
-- Arbitrary restaurant images load directly in the browser instead of through the Next.js image proxy.
+- Arbitrary site images load directly in the browser instead of through the Next.js image proxy.
 
 ## Useful routes
 
 - `/` — marketing and URL intake
+- `/niche/[vertical]` — factory niche page for publicly accessible verticals
 - `/create` — import and preview studio
-- `/claim/[slug]` — pricing and claim checkout
+- `/claim/[slug]` — pricing and claim checkout, when that vertical's claim mode is enabled
 - `/dashboard` — authenticated vertical-aware owner management
 - `/dashboard?demo=1` — local demo dashboard
 - `/admin` — dual-gated superadmin operator console

--- a/docs/verticals/food-retail.md
+++ b/docs/verticals/food-retail.md
@@ -13,7 +13,8 @@ flowchart LR
   C --> D[(Shared Site and Catalog tables)]
   D --> E[Private preview]
   D --> F[Food retail owner dashboard]
-  F --> G[Private owner review]
+  F --> G[Factory claim]
+  G --> H[Publish on platform subdomain]
 ```
 
 ## Vertical boundary
@@ -89,6 +90,18 @@ carry the vertical data, so no existing rows are rewritten and the migration
 does not seed product facts. The owner PUT route parses FOOD_RETAIL drafts with
 the registered schema before the shared optimistic-revision persistence path.
 
+## Capability row
+
+Matches the README matrix and `resolveOwnerOperations(FOOD_RETAIL)`:
+
+| Vertical | Factory visibility | Standalone launch | Claim mode | Owner mutation | Platform publication | Custom domains | Monitoring | Leads | Articles |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Food Retail | private | unlaunched | factory | enabled | enabled | enabled | enabled | not-yet | not-yet |
+
+Owner photo library is enabled. Owner analytics, lead inbox, and articles stay
+`not-yet`. This vertical does not inherit restaurant reservations or booking
+leads.
+
 ## Factory claim and standalone launch gates
 
 Standalone niche marketing stays closed:
@@ -96,8 +109,10 @@ Standalone niche marketing stays closed:
 - `marketing.hostnames = []`
 - `marketing.domain = null`
 - `marketing.email = null`
+- `marketing.publiclyAccessible = false`
 - `claimMode = "factory"`
 - `publicationEnabled = true`
+- `publicationMutationEnabled = true`
 
 An approved private preview can claim the shared Cornershopdev $49 plan and
 publish at `<slug>.cornershop.dev`. That factory path requires:

--- a/docs/verticals/local-service.md
+++ b/docs/verticals/local-service.md
@@ -3,8 +3,9 @@
 `LOCAL_SERVICE` is the bounded local-trade implementation for plumbers,
 electricians, builders, repair businesses, and artisans. It is registered in
 the existing vertical registry and uses the shared crawler, import workflow,
-site tables, renderer, owner editing, analytics, domain routing, and
-source-monitoring engine. It does not fork the app and it
+site tables, renderer, owner editing, domain routing, and
+source-monitoring engine. Owner analytics, lead inbox, and articles are
+not-yet. It does not fork the app and it
 does not accept model-authored HTML, CSS, class names, or components.
 
 ## Data contract
@@ -90,13 +91,26 @@ use the shared billing, same-origin, optimistic-revision, immutable snapshot,
 and audit boundaries. The editor saves before publication and requires a
 3–280 character change summary plus explicit confirmation.
 
+## Capability row
+
+Matches the README matrix and `resolveOwnerOperations(LOCAL_SERVICE)`:
+
+| Vertical | Factory visibility | Standalone launch | Claim mode | Owner mutation | Platform publication | Custom domains | Monitoring | Leads | Articles |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Local Service | private | unlaunched | factory | enabled | enabled | enabled | enabled | not-yet | not-yet |
+
+Owner photo library is enabled. Owner analytics, lead inbox, and articles stay
+`not-yet`. The renderer disables the restaurant booking-request form.
+
 ## Launch gate
 
 Tradefront has no standalone niche storefront. Its marketing config therefore
 keeps hostname, domain, and niche sender empty, while `claimMode: "factory"`
 allows an approved private preview to use Cornershopdev's verified sender,
-shared $49 checkout, and `<slug>.cornershop.dev` public URL. A future standalone
-niche still must satisfy `verticalLaunchReadiness`:
+shared $49 checkout, and `<slug>.cornershop.dev` public URL.
+`publicationEnabled` and `publicationMutationEnabled` are both true for that
+factory path. A future standalone niche still must satisfy
+`verticalLaunchReadiness`:
 
 1. a configured public domain;
 2. that exact domain registered in the proxy hostname list;

--- a/src/lib/docs-capability-contract.test.ts
+++ b/src/lib/docs-capability-contract.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, it } from "bun:test";
+import {
+  isVerticalPublicationEnabled,
+  isVerticalPubliclyLaunched,
+  listVerticalIds,
+  resolveOwnerOperations,
+  resolveVerticalConfig,
+} from "@/lib/verticals/registry";
+import type { VerticalId } from "@/lib/verticals/types";
+
+const repoRoot = new URL("../..", import.meta.url);
+
+const CAPABILITY_HEADERS = [
+  "Vertical",
+  "Factory visibility",
+  "Standalone launch",
+  "Claim mode",
+  "Owner mutation",
+  "Platform publication",
+  "Custom domains",
+  "Monitoring",
+  "Leads",
+  "Articles",
+] as const;
+
+const STACK_MAJOR_PATTERNS = [
+  { packageName: "next", pattern: /Next\.js (\d+)/ },
+  { packageName: "react", pattern: /React (\d+)/ },
+  { packageName: "prisma", pattern: /Prisma (\d+)/ },
+  { packageName: "ai", pattern: /Vercel AI SDK (\d+)/ },
+  { packageName: "tailwindcss", pattern: /Tailwind CSS v(\d+)/ },
+] as const;
+
+const DOC_FILES = [
+  "README.md",
+  "docs/verticals/food-retail.md",
+  "docs/verticals/local-service.md",
+] as const;
+
+const GUIDE_VERTICAL: Record<
+  "docs/verticals/food-retail.md" | "docs/verticals/local-service.md",
+  VerticalId
+> = {
+  "docs/verticals/food-retail.md": "FOOD_RETAIL",
+  "docs/verticals/local-service.md": "LOCAL_SERVICE",
+};
+
+type PackageJson = {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  scripts?: Record<string, string>;
+};
+
+type MarkdownTable = {
+  headers: string[];
+  rows: string[][];
+};
+
+const [readme, foodRetailGuide, localServiceGuide, packageJson] =
+  await Promise.all([
+    readRepoFile("README.md"),
+    readRepoFile("docs/verticals/food-retail.md"),
+    readRepoFile("docs/verticals/local-service.md"),
+    readRepoJson("package.json"),
+  ]);
+
+const docsByPath = {
+  "README.md": readme,
+  "docs/verticals/food-retail.md": foodRetailGuide,
+  "docs/verticals/local-service.md": localServiceGuide,
+} as const;
+
+describe("documented vertical capabilities", () => {
+  it("keeps a README row for every registered vertical equal to the registry", () => {
+    const documented = capabilityRows(readme);
+    const expected = Object.fromEntries(
+      listVerticalIds().map((id) => [verticalLabel(id), expectedCapabilityRow(id)]),
+    );
+
+    expect(Object.keys(documented).sort()).toEqual(Object.keys(expected).sort());
+    expect(documented).toEqual(expected);
+  });
+
+  it("keeps Food Retail and Local Service guides on the same capability row", () => {
+    for (const relativePath of Object.keys(GUIDE_VERTICAL) as Array<
+      keyof typeof GUIDE_VERTICAL
+    >) {
+      const id = GUIDE_VERTICAL[relativePath];
+      expect(capabilityRows(docsByPath[relativePath])).toEqual({
+        [verticalLabel(id)]: expectedCapabilityRow(id),
+      });
+    }
+  });
+});
+
+describe("documented stack majors", () => {
+  it("matches package.json majors for every named stack package", () => {
+    for (const { packageName, pattern } of STACK_MAJOR_PATTERNS) {
+      const match = readme.match(pattern);
+      expect(match?.[1]).toBeDefined();
+      expect(Number(match?.[1])).toBe(packageMajor(packageName));
+    }
+
+    expect(packageMajor("prisma")).toBe(packageMajor("@prisma/client"));
+    expect(readme).not.toContain("Vercel AI SDK 6");
+  });
+});
+
+describe("documented links and commands", () => {
+  it("resolves internal documentation links and bun commands without network", async () => {
+    for (const relativePath of DOC_FILES) {
+      const source = docsByPath[relativePath];
+      const fileUrl = new URL(relativePath, repoRoot);
+
+      for (const target of markdownLinkTargets(source)) {
+        if (isExternalOrFragment(target)) continue;
+        const resolved = new URL(stripFragment(target), fileUrl);
+        expect(resolved.protocol).toBe("file:");
+        expect(await Bun.file(resolved).exists()).toBe(true);
+      }
+
+      for (const script of bunRunScripts(source)) {
+        expect(packageJson.scripts?.[script]).toBeDefined();
+      }
+
+      for (const binary of bunxBinaries(source)) {
+        expect(packageSpec(bunxPackageName(binary))).toBeDefined();
+      }
+    }
+  });
+});
+
+async function readRepoFile(relativePath: string): Promise<string> {
+  return Bun.file(new URL(relativePath, repoRoot)).text();
+}
+
+async function readRepoJson(relativePath: string): Promise<PackageJson> {
+  return Bun.file(new URL(relativePath, repoRoot)).json() as Promise<PackageJson>;
+}
+
+function verticalLabel(id: VerticalId): string {
+  return id
+    .toLowerCase()
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function expectedCapabilityRow(id: VerticalId): Record<string, string> {
+  const config = resolveVerticalConfig(id);
+  const operations = resolveOwnerOperations(id);
+  return {
+    Vertical: verticalLabel(id),
+    "Factory visibility": config.marketing.publiclyAccessible
+      ? "public"
+      : "private",
+    "Standalone launch": isVerticalPubliclyLaunched(id)
+      ? "launched"
+      : "unlaunched",
+    "Claim mode": config.claimMode,
+    "Owner mutation": operations.publicationMutation,
+    "Platform publication": isVerticalPublicationEnabled(id)
+      ? "enabled"
+      : "disabled",
+    "Custom domains": operations.customDomain,
+    Monitoring: operations.sourceMonitoring,
+    Leads: operations.bookingInbox,
+    Articles: operations.articles,
+  };
+}
+
+function capabilityRows(source: string): Record<string, Record<string, string>> {
+  const table = parseMarkdownTables(source).find((candidate) =>
+    headersMatch(candidate.headers, CAPABILITY_HEADERS),
+  );
+  expect(table).toBeDefined();
+  if (!table) return {};
+
+  const rows: Record<string, Record<string, string>> = {};
+  for (const cells of table.rows) {
+    expect(cells).toHaveLength(CAPABILITY_HEADERS.length);
+    const row = Object.fromEntries(
+      CAPABILITY_HEADERS.map((header, index) => [header, cells[index] ?? ""]),
+    );
+    const label = row.Vertical;
+    expect(label).toBeTruthy();
+    expect(rows[label]).toBeUndefined();
+    rows[label] = row;
+  }
+  return rows;
+}
+
+function parseMarkdownTables(source: string): MarkdownTable[] {
+  const tables: MarkdownTable[] = [];
+  const lines = source.split("\n");
+  for (let index = 0; index < lines.length - 1; index += 1) {
+    const headers = splitRow(lines[index] ?? "");
+    const divider = splitRow(lines[index + 1] ?? "");
+    if (!headers || !divider || !isDividerRow(divider)) continue;
+    if (headers.length !== divider.length) continue;
+
+    const rows: string[][] = [];
+    let cursor = index + 2;
+    while (cursor < lines.length) {
+      const cells = splitRow(lines[cursor] ?? "");
+      if (!cells || cells.length !== headers.length) break;
+      if (!isDividerRow(cells)) rows.push(cells);
+      cursor += 1;
+    }
+    tables.push({ headers, rows });
+  }
+  return tables;
+}
+
+function splitRow(line: string): string[] | null {
+  const trimmed = line.trim();
+  if (!trimmed.includes("|")) return null;
+  return trimmed
+    .replace(/^\|/, "")
+    .replace(/\|$/, "")
+    .split("|")
+    .map((cell) => cell.trim());
+}
+
+function isDividerRow(cells: string[]): boolean {
+  return cells.every((cell) => /^:?-{3,}:?$/.test(cell));
+}
+
+function headersMatch(
+  headers: string[],
+  expected: readonly string[],
+): boolean {
+  return (
+    headers.length === expected.length &&
+    expected.every((header, index) => headers[index] === header)
+  );
+}
+
+function packageSpec(name: string): string | undefined {
+  return packageJson.dependencies?.[name] ?? packageJson.devDependencies?.[name];
+}
+
+function packageMajor(name: string): number {
+  const spec = packageSpec(name);
+  const match = spec?.match(/\d+/);
+  if (!match) {
+    throw new Error(`Missing version for ${name}`);
+  }
+  return Number(match[0]);
+}
+
+function markdownLinkTargets(source: string): string[] {
+  return [...source.matchAll(/\[[^\]]*]\(([^)]+)\)/g)].map((match) => {
+    const raw = match[1]?.trim() ?? "";
+    const space = raw.search(/\s/);
+    return space === -1 ? raw : raw.slice(0, space);
+  });
+}
+
+function isExternalOrFragment(target: string): boolean {
+  return (
+    target.startsWith("#") ||
+    target.startsWith("http://") ||
+    target.startsWith("https://") ||
+    target.startsWith("mailto:")
+  );
+}
+
+function stripFragment(target: string): string {
+  const hash = target.indexOf("#");
+  return hash === -1 ? target : target.slice(0, hash);
+}
+
+function bunRunScripts(source: string): string[] {
+  return [...source.matchAll(/\bbun run ([a-zA-Z0-9:_-]+)/g)].map(
+    (match) => match[1] ?? "",
+  );
+}
+
+function bunxBinaries(source: string): string[] {
+  return [...source.matchAll(/\bbunx(?: --bun)? ([a-zA-Z0-9@/_-]+)/g)].map(
+    (match) => match[1] ?? "",
+  );
+}
+
+function bunxPackageName(binary: string): string {
+  if (binary === "tsc") return "typescript";
+  if (binary === "next") return "next";
+  return binary;
+}


### PR DESCRIPTION
Depends on #177 / #156 and preceding residual issues (#176, #175, #174, #172, #168).

## Summary

Repository documentation now matches the runtime capability registry and installed package majors. This PR does not change runtime capability behavior.

- **Capability matrix:** README documents independent axes for factory visibility, standalone niche launch, claim mode, owner mutation, platform publication, custom domains, monitoring, leads, and articles. Restaurant is the launched niche. Food Retail and Local Service are factory-claimable and unpublished as standalone niches. Beauty is a non-chargeable factory preview with claim and owner mutation unsupported.
- **Guides:** Food Retail and Local Service rows agree with the README and `resolveOwnerOperations`. Publication/rollback and factory claim are no longer described as disabled.
- **Stack:** Next.js 16, React 19, Prisma 7, Tailwind CSS v4, and Vercel AI SDK 7 match `package.json`. Production Bun pin is 1.4.0.
- **Security:** Claim, mutation, domain, photo, monitoring, analytics, article, and lead routes are described as vertical-aware and fail-closed, not restaurant-only.
- **Contract test:** `src/lib/docs-capability-contract.test.ts` compares documented rows to the registry/owner-operations map, documented stack majors to `package.json`, and internal links/`bun run`/`bunx` commands to files and scripts without network.

## Why

README described a restaurant-only lifecycle as universal, contradicted Food Retail and Local Service claim/publication config, named AI SDK 6, and kept restaurant-only security wording.

## Test plan

- [x] `bun test src/lib/docs-capability-contract.test.ts`
- [x] `bun run lint`
- [x] `next typegen` + `bunx tsc --noEmit`
- [x] `git diff --check`
- [ ] PR CI required checks

Closes #157