### PR TITLE
chore(deploy): use managed Redis

### DIFF
--- a/deploy/aws/deploy.sh
+++ b/deploy/aws/deploy.sh
@@ -236,24 +236,6 @@ chmod 500 "$bootstrap_file" "$host_launcher_file"
 echo "release-state caddy-configured sha=${deployed_sha}"
 
 docker network inspect shipshit >/dev/null
-docker volume create cornershopdev-redis-data >/dev/null
-if ! docker inspect cornershopdev-redis >/dev/null 2>&1; then
-  docker run -d \
-    --name cornershopdev-redis \
-    --network shipshit \
-    --restart unless-stopped \
-    --memory 128m \
-    --cpus 0.25 \
-    --volume cornershopdev-redis-data:/data \
-    redis:7.4-alpine \
-    redis-server \
-    --appendonly yes \
-    --appendfsync everysec \
-    --maxmemory 96mb \
-    --maxmemory-policy noeviction >/dev/null
-elif [[ "$(docker inspect --format '{{.State.Running}}' cornershopdev-redis)" != "true" ]]; then
-  docker start cornershopdev-redis >/dev/null
-fi
 
 aws s3 cp "$artifact_uri" "$artifact_file" --region us-west-1 --only-show-errors
 gzip -dc "$artifact_file" | docker load >/dev/null

--- a/docs/operations/platform-services.md
+++ b/docs/operations/platform-services.md
@@ -14,7 +14,7 @@ encrypted SSM parameters on the EC2 host.
 | --------------- | ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
 | PostgreSQL      | Dedicated database and login on the existing private RDS instance                                | `DATABASE_URL`                                                                           |
 | Workflow        | PostgreSQL World with a Cornershopdev job prefix and bounded concurrency                         | `WORKFLOW_*`                                                                             |
-| Redis           | Dedicated container and persistent Docker volume, not published to the host                      | `REDIS_URL`                                                                              |
+| Redis           | Dedicated private ElastiCache replication group with TLS, authentication, and encryption at rest | `REDIS_URL`                                                                              |
 | Images          | Private versioned S3 bucket served through CloudFront OAC                                        | `AWS_REGION`, `S3_BUCKET`, `S3_PUBLIC_BASE_URL`                                          |
 | Billing         | Stripe Checkout, signed webhooks, and Customer Portal                                            | `STRIPE_*`, `CLAIM_TOKEN_SECRET`                                                         |
 | Operator alerts | Durable PostgreSQL outbox delivered through Resend                                               | `OPERATOR_ALERT_EMAILS`, `RESEND_API_KEY`                                                |

--- a/src/lib/release-integration-contract.test.ts
+++ b/src/lib/release-integration-contract.test.ts
@@ -46,6 +46,13 @@ describe("release integration contract", () => {
     }
   });
 
+  it("keeps production Redis on the required external managed service", async () => {
+    const deployScript = await readRepoFile("deploy/aws/deploy.sh");
+    expect(deployScript).toMatch(/required_parameters=\([\s\S]*?REDIS_URL/);
+    expect(deployScript).not.toContain("cornershopdev-redis-data");
+    expect(deployScript).not.toContain("redis:7.4-alpine");
+  });
+
   it("keeps the browser journey as a production deploy dependency", async () => {
     const ci = await readRepoFile(".github/workflows/ci.yml");
     expect(ci).toMatch(


### PR DESCRIPTION
## Summary
- stop provisioning a local Redis container and volume during production deploys
- document the private encrypted TLS ElastiCache target
- add a release contract preventing local Redis from returning

## Verification
- 1,177 tests passed; 110 database-gated tests skipped locally
- ESLint passed
- ShellCheck passed
- focused release contract: 7/7 passed

## Infrastructure
- cornershopdev-prod: private Redis 7.1 ElastiCache with TLS, AUTH, encryption at rest, and one-day snapshots
- production REDIS_URL now points to the verified managed endpoint