### PR TITLE
fix(deploy): keep article gate awk portable

### DIFF
--- a/deploy/aws/deploy.sh
+++ b/deploy/aws/deploy.sh
@@ -55,10 +55,7 @@ set_article_edge_gate() {
     /^# END CORNERSHOPDEV$/ { managed = 0 }
     {
       print
-      if (
-        state == "closed" && managed &&
-        ($0 == "api.cornershop.dev {" || $0 == "https:// {")
-      ) {
+      if (state == "closed" && managed && ($0 == "api.cornershop.dev {" || $0 == "https:// {")) {
         print "\t# BEGIN ARTICLE MUTATION GATE"
         print "\t@articleMutations {"
         print "\t\tmethod POST"

--- a/src/lib/release-integration-contract.test.ts
+++ b/src/lib/release-integration-contract.test.ts
@@ -53,6 +53,11 @@ describe("release integration contract", () => {
     expect(deployScript).not.toContain("redis:7.4-alpine");
   });
 
+  it("keeps the host article-gate awk condition portable", async () => {
+    const deployScript = await readRepoFile("deploy/aws/deploy.sh");
+    expect(deployScript).not.toMatch(/if \(\s*\n/);
+  });
+
   it("keeps the browser journey as a production deploy dependency", async () => {
     const ci = await readRepoFile(".github/workflows/ci.yml");
     expect(ci).toMatch(


### PR DESCRIPTION
## Summary
- keep the production article mutation gate compatible with the EC2 host awk
- pin the portability contract in the release integration suite

## Root cause
Release v0.4.3 reached the host, verified the immutable deployment script, loaded configuration, and configured Caddy, then failed because the host awk rejected a multiline `if (` condition. The previous production container remained healthy.

## Verification
- `bun test src/lib/release-integration-contract.test.ts` (8/8)
- `shellcheck deploy/aws/deploy.sh`
- `bash deploy/aws/test-release-bundle.sh`
- `git diff --check`

Unblocks the already-approved managed Redis cutover; no feature behavior changes.