### PR TITLE
feat(factory): Maltese chrome, a euro founding offer, and an opt-in PostHog pixel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,3 +96,10 @@ EMAIL_FROM=Vincent from Cornershopdev <vincent@send.cornershop.dev>
 # Where a reply lands when the fallback above was used. Leave unset and the
 # header is simply omitted.
 EMAIL_REPLY_TO=vincent@reply.cornershop.dev
+
+# Product analytics on the public factory funnel only; customer storefronts are
+# never instrumented. Leave the key unset and the pixel is a complete no-op, so
+# a fork or a local checkout needs no PostHog project at all. The host defaults
+# to the EU cloud; set it to a reverse-proxy origin to serve ingestion first-party.
+NEXT_PUBLIC_POSTHOG_KEY=
+NEXT_PUBLIC_POSTHOG_HOST=

--- a/.env.example
+++ b/.env.example
@@ -60,7 +60,7 @@ LEAD_DISCOVERY_NOMINATIM_BASE_URL=
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
 # The public offer is one active, non-metered, tax-exclusive Stripe Price:
-# USD 49.00 every month. Stripe Checkout presents local currency automatically.
+# EUR 49.00 every month. Stripe Checkout presents local currency automatically.
 STRIPE_PRICE_ID=
 
 # Claim links and email delivery. Checkout requires a hashed ClaimInvitation;

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ What happens after preview depends on the matrix above:
   on-demand TLS; monitor the menu, imagery, and links; review first-party
   booking leads; publish articles.
 - **Food Retail and Local Service (`factory`)** — an approved preview can
-  claim the shared $49 Cornershopdev plan and publish on
+  claim the shared €49 Cornershopdev plan and publish on
   `<slug>.cornershop.dev`. Custom domains and source monitoring are enabled.
   Owner analytics, lead inbox, and articles are not-yet.
 - **Beauty (`disabled`)** — the factory `/niche/beauty` preview stays
@@ -395,7 +395,7 @@ generation endpoint.
 
 - `STRIPE_SECRET_KEY`
 - `STRIPE_WEBHOOK_SECRET`
-- `STRIPE_PRICE_ID` (the one USD 49 monthly founding Price)
+- `STRIPE_PRICE_ID` (the one EUR 49 monthly founding Price)
 
 Configure the webhook endpoint as:
 
@@ -408,7 +408,7 @@ Customer Portal setup, and the production activation blockers are documented
 in [`docs/operations/stripe-billing.md`](docs/operations/stripe-billing.md).
 Checkout requires a valid hashed claim invitation; a public preview URL alone
 cannot authorize billing or ownership. Launch Checkout offers only the founding subscription; the deployment-time Stripe
-preflight proves that it is the active, tax-exclusive USD 49.00 monthly Price.
+preflight proves that it is the active, tax-exclusive EUR 49.00 monthly Price.
 
 ### Owner sign-in
 

--- a/docs/operations/first-customer-production-exercise.md
+++ b/docs/operations/first-customer-production-exercise.md
@@ -48,7 +48,7 @@ Obtain and privately record each authorization before the related action:
 
 1. An owner or authorized representative consents to receive the one-time claim
    invitation and supplies evidence of authority.
-2. The same representative approves the exact $49/month offer and authorizes
+2. The same representative approves the exact €49/month offer and authorizes
    the live Stripe Checkout.
 3. The owner confirms the intended menu edit and source booking/ordering links.
 4. The domain administrator authorizes the exact DNS change.
@@ -64,7 +64,7 @@ an imported menu, or a successful test-mode exercise.
 - Record the deployed commit SHA, release URL, deployment run, and successful
   protected readiness result.
 - In Stripe live mode, review the configured founding Price. It must be active,
-  tax-exclusive, non-metered, USD 49.00, recurring monthly, and the same ID
+  tax-exclusive, non-metered, EUR 49.00, recurring monthly, and the same ID
   configured as `STRIPE_PRICE_ID`.
 - Confirm the live webhook endpoint and supported events are enabled.
 - Confirm claim and sign-in delivery status is driven by signed provider events,

--- a/docs/operations/first-customer-validation.md
+++ b/docs/operations/first-customer-validation.md
@@ -52,7 +52,7 @@ real-world acceptance evidence.
 
 ## The one-price offer
 
-### Restofront Founding Restaurant — $49/month
+### Restofront Founding Restaurant — €49/month
 
 VAT is added when applicable. There is no setup fee, annual alternative,
 discount, trial, second tier, or usage charge in the first-customer offer. The
@@ -90,11 +90,11 @@ owner uploads, or explicitly permissioned customer imagery may go live.
 | Booking-request inbox and first-party analytics | Deployed in PR #59 | Analytics activate only on a verified customer domain; no customer-domain data exists yet. |
 | Safe private Save and atomic Publish | Merged on main; not production-deployed | Do not imply that production has the implementation until a SHA-bound release deploy proves it. Acceptance still requires a real owner save, unchanged-live-pointer evidence, and exact published-version evidence. |
 | Secure, owner-bound invitation | Merged on main; not production-deployed | Do not send a claim URL until production config/deploy gates pass and a real owner authorizes the exercise. Acceptance still requires authorized owner receipt, signed provider delivery, one acceptance, and rejected replay evidence. |
-| Durable one-plan billing lifecycle | Merged on main; not production-deployed | Do not initiate a live checkout until the exact release is deployed and the customer authorizes a live charge. Acceptance still requires an authorized settled live $49 charge and idempotent live webhook evidence. |
+| Durable one-plan billing lifecycle | Merged on main; not production-deployed | Do not initiate a live checkout until the exact release is deployed and the customer authorizes a live charge. Acceptance still requires an authorized settled live €49 charge and idempotent live webhook evidence. |
 
-Public Restofront marketing and the claim UI sell this same $49/month founding
+Public Restofront marketing and the claim UI sell this same €49/month founding
 plan and authentic-image policy. Live Stripe still has to match: create the one founding
-price at $49 USD and set SSM `STRIPE_PRICE_ID`. Code cannot
+price at EUR 49 and set SSM `STRIPE_PRICE_ID`. Code cannot
 change the Stripe dashboard.
 
 ## Production evidence snapshot
@@ -191,7 +191,7 @@ and evidence links.
 | City/country | `[city, country]` |
 | Authorized owner/representative verified at | `[timestamp — pending]` |
 | Offer revision shown | `[commit SHA]` |
-| Price | `$49/month + applicable VAT` |
+| Price | `€49/month + applicable VAT` |
 | First settled charge at | `[timestamp — pending]` |
 | Stripe non-sensitive evidence ID | `[pending]` |
 | Custom domain | `[pending]` |
@@ -200,7 +200,7 @@ and evidence links.
 
 ### One-time founder-assisted onboarding
 
-Record minutes, even when the activity is bundled into the $49 offer.
+Record minutes, even when the activity is bundled into the €49 offer.
 
 | Activity | Started | Finished | Founder minutes | External cost | Notes/evidence |
 | --- | --- | --- | ---: | ---: | --- |
@@ -238,14 +238,14 @@ Fill these with actual provider charges and an explicit internal founder-hour
 rate; do not silently value founder time at zero.
 
 ```text
-monthly revenue excluding VAT                    = $49.00
+monthly revenue excluding VAT                    = €49.00
 payment processing                               = [actual]
 incremental hosting/storage/AI/email              = [actual]
 other customer-variable cost                     = [actual]
 gross profit before founder labour                = revenue - variable costs
 gross margin                                      = gross profit / revenue
 
-internal founder hourly rate                      = [explicit $/hour]
+internal founder hourly rate                      = [explicit €/hour]
 recurring support cost                            = support minutes / 60 × rate
 monthly contribution after recurring support      = gross profit - support cost
 onboarding labour cost                            = onboarding minutes / 60 × rate
@@ -255,7 +255,7 @@ onboarding labour cost                            = onboarding minutes / 60 × r
 ```
 
 Record CAC separately. The existing commercial stop threshold is CAC above
-$200 at $49/month.
+€200 at €49/month.
 
 ## Second-qualified-lead gate
 
@@ -315,7 +315,7 @@ inventing a date would falsely imply that the 30-day clock has started.
 | Qualified conversations |  | Record channel and lawful contact basis. |
 | Paying customers |  | Fewer than 5 from roughly 60 previews, or below 4% preview-to-paid, is a stop/change signal. |
 | Preview-to-paid conversion |  | Compare with 4%. |
-| CAC |  | Above $200 at $49/month is a stop/change signal. |
+| CAC |  | Above €200 at €49/month is a stop/change signal. |
 | Claim completion time |  | Above 20 minutes is a stop/change signal. |
 | Claim completion rate |  | Below 60% is a stop/change signal. |
 | Founder onboarding minutes |  | Explain the largest manual steps. |
@@ -331,7 +331,7 @@ inventing a date would falsely imply that the 30-day clock has started.
 
 Choose exactly one:
 
-- `KEEP` — continue the same $49 offer and one-city wedge for the next cohort.
+- `KEEP` — continue the same €49 offer and one-city wedge for the next cohort.
 - `CHANGE` — state one falsifiable change to price, scope, onboarding, channel,
   or product, its owner, deadline, and success threshold.
 - `STOP` — stop acquiring or charging new restaurants, preserve customer
@@ -364,7 +364,7 @@ Issue/PR links:
    delegated to code or inferred.
 6. Have the owner review the source content, images, price, hours, and retained
    provider links.
-7. Only with explicit customer authorization, run one live $49 checkout and
+7. Only with explicit customer authorization, run one live €49 checkout and
    verify webhook-only provisioning.
 8. Have the owner sign in, make an intentional menu edit, prove Save isolation,
    then publish.

--- a/docs/operations/stripe-billing.md
+++ b/docs/operations/stripe-billing.md
@@ -16,13 +16,13 @@ The deployment requires all of:
 - `RESEND_API_KEY`
 
 The launch Checkout offers exactly one plan for every claim-enabled vertical:
-the Cornershopdev founding subscription at USD 49.00 per month. Its Stripe Price and Product must be live,
+the Cornershopdev founding subscription at EUR 49.00 per month. Its Stripe Price and Product must be live,
 active, non-metered, tax-exclusive, and recurring monthly. Test mode and live mode have separate keys,
 prices, Customer Portal configurations, webhook endpoints, and signing secrets.
 Never copy a test identifier into Production or a live identifier into local
 development.
 
-Checkout enables Adaptive Pricing so eligible customers see and pay in local currency while the durable integration contract remains USD 49. Checkout disables promotion codes for this offer, requires billing-address and
+Checkout enables Adaptive Pricing so eligible customers see and pay in local currency while the durable integration contract remains EUR 49. Checkout disables promotion codes for this offer, requires billing-address and
 tax-ID collection, and provisions only when Stripe reports
 `payment_status=paid`. A completed zero-payment session cannot create ownership.
 
@@ -148,7 +148,7 @@ membership, or owner.
 These are deliberate production changes and require explicit authority plus
 durable release evidence:
 
