### PR TITLE
fix(deploy): ship article rollout operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,10 @@ RUN bun build scripts/preflight-first-customer-migration.ts \
   --target=bun \
   --packages=external \
   --outfile=.operator-scripts/preflight-first-customer-migration.ts
+RUN bun build scripts/article-rollout.ts \
+  --target=bun \
+  --packages=external \
+  --outfile=.operator-scripts/article-rollout.ts
 RUN bun build scripts/verify-first-customer-production.ts \
   --target=bun \
   --packages=external \

--- a/deploy/aws/test-container-runtime.sh
+++ b/deploy/aws/test-container-runtime.sh
@@ -74,6 +74,10 @@ if ! docker exec "$container" test -f /app/scripts/dispatch-inbound-forwards.ts;
   echo "Expected the inbound read-copy dispatcher in the candidate image" >&2
   exit 1
 fi
+if ! docker exec "$container" test -f /app/scripts/article-rollout.ts; then
+  echo "Expected the article rollout gate in the candidate image" >&2
+  exit 1
+fi
 if ! docker exec --env OUTREACH_INBOUND_FORWARD_TO= "$container" \
   bun run operator:dispatch-inbound-forwards >/dev/null; then
   echo "Expected the disabled inbound read-copy dispatcher to start safely" >&2

--- a/src/lib/release-integration-contract.test.ts
+++ b/src/lib/release-integration-contract.test.ts
@@ -58,6 +58,14 @@ describe("release integration contract", () => {
     expect(deployScript).not.toMatch(/if \(\s*\n/);
   });
 
+  it("ships the article rollout operator used by production deploys", async () => {
+    const dockerfile = await readRepoFile("Dockerfile");
+    expect(dockerfile).toContain("bun build scripts/article-rollout.ts");
+    expect(dockerfile).toContain(
+      "--outfile=.operator-scripts/article-rollout.ts",
+    );
+  });
+
   it("keeps the browser journey as a production deploy dependency", async () => {
     const ci = await readRepoFile(".github/workflows/ci.yml");
     expect(ci).toMatch(


### PR DESCRIPTION
## Summary
- bundle the article rollout operator into the production image
- verify its runtime presence in container CI
- pin the deploy/image contract in the release integration suite

## Root cause
Release v0.4.4 passed repository and image builds, then its fail-closed host deployment could not run `operator:article-rollout` because `/app/scripts/article-rollout.ts` was absent from the runner image. The previous production container was restored and is healthy.

## Verification
- `bun test src/lib/release-integration-contract.test.ts` (9/9)
- `shellcheck deploy/aws/test-container-runtime.sh`
- `bun run lint`
- `git diff --check`

This only completes the already-approved managed Redis release; no feature behavior changes.