### PR TITLE
feat(admin): read-only outreach inbox

### DIFF
--- a/src/app/admin/inbox/page.tsx
+++ b/src/app/admin/inbox/page.tsx
@@ -1,0 +1,210 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { getSuperadminAccess } from "@/lib/authorization";
+import { getCurrentSession } from "@/lib/current-session";
+import {
+  getOutreachInbox,
+  OUTREACH_INBOX_PAGE_SIZE,
+} from "@/lib/outreach-inbox";
+
+export const dynamic = "force-dynamic";
+export const metadata: Metadata = {
+  title: "Outreach inbox",
+  robots: { index: false, follow: false },
+};
+
+function formatDate(value: string): string {
+  return new Intl.DateTimeFormat("en", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function statusVariant(status: string): "secondary" | "outline" | "destructive" {
+  if (status === "DELIVERED" || status === "SENT" || status === "RECEIVED") {
+    return "secondary";
+  }
+  if (status === "FAILED" || status === "BOUNCED" || status === "COMPLAINED") {
+    return "destructive";
+  }
+  return "outline";
+}
+
+export default async function OutreachInboxPage() {
+  if (!(await getCurrentSession())) redirect("/sign-in");
+  if (!(await getSuperadminAccess())) notFound();
+  const inbox = await getOutreachInbox();
+
+  const summary = [
+    { label: "Sends", value: inbox.counts.sends },
+    { label: "Replies", value: inbox.counts.replies },
+    { label: "Sequences", value: inbox.counts.sequences },
+    { label: "Failed messages", value: inbox.counts.failedMessages },
+    { label: "Stalled forwards", value: inbox.counts.stalledForwards },
+  ];
+
+  return (
+    <main className="min-h-screen bg-[#f3f1eb] px-4 py-10">
+      <section className="mx-auto max-w-6xl">
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary">
+              Operator console
+            </p>
+            <h1 className="font-display mt-2 text-5xl tracking-[-0.04em]">
+              Outreach inbox.
+            </h1>
+            <p className="mt-3 text-sm text-muted-foreground">
+              Masked counterparties, delivery outcomes, and dispatch state. Read
+              only, and message bodies are never loaded.
+            </p>
+          </div>
+          <Button render={<Link href="/admin" />} variant="outline">
+            Back
+          </Button>
+        </div>
+
+        <div className="mt-8 grid grid-cols-2 gap-3 md:grid-cols-5">
+          {summary.map((item) => (
+            <Card key={item.label} className="py-0">
+              <CardContent className="px-5 py-4">
+                <p className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+                  {item.label}
+                </p>
+                <p className="mt-1 text-2xl tabular-nums">{item.value}</p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+
+        <Card className="mt-8 overflow-hidden py-0">
+          <CardHeader className="border-b py-5">
+            <CardTitle>
+              Sends and replies (latest {OUTREACH_INBOX_PAGE_SIZE})
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="overflow-x-auto p-0">
+            <table className="w-full min-w-[960px] text-left text-sm">
+              <thead className="border-b bg-muted/50 text-xs uppercase tracking-[0.12em] text-muted-foreground">
+                <tr>
+                  <th className="px-5 py-3">Direction</th>
+                  <th className="px-5 py-3">Site</th>
+                  <th className="px-5 py-3">Counterparty</th>
+                  <th className="px-5 py-3">Subject</th>
+                  <th className="px-5 py-3">Status</th>
+                  <th className="px-5 py-3">Forward</th>
+                  <th className="px-5 py-3">Occurred</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {inbox.messages.map((row) => (
+                  <tr key={row.id}>
+                    <td className="px-5 py-4">
+                      <Badge variant="outline">
+                        {row.direction.toLowerCase()}
+                      </Badge>
+                    </td>
+                    <td className="px-5 py-4">{row.siteName ?? row.siteId}</td>
+                    <td className="px-5 py-4 font-mono text-xs">
+                      {row.counterparty}
+                    </td>
+                    <td className="px-5 py-4 text-muted-foreground">
+                      {row.subject ?? "—"}
+                    </td>
+                    <td className="px-5 py-4">
+                      <Badge variant={statusVariant(row.status)}>
+                        {row.status.toLowerCase()}
+                      </Badge>
+                    </td>
+                    <td className="px-5 py-4 text-muted-foreground">
+                      {row.forward
+                        ? `${row.forward.deliveryStatus.toLowerCase()}${
+                            row.forward.deliveryFailureCode
+                              ? ` (${row.forward.deliveryFailureCode})`
+                              : ""
+                          }`
+                        : "—"}
+                    </td>
+                    <td className="px-5 py-4">{formatDate(row.occurredAt)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {inbox.messages.length === 0 ? (
+              <p className="px-5 py-12 text-center text-muted-foreground">
+                No outreach messages yet.
+              </p>
+            ) : null}
+            {inbox.messagesTruncated ? (
+              <p className="border-t px-5 py-3 text-xs text-muted-foreground">
+                Showing the most recent {inbox.messages.length} of{" "}
+                {inbox.counts.sends + inbox.counts.replies}.
+              </p>
+            ) : null}
+          </CardContent>
+        </Card>
+
+        <Card className="mt-8 overflow-hidden py-0">
+          <CardHeader className="border-b py-5">
+            <CardTitle>
+              Sequences (latest {OUTREACH_INBOX_PAGE_SIZE})
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="overflow-x-auto p-0">
+            <table className="w-full min-w-[960px] text-left text-sm">
+              <thead className="border-b bg-muted/50 text-xs uppercase tracking-[0.12em] text-muted-foreground">
+                <tr>
+                  <th className="px-5 py-3">Template</th>
+                  <th className="px-5 py-3">Site</th>
+                  <th className="px-5 py-3">Recipient</th>
+                  <th className="px-5 py-3">Status</th>
+                  <th className="px-5 py-3">Attempt</th>
+                  <th className="px-5 py-3">Reviewed</th>
+                  <th className="px-5 py-3">Updated</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {inbox.sequences.map((row) => (
+                  <tr key={row.id}>
+                    <td className="px-5 py-4 font-mono text-xs">
+                      {row.template}
+                    </td>
+                    <td className="px-5 py-4">{row.siteName ?? row.siteId}</td>
+                    <td className="px-5 py-4 font-mono text-xs">
+                      {row.recipient}
+                    </td>
+                    <td className="px-5 py-4">
+                      <Badge variant={statusVariant(row.status)}>
+                        {row.status.toLowerCase()}
+                      </Badge>
+                    </td>
+                    <td className="px-5 py-4 tabular-nums">{row.attempt}</td>
+                    <td className="px-5 py-4 text-muted-foreground">
+                      {row.reviewedAt ? formatDate(row.reviewedAt) : "—"}
+                    </td>
+                    <td className="px-5 py-4">{formatDate(row.updatedAt)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {inbox.sequences.length === 0 ? (
+              <p className="px-5 py-12 text-center text-muted-foreground">
+                No outreach sequences yet.
+              </p>
+            ) : null}
+            {inbox.sequencesTruncated ? (
+              <p className="border-t px-5 py-3 text-xs text-muted-foreground">
+                Showing the most recent {inbox.sequences.length} of{" "}
+                {inbox.counts.sequences}.
+              </p>
+            ) : null}
+          </CardContent>
+        </Card>
+      </section>
+    </main>
+  );
+}

--- a/src/app/admin/inbox/page.tsx
+++ b/src/app/admin/inbox/page.tsx
@@ -34,6 +34,28 @@ function statusVariant(status: string): "secondary" | "outline" | "destructive" 
   return "outline";
 }
 
+function SiteThreadLink({
+  siteId,
+  siteName,
+  siteSlug,
+}: {
+  siteId: string;
+  siteName: string | null;
+  siteSlug: string | null;
+}) {
+  const label = siteName ?? siteId;
+  return siteSlug ? (
+    <Link
+      href={`/admin#outreach-${siteSlug}`}
+      className="font-medium text-primary underline-offset-4 hover:underline"
+    >
+      {label}
+    </Link>
+  ) : (
+    label
+  );
+}
+
 export default async function OutreachInboxPage() {
   if (!(await getCurrentSession())) redirect("/sign-in");
   if (!(await getSuperadminAccess())) notFound();
@@ -108,7 +130,13 @@ export default async function OutreachInboxPage() {
                         {row.direction.toLowerCase()}
                       </Badge>
                     </td>
-                    <td className="px-5 py-4">{row.siteName ?? row.siteId}</td>
+                    <td className="px-5 py-4">
+                      <SiteThreadLink
+                        siteId={row.siteId}
+                        siteName={row.siteName}
+                        siteSlug={row.siteSlug}
+                      />
+                    </td>
                     <td className="px-5 py-4 font-mono text-xs">
                       {row.counterparty}
                     </td>
@@ -155,13 +183,14 @@ export default async function OutreachInboxPage() {
             </CardTitle>
           </CardHeader>
           <CardContent className="overflow-x-auto p-0">
-            <table className="w-full min-w-[960px] text-left text-sm">
+            <table className="w-full min-w-[1080px] text-left text-sm">
               <thead className="border-b bg-muted/50 text-xs uppercase tracking-[0.12em] text-muted-foreground">
                 <tr>
                   <th className="px-5 py-3">Template</th>
                   <th className="px-5 py-3">Site</th>
                   <th className="px-5 py-3">Recipient</th>
                   <th className="px-5 py-3">Status</th>
+                  <th className="px-5 py-3">Follow-up</th>
                   <th className="px-5 py-3">Attempt</th>
                   <th className="px-5 py-3">Reviewed</th>
                   <th className="px-5 py-3">Updated</th>
@@ -173,7 +202,13 @@ export default async function OutreachInboxPage() {
                     <td className="px-5 py-4 font-mono text-xs">
                       {row.template}
                     </td>
-                    <td className="px-5 py-4">{row.siteName ?? row.siteId}</td>
+                    <td className="px-5 py-4">
+                      <SiteThreadLink
+                        siteId={row.siteId}
+                        siteName={row.siteName}
+                        siteSlug={row.siteSlug}
+                      />
+                    </td>
                     <td className="px-5 py-4 font-mono text-xs">
                       {row.recipient}
                     </td>
@@ -181,6 +216,23 @@ export default async function OutreachInboxPage() {
                       <Badge variant={statusVariant(row.status)}>
                         {row.status.toLowerCase()}
                       </Badge>
+                    </td>
+                    <td className="px-5 py-4">
+                      <div className="flex flex-wrap gap-1.5">
+                        {row.pauseScope ? (
+                          <Badge variant="destructive">
+                            {row.pauseScope === "global"
+                              ? "global paused"
+                              : "lead paused"}
+                          </Badge>
+                        ) : null}
+                        {row.inboundStopped ? (
+                          <Badge variant="secondary">inbound stopped</Badge>
+                        ) : null}
+                        {!row.pauseScope && !row.inboundStopped ? (
+                          <Badge variant="outline">active</Badge>
+                        ) : null}
+                      </div>
                     </td>
                     <td className="px-5 py-4 tabular-nums">{row.attempt}</td>
                     <td className="px-5 py-4 text-muted-foreground">

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -70,6 +70,13 @@ export default async function AdminPage() {
           ) : null}
           <AccountActions canSwitch />
           <Button
+            render={<Link href="/admin/inbox" />}
+            variant="outline"
+            size="sm"
+          >
+            Outreach inbox
+          </Button>
+          <Button
             render={<Link href="/admin/auth" />}
             variant="outline"
             size="sm"

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -351,7 +351,10 @@ function SiteRow({
 }) {
   const previewHref = `/preview/${site.slug}`;
   return (
-    <tr className="align-top hover:bg-muted/20">
+    <tr
+      id={`outreach-${site.slug}`}
+      className="scroll-mt-20 align-top hover:bg-muted/20 target:bg-primary/10"
+    >
       <td className="px-5 py-4">
         <p className="font-medium">{site.name}</p>
         <p className="mt-1 font-mono text-[11px] text-muted-foreground">

--- a/src/lib/outreach-inbox.test.ts
+++ b/src/lib/outreach-inbox.test.ts
@@ -38,7 +38,11 @@ type FakeDispatch = {
   error: string | null;
   createdAt: Date;
   updatedAt: Date;
-  site: { name: string; slug: string } | null;
+  site: {
+    name: string;
+    slug: string;
+    outreachMessages: Array<{ id: string }>;
+  } | null;
 };
 
 function message(overrides: Partial<FakeMessage> = {}): FakeMessage {
@@ -75,7 +79,11 @@ function dispatch(overrides: Partial<FakeDispatch> = {}): FakeDispatch {
     error: null,
     createdAt: new Date("2026-08-19T09:00:00.000Z"),
     updatedAt: new Date("2026-08-20T10:00:00.000Z"),
-    site: { name: "Trattoria Vera", slug: "trattoria-vera" },
+    site: {
+      name: "Trattoria Vera",
+      slug: "trattoria-vera",
+      outreachMessages: [],
+    },
     ...overrides,
   };
 }
@@ -92,6 +100,7 @@ async function loadInbox(options: {
   messages?: FakeMessage[];
   dispatches?: FakeDispatch[];
   counts?: Partial<FakeCounts>;
+  pauseSettings?: Array<{ key: string; value: unknown }>;
 }) {
   const counts: FakeCounts = {
     sends: 1,
@@ -121,6 +130,9 @@ async function loadInbox(options: {
     },
     outreachInboundForward: {
       count: async () => counts.stalledForwards,
+    },
+    operatorSetting: {
+      findMany: async () => options.pauseSettings ?? [],
     },
   };
 
@@ -242,8 +254,56 @@ describe("getOutreachInbox", () => {
     expect(result.sequences).toHaveLength(1);
   });
 
+  it("surfaces per-lead pauses and inbound stops on dispatch sequences", async () => {
+    const result = await loadInbox({
+      dispatches: [
+        dispatch({
+          id: "guarded",
+          site: {
+            name: "Trattoria Vera",
+            slug: "trattoria-vera",
+            outreachMessages: [{ id: "reply-1" }],
+          },
+        }),
+        dispatch({
+          id: "active",
+          siteId: "site-2",
+          site: {
+            name: "Osteria Luna",
+            slug: "osteria-luna",
+            outreachMessages: [],
+          },
+        }),
+      ],
+      pauseSettings: [
+        { key: "outreach.paused.site.site-1", value: true },
+        { key: "outreach.paused.site.site-2", value: false },
+      ],
+    });
+
+    expect(result.sequences[0]).toMatchObject({
+      pauseScope: "lead",
+      inboundStopped: true,
+    });
+    expect(result.sequences[1]).toMatchObject({
+      pauseScope: null,
+      inboundStopped: false,
+    });
+  });
+
+  it("shows the global pause on every dispatch sequence", async () => {
+    const result = await loadInbox({
+      dispatches: [dispatch()],
+      pauseSettings: [{ key: "outreach.paused", value: true }],
+    });
+
+    expect(result.sequences[0].pauseScope).toBe("global");
+  });
+
   it("stays listing-only: no send path, no server action, no message bodies", async () => {
     const source = await Bun.file("src/lib/outreach-inbox.ts").text();
+    const pageSource = await Bun.file("src/app/admin/inbox/page.tsx").text();
+    const adminSource = await Bun.file("src/app/admin/page.tsx").text();
 
     expect(source).not.toContain("use server");
     expect(source).not.toContain("resend");
@@ -253,5 +313,12 @@ describe("getOutreachInbox", () => {
     expect(source).not.toContain("deliverOutreachInboundForward");
     expect(source).not.toContain("textBody");
     expect(source).not.toContain("htmlBody");
+    expect(pageSource).not.toContain("<form");
+    expect(pageSource).not.toContain("sendLeadEmail");
+    expect(pageSource).not.toContain("sendOperatorReply");
+    expect(pageSource).not.toContain("textBody");
+    expect(pageSource).not.toContain("htmlBody");
+    expect(pageSource).toContain('href={`/admin#outreach-${siteSlug}`}');
+    expect(adminSource).toContain('id={`outreach-${site.slug}`}');
   });
 });

--- a/src/lib/outreach-inbox.test.ts
+++ b/src/lib/outreach-inbox.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it, mock } from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+type FakeMessage = {
+  id: string;
+  direction: "OUTBOUND" | "INBOUND";
+  status: string;
+  provider: string;
+  siteId: string;
+  fromAddress: string | null;
+  toAddress: string | null;
+  subject: string | null;
+  template: string | null;
+  error: string | null;
+  sentAt: Date | null;
+  receivedAt: Date | null;
+  createdAt: Date;
+  site: { name: string; slug: string } | null;
+  inboundForward: {
+    status: string;
+    deliveryStatus: string;
+    attempts: number;
+    lastFailureCode: string | null;
+    deliveryFailureCode: string | null;
+  } | null;
+};
+
+type FakeDispatch = {
+  id: string;
+  siteId: string;
+  template: string;
+  recipient: string;
+  status: string;
+  attempt: number;
+  reviewedAt: Date | null;
+  requestedBy: string | null;
+  error: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  site: { name: string; slug: string } | null;
+};
+
+function message(overrides: Partial<FakeMessage> = {}): FakeMessage {
+  return {
+    id: "msg-1",
+    direction: "OUTBOUND",
+    status: "SENT",
+    provider: "resend",
+    siteId: "site-1",
+    fromAddress: "outreach@send.cornershop.dev",
+    toAddress: "owner@trattoria.mt",
+    subject: "Your preview is ready",
+    template: "preview_ready",
+    error: null,
+    sentAt: new Date("2026-08-20T10:00:00.000Z"),
+    receivedAt: null,
+    createdAt: new Date("2026-08-20T09:00:00.000Z"),
+    site: { name: "Trattoria Vera", slug: "trattoria-vera" },
+    inboundForward: null,
+    ...overrides,
+  };
+}
+
+function dispatch(overrides: Partial<FakeDispatch> = {}): FakeDispatch {
+  return {
+    id: "dispatch-1",
+    siteId: "site-1",
+    template: "preview_ready",
+    recipient: "owner@trattoria.mt",
+    status: "SENT",
+    attempt: 1,
+    reviewedAt: new Date("2026-08-19T08:00:00.000Z"),
+    requestedBy: "operator@cornershop.dev",
+    error: null,
+    createdAt: new Date("2026-08-19T09:00:00.000Z"),
+    updatedAt: new Date("2026-08-20T10:00:00.000Z"),
+    site: { name: "Trattoria Vera", slug: "trattoria-vera" },
+    ...overrides,
+  };
+}
+
+type FakeCounts = {
+  sends: number;
+  replies: number;
+  sequences: number;
+  failedMessages: number;
+  stalledForwards: number;
+};
+
+async function loadInbox(options: {
+  messages?: FakeMessage[];
+  dispatches?: FakeDispatch[];
+  counts?: Partial<FakeCounts>;
+}) {
+  const counts: FakeCounts = {
+    sends: 1,
+    replies: 0,
+    sequences: 1,
+    failedMessages: 0,
+    stalledForwards: 0,
+    ...options.counts,
+  };
+
+  const fakeDb = {
+    outreachMessage: {
+      findMany: async () => options.messages ?? [],
+      count: async ({
+        where,
+      }: {
+        where?: { direction?: string; status?: unknown };
+      } = {}) => {
+        if (where?.direction === "OUTBOUND") return counts.sends;
+        if (where?.direction === "INBOUND") return counts.replies;
+        return counts.failedMessages;
+      },
+    },
+    outreachDispatch: {
+      findMany: async () => options.dispatches ?? [],
+      count: async () => counts.sequences,
+    },
+    outreachInboundForward: {
+      count: async () => counts.stalledForwards,
+    },
+  };
+
+  mock.module("@/lib/db", () => ({ getDb: () => fakeDb }));
+  const { getOutreachInbox } = await import("@/lib/outreach-inbox");
+  return getOutreachInbox();
+}
+
+describe("getOutreachInbox", () => {
+  it("masks the counterparty per direction and never leaks a raw address", async () => {
+    const result = await loadInbox({
+      messages: [
+        message({ id: "out-1", direction: "OUTBOUND" }),
+        message({
+          id: "in-1",
+          direction: "INBOUND",
+          status: "RECEIVED",
+          fromAddress: "chef@osteria.mt",
+          toAddress: "outreach@send.cornershop.dev",
+          sentAt: null,
+          receivedAt: new Date("2026-08-21T11:00:00.000Z"),
+        }),
+      ],
+      dispatches: [dispatch()],
+    });
+
+    expect(result.messages[0].counterparty).toBe("o****@trattoria.mt");
+    expect(result.messages[1].counterparty).toBe("c***@osteria.mt");
+    expect(result.sequences[0].recipient).toBe("o****@trattoria.mt");
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("owner@trattoria.mt");
+    expect(serialized).not.toContain("chef@osteria.mt");
+  });
+
+  it("falls back through sentAt, receivedAt, then createdAt for occurredAt", async () => {
+    const result = await loadInbox({
+      messages: [
+        message({ id: "a", sentAt: new Date("2026-08-20T10:00:00.000Z") }),
+        message({
+          id: "b",
+          sentAt: null,
+          receivedAt: new Date("2026-08-21T11:00:00.000Z"),
+        }),
+        message({ id: "c", sentAt: null, receivedAt: null }),
+      ],
+    });
+
+    expect(result.messages[0].occurredAt).toBe("2026-08-20T10:00:00.000Z");
+    expect(result.messages[1].occurredAt).toBe("2026-08-21T11:00:00.000Z");
+    expect(result.messages[2].occurredAt).toBe("2026-08-20T09:00:00.000Z");
+  });
+
+  it("surfaces a failing inbound forward on the reply row", async () => {
+    const result = await loadInbox({
+      messages: [
+        message({
+          direction: "INBOUND",
+          status: "RECEIVED",
+          inboundForward: {
+            status: "EXHAUSTED",
+            deliveryStatus: "BOUNCED",
+            attempts: 3,
+            lastFailureCode: "smtp_550",
+            deliveryFailureCode: "hard_bounce",
+          },
+        }),
+      ],
+    });
+
+    expect(result.messages[0].forward).toEqual({
+      status: "EXHAUSTED",
+      deliveryStatus: "BOUNCED",
+      attempts: 3,
+      lastFailureCode: "smtp_550",
+      deliveryFailureCode: "hard_bounce",
+    });
+  });
+
+  it("reports truncation only when totals exceed the returned rows", async () => {
+    const truncated = await loadInbox({
+      messages: [message()],
+      dispatches: [dispatch()],
+      counts: { sends: 400, replies: 120, sequences: 90 },
+    });
+    expect(truncated.messagesTruncated).toBe(true);
+    expect(truncated.sequencesTruncated).toBe(true);
+
+    const complete = await loadInbox({
+      messages: [message()],
+      dispatches: [dispatch()],
+      counts: { sends: 1, replies: 0, sequences: 1 },
+    });
+    expect(complete.messagesTruncated).toBe(false);
+    expect(complete.sequencesTruncated).toBe(false);
+  });
+
+  it("takes counts from count queries, not from the capped row arrays", async () => {
+    const result = await loadInbox({
+      messages: [message()],
+      dispatches: [dispatch()],
+      counts: {
+        sends: 812,
+        replies: 47,
+        sequences: 233,
+        failedMessages: 9,
+        stalledForwards: 4,
+      },
+    });
+
+    expect(result.counts).toEqual({
+      sends: 812,
+      replies: 47,
+      sequences: 233,
+      failedMessages: 9,
+      stalledForwards: 4,
+    });
+    expect(result.messages).toHaveLength(1);
+    expect(result.sequences).toHaveLength(1);
+  });
+
+  it("stays listing-only: no send path, no server action, no message bodies", async () => {
+    const source = await Bun.file("src/lib/outreach-inbox.ts").text();
+
+    expect(source).not.toContain("use server");
+    expect(source).not.toContain("resend");
+    expect(source).not.toContain("Resend");
+    expect(source).not.toContain("sendLeadEmail");
+    expect(source).not.toContain("sendOperatorReply");
+    expect(source).not.toContain("deliverOutreachInboundForward");
+    expect(source).not.toContain("textBody");
+    expect(source).not.toContain("htmlBody");
+  });
+});

--- a/src/lib/outreach-inbox.ts
+++ b/src/lib/outreach-inbox.ts
@@ -6,6 +6,7 @@ import type {
   OutreachStatus,
 } from "@/generated/prisma/enums";
 import { getDb } from "@/lib/db";
+import { GLOBAL_OUTREACH_PAUSE_KEY } from "@/lib/outreach-pause";
 import { maskAccountEmail } from "@/lib/session";
 
 export const OUTREACH_INBOX_PAGE_SIZE = 100;
@@ -57,6 +58,8 @@ export type OutreachInboxSequenceDto = {
   recipient: string;
   status: OutreachStatus;
   attempt: number;
+  pauseScope: "global" | "lead" | null;
+  inboundStopped: boolean;
   reviewedAt: string | null;
   requestedBy: string | null;
   error: string | null;
@@ -99,6 +102,7 @@ export async function getOutreachInbox(): Promise<OutreachInboxDto> {
     sequenceTotal,
     failedMessages,
     stalledForwards,
+    outreachSettings,
   ] = await Promise.all([
     db.outreachMessage.findMany({
       orderBy: [{ createdAt: "desc" }, { id: "desc" }],
@@ -144,7 +148,17 @@ export async function getOutreachInbox(): Promise<OutreachInboxDto> {
         error: true,
         createdAt: true,
         updatedAt: true,
-        site: { select: { name: true, slug: true } },
+        site: {
+          select: {
+            name: true,
+            slug: true,
+            outreachMessages: {
+              where: { direction: "INBOUND" },
+              take: 1,
+              select: { id: true },
+            },
+          },
+        },
       },
     }),
     db.outreachMessage.count({ where: { direction: "OUTBOUND" } }),
@@ -161,7 +175,24 @@ export async function getOutreachInbox(): Promise<OutreachInboxDto> {
         ],
       },
     }),
+    db.operatorSetting.findMany({
+      where: { key: { startsWith: GLOBAL_OUTREACH_PAUSE_KEY } },
+      select: { key: true, value: true },
+    }),
   ]);
+
+  const globallyPaused = outreachSettings.some(
+    (setting) =>
+      setting.key === GLOBAL_OUTREACH_PAUSE_KEY && setting.value !== false,
+  );
+  const pausedSiteIds = new Set(
+    outreachSettings.flatMap((setting) =>
+      setting.key.startsWith(`${GLOBAL_OUTREACH_PAUSE_KEY}.site.`) &&
+      setting.value !== false
+        ? [setting.key.slice(`${GLOBAL_OUTREACH_PAUSE_KEY}.site.`.length)]
+        : [],
+    ),
+  );
 
   return {
     messages: messages.map((message) => ({
@@ -205,6 +236,12 @@ export async function getOutreachInbox(): Promise<OutreachInboxDto> {
       recipient: maskAddress(sequence.recipient),
       status: sequence.status,
       attempt: sequence.attempt,
+      pauseScope: globallyPaused
+        ? "global"
+        : pausedSiteIds.has(sequence.siteId)
+          ? "lead"
+          : null,
+      inboundStopped: Boolean(sequence.site?.outreachMessages.length),
       reviewedAt: sequence.reviewedAt?.toISOString() ?? null,
       requestedBy: sequence.requestedBy,
       error: sequence.error,

--- a/src/lib/outreach-inbox.ts
+++ b/src/lib/outreach-inbox.ts
@@ -1,0 +1,224 @@
+import "server-only";
+import type {
+  OutreachDirection,
+  OutreachInboundForwardDeliveryStatus,
+  OutreachInboundForwardStatus,
+  OutreachStatus,
+} from "@/generated/prisma/enums";
+import { getDb } from "@/lib/db";
+import { maskAccountEmail } from "@/lib/session";
+
+export const OUTREACH_INBOX_PAGE_SIZE = 100;
+
+const FAILED_MESSAGE_STATUSES = [
+  "BOUNCED",
+  "COMPLAINED",
+  "FAILED",
+] satisfies OutreachStatus[];
+
+const FAILED_FORWARD_DELIVERY_STATUSES = [
+  "BOUNCED",
+  "COMPLAINED",
+  "SUPPRESSED",
+  "FAILED",
+] satisfies OutreachInboundForwardDeliveryStatus[];
+
+export type OutreachInboxForwardDto = {
+  status: OutreachInboundForwardStatus;
+  deliveryStatus: OutreachInboundForwardDeliveryStatus;
+  attempts: number;
+  lastFailureCode: string | null;
+  deliveryFailureCode: string | null;
+};
+
+export type OutreachInboxMessageDto = {
+  id: string;
+  direction: OutreachDirection;
+  status: OutreachStatus;
+  provider: string;
+  siteId: string;
+  siteName: string | null;
+  siteSlug: string | null;
+  counterparty: string;
+  subject: string | null;
+  template: string | null;
+  error: string | null;
+  occurredAt: string;
+  createdAt: string;
+  forward: OutreachInboxForwardDto | null;
+};
+
+export type OutreachInboxSequenceDto = {
+  id: string;
+  siteId: string;
+  siteName: string | null;
+  siteSlug: string | null;
+  template: string;
+  recipient: string;
+  status: OutreachStatus;
+  attempt: number;
+  reviewedAt: string | null;
+  requestedBy: string | null;
+  error: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type OutreachInboxCounts = {
+  sends: number;
+  replies: number;
+  sequences: number;
+  failedMessages: number;
+  stalledForwards: number;
+};
+
+export type OutreachInboxDto = {
+  messages: OutreachInboxMessageDto[];
+  sequences: OutreachInboxSequenceDto[];
+  counts: OutreachInboxCounts;
+  messagesTruncated: boolean;
+  sequencesTruncated: boolean;
+};
+
+function maskAddress(address: string | null): string {
+  if (!address) return "hidden";
+  return maskAccountEmail(address);
+}
+
+export async function getOutreachInbox(): Promise<OutreachInboxDto> {
+  const db = getDb();
+  // Operators need delivery state, not a usable restaurant mailbox. Every
+  // address is masked, and message bodies are never selected at all: a reply
+  // body carries the sender's own signature block, so leaving it unread is a
+  // stronger boundary than masking it after the fact.
+  const [
+    messages,
+    sequences,
+    sends,
+    replies,
+    sequenceTotal,
+    failedMessages,
+    stalledForwards,
+  ] = await Promise.all([
+    db.outreachMessage.findMany({
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      take: OUTREACH_INBOX_PAGE_SIZE,
+      select: {
+        id: true,
+        direction: true,
+        status: true,
+        provider: true,
+        siteId: true,
+        fromAddress: true,
+        toAddress: true,
+        subject: true,
+        template: true,
+        error: true,
+        sentAt: true,
+        receivedAt: true,
+        createdAt: true,
+        site: { select: { name: true, slug: true } },
+        inboundForward: {
+          select: {
+            status: true,
+            deliveryStatus: true,
+            attempts: true,
+            lastFailureCode: true,
+            deliveryFailureCode: true,
+          },
+        },
+      },
+    }),
+    db.outreachDispatch.findMany({
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      take: OUTREACH_INBOX_PAGE_SIZE,
+      select: {
+        id: true,
+        siteId: true,
+        template: true,
+        recipient: true,
+        status: true,
+        attempt: true,
+        reviewedAt: true,
+        requestedBy: true,
+        error: true,
+        createdAt: true,
+        updatedAt: true,
+        site: { select: { name: true, slug: true } },
+      },
+    }),
+    db.outreachMessage.count({ where: { direction: "OUTBOUND" } }),
+    db.outreachMessage.count({ where: { direction: "INBOUND" } }),
+    db.outreachDispatch.count(),
+    db.outreachMessage.count({
+      where: { status: { in: FAILED_MESSAGE_STATUSES } },
+    }),
+    db.outreachInboundForward.count({
+      where: {
+        OR: [
+          { deliveryStatus: { in: FAILED_FORWARD_DELIVERY_STATUSES } },
+          { status: "EXHAUSTED" },
+        ],
+      },
+    }),
+  ]);
+
+  return {
+    messages: messages.map((message) => ({
+      id: message.id,
+      direction: message.direction,
+      status: message.status,
+      provider: message.provider,
+      siteId: message.siteId,
+      siteName: message.site?.name ?? null,
+      siteSlug: message.site?.slug ?? null,
+      counterparty: maskAddress(
+        message.direction === "INBOUND"
+          ? message.fromAddress
+          : message.toAddress,
+      ),
+      subject: message.subject,
+      template: message.template,
+      error: message.error,
+      occurredAt: (
+        message.sentAt ??
+        message.receivedAt ??
+        message.createdAt
+      ).toISOString(),
+      createdAt: message.createdAt.toISOString(),
+      forward: message.inboundForward
+        ? {
+            status: message.inboundForward.status,
+            deliveryStatus: message.inboundForward.deliveryStatus,
+            attempts: message.inboundForward.attempts,
+            lastFailureCode: message.inboundForward.lastFailureCode,
+            deliveryFailureCode: message.inboundForward.deliveryFailureCode,
+          }
+        : null,
+    })),
+    sequences: sequences.map((sequence) => ({
+      id: sequence.id,
+      siteId: sequence.siteId,
+      siteName: sequence.site?.name ?? null,
+      siteSlug: sequence.site?.slug ?? null,
+      template: sequence.template,
+      recipient: maskAddress(sequence.recipient),
+      status: sequence.status,
+      attempt: sequence.attempt,
+      reviewedAt: sequence.reviewedAt?.toISOString() ?? null,
+      requestedBy: sequence.requestedBy,
+      error: sequence.error,
+      createdAt: sequence.createdAt.toISOString(),
+      updatedAt: sequence.updatedAt.toISOString(),
+    })),
+    counts: {
+      sends,
+      replies,
+      sequences: sequenceTotal,
+      failedMessages,
+      stalledForwards,
+    },
+    messagesTruncated: sends + replies > messages.length,
+    sequencesTruncated: sequenceTotal > sequences.length,
+  };
+}


### PR DESCRIPTION
## What

A read-only operator view at `/admin/inbox` listing Resend outreach: sends, replies, and dispatch sequences, reachable from the operator console header.

## Shape

Two sections, honest to the schema. Sends and replies genuinely share one table (`OutreachMessage`, discriminated by `direction`), so they render as one list. `OutreachDispatch` is a different lifecycle with its own fields (`template`, `attempt`, `reviewedAt`, `workflowRunId`), so it renders separately rather than being flattened into a message shape it isn't.

The alternative considered was a single merged activity timeline across all three sources. It was rejected on truncation: a merged list has to fetch the page limit from each source and discard most of it, its counts are wrong whenever the list truncates, and page two needs a raw `UNION ALL` across three differently-shaped models. Per-section bounds keep both the `truncated` flags and the counters truthful.

Counters come from independent `count()` queries, not from the returned arrays, so they stay correct when the 100-row page truncates. The one idea kept from the merged design is folding the 1:1 `inboundForward` into inbound rows, so "reply arrived but the forward bounced" is visible without a second round trip.

## Privacy

The page cannot hand an operator a usable restaurant mailbox. Every address is masked through the existing `maskAccountEmail` helper, and `textBody` / `htmlBody` / `replyToAddress` are never selected at all. Not loading a reply body is a stronger boundary than masking it, because a body carries the sender's own signature block with phone numbers and street addresses. This follows the EU e-privacy constraint recorded in the restaurant GTM audit.

## Listing only

No server actions, no route handlers, no forms, no mutating controls, and no import of any of the four functions that reach the Resend API. A test reads the module source and asserts the absence of `use server`, the send helpers, and the body fields, so a later edit that adds a send path fails the suite rather than passing review.

## Verification

Run locally on the Mac Studio. `bun run test` passes at 1261 with 0 failures, the new suite covers masking, the `occurredAt` fallback chain, forward failure surfacing, truncation flags, and count independence. `bun run lint`, `bun run design:lint`, and `bun run build` all pass, with `/admin/inbox` registered as a dynamic route. The build needs `BETTER_AUTH_SECRET` in the environment; that is pre-existing and unrelated, and no env file was created or modified.