-1. Create or approve the one live founding Product and USD 49 Price. Record
+1. Create or approve the one live founding Product and EUR 49 Price. Record
    the approved amount, currency, interval, tax behavior, and live Price ID.
 2. Configure and test the live Customer Portal. Enable only the intended
    payment-method, cancellation, invoice, and plan-change features.
@@ -166,7 +166,7 @@ durable release evidence:
    `/shipshit/production/cornershopdev/`.
 5. Deploy the reviewed release. Before cutover, deployment runs
    `operator:preflight-stripe --mode live`; it fails if the live founding Price
-   drifts from USD 49.00 monthly or its Product/mode/tax contract. The frequent
+   drifts from EUR 49.00 monthly or its Product/mode/tax contract. The frequent
    `/api/health/ready` probe remains provider-read-free and reports missing
    billing configuration without returning any credential or identifier.
 6. Complete one explicitly authorized low-risk live Checkout, then verify one

--- a/docs/verticals/food-retail.md
+++ b/docs/verticals/food-retail.md
@@ -114,7 +114,7 @@ Standalone niche marketing stays closed:
 - `publicationEnabled = true`
 - `publicationMutationEnabled = true`
 
-An approved private preview can claim the shared Cornershopdev $49 plan and
+An approved private preview can claim the shared Cornershopdev €49 plan and
 publish at `<slug>.cornershop.dev`. That factory path requires:
 
 - [x] platform wildcard DNS and on-demand TLS cover the shared public URL;

--- a/docs/verticals/local-service.md
+++ b/docs/verticals/local-service.md
@@ -107,7 +107,7 @@ Owner photo library is enabled. Owner analytics, lead inbox, and articles stay
 Tradefront has no standalone niche storefront. Its marketing config therefore
 keeps hostname, domain, and niche sender empty, while `claimMode: "factory"`
 allows an approved private preview to use Cornershopdev's verified sender,
-shared $49 checkout, and `<slug>.cornershop.dev` public URL.
+shared €49 checkout, and `<slug>.cornershop.dev` public URL.
 `publicationEnabled` and `publicationMutationEnabled` are both true for that
 factory path. A future standalone niche still must satisfy
 `verticalLaunchReadiness`:

--- a/scripts/verify-first-customer-production.ts
+++ b/scripts/verify-first-customer-production.ts
@@ -11,7 +11,7 @@ import {
   type FirstCustomerProductionManifest,
 } from "@/lib/first-customer-evidence";
 import { getDb } from "@/lib/db";
-import { isStripeLiveApiKey } from "@/lib/billing-plans";
+import { FOUNDING_PRICE, isStripeLiveApiKey } from "@/lib/billing-plans";
 import {
   evidenceDigest,
   integrationUrlDigest,
@@ -523,13 +523,13 @@ async function inspectStripe(manifest: FirstCustomerProductionManifest) {
     paidInvoice?.id === invoiceId &&
     paidInvoice.livemode &&
     paidInvoice.status === "paid" &&
-    paidInvoice.currency.toLowerCase() === "usd" &&
-    paidInvoice.subtotal === 4_900 &&
+    paidInvoice.currency.toLowerCase() === FOUNDING_PRICE.currency &&
+    paidInvoice.subtotal === FOUNDING_PRICE.unitAmount &&
     (paidInvoice.total_discount_amounts ?? []).reduce(
       (total, discount) => total + discount.amount,
       0,
     ) === 0 &&
-    paidInvoice.amount_paid >= 4_900 &&
+    paidInvoice.amount_paid >= FOUNDING_PRICE.unitAmount &&
     invoiceSettledAt instanceof Date;
   return {
     checkoutCreatedAt: new Date(checkout.created * 1_000),
@@ -539,19 +539,19 @@ async function inspectStripe(manifest: FirstCustomerProductionManifest) {
       price.active &&
       activeProduct &&
       price.id === priceId &&
-      price.currency.toLowerCase() === "usd" &&
-      price.unit_amount === 4_900 &&
-      price.tax_behavior === "exclusive" &&
-      price.recurring?.interval === "month" &&
-      price.recurring.interval_count === 1 &&
+      price.currency.toLowerCase() === FOUNDING_PRICE.currency &&
+      price.unit_amount === FOUNDING_PRICE.unitAmount &&
+      price.tax_behavior === FOUNDING_PRICE.taxBehavior &&
+      price.recurring?.interval === FOUNDING_PRICE.interval &&
+      price.recurring.interval_count === FOUNDING_PRICE.intervalCount &&
       price.recurring.usage_type !== "metered",
     settledPayment:
       checkout.livemode &&
       checkout.mode === "subscription" &&
       checkout.status === "complete" &&
       checkout.payment_status === "paid" &&
-      checkout.currency?.toLowerCase() === "usd" &&
-      checkout.amount_subtotal === 4_900 &&
+      checkout.currency?.toLowerCase() === FOUNDING_PRICE.currency &&
+      checkout.amount_subtotal === FOUNDING_PRICE.unitAmount &&
       (checkout.total_details?.amount_discount ?? 0) === 0 &&
       checkoutSubscription === manifest.stripe.subscriptionId &&
       subscription.livemode &&

--- a/src/app/claim/layout.tsx
+++ b/src/app/claim/layout.tsx
@@ -1,3 +1,4 @@
+import { FactoryAnalytics } from "@/components/factory-analytics";
 import { EditorialFontScope } from "@/components/fonts/editorial-font-scope";
 
 export default function ClaimLayout({
@@ -5,5 +6,10 @@ export default function ClaimLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return <EditorialFontScope>{children}</EditorialFontScope>;
+  return (
+    <EditorialFontScope>
+      <FactoryAnalytics />
+      {children}
+    </EditorialFontScope>
+  );
 }

--- a/src/app/create/import-studio.tsx
+++ b/src/app/create/import-studio.tsx
@@ -123,7 +123,7 @@ const verticalCopy = {
     emptyStatePrompt:
       "Start with a trade website or business name. No account is needed to see the result.",
     claimHint:
-      "Review every service, availability statement, credential, project and contact link, then claim the $49 founding plan.",
+      "Review every service, availability statement, credential, project and contact link, then claim the €49 founding plan.",
     catalogStage: "Recover services and evidence",
     integrationsStage: "Preserve phone, WhatsApp and quote links",
     previewCatalogLabel: "Services",
@@ -146,7 +146,7 @@ const verticalCopy = {
     emptyStatePrompt:
       "Start with a food shop website or name. No account is needed to see the result.",
     claimHint:
-      "Review every product, price, availability note, allergen source and ordering link, then claim the $49 founding plan.",
+      "Review every product, price, availability note, allergen source and ordering link, then claim the €49 founding plan.",
     catalogStage: "Recover product ranges and prices",
     integrationsStage: "Preserve preorder, pickup and delivery links",
     previewCatalogLabel: "Product ranges",

--- a/src/app/create/layout.tsx
+++ b/src/app/create/layout.tsx
@@ -1,3 +1,4 @@
+import { FactoryAnalytics } from "@/components/factory-analytics";
 import { EditorialFontScope } from "@/components/fonts/editorial-font-scope";
 
 export default function CreateLayout({
@@ -5,5 +6,10 @@ export default function CreateLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return <EditorialFontScope>{children}</EditorialFontScope>;
+  return (
+    <EditorialFontScope>
+      <FactoryAnalytics />
+      {children}
+    </EditorialFontScope>
+  );
 }

--- a/src/app/niche/[vertical]/layout.tsx
+++ b/src/app/niche/[vertical]/layout.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation";
+import { FactoryAnalytics } from "@/components/factory-analytics";
 import { NicheFontScope } from "@/components/fonts/niche-font-scope";
 import { resolveVerticalBySlug } from "@/lib/verticals/registry";
 
@@ -13,5 +14,10 @@ export default async function NicheLayout({
   const id = resolveVerticalBySlug(vertical);
   if (!id) notFound();
 
-  return <NicheFontScope vertical={id}>{children}</NicheFontScope>;
+  return (
+    <NicheFontScope vertical={id}>
+      <FactoryAnalytics />
+      {children}
+    </NicheFontScope>
+  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,6 +15,7 @@ import {
   Terminal,
   Workflow,
 } from "lucide-react";
+import { FactoryAnalytics } from "@/components/factory-analytics";
 import { SiteHeader } from "@/components/site-header";
 import { factoryFontVariables } from "@/components/fonts/factory-font-scope";
 import { FACTORY_BRAND } from "@/lib/brand";
@@ -93,6 +94,7 @@ export default function Home() {
     <div
       className={`${factoryFontVariables} ${styles.factoryShell} min-h-screen font-sans`}
     >
+      <FactoryAnalytics />
       <SiteHeader
         brand={FACTORY_BRAND}
         inverse

--- a/src/app/themes/layout.tsx
+++ b/src/app/themes/layout.tsx
@@ -1,15 +1,14 @@
 import { FactoryAnalytics } from "@/components/factory-analytics";
-import { AuthFontScope } from "@/components/fonts/auth-font-scope";
 
-export default function SignInLayout({
+export default function ThemesLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
   return (
-    <AuthFontScope>
+    <>
       <FactoryAnalytics />
       {children}
-    </AuthFontScope>
+    </>
   );
 }

--- a/src/components/factory-analytics.tsx
+++ b/src/components/factory-analytics.tsx
@@ -1,0 +1,24 @@
+import {
+  factoryAnalyticsSnippet,
+  resolveFactoryAnalytics,
+} from "@/lib/factory-analytics";
+
+/**
+ * Next inlines `process.env.NEXT_PUBLIC_*` only where it reads as a literal
+ * member expression, so the reads stay here and the decision stays testable in
+ * `resolveFactoryAnalytics`.
+ */
+export function FactoryAnalytics() {
+  const config = resolveFactoryAnalytics({
+    NEXT_PUBLIC_POSTHOG_KEY: process.env.NEXT_PUBLIC_POSTHOG_KEY,
+    NEXT_PUBLIC_POSTHOG_HOST: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+  });
+  if (!config) return null;
+
+  return (
+    <script
+      id="factory-analytics"
+      dangerouslySetInnerHTML={{ __html: factoryAnalyticsSnippet(config) }}
+    />
+  );
+}

--- a/src/lib/ai/site-generation.ts
+++ b/src/lib/ai/site-generation.ts
@@ -3,6 +3,7 @@ import { generateText, Output } from "ai";
 import { normalizeAccountEmail } from "@/lib/account-email";
 import type { ExtractedSite } from "@/lib/importer";
 import { slugify } from "@/lib/site-draft";
+import { siteUiLocale } from "@/lib/site-locales";
 import type { RestaurantDraft } from "@/lib/restaurant";
 import { applyRegeneratedRestaurantTranslation } from "@/lib/restaurant-menu-editor";
 import { repairPalette } from "@/lib/source-reconstruction";
@@ -249,11 +250,8 @@ export function deterministicDraft<
 ): TDraft {
   const name = source.name || source.source;
   const locale = source.sourceLocale ?? "en";
-  const localeLanguage = locale.toLowerCase().split("-")[0];
   const deterministicCopy =
-    vertical.deterministicCopy?.[locale] ??
-    vertical.deterministicCopy?.[localeLanguage] ??
-    vertical.deterministicCopy?.en;
+    vertical.deterministicCopy?.[siteUiLocale(locale)];
   const verticalName = vertical.id.toLowerCase().replaceAll("_", " ");
   const catalogName =
     deterministicCopy?.catalogName ?? vertical.vocabulary.catalog;

--- a/src/lib/billing-plans.test.ts
+++ b/src/lib/billing-plans.test.ts
@@ -28,7 +28,7 @@ describe("Cornershopdev founding Stripe price", () => {
   const price = {
     id: "price_founding",
     active: true,
-    currency: "usd",
+    currency: "eur",
     unit_amount: 4_900,
     type: "recurring",
     livemode: true,
@@ -41,7 +41,7 @@ describe("Cornershopdev founding Stripe price", () => {
     product: { active: true },
   };
 
-  it("accepts only the approved live $49 USD monthly exclusive-tax offer", () => {
+  it("accepts only the approved live EUR 49 monthly exclusive-tax offer", () => {
     expect(() =>
       validateFoundingPrice(price, {
         expectedPriceId: "price_founding",
@@ -50,9 +50,10 @@ describe("Cornershopdev founding Stripe price", () => {
     ).not.toThrow();
   });
 
-  it("rejects wrong amount, mode, cadence, tax, or archived product", () => {
+  it("rejects wrong amount, currency, mode, cadence, tax, or archived product", () => {
     for (const candidate of [
       { ...price, unit_amount: 4_999 },
+      { ...price, currency: "usd" },
       { ...price, livemode: false },
       { ...price, recurring: { ...price.recurring, interval: "year" } },
       { ...price, tax_behavior: "inclusive" },

--- a/src/lib/billing-plans.ts
+++ b/src/lib/billing-plans.ts
@@ -10,12 +10,19 @@ export type BillingPlan = {
 };
 
 export const FOUNDING_PRICE = {
-  currency: "usd",
+  currency: "eur",
   unitAmount: 4_900,
   interval: "month",
   intervalCount: 1,
   taxBehavior: "exclusive",
 } as const;
+
+/**
+ * Kept beside the price it renders. The offer is sold in euros to European
+ * businesses, so the amount and the symbol in front of it are one decision:
+ * changing the currency without the symbol prints the wrong money.
+ */
+export const FOUNDING_PRICE_SYMBOL = "€";
 
 export type StripePriceConfiguration = {
   id: string;

--- a/src/lib/claim-launch-offer.test.ts
+++ b/src/lib/claim-launch-offer.test.ts
@@ -31,15 +31,15 @@ describe("claim launch offer mapping", () => {
   it("prints the founding Stripe contract as the shared display price", () => {
     expect(CLAIM_CHECKOUT_PLAN_ID).toBe(FOUNDING_PLAN_ID);
     expect(FOUNDING_PRICE).toMatchObject({
-      currency: "usd",
+      currency: "eur",
       unitAmount: 4_900,
       interval: "month",
       intervalCount: 1,
     });
     expect(foundingOfferDisplay()).toEqual({
-      price: "$49",
+      price: "€49",
       cadence: "/month",
-      currency: "usd",
+      currency: "eur",
     });
   });
 

--- a/src/lib/claim-launch-offer.ts
+++ b/src/lib/claim-launch-offer.ts
@@ -1,6 +1,7 @@
 import {
   FOUNDING_PLAN_ID,
   FOUNDING_PRICE,
+  FOUNDING_PRICE_SYMBOL,
   type BillingPlanId,
 } from "@/lib/billing-plans";
 import type { BrandIdentity } from "@/lib/brand";
@@ -76,14 +77,14 @@ export function foundingOfferDisplay(
     intervalCount: number;
   } = FOUNDING_PRICE,
 ): FoundingOfferDisplay | null {
-  if (price.currency !== "usd") return null;
+  if (price.currency !== FOUNDING_PRICE.currency) return null;
   if (price.intervalCount !== 1) return null;
   const majorUnits = price.unitAmount / 100;
   if (!Number.isInteger(majorUnits) || majorUnits <= 0) return null;
   return {
-    price: `$${majorUnits}`,
+    price: `${FOUNDING_PRICE_SYMBOL}${majorUnits}`,
     cadence: `/${price.interval}`,
-    currency: "usd",
+    currency: FOUNDING_PRICE.currency,
   };
 }
 

--- a/src/lib/claim-panel.test.tsx
+++ b/src/lib/claim-panel.test.tsx
@@ -25,7 +25,7 @@ describe("claim panel offer identity", () => {
 
     expect(html).toContain("Claim Osteria Luna");
     expect(html).toContain("Founding");
-    expect(html).toContain("$49");
+    expect(html).toContain("€49");
     expect(html).toContain("/month");
     expect(html).toContain("mobile-first restaurant website");
     expect(html).toContain('placeholder="owner@restaurant.com"');
@@ -78,7 +78,7 @@ describe("claim panel offer identity", () => {
     expect(html).toContain("role=\"status\"");
     expect(html).toContain("launch offer for this site is not configured");
     expect(html).not.toContain("Founding");
-    expect(html).not.toContain("$49");
+    expect(html).not.toContain("€49");
     expect(html).not.toContain("owner@restaurant.com");
     expect(html).not.toContain("owner@shop.com");
     expect(html).not.toContain("Verify ownership by email");

--- a/src/lib/factory-analytics.test.ts
+++ b/src/lib/factory-analytics.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "bun:test";
+import { readFile } from "node:fs/promises";
+import {
+  FACTORY_ANALYTICS_DEFAULT_HOST,
+  factoryAnalyticsSnippet,
+  resolveFactoryAnalytics,
+} from "@/lib/factory-analytics";
+
+/**
+ * The public factory funnel. Every surface here is ours; none of them is served
+ * on a customer's domain.
+ */
+const INSTRUMENTED_SURFACES = [
+  "src/app/page.tsx",
+  "src/app/create/layout.tsx",
+  "src/app/claim/layout.tsx",
+  "src/app/sign-in/layout.tsx",
+  "src/app/niche/[vertical]/layout.tsx",
+  "src/app/themes/layout.tsx",
+];
+
+/**
+ * Storefronts and owner surfaces. `proxy.ts` rewrites verified custom domains
+ * onto `/preview`, so a mount added here would publish a third-party script on
+ * someone else's domain.
+ */
+const UNINSTRUMENTED_SURFACES = [
+  "src/app/layout.tsx",
+  "src/app/preview/layout.tsx",
+  "src/app/pro/layout.tsx",
+  "src/app/dashboard/page.tsx",
+  "src/app/workspace/layout.tsx",
+  "src/app/admin/layout.tsx",
+];
+
+async function surfaceSource(path: string): Promise<string> {
+  return readFile(new URL(`../../${path}`, import.meta.url), "utf8");
+}
+
+describe("factory analytics configuration", () => {
+  it("no-ops when the project key is absent, blank, or whitespace", () => {
+    expect(resolveFactoryAnalytics({})).toBeNull();
+    expect(resolveFactoryAnalytics({ NEXT_PUBLIC_POSTHOG_KEY: "" })).toBeNull();
+    expect(
+      resolveFactoryAnalytics({ NEXT_PUBLIC_POSTHOG_KEY: "   " }),
+    ).toBeNull();
+    expect(
+      resolveFactoryAnalytics({
+        NEXT_PUBLIC_POSTHOG_HOST: "https://eu.i.posthog.com",
+      }),
+    ).toBeNull();
+  });
+
+  it("falls back to the European ingestion host and its asset origin", () => {
+    expect(
+      resolveFactoryAnalytics({ NEXT_PUBLIC_POSTHOG_KEY: " phc_example " }),
+    ).toEqual({
+      projectKey: "phc_example",
+      apiHost: FACTORY_ANALYTICS_DEFAULT_HOST,
+      assetHost: "https://eu-assets.i.posthog.com",
+    });
+  });
+
+  it("keeps a reverse-proxy host verbatim and trims its trailing slash", () => {
+    expect(
+      resolveFactoryAnalytics({
+        NEXT_PUBLIC_POSTHOG_KEY: "phc_example",
+        NEXT_PUBLIC_POSTHOG_HOST: "https://cornershop.dev/ingest/",
+      }),
+    ).toEqual({
+      projectKey: "phc_example",
+      apiHost: "https://cornershop.dev/ingest",
+      assetHost: "https://cornershop.dev/ingest",
+    });
+  });
+
+  it("fails closed on a host that is not plain https", () => {
+    for (const host of [
+      "http://eu.i.posthog.com",
+      "eu.i.posthog.com",
+      "javascript:alert(1)",
+      "https://eu.i.posthog.com?token=leak",
+    ]) {
+      expect(
+        resolveFactoryAnalytics({
+          NEXT_PUBLIC_POSTHOG_KEY: "phc_example",
+          NEXT_PUBLIC_POSTHOG_HOST: host,
+        }),
+      ).toBeNull();
+    }
+  });
+});
+
+describe("factory analytics snippet", () => {
+  const config = resolveFactoryAnalytics({
+    NEXT_PUBLIC_POSTHOG_KEY: "phc_example",
+  });
+
+  it("loads the vendor bundle and initialises it once it has arrived", () => {
+    expect(config).not.toBeNull();
+    const snippet = factoryAnalyticsSnippet(config!);
+
+    expect(snippet).toContain(
+      '"https://eu-assets.i.posthog.com/static/array.js"',
+    );
+    expect(snippet).toContain("s.onload=function()");
+    expect(snippet).toContain('window.posthog.init("phc_example"');
+    expect(snippet).toContain('"capture_pageview":"history_change"');
+  });
+
+  it("emits no character that could close the inline script element", () => {
+    const escaped = factoryAnalyticsSnippet({
+      projectKey: '</script><img src=x onerror=alert(1)>',
+      apiHost: "https://eu.i.posthog.com",
+      assetHost: "https://eu-assets.i.posthog.com",
+    });
+
+    expect(escaped).not.toContain("<");
+    expect(escaped).toContain("\\u003c/script");
+  });
+});
+
+describe("factory analytics mount points", () => {
+  it("instruments every public factory funnel surface", async () => {
+    for (const path of INSTRUMENTED_SURFACES) {
+      const source = await surfaceSource(path);
+      expect(source).toContain(
+        'from "@/components/factory-analytics"',
+      );
+      expect(source).toContain("<FactoryAnalytics />");
+    }
+  });
+
+  it("keeps the pixel off storefront and owner surfaces", async () => {
+    for (const path of UNINSTRUMENTED_SURFACES) {
+      expect(await surfaceSource(path)).not.toContain("FactoryAnalytics");
+    }
+  });
+});

--- a/src/lib/factory-analytics.ts
+++ b/src/lib/factory-analytics.ts
@@ -1,0 +1,87 @@
+/**
+ * Product analytics for the public factory funnel, and nowhere else.
+ *
+ * `proxy.ts` rewrites every verified custom domain onto `/preview/<slug>`, so a
+ * pixel mounted in the root layout would ship a third-party script inside the
+ * storefronts we publish on customers' own domains. The mount points are named
+ * in `factory-analytics.test.ts`; this module only decides whether there is
+ * anything to mount at all.
+ */
+export const FACTORY_ANALYTICS_DEFAULT_HOST = "https://eu.i.posthog.com";
+
+export type FactoryAnalyticsEnvironment = {
+  NEXT_PUBLIC_POSTHOG_KEY?: string;
+  NEXT_PUBLIC_POSTHOG_HOST?: string;
+};
+
+export type FactoryAnalyticsConfig = {
+  projectKey: string;
+  apiHost: string;
+  assetHost: string;
+};
+
+/**
+ * Returns null — a complete no-op — whenever the project key is absent or the
+ * host is unusable. An unconfigured deployment, a fork, and a local checkout all
+ * take that path, so the public factory never depends on a key existing.
+ */
+export function resolveFactoryAnalytics(
+  env: FactoryAnalyticsEnvironment,
+): FactoryAnalyticsConfig | null {
+  const projectKey = env.NEXT_PUBLIC_POSTHOG_KEY?.trim();
+  if (!projectKey) return null;
+
+  const configuredHost = env.NEXT_PUBLIC_POSTHOG_HOST?.trim();
+  const apiHost = normalizeIngestionHost(
+    configuredHost && configuredHost.length > 0
+      ? configuredHost
+      : FACTORY_ANALYTICS_DEFAULT_HOST,
+  );
+  if (!apiHost) return null;
+
+  return {
+    projectKey,
+    apiHost,
+    assetHost: apiHost.replace(".i.posthog.com", "-assets.i.posthog.com"),
+  };
+}
+
+/**
+ * The vendor snippet is a minified stub whose only job is queueing calls made
+ * before `array.js` arrives. Initialising in `onload` needs no queue, so the
+ * loader stays readable in a public repository and still guarantees ordering.
+ */
+export function factoryAnalyticsSnippet(config: FactoryAnalyticsConfig): string {
+  const source = JSON.stringify(`${config.assetHost}/static/array.js`);
+  const projectKey = JSON.stringify(config.projectKey);
+  const options = JSON.stringify({
+    api_host: config.apiHost,
+    capture_pageview: "history_change",
+    person_profiles: "identified_only",
+  });
+  return [
+    "(function(){",
+    'var s=document.createElement("script");',
+    `s.src=${source};`,
+    "s.async=true;",
+    's.crossOrigin="anonymous";',
+    "s.onload=function(){",
+    `if(window.posthog)window.posthog.init(${projectKey},${options});`,
+    "};",
+    "document.head.appendChild(s);",
+    "})();",
+  ]
+    .join("")
+    .replace(/</g, "\\u003c");
+}
+
+function normalizeIngestionHost(value: string): string | null {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:") return null;
+    if (url.search.length > 0 || url.hash.length > 0) return null;
+    return `${url.origin}${url.pathname}`.replace(/\/+$/, "");
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/first-customer-flow.postgres.test.ts
+++ b/src/lib/first-customer-flow.postgres.test.ts
@@ -612,7 +612,7 @@ function checkoutFixture(
     mode: "subscription",
     status: "complete",
     payment_status: "paid",
-    currency: "usd",
+    currency: "eur",
     amount_subtotal: 4_900,
     total_details: {
       amount_discount: 0,

--- a/src/lib/funnel-accessibility.test.tsx
+++ b/src/lib/funnel-accessibility.test.tsx
@@ -92,7 +92,7 @@ describe("create funnel accessibility", () => {
       "salon.com or salon name",
     );
     expect(html).toContain("The preview stays private and is not chargeable.");
-    expect(html).not.toContain("$49");
+    expect(html).not.toContain("€49");
     expect(html).not.toContain("founding plan");
   });
 
@@ -188,7 +188,7 @@ describe("claim funnel accessibility", () => {
     expect(html).toContain(`id="${email.id}-description"`);
     expect(html).toContain("Verify ownership by email");
     expect(html).toContain('type="submit"');
-    expect(html).toContain("$49");
+    expect(html).toContain("€49");
   });
 
   it("announces checkout processing through a live status region", () => {

--- a/src/lib/site-i18n.ts
+++ b/src/lib/site-i18n.ts
@@ -1,3 +1,4 @@
+import type { SiteUiLocale } from "@/lib/site-locales";
 import type { ErasedVerticalConfig } from "@/lib/verticals/registry";
 import type { VerticalTemplateCopy } from "@/lib/verticals/types";
 
@@ -6,7 +7,9 @@ import type { VerticalTemplateCopy } from "@/lib/verticals/types";
  * language, then `en`, then whatever the vertical shipped first. This replaces the
  * old hardcoded `fr`-or-`en` branch — with the same outcome for the restaurant
  * dictionaries (`fr`/`fr-FR` → fr, everything else → en) — so a vertical that
- * ships more locales, or fewer, needs no renderer change.
+ * ships more locales, or fewer, needs no renderer change. `SITE_UI_LOCALES` names
+ * which locales that is; this function is what makes an unshipped one degrade
+ * rather than crash.
  */
 function pickLocaleEntry<T>(byLocale: Record<string, T>, locale: string): T {
   const normalized = locale.toLowerCase();
@@ -65,7 +68,27 @@ const sharedSiteDictionary = {
     pickupHeading: "Retrait",
     blogNav: "Blog",
   },
-} satisfies Record<string, Record<string, string>>;
+  mt: {
+    bookingRequestName: "Ismek",
+    bookingRequestEmail: "Email",
+    bookingRequestPhone: "Telefon",
+    bookingRequestWhen: "Ħin preferut",
+    bookingRequestPartySize: "Numru ta’ persuni",
+    bookingRequestNotes: "Hemm xi ħaġa li għandna nkunu nafu?",
+    bookingRequestOptional: "mhux obbligatorju",
+    bookingRequestSubmit: "Ibgħat it-talba",
+    bookingRequestSending: "Qed tintbagħat…",
+    bookingRequestSuccess: "Grazzi — nikkuntattjawk dalwaqt.",
+    bookingRequestError:
+      "It-talba tiegħek ma setgħetx tintbagħat. Erġa’ pprova.",
+    bookingRequestPreviewNotice:
+      "Din hija previżjoni — it-talbiet ma jintbagħtux.",
+    bookingEmbedPreviewNotice:
+      "Il-widget tal-ibbukkjar jintwera fis-sit pubblikat.",
+    pickupHeading: "Ġbir",
+    blogNav: "Blog",
+  },
+} satisfies Record<SiteUiLocale, Record<string, string>>;
 
 /**
  * Shared copy first, the vertical's own copy on top: a vertical may override any

--- a/src/lib/site-locales.test.ts
+++ b/src/lib/site-locales.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+import { getSiteDictionary, getTemplateCopy } from "@/lib/site-i18n";
+import { SITE_UI_LOCALES, siteUiLocale } from "@/lib/site-locales";
+import { listVerticalIds, resolveVerticalConfig } from "@/lib/verticals/registry";
+
+describe("siteUiLocale", () => {
+  it("resolves a shipped locale, its regional variants, and nothing else", () => {
+    expect(siteUiLocale("mt")).toBe("mt");
+    expect(siteUiLocale("mt-MT")).toBe("mt");
+    expect(siteUiLocale("fr-CA")).toBe("fr");
+    expect(siteUiLocale("MT")).toBe("mt");
+    expect(siteUiLocale("de")).toBe("en");
+  });
+});
+
+/**
+ * The compiler already forces every dictionary to carry a key per shipped
+ * locale. What it cannot see is a key present but left blank, which is how a
+ * locale ships looking added while rendering an empty heading. English is the
+ * reference: a key it fills, every locale must fill, and a key it leaves blank
+ * on purpose stays blank everywhere.
+ */
+describe("shipped locale parity", () => {
+  for (const verticalId of listVerticalIds()) {
+    const config = resolveVerticalConfig(verticalId);
+
+    it(`${verticalId} translates its dictionary into every shipped locale`, () => {
+      const english = getSiteDictionary(config, "en");
+      for (const locale of SITE_UI_LOCALES) {
+        const dictionary = getSiteDictionary(config, locale);
+        expect(Object.keys(dictionary).sort()).toEqual(
+          Object.keys(english).sort(),
+        );
+        for (const [key, value] of Object.entries(english)) {
+          expect(dictionary[key].length > 0).toBe(value.length > 0);
+        }
+      }
+    });
+
+    it(`${verticalId} translates every template into every shipped locale`, () => {
+      for (const template of Object.values(config.templates.definitions)) {
+        for (const locale of SITE_UI_LOCALES) {
+          const copy = getTemplateCopy(template, locale);
+          expect(copy.catalogEyebrow.length).toBeGreaterThan(0);
+          expect(copy.catalogHeading.length).toBeGreaterThan(0);
+          expect(copy.featuredHeading.length).toBeGreaterThan(0);
+          expect(copy.featuredSubheading.length).toBeGreaterThan(0);
+        }
+      }
+    });
+  }
+});

--- a/src/lib/site-locales.ts
+++ b/src/lib/site-locales.ts
@@ -1,0 +1,27 @@
+/**
+ * The locales the factory itself ships chrome for, as opposed to `localeSchema`,
+ * which is an open BCP 47 code because a scraped business writes its own site in
+ * whatever language it likes. Those are two different things: a Maltese bakery
+ * can carry `mt` content long before the engine has a Maltese word for "Pickup".
+ *
+ * Declaring the shipped set here, and typing every locale-keyed dictionary
+ * against it, is what makes a locale impossible to half-add: appending a code
+ * turns every dictionary missing that locale into a compile error rather than a
+ * silent fall back to English in production.
+ */
+export const SITE_UI_LOCALES = ["en", "fr", "mt"] as const;
+
+export type SiteUiLocale = (typeof SITE_UI_LOCALES)[number];
+
+/**
+ * The shipped locale a request's BCP 47 code resolves to. Region subtags are
+ * dropped (`fr-FR` and `fr-CA` share one dictionary), and anything unshipped
+ * lands on `en` — the same locale → language → `en` order `pickLocaleEntry`
+ * applies to the dictionaries themselves.
+ */
+export function siteUiLocale(locale: string): SiteUiLocale {
+  const language = locale.toLowerCase().split("-")[0];
+  return (
+    SITE_UI_LOCALES.find((shipped) => shipped === language) ?? "en"
+  );
+}

--- a/src/lib/stripe-billing-preflight.test.ts
+++ b/src/lib/stripe-billing-preflight.test.ts
@@ -17,7 +17,7 @@ function stripePrice(
         ({
           id: "price_founding",
           active: true,
-          currency: "usd",
+          currency: "eur",
           unit_amount: 4_900,
           type: "recurring",
           livemode: true,
@@ -46,7 +46,7 @@ describe("Stripe billing preflight", () => {
       ready: true,
       mode: "live",
       amount: 4_900,
-      currency: "usd",
+      currency: "eur",
       interval: "month",
       taxBehavior: "exclusive",
     });

--- a/src/lib/stripe-webhook.test.ts
+++ b/src/lib/stripe-webhook.test.ts
@@ -954,7 +954,7 @@ function checkoutFixture(
     mode: "subscription",
     status: "complete",
     payment_status: "paid",
-    currency: "usd",
+    currency: "eur",
     amount_subtotal: 4_900,
     total_details: {
       amount_discount: 0,
@@ -963,8 +963,8 @@ function checkoutFixture(
     },
     adaptive_pricing: { enabled: true },
     presentment_details: {
-      presentment_amount: 4_300,
-      presentment_currency: "eur",
+      presentment_amount: 5_300,
+      presentment_currency: "usd",
     },
     client_reference_id: "invite_1",
     customer: "cus_1",

--- a/src/lib/verticals/beauty/config.ts
+++ b/src/lib/verticals/beauty/config.ts
@@ -21,6 +21,7 @@ import {
   type BeautyTemplate,
 } from "@/lib/verticals/beauty/templates";
 import { beautyOwnerOperations } from "@/lib/owner-operations";
+import type { SiteUiLocale } from "@/lib/site-locales";
 import type { VerticalConfig } from "@/lib/verticals/types";
 
 export const beautyDictionaryExtensions = {
@@ -46,7 +47,18 @@ export const beautyDictionaryExtensions = {
     bookingRequestIntro:
       "Dites-nous ce que vous souhaitez et quand, nous confirmerons par e-mail ou par téléphone.",
   },
-} satisfies Record<string, Record<string, string>>;
+  mt: {
+    language: "Lingwa",
+    reservationsVia: "Ibbukkja permezz ta’",
+    bookingPartner: "is-sieħeb tagħna tal-ibbukkjar",
+    seasonalNotice: "Is-servizzi u d-disponibbiltà jistgħu jinbidlu.",
+    heroImageAlt: "L-intern ta’",
+    bookingHeading: "Appuntamenti",
+    bookingRequestHeading: "Itlob appuntament",
+    bookingRequestIntro:
+      "Għidilna x’tixtieq u meta, u aħna nikkonfermaw bl-email jew bit-telefon.",
+  },
+} satisfies Record<SiteUiLocale, Record<string, string>>;
 
 const serviceStyleLabels: Record<ServiceStyle, string> = {
   barbershop: "Barbershop",

--- a/src/lib/verticals/beauty/lifecycle.test.ts
+++ b/src/lib/verticals/beauty/lifecycle.test.ts
@@ -43,7 +43,7 @@ const claimInvitations = await Bun.file(
 
 const forbiddenLifecyclePromise = new RegExp(
   [
-    "\\$49",
+    "[€$]49",
     "\\bclaim(?:s|ed|ing)?\\b",
     "\\bpay(?:ment|ing)?\\b",
     "\\bpaid\\b",

--- a/src/lib/verticals/beauty/templates.ts
+++ b/src/lib/verticals/beauty/templates.ts
@@ -2,6 +2,7 @@ import type {
   BeautyAttributes,
   ServiceStyle,
 } from "@/lib/verticals/beauty/schema";
+import type { SiteUiLocale } from "@/lib/site-locales";
 import type { VerticalTemplateCopy } from "@/lib/verticals/types";
 
 /**
@@ -17,7 +18,7 @@ export type BeautyTemplate = {
   titleClassName: string;
   sectionClassName: string;
   showServiceImagesByDefault: boolean;
-  copy: Record<"en" | "fr", VerticalTemplateCopy>;
+  copy: Record<SiteUiLocale, VerticalTemplateCopy>;
 };
 
 /**
@@ -49,6 +50,12 @@ export const beautyTemplates: Record<ServiceStyle, BeautyTemplate> = {
         featuredHeading: "Au fauteuil",
         featuredSubheading: "Un travail net, au prix annoncé.",
       },
+      mt: {
+        catalogEyebrow: "Servizzi",
+        catalogHeading: "Qtugħ, tqaxxir u manutenzjoni.",
+        featuredHeading: "Fuq is-siġġu",
+        featuredSubheading: "Xogħol dirett, bi prezz mgħarraf minn qabel.",
+      },
     },
   },
   "classic-salon": {
@@ -72,6 +79,12 @@ export const beautyTemplates: Record<ServiceStyle, BeautyTemplate> = {
         catalogHeading: "Couleur, coupe et soin.",
         featuredHeading: "Au salon",
         featuredSubheading: "Chaque prestation, sa durée et son prix.",
+      },
+      mt: {
+        catalogEyebrow: "Is-servizzi tagħna",
+        catalogHeading: "Kulur, qtugħ u kura.",
+        featuredHeading: "Fis-salon",
+        featuredSubheading: "Kull servizz bil-ħin u l-prezz tiegħu.",
       },
     },
   },
@@ -98,6 +111,12 @@ export const beautyTemplates: Record<ServiceStyle, BeautyTemplate> = {
         featuredHeading: "Réalisations",
         featuredSubheading: "Ce que le studio fait vraiment.",
       },
+      mt: {
+        catalogEyebrow: "Il-menu tal-istudjo",
+        catalogHeading: "Xogħol maħsub, bi prezz ċar.",
+        featuredHeading: "Xogħol reċenti",
+        featuredSubheading: "Dak li fil-fatt jagħmel l-istudjo.",
+      },
     },
   },
   "spa-luxe": {
@@ -122,6 +141,12 @@ export const beautyTemplates: Record<ServiceStyle, BeautyTemplate> = {
         featuredHeading: "La carte des soins",
         featuredSubheading: "Chaque rituel avec sa durée.",
       },
+      mt: {
+        catalogEyebrow: "Trattamenti",
+        catalogHeading: "Ħin imwarrab għalik.",
+        featuredHeading: "Il-lista tat-trattamenti",
+        featuredSubheading: "Kull ritwal bit-tul tiegħu.",
+      },
     },
   },
   "express-nails": {
@@ -145,6 +170,12 @@ export const beautyTemplates: Record<ServiceStyle, BeautyTemplate> = {
         catalogHeading: "Vite fait, bien fait.",
         featuredHeading: "Dernières poses",
         featuredSubheading: "Des finitions telles qu’affichées.",
+      },
+      mt: {
+        catalogEyebrow: "Il-lista",
+        catalogHeading: "Tidħol u toħroġ, tidher fl-aqwa tiegħek.",
+        featuredHeading: "L-aħħar settijiet",
+        featuredSubheading: "Rifinituri eżattament kif murija.",
       },
     },
   },

--- a/src/lib/verticals/food-retail/config.ts
+++ b/src/lib/verticals/food-retail/config.ts
@@ -21,6 +21,7 @@ import {
   type FoodRetailTemplate,
 } from "@/lib/verticals/food-retail/templates";
 import { foodRetailOwnerOperations } from "@/lib/owner-operations";
+import { siteUiLocale, type SiteUiLocale } from "@/lib/site-locales";
 import type { VerticalConfig } from "@/lib/verticals/types";
 
 export const foodRetailDictionaryExtensions = {
@@ -48,17 +49,59 @@ export const foodRetailDictionaryExtensions = {
     bookingRequestIntro: "",
     pickupHeading: "Retrait",
   },
-} satisfies Record<string, Record<string, string>>;
+  mt: {
+    language: "Lingwa",
+    reservationsVia: "Ordna permezz ta’",
+    bookingPartner: "is-sieħeb tal-ordnijiet tal-ħanut",
+    seasonalNotice:
+      "Id-dettalji tal-prodotti jistgħu jinbidlu. Ikkuntattja l-ħanut qabel ma tivvjaġġa.",
+    heroImageAlt: "Il-ħanut u l-prodotti ta’",
+    bookingHeading: "Ordnijiet",
+    bookingRequestHeading: "",
+    bookingRequestIntro: "",
+    pickupHeading: "Ġbir",
+  },
+} satisfies Record<SiteUiLocale, Record<string, string>>;
 
-const shopTypeLabels: Record<FoodShopType, Record<"en" | "fr", string>> = {
-  bakery: { en: "Bakery", fr: "Boulangerie" },
-  patisserie: { en: "Patisserie", fr: "Pâtisserie" },
-  butcher: { en: "Butcher", fr: "Boucherie" },
-  deli: { en: "Deli", fr: "Traiteur" },
-  cheesemonger: { en: "Cheesemonger", fr: "Fromagerie" },
-  grocer: { en: "Grocer", fr: "Épicerie" },
-  "local-food-shop": { en: "Local food shop", fr: "Commerce alimentaire" },
+const shopTypeLabels: Record<FoodShopType, Record<SiteUiLocale, string>> = {
+  bakery: { en: "Bakery", fr: "Boulangerie", mt: "Furnara" },
+  patisserie: { en: "Patisserie", fr: "Pâtisserie", mt: "Pastizzerija" },
+  butcher: { en: "Butcher", fr: "Boucherie", mt: "Ħanut tal-laħam" },
+  deli: { en: "Deli", fr: "Traiteur", mt: "Delikatessen" },
+  cheesemonger: { en: "Cheesemonger", fr: "Fromagerie", mt: "Ħanut tal-ġobon" },
+  grocer: { en: "Grocer", fr: "Épicerie", mt: "Ħanut tal-merċa" },
+  "local-food-shop": {
+    en: "Local food shop",
+    fr: "Commerce alimentaire",
+    mt: "Ħanut tal-ikel lokali",
+  },
 };
+
+/**
+ * The product badges the renderer stamps on a catalog row. A table rather than a
+ * `fr ? … : …` ternary chain: a ternary answers "not French" with English, so a
+ * new locale would ship silently half-translated instead of failing to compile.
+ */
+const itemBadgeLabels = {
+  en: {
+    inStock: "In stock",
+    outOfStock: "Out of stock",
+    preorder: "Preorder",
+    allergens: "Allergens",
+  },
+  fr: {
+    inStock: "En stock",
+    outOfStock: "Rupture de stock",
+    preorder: "Précommande",
+    allergens: "Allergènes",
+  },
+  mt: {
+    inStock: "Fl-istokk",
+    outOfStock: "Mhux fl-istokk",
+    preorder: "Ordni bil-quddiem",
+    allergens: "Allerġeni",
+  },
+} satisfies Record<SiteUiLocale, Record<string, string>>;
 
 /**
  * FOOD_RETAIL treats the model as a presentation assistant, never an evidence
@@ -123,10 +166,6 @@ export function bindGeneratedFoodRetailDraftToEvidence({
   };
 }
 
-function language(locale: string): "en" | "fr" {
-  return locale.toLowerCase().startsWith("fr") ? "fr" : "en";
-}
-
 export const foodRetailConfig = {
   id: Vertical.FOOD_RETAIL,
   vocabulary: {
@@ -169,6 +208,14 @@ export const foodRetailConfig = {
       emptyCatalogDescription:
         "Aucune gamme de produits n’était présente dans les données source structurées.",
     },
+    mt: {
+      eyebrow: "Previżjoni privata tal-ħanut tal-ikel",
+      description:
+        "Previżjoni privata tal-ħanut tal-ikel mibnija biss mill-informazzjoni tas-sors disponibbli bħalissa.",
+      catalogName: "Firxiet ta’ prodotti",
+      emptyCatalogDescription:
+        "Ebda dettall ta’ firxa ta’ prodotti ma nstab fid-data strutturata tas-sors.",
+    },
   },
   itemAttributesSchema: foodRetailItemAttributesSchema,
   itemAttributeDefaults: {
@@ -203,26 +250,24 @@ export const foodRetailConfig = {
     buildEyebrow: (attributes, site) =>
       `${shopTypeLabels[attributes.shopType].en} · ${site.address ?? "Local"}`,
     itemBadges: (attributes, locale, available) => {
-      const localeLanguage = language(locale);
+      const labels = itemBadgeLabels[siteUiLocale(locale)];
       const badges: string[] = [];
       if (attributes.stockSourceUrl && available === true) {
-        badges.push(localeLanguage === "fr" ? "En stock" : "In stock");
+        badges.push(labels.inStock);
       }
       if (attributes.stockSourceUrl && available === false) {
-        badges.push(
-          localeLanguage === "fr" ? "Rupture de stock" : "Out of stock",
-        );
+        badges.push(labels.outOfStock);
       }
       if (attributes.seasonalAvailability) {
         badges.push(attributes.seasonalAvailability);
       }
       if (attributes.preorderRequired === true) {
-        badges.push(localeLanguage === "fr" ? "Précommande" : "Preorder");
+        badges.push(labels.preorder);
       }
       if (attributes.preorderNote) badges.push(attributes.preorderNote);
       if (attributes.allergens.length > 0 && attributes.allergenSourceUrl) {
         badges.push(
-          `${localeLanguage === "fr" ? "Allergènes" : "Allergens"}: ${attributes.allergens.join(", ")}`,
+          `${labels.allergens}: ${attributes.allergens.join(", ")}`,
         );
       }
       return badges;

--- a/src/lib/verticals/food-retail/marketing.ts
+++ b/src/lib/verticals/food-retail/marketing.ts
@@ -106,11 +106,11 @@ export const foodRetailMarketing = {
   pricing: {
     eyebrow: "One founding offer",
     headline: "A maintained local storefront.",
-    copy: "Claim the reviewed preview for $49/month through Cornershopdev. Local currency is shown at checkout.",
+    copy: "Claim the reviewed preview for €49/month through Cornershopdev. Local currency is shown at checkout.",
     plans: [
       {
         name: "Founding",
-        price: "$49",
+        price: "€49",
         cadence: "/month",
         copy: "One maintained, mobile-first food-retail website on the business's own domain.",
         features: [

--- a/src/lib/verticals/food-retail/templates.ts
+++ b/src/lib/verticals/food-retail/templates.ts
@@ -2,6 +2,7 @@ import type {
   FoodRetailAttributes,
   FoodShopType,
 } from "@/lib/verticals/food-retail/schema";
+import type { SiteUiLocale } from "@/lib/site-locales";
 import type { VerticalTemplateCopy } from "@/lib/verticals/types";
 
 export type FoodRetailTemplateId =
@@ -17,7 +18,7 @@ export type FoodRetailTemplate = {
   titleClassName: string;
   sectionClassName: string;
   showProductImagesByDefault: boolean;
-  copy: Record<"en" | "fr", VerticalTemplateCopy>;
+  copy: Record<SiteUiLocale, VerticalTemplateCopy>;
 };
 
 export const foodRetailTemplates: Record<
@@ -46,6 +47,12 @@ export const foodRetailTemplates: Record<
         featuredHeading: "Produits sélectionnés",
         featuredSubheading: "Parcourez les produits présentés par la boutique.",
       },
+      mt: {
+        catalogEyebrow: "Il-firxa tal-prodotti",
+        catalogHeading: "Esplora l-firxa ppubblikata.",
+        featuredHeading: "Prodotti magħżula",
+        featuredSubheading: "Ara l-prodotti elenkati mill-ħanut.",
+      },
     },
   },
   "craft-counter": {
@@ -70,6 +77,12 @@ export const foodRetailTemplates: Record<
         featuredHeading: "Produits sélectionnés",
         featuredSubheading: "Informations fournies par la boutique.",
       },
+      mt: {
+        catalogEyebrow: "Il-firxa",
+        catalogHeading: "Prodotti mill-firxa ppubblikata.",
+        featuredHeading: "Prodotti magħżula",
+        featuredSubheading: "Dettalji pprovduti mill-ħanut.",
+      },
     },
   },
   "market-shelves": {
@@ -93,6 +106,12 @@ export const foodRetailTemplates: Record<
         catalogHeading: "Ce que publie la boutique.",
         featuredHeading: "Produits sélectionnés",
         featuredSubheading: "Un aperçu de la gamme publiée.",
+      },
+      mt: {
+        catalogEyebrow: "Firxiet ta’ prodotti",
+        catalogHeading: "Dak li jippubblika l-ħanut.",
+        featuredHeading: "Prodotti magħżula",
+        featuredSubheading: "Ħarsa aktar mill-qrib lejn il-firxa ppubblikata.",
       },
     },
   },

--- a/src/lib/verticals/local-service/config.ts
+++ b/src/lib/verticals/local-service/config.ts
@@ -21,6 +21,7 @@ import {
   type LocalServiceTemplate,
 } from "@/lib/verticals/local-service/templates";
 import { localServiceOwnerOperations } from "@/lib/owner-operations";
+import { siteUiLocale, type SiteUiLocale } from "@/lib/site-locales";
 import type { VerticalConfig } from "@/lib/verticals/types";
 
 const tradeLabels: Record<LocalServiceTradeType, string> = {
@@ -33,7 +34,7 @@ const tradeLabels: Record<LocalServiceTradeType, string> = {
 };
 
 const availabilityLabels: Record<
-  "en" | "fr",
+  SiteUiLocale,
   Record<LocalServiceAttributes["availabilityPosture"], string | null>
 > = {
   en: {
@@ -52,11 +53,48 @@ const availabilityLabels: Record<
     "24-7-emergency": "Service d’urgence 24 h/24 indiqué",
     "by-appointment": "Sur rendez-vous",
   },
+  mt: {
+    "not-stated": null,
+    scheduled: "Xogħol skedat",
+    "same-day": "Disponibbiltà fl-istess ġurnata indikata",
+    "emergency-callout": "Sejħiet ta’ emerġenza indikati",
+    "24-7-emergency": "Servizz ta’ emerġenza 24/7 indikat",
+    "by-appointment": "B’appuntament",
+  },
 };
 
-function localServiceLanguage(locale: string): "en" | "fr" {
-  return locale.toLowerCase().split("-")[0] === "fr" ? "fr" : "en";
-}
+/**
+ * Every word the renderer stamps on a service row or a trust line, as a table
+ * rather than a chain of `fr ? … : …` ternaries. The ternary form answers "not
+ * French" with English, so a fourth locale would ship reading half-English
+ * instead of failing to compile.
+ */
+const localServiceLabels = {
+  en: {
+    quoteRequired: "Quote required",
+    priceFrom: "From",
+    hourly: "Hourly",
+    emergencyCallout: "Emergency callout",
+    insured: "Insurance stated by the business",
+    notInsured: "Business states that it is not insured",
+  },
+  fr: {
+    quoteRequired: "Devis requis",
+    priceFrom: "À partir de",
+    hourly: "Tarif horaire",
+    emergencyCallout: "Intervention d’urgence",
+    insured: "Assurance indiquée par l’entreprise",
+    notInsured: "L’entreprise indique ne pas être assurée",
+  },
+  mt: {
+    quoteRequired: "Kwotazzjoni meħtieġa",
+    priceFrom: "Minn",
+    hourly: "Rata bis-siegħa",
+    emergencyCallout: "Sejħa ta’ emerġenza",
+    insured: "Assigurazzjoni indikata min-negozju",
+    notInsured: "In-negozju jindika li mhuwiex assigurat",
+  },
+} satisfies Record<SiteUiLocale, Record<string, string>>;
 
 /**
  * LOCAL_SERVICE treats model output as an untrusted presentation proposal.
@@ -118,7 +156,22 @@ export const localServiceDictionaryExtensions = {
     trustHeading: "Éléments de confiance",
     projectsHeading: "Projets",
   },
-} satisfies Record<string, Record<string, string>>;
+  mt: {
+    language: "Lingwa",
+    reservationsVia: "Ikkuntattja permezz ta’",
+    bookingPartner: "is-sieħeb tagħna tal-iskedar",
+    seasonalNotice:
+      "Il-kopertura tas-servizz u d-disponibbiltà jistgħu jinbidlu. Ikkonferma qabel ma tibda x-xogħol.",
+    heroImageAlt: "Ritratt ta’",
+    bookingHeading: "Kuntatt",
+    bookingRequestHeading: "",
+    bookingRequestIntro: "",
+    serviceAreasHeading: "Żoni ta’ servizz",
+    credentialsHeading: "Kwalifiki u assigurazzjoni",
+    trustHeading: "Għaliex iċ-ċlijenti jċemplu",
+    projectsHeading: "Proġetti",
+  },
+} satisfies Record<SiteUiLocale, Record<string, string>>;
 
 const attributeDefaults: LocalServiceAttributes = {
   tradeType: "general-trades",
@@ -186,6 +239,14 @@ export const localServiceConfig = {
       emptyCatalogDescription:
         "Aucun service n’était présent dans les données source structurées.",
     },
+    mt: {
+      eyebrow: "Previżjoni privata tas-servizz lokali",
+      description:
+        "Previżjoni privata mibnija biss mill-informazzjoni tas-sors disponibbli bħalissa.",
+      catalogName: "Servizzi",
+      emptyCatalogDescription:
+        "Ebda dettall ta’ servizz ma nstab fid-data strutturata tas-sors.",
+    },
   },
   itemAttributesSchema: localServiceItemAttributesSchema,
   itemAttributeDefaults: {
@@ -218,29 +279,25 @@ export const localServiceConfig = {
     buildEyebrow: (attributes, site) =>
       `${tradeLabels[attributes.tradeType]} · ${site.address ?? "Local"}`,
     itemBadges: (attributes, locale) => {
-      const language = localServiceLanguage(locale);
+      const labels = localServiceLabels[siteUiLocale(locale)];
       const badges: string[] = [];
       if (attributes.pricingModel === "quote") {
-        badges.push(language === "fr" ? "Devis requis" : "Quote required");
+        badges.push(labels.quoteRequired);
       }
       if (attributes.pricingModel === "from") {
-        badges.push(language === "fr" ? "À partir de" : "From");
+        badges.push(labels.priceFrom);
       }
       if (attributes.pricingModel === "hourly") {
-        badges.push(
-          attributes.priceUnit ||
-            (language === "fr" ? "Tarif horaire" : "Hourly"),
-        );
+        badges.push(attributes.priceUnit || labels.hourly);
       } else if (attributes.priceUnit) badges.push(attributes.priceUnit);
       if (attributes.emergencyEligible) {
-        badges.push(
-          language === "fr" ? "Intervention d’urgence" : "Emergency callout",
-        );
+        badges.push(labels.emergencyCallout);
       }
       return badges;
     },
     businessDetails: (attributes, locale) => {
-      const language = localServiceLanguage(locale);
+      const language = siteUiLocale(locale);
+      const labels = localServiceLabels[language];
       return {
         availability:
           availabilityLabels[language][attributes.availabilityPosture],
@@ -252,18 +309,9 @@ export const localServiceConfig = {
         ),
         trustSignals: [
           ...(attributes.insuranceStatus === "insured"
-            ? [
-                attributes.insuranceDetail ||
-                  (language === "fr"
-                    ? "Assurance indiquée par l’entreprise"
-                    : "Insurance stated by the business"),
-              ]
+            ? [attributes.insuranceDetail || labels.insured]
             : attributes.insuranceStatus === "not-insured"
-              ? [
-                  language === "fr"
-                    ? "L’entreprise indique ne pas être assurée"
-                    : "Business states that it is not insured",
-                ]
+              ? [labels.notInsured]
               : []),
           ...attributes.trustSignals.map((signal) =>
             [signal.label, signal.detail].filter(Boolean).join(" · "),

--- a/src/lib/verticals/local-service/marketing.ts
+++ b/src/lib/verticals/local-service/marketing.ts
@@ -109,7 +109,7 @@ export const localServiceMarketing = {
     plans: [
       {
         name: "Founding",
-        price: "$49",
+        price: "€49",
         cadence: "/month",
         copy: "The complete local-service website for one independent business.",
         features: [

--- a/src/lib/verticals/local-service/templates.ts
+++ b/src/lib/verticals/local-service/templates.ts
@@ -2,6 +2,7 @@ import type {
   LocalServiceAttributes,
   LocalServiceTradeType,
 } from "@/lib/verticals/local-service/schema";
+import type { SiteUiLocale } from "@/lib/site-locales";
 import type { VerticalTemplateCopy } from "@/lib/verticals/types";
 
 export type LocalServiceTemplate = {
@@ -12,7 +13,7 @@ export type LocalServiceTemplate = {
   titleClassName: string;
   sectionClassName: string;
   showProjectImagesByDefault: boolean;
-  copy: Record<"en" | "fr", VerticalTemplateCopy>;
+  copy: Record<SiteUiLocale, VerticalTemplateCopy>;
 };
 
 const sharedTitle =
@@ -83,6 +84,13 @@ function template(
         featuredHeading: "Projets",
         featuredSubheading: "Informations de projet fournies par l’entreprise.",
       },
+      mt: {
+        catalogEyebrow: tradeLabelMt(id),
+        catalogHeading: "Servizzi elenkati min-negozju.",
+        featuredHeading: "Proġetti",
+        featuredSubheading:
+          "Informazzjoni dwar il-proġetti pprovduta min-negozju.",
+      },
     },
   };
 }
@@ -95,6 +103,17 @@ function tradeLabelFr(id: LocalServiceTradeType): string {
     repair: "Dépannage",
     artisan: "Artisan",
     "general-trades": "Entreprise locale",
+  }[id];
+}
+
+function tradeLabelMt(id: LocalServiceTradeType): string {
+  return {
+    plumber: "Plamer",
+    electrician: "Elettriċista",
+    builder: "Bennej",
+    repair: "Tiswijiet",
+    artisan: "Artiġjan",
+    "general-trades": "Negozju lokali",
   }[id];
 }
 

--- a/src/lib/verticals/restaurant/config.ts
+++ b/src/lib/verticals/restaurant/config.ts
@@ -26,6 +26,7 @@ import {
   type RestaurantTemplate,
 } from "@/lib/verticals/restaurant/templates";
 import { restaurantOwnerOperations } from "@/lib/owner-operations";
+import type { SiteUiLocale } from "@/lib/site-locales";
 import type { VerticalConfig } from "@/lib/verticals/types";
 
 export const restaurantDictionaryExtensions = {
@@ -102,7 +103,41 @@ export const restaurantDictionaryExtensions = {
     familyMenuEyebrow: "Toute la carte",
     familyMenuHeading: "De quoi contenter tout le monde.",
   },
-} satisfies Record<string, Record<string, string>>;
+  mt: {
+    language: "Lingwa",
+    reservationsVia: "Riżervazzjonijiet permezz ta’",
+    bookingPartner: "is-sieħeb tagħna tal-ibbukkjar",
+    seasonalNotice: "Il-menu u d-disponibbiltà jistgħu jinbidlu mal-istaġun.",
+    heroImageAlt: "Is-sala tal-ikel ta’",
+    bookingHeading: "Riżervazzjonijiet",
+    bookingRequestHeading: "Itlob mejda",
+    bookingRequestIntro:
+      "Għidilna meta tixtieq tiġi u aħna nikkonfermaw bl-email jew bit-telefon.",
+    themePlanVisit: "Ippjana żjara",
+    themeMenuEyebrow: "Il-menu",
+    terroirMenuHeading: "Iggwidati mill-istaġun.",
+    terroirVisitEyebrow: "Mal-mejda",
+    terroirVisitHeading: "Sib il-ħin għall-menu kollu.",
+    themeBrowseMenu: "Ara l-menu",
+    themeMenuCategories: "Kategoriji tal-menu",
+    counterMenuEyebrow: "Lest meta tkun lest",
+    counterMenuHeading: "Agħżel l-ordni tiegħek.",
+    afterDarkEventsEyebrow: "X’hemm għaddej",
+    afterDarkMenuEyebrow: "Ikel u xorb",
+    afterDarkMenuHeading: "Ibqa’ wara nżul ix-xemx.",
+    afterDarkMenuIntro:
+      "Xorb tad-dar u platti tard, ippreżentati b’mod ċar biżżejjed biex tagħżel fid-dawl baxx.",
+    afterDarkClosing: "Mejda, xarba, imbagħad kanzunetta oħra.",
+    neighborhoodMenuHeading: "X’hemm fuq il-mejda.",
+    neighborhoodVisitEyebrow: "Ejja għandna",
+    neighborhoodVisitHeading: "Sala familjari. Post irriżervat.",
+    daylightMenuEyebrow: "Mill-bank",
+    daylightMenuHeading: "Moħmi llum. Lest issa.",
+    daylightVisitHeading: "Għaddi minn hawn sakemm id-dawl ikun tajjeb.",
+    familyMenuEyebrow: "Il-menu sħiħ",
+    familyMenuHeading: "Xi ħaġa għal kulħadd.",
+  },
+} satisfies Record<SiteUiLocale, Record<string, string>>;
 
 export const restaurantConfig = {
   id: Vertical.RESTAURANT,

--- a/src/lib/verticals/restaurant/marketing.test.ts
+++ b/src/lib/verticals/restaurant/marketing.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { readFile } from "node:fs/promises";
 import { Vertical } from "@/generated/prisma/enums";
+import { foundingOfferDisplay } from "@/lib/claim-launch-offer";
 import { foodRetailMarketing } from "@/lib/verticals/food-retail/marketing";
 import { localServiceMarketing } from "@/lib/verticals/local-service/marketing";
 import { restaurantMarketing } from "@/lib/verticals/restaurant/marketing";
@@ -11,20 +12,20 @@ import {
 } from "@/lib/verticals/registry";
 
 /**
- * GTM audit + first-customer runbook: launch is one $49/month founding plan.
+ * GTM audit + first-customer runbook: launch is one €49/month founding plan.
  * Headlining $25/$50 or generated food imagery as a paid extra is the
  * regression these assertions exist to catch.
  */
 describe("Restofront founding offer", () => {
-  it("sells only one $49/month founding plan", () => {
-    expect(restaurantMarketing.hero.proofPoints).toContain("$49/month");
+  it("sells only one €49/month founding plan", () => {
+    expect(restaurantMarketing.hero.proofPoints).toContain("€49/month");
     expect(restaurantMarketing.hero.proofPoints.join(" ")).not.toContain("$25");
 
     expect(restaurantMarketing.pricing.plans).toHaveLength(1);
     const [plan] = restaurantMarketing.pricing.plans;
     expect(plan).toMatchObject({
       name: "Founding",
-      price: "$49",
+      price: "€49",
       cadence: "/month",
       featured: true,
     });
@@ -60,7 +61,7 @@ describe("Restofront founding offer", () => {
 
     for (const marketing of claimEnabledMarketing) {
       expect(marketing.pricing?.plans).toHaveLength(1);
-      expect(marketing.pricing?.plans[0]?.price).toBe("$49");
+      expect(marketing.pricing?.plans[0]?.price).toBe(foundingOfferDisplay()?.price);
       expect(marketing.pricing?.copy).toContain("Local currency");
     }
     expect(foodRetailMarketing.pricing.plans[0]?.features).not.toEqual(

--- a/src/lib/verticals/restaurant/marketing.ts
+++ b/src/lib/verticals/restaurant/marketing.ts
@@ -43,7 +43,7 @@ export const restaurantMarketing = {
     headline: "Your front door, always current.",
     subheadline:
       "Give us the restaurant. Get back a polished mobile-first website with the menu already inside—and keep the booking and ordering tools that already work.",
-    proofPoints: ["No setup call", "Private preview first", "$49/month"],
+    proofPoints: ["No setup call", "Private preview first", "€49/month"],
   },
   form: {
     placeholder: "Restaurant website or name",
@@ -140,7 +140,7 @@ export const restaurantMarketing = {
     plans: [
       {
         name: "Founding",
-        price: "$49",
+        price: "€49",
         cadence: "/month",
         copy: "One maintained, mobile-first restaurant website on the restaurant's own domain.",
         features: [

--- a/src/lib/verticals/restaurant/templates.ts
+++ b/src/lib/verticals/restaurant/templates.ts
@@ -1,3 +1,4 @@
+import type { SiteUiLocale } from "@/lib/site-locales";
 import type { RestaurantAttributes } from "@/lib/verticals/restaurant/schema";
 import type { VerticalTemplateCopy } from "@/lib/verticals/types";
 
@@ -23,7 +24,7 @@ export type RestaurantTemplate = {
   titleClassName: string;
   sectionClassName: string;
   showMenuImagesByDefault: boolean;
-  copy: Record<"en" | "fr", VerticalTemplateCopy>;
+  copy: Record<SiteUiLocale, VerticalTemplateCopy>;
 };
 
 export const restaurantTemplates: Record<
@@ -52,6 +53,12 @@ export const restaurantTemplates: Record<
         featuredHeading: "Quelques assiettes",
         featuredSubheading: "Des plats fidèles à la saison.",
       },
+      mt: {
+        catalogEyebrow: "Il-menu",
+        catalogHeading: "Tisjir iggwidat mill-istaġun.",
+        featuredHeading: "Ftit platti",
+        featuredSubheading: "Platti fidili lejn l-istaġun.",
+      },
     },
   },
   fresh: {
@@ -76,6 +83,12 @@ export const restaurantTemplates: Record<
         catalogHeading: "Une cuisine fraîche, servie simplement.",
         featuredHeading: "À table aujourd’hui",
         featuredSubheading: "Des produits frais, sans artifice.",
+      },
+      mt: {
+        catalogEyebrow: "Frisk illum",
+        catalogHeading: "Ikel ħafif, servut b’mod ċar.",
+        featuredHeading: "X’qed inservu",
+        featuredSubheading: "Ikel frisk, muri onestament.",
       },
     },
   },
@@ -102,6 +115,12 @@ export const restaurantTemplates: Record<
         featuredHeading: "En cuisine",
         featuredSubheading: "Les plats parlent d’eux-mêmes.",
       },
+      mt: {
+        catalogEyebrow: "Is-selezzjoni",
+        catalogHeading: "Togħma qawwija. Bla tidwir.",
+        featuredHeading: "Ara x’hemm fil-kċina",
+        featuredSubheading: "L-ikel jitkellem waħdu.",
+      },
     },
   },
   nocturne: {
@@ -125,6 +144,12 @@ export const restaurantTemplates: Record<
         catalogHeading: "Précision, texture et équilibre.",
         featuredHeading: "Depuis la cuisine",
         featuredSubheading: "Un même langage, assiette après assiette.",
+      },
+      mt: {
+        catalogEyebrow: "Menu",
+        catalogHeading: "Preċiżjoni, tessitura u bilanċ.",
+        featuredHeading: "Mill-kċina",
+        featuredSubheading: "Lingwaġġ viżiv wieħed, platt wara platt.",
       },
     },
   },
@@ -150,6 +175,12 @@ export const restaurantTemplates: Record<
         featuredHeading: "De la mer à la table",
         featuredSubheading: "Des saveurs nettes et franches.",
       },
+      mt: {
+        catalogEyebrow: "Mill-kosta",
+        catalogHeading: "Il-qabda, imħejjija b’sempliċità.",
+        featuredHeading: "Mill-baħar għall-mejda",
+        featuredSubheading: "Togħmiet nodfa, fid-dieher.",
+      },
     },
   },
   warm: {
@@ -173,6 +204,12 @@ export const restaurantTemplates: Record<
         catalogHeading: "Fait maison. Servi au bon moment.",
         featuredHeading: "À table",
         featuredSubheading: "Les plats, tels qu’ils arrivent.",
+      },
+      mt: {
+        catalogEyebrow: "Il-menu",
+        catalogHeading: "Magħmul hawn. Servut meta jkun lest.",
+        featuredHeading: "Ħarsa lejn il-mejda",
+        featuredSubheading: "Il-platti, kif jaslu.",
       },
     },
   },

--- a/src/lib/verticals/types.ts
+++ b/src/lib/verticals/types.ts
@@ -1,6 +1,7 @@
 import type { z } from "zod";
 import type { Vertical } from "@/generated/prisma/enums";
 import type { BrandIdentity } from "@/lib/brand";
+import type { SiteUiLocale } from "@/lib/site-locales";
 
 export type VerticalId = Vertical;
 
@@ -120,7 +121,7 @@ export type VerticalTemplateDefinition = {
   brandClassName: string;
   titleClassName: string;
   sectionClassName: string;
-  copy: Record<string, VerticalTemplateCopy>;
+  copy: Record<SiteUiLocale, VerticalTemplateCopy>;
 };
 
 export type LinkClassificationHint = {
@@ -335,7 +336,7 @@ export type VerticalConfig<
   }) => TAttributes;
   /** Locale-specific vocabulary for sparse no-model imports. */
   deterministicCopy?: Record<
-    string,
+    SiteUiLocale,
     {
       eyebrow: string;
       description: string;
@@ -440,7 +441,7 @@ export type VerticalConfig<
     relevantPathPattern: RegExp;
     linkKeywordHints: LinkClassificationHint[];
   };
-  i18n: Record<string, Record<string, string>>;
+  i18n: Record<SiteUiLocale, Record<string, string>>;
   rendererCapabilities: (attributes: TAttributes) => {
     showGallery: boolean;
     /** Which existing integration becomes the conversion-first header action. */

--- a/tests/e2e/first-customer.pw.ts
+++ b/tests/e2e/first-customer.pw.ts
@@ -75,7 +75,7 @@ test("claim, paid webhook, sign-in, workspace selection, private save, atomic pu
   await expect(
     page.getByText("$53.00 local presentment for the €49 monthly plan"),
   ).toBeVisible();
-  await page.getByRole("button", { name: "Pay €43 in test mode" }).click();
+  await page.getByRole("button", { name: "Pay $53 in test mode" }).click();
 
   await expect(page).toHaveURL(/\/workspace\/select$/);
   await expect(page.getByText(e2e.targetName)).toBeVisible();

--- a/tests/e2e/first-customer.pw.ts
+++ b/tests/e2e/first-customer.pw.ts
@@ -73,7 +73,7 @@ test("claim, paid webhook, sign-in, workspace selection, private save, atomic pu
   await page.getByRole("button", { name: "Claim and continue" }).click();
   await expect(page).toHaveURL(/127\.0\.0\.1:4100\/checkout\/cs_test_/);
   await expect(
-    page.getByText("€43.00 local presentment for the $49 monthly plan"),
+    page.getByText("$53.00 local presentment for the €49 monthly plan"),
   ).toBeVisible();
   await page.getByRole("button", { name: "Pay €43 in test mode" }).click();
 

--- a/tests/e2e/support/fake-providers.ts
+++ b/tests/e2e/support/fake-providers.ts
@@ -36,7 +36,7 @@ Bun.serve({
         object: "price",
         active: true,
         livemode: false,
-        currency: "usd",
+        currency: "eur",
         unit_amount: 4_900,
         type: "recurring",
         tax_behavior: "exclusive",
@@ -70,12 +70,12 @@ Bun.serve({
         mode: "subscription",
         status: "open",
         payment_status: "unpaid",
-        currency: "usd",
+        currency: "eur",
         amount_subtotal: 4_900,
         adaptive_pricing: { enabled: true },
         presentment_details: {
-          presentment_amount: 4_300,
-          presentment_currency: "eur",
+          presentment_amount: 5_300,
+          presentment_currency: "usd",
         },
         allow_promotion_codes: false,
         automatic_tax: { enabled: true },
@@ -117,7 +117,7 @@ Bun.serve({
       const session = sessions.get(checkoutPage[1]!);
       if (!session) return new Response("Not found", { status: 404 });
       return new Response(
-        `<!doctype html><html><body><h1>Stripe test-mode founding checkout</h1><p>€43.00 local presentment for the $49 monthly plan</p><form method="post" action="/checkout/${checkoutPage[1]}/pay"><button type="submit">Pay €43 in test mode</button></form></body></html>`,
+        `<!doctype html><html><body><h1>Stripe test-mode founding checkout</h1><p>$53.00 local presentment for the €49 monthly plan</p><form method="post" action="/checkout/${checkoutPage[1]}/pay"><button type="submit">Pay $53 in test mode</button></form></body></html>`,
         { headers: { "content-type": "text/html; charset=utf-8" } },
       );
     }


### PR DESCRIPTION
## Why

Three public-factory leftovers. Maltese businesses could not be served in their
own language, the founding offer was sold in dollars to European customers, and
there was no product analytics on the funnel at all.

## Scope

**Maltese chrome.** `SITE_UI_LOCALES` is new, and every locale-keyed dictionary
in the engine is now typed against it. Adding `mt` to that union turned every
place that had to gain Maltese into a compile error, which is how the sweep
across four verticals stayed honest rather than depending on someone remembering
each file. Two `fr ? … : …` ternaries in food-retail and local-service defeated
that lever by answering "not French" with English, so they became locale tables.
`site-locales.test.ts` then asserts key-set parity against English per vertical,
catching values that are present but blank, which the compiler cannot see.

**Euro founding offer.** The Stripe contract, the marketing price, and the
checkout total were three independent USD literals. `FOUNDING_PRICE` now carries
`eur`, `FOUNDING_PRICE_SYMBOL` lives beside it because amount and symbol are one
decision, and `foundingOfferDisplay` derives both instead of hardcoding `$` and
`usd`. `scripts/verify-first-customer-production.ts` reads currency, amount, tax
behaviour, and cadence from the same constant rather than repeating hardcoded
checks. `billing-plans.test.ts` gained the currency rejection case it never had:
the validator always compared currency, but nothing proved a USD price fails
closed.

**PostHog pixel.** Off unless `NEXT_PUBLIC_POSTHOG_KEY` is set. Missing, blank,
or whitespace renders no script tag at all, and an unusable host fails closed the
same way. No key is committed, and `.env.example` carries empty placeholders.

## Tradeoffs

The pixel mounts on six named funnel surfaces instead of the root layout.
`proxy.ts` rewrites verified custom domains onto `/preview`, so the root layout
also serves customer storefronts on customers' own domains, where a third-party
script does not belong. `factory-analytics.test.ts` enumerates the instrumented
and uninstrumented lists so neither drifts.

The loader initialises in `onload` rather than pasting the vendor's minified
queueing stub. Ordering is guaranteed either way, and the readable version is
auditable in a public repository.

The article composer keeps `TemplateLanguage = "en" | "fr"` with `en` and `fr` as
named fields plus its own price and date formatting. Retyping it is a much larger
blast radius than storefront chrome, so Maltese sites fall back to English
articles through the existing `articleLanguage` default. Deliberately out of
scope for this pass.

The CAC threshold in `first-customer-validation.md` moved from `$200` to `€200`.
The number is unchanged; leaving the symbol would have printed a mixed-currency
ratio against a €49 offer.

## Blast radius

Every claim-enabled vertical's public price changes from `$49` to `€49`, and
`isValidFoundingPlan` requires the marketing literal to equal the display price,
so those move together or the claim panel renders no offer. **The live Stripe
Price must be recreated in EUR and `STRIPE_PRICE_ID` repointed before deploy** —
`validateFoundingPrice` and the deployment preflight will otherwise fail closed
against the existing USD Price, which is the intended behaviour, not a
regression. No Stripe secret is in this diff.

Maltese is additive. `localeSchema` is open BCP 47 and already accepted `mt`;
`pickLocaleEntry` still degrades unshipped locales to English.

## Verification

`bun run lint` clean. `bunx tsc --noEmit` clean apart from the pre-existing
`RouteContext` errors that need a build to generate. `bun test`: 1396 tests
across 184 files, 1272 pass, 0 fail.

The pixel's no-op was proven by rendering the component rather than inferred from
the branch: key unset and key empty both produce an empty string, and a key set
produces the loader with the EU asset host.