### PR TITLE
fix(outreach): stop inbound mail from consuming send quota

### DIFF
--- a/src/app/api/webhooks/resend/inbound/route.ts
+++ b/src/app/api/webhooks/resend/inbound/route.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { captureOperatorAlert } from "@/lib/operator-alerts";
 import { recordInboundOutreachMessage } from "@/lib/outreach-inbound";
 import { verifyResendWebhook } from "@/lib/resend-webhook";
 
@@ -24,13 +23,8 @@ export async function POST(request: Request) {
   const verified = verifyResendWebhook(request, rawBody, secret);
   if (!verified.ok) {
     if (verified.error === "Resend webhook is not configured") {
-      await captureOperatorAlert({
-        kind: "OUTREACH_SEND_FAILURE",
-        dedupKey: "inbound-webhook-configuration",
-        title: "Resend inbound webhook configuration is missing",
-        message:
-          "An inbound Resend webhook reached the application without its configured signing secret. Restore RESEND_INBOUND_WEBHOOK_SECRET and redeploy.",
-        context: { category: "configuration" },
+      console.error("[resend-inbound-webhook] configuration missing", {
+        failure: "signing_secret_missing",
       });
     }
     return Response.json({ error: verified.error }, { status: verified.status });
@@ -46,13 +40,8 @@ export async function POST(request: Request) {
   }
 
   if (!process.env.DATABASE_URL) {
-    await captureOperatorAlert({
-      kind: "OUTREACH_SEND_FAILURE",
-      dedupKey: "inbound-webhook-persistence",
-      title: "Resend inbound webhook persistence is unavailable",
-      message:
-        "A signed inbound webhook could not reach PostgreSQL. Resend will retry; restore database availability before replaying events.",
-      context: { category: "database" },
+    console.error("[resend-inbound-webhook] persistence unavailable", {
+      failure: "database_unavailable",
     });
     return Response.json(
       { error: "Webhook persistence is unavailable" },
@@ -89,14 +78,6 @@ export async function POST(request: Request) {
     console.error("[resend-inbound-webhook] processing failed", {
       emailId: event.data.email_id,
       failure: "processing_failed",
-    });
-    await captureOperatorAlert({
-      kind: "OUTREACH_SEND_FAILURE",
-      dedupKey: `inbound:${event.data.email_id}`,
-      title: "Resend inbound webhook processing failed",
-      message:
-        "A signed inbound email returned a server failure. Inspect the outreach mailbox and application logs.",
-      context: { emailId: event.data.email_id },
     });
     return Response.json(
       { error: "Webhook processing failed" },

--- a/src/lib/outreach-inbound.test.ts
+++ b/src/lib/outreach-inbound.test.ts
@@ -4,6 +4,7 @@ mock.module("server-only", () => ({}));
 
 const alerts: Array<Record<string, unknown>> = [];
 const auditEvents: Array<Record<string, unknown>> = [];
+const operatorAuditEvents: Array<Record<string, unknown>> = [];
 const messages: Array<Record<string, unknown>> = [];
 const forwards: Array<Record<string, unknown>> = [];
 let transactionDepth = 0;
@@ -100,20 +101,25 @@ const fakeDb = {
     }) => {
       if (input.where.OR) {
         return (
-          messages.find((message) =>
-            input.where.OR?.some((clause) =>
-              Object.entries(clause).every(([key, value]) => {
-                if (
-                  value &&
-                  typeof value === "object" &&
-                  "in" in value &&
-                  Array.isArray((value as { in: unknown[] }).in)
-                ) {
-                  return (value as { in: unknown[] }).in.includes(message[key]);
-                }
-                return message[key] === value;
-              }),
-            ),
+          messages.find(
+            (message) =>
+              (!input.where.direction ||
+                message.direction === input.where.direction) &&
+              input.where.OR?.some((clause) =>
+                Object.entries(clause).every(([key, value]) => {
+                  if (
+                    value &&
+                    typeof value === "object" &&
+                    "in" in value &&
+                    Array.isArray((value as { in: unknown[] }).in)
+                  ) {
+                    return (value as { in: unknown[] }).in.includes(
+                      message[key],
+                    );
+                  }
+                  return message[key] === value;
+                }),
+              ),
           ) ?? null
         );
       }
@@ -197,6 +203,12 @@ const fakeDb = {
       return input.data;
     },
   },
+  operatorAuditEvent: {
+    create: async (input: { data: Record<string, unknown> }) => {
+      operatorAuditEvents.push(input.data);
+      return input.data;
+    },
+  },
   outreachInboundForward: {
     upsert: async (input: {
       where: { outreachMessageId: string };
@@ -235,13 +247,15 @@ const fakeDb = {
   },
 };
 
-const { recordInboundOutreachMessage } = await import("@/lib/outreach-inbound");
+const { isAllowlistedInboundSender, recordInboundOutreachMessage } =
+  await import("@/lib/outreach-inbound");
 const previousForwardTarget = process.env.OUTREACH_INBOUND_FORWARD_TO;
 
 describe("inbound outreach mailbox", () => {
   beforeEach(() => {
     alerts.length = 0;
     auditEvents.length = 0;
+    operatorAuditEvents.length = 0;
     messages.length = 0;
     forwards.length = 0;
     transactionDepth = 0;
@@ -266,7 +280,17 @@ describe("inbound outreach mailbox", () => {
     }
   });
 
-  it("matches In-Reply-To, stores RECEIVED mail, and alerts the operator", async () => {
+  it("allowlists only the two genfeed sender domains", () => {
+    expect(isAllowlistedInboundSender("Vincent <test@genfeed.ai>")).toBe(true);
+    expect(isAllowlistedInboundSender("test@send.genfeed.ai")).toBe(true);
+    expect(isAllowlistedInboundSender("test@other.genfeed.ai")).toBe(false);
+    expect(isAllowlistedInboundSender("test@genfeed.ai.example.test")).toBe(
+      false,
+    );
+  });
+
+  it("matches In-Reply-To and stores RECEIVED mail without scheduling an email", async () => {
+    process.env.OUTREACH_INBOUND_FORWARD_TO = "operator@example.test";
     const result = await recordInboundOutreachMessage({
       eventId: "svix_1",
       occurredAt: new Date("2026-08-19T09:00:00.000Z"),
@@ -296,11 +320,11 @@ describe("inbound outreach mailbox", () => {
     expect(auditEvents.map((event) => event.type)).toEqual([
       "outreach.inbound.received",
     ]);
-    expect(alerts[0]).toMatchObject({ kind: "OUTREACH_REPLY" });
+    expect(alerts).toHaveLength(0);
     expect(forwards).toHaveLength(0);
   });
 
-  it("commits one forward intent atomically with the inbound mailbox row", async () => {
+  it("does not enqueue an inbound email forward", async () => {
     process.env.OUTREACH_INBOUND_FORWARD_TO = " Operator@Example.test ";
 
     const result = await recordInboundOutreachMessage({
@@ -317,45 +341,11 @@ describe("inbound outreach mailbox", () => {
     });
 
     expect(result).toMatchObject({ handled: true, created: true });
-    expect(forwards).toEqual([
-      expect.objectContaining({
-        outreachMessageId: "inbound_1",
-        idempotencyKey: "outreach-inbound-forward:inbound_1",
-        targetAddress: "operator@example.test",
-        siteName: "Chez Léa",
-        siteSlug: "chez-lea",
-        createdInsideTransaction: true,
-      }),
-    ]);
+    expect(forwards).toHaveLength(0);
+    expect(alerts).toHaveLength(0);
   });
 
-  it("persists ingestion and a blocked intent when the configured target is unsafe", async () => {
-    process.env.OUTREACH_INBOUND_FORWARD_TO =
-      "vincent+loop@restofront.com";
-
-    const result = await recordInboundOutreachMessage({
-      eventId: "svix_unsafe_forward",
-      occurredAt: new Date("2026-08-19T09:00:00.000Z"),
-      metadata: {
-        emailId: "recv_1",
-        from: "owner@chez-lea.test",
-        to: ["vincent@restofront.com"],
-        subject: "Re: preview",
-        rfcMessageId: "<reply@chez-lea.test>",
-        receivedFor: ["vincent@restofront.com"],
-      },
-    });
-
-    expect(result).toMatchObject({ handled: true, created: true });
-    expect(messages.at(-1)).toMatchObject({ direction: "INBOUND" });
-    expect(forwards[0]).toMatchObject({
-      targetAddress: null,
-      lastFailureCode: "configuration_invalid",
-      createdInsideTransaction: true,
-    });
-  });
-
-  it("matches a headerless reply only by the private lead recipient", async () => {
+  it("drops a headerless customer email instead of inferring a thread", async () => {
     fetchReceived.mockResolvedValueOnce({
       id: "recv_headerless",
       from: "owner@chez-lea.test",
@@ -381,43 +371,148 @@ describe("inbound outreach mailbox", () => {
       },
     });
 
-    expect(result).toMatchObject({
-      handled: true,
-      created: true,
-      siteId: "site_1",
+    expect(result).toEqual({
+      handled: false,
+      created: false,
+      retry: false,
+      siteId: null,
+      messageId: null,
     });
-    expect(messages.at(-1)).toMatchObject({
-      fromAddress: "owner@chez-lea.test",
+    expect(
+      messages.filter((message) => message.direction === "INBOUND"),
+    ).toHaveLength(0);
+    expect(alerts).toHaveLength(0);
+    expect(operatorAuditEvents.at(-1)).toMatchObject({
+      type: "outreach.inbound.unmatched_dropped",
+    });
+  });
+
+  it("logs and drops an unmatched random sender without emailing", async () => {
+    fetchReceived.mockResolvedValueOnce({
+      id: "recv_random",
+      from: "stranger@example.test",
+      to: ["vincent@cornershop.dev"],
+      subject: "Unrelated mail",
+      text: "This is not an outreach reply.",
+      html: null,
+      messageId: "<random@example.test>",
+      receivedFor: ["vincent@cornershop.dev"],
+      headers: {},
+    });
+
+    const result = await recordInboundOutreachMessage({
+      eventId: "svix_random",
+      occurredAt: new Date("2026-08-19T09:06:00.000Z"),
+      metadata: {
+        emailId: "recv_random",
+        from: "stranger@example.test",
+        to: ["vincent@cornershop.dev"],
+        subject: "Unrelated mail",
+        rfcMessageId: "<random@example.test>",
+        receivedFor: ["vincent@cornershop.dev"],
+      },
+    });
+
+    expect(result).toEqual({
+      handled: false,
+      created: false,
+      retry: false,
+      siteId: null,
+      messageId: null,
+    });
+    expect(alerts).toHaveLength(0);
+    expect(forwards).toHaveLength(0);
+    expect(operatorAuditEvents.at(-1)).toMatchObject({
+      type: "outreach.inbound.unmatched_dropped",
+      metadata: {
+        emailId: "recv_random",
+        senderDomain: "example.test",
+        allowlisted: false,
+      },
+    });
+  });
+
+  it("accepts allowlisted genfeed mail at a root without requiring a site", async () => {
+    fetchReceived.mockResolvedValueOnce({
+      id: "recv_genfeed",
+      from: "Vincent <test@send.genfeed.ai>",
+      to: ["vincent@cornershop.dev"],
+      subject: "Named mail test",
+      text: "Allowlisted test mail.",
+      html: null,
+      messageId: "<named-test@send.genfeed.ai>",
+      receivedFor: ["vincent@cornershop.dev"],
+      headers: {},
+    });
+
+    const result = await recordInboundOutreachMessage({
+      eventId: "svix_genfeed",
+      occurredAt: new Date("2026-08-19T09:07:00.000Z"),
+      metadata: {
+        emailId: "recv_genfeed",
+        from: "Vincent <test@send.genfeed.ai>",
+        to: ["vincent@cornershop.dev"],
+        subject: "Named mail test",
+        rfcMessageId: "<named-test@send.genfeed.ai>",
+        receivedFor: ["vincent@cornershop.dev"],
+      },
+    });
+
+    expect(result).toEqual({
+      handled: false,
+      created: false,
+      retry: false,
+      siteId: null,
+      messageId: null,
+    });
+    expect(alerts).toHaveLength(0);
+    expect(forwards).toHaveLength(0);
+    expect(operatorAuditEvents.at(-1)).toMatchObject({
+      type: "outreach.inbound.allowlisted_unmatched",
+      metadata: {
+        emailId: "recv_genfeed",
+        senderDomain: "send.genfeed.ai",
+        allowlisted: true,
+      },
+    });
+  });
+
+  it("does not match an inbound message referenced by another inbound message", async () => {
+    messages.push({
+      id: "prior_inbound",
       siteId: "site_1",
+      direction: "INBOUND",
+      rfcMessageId: "prior-inbound@example.test",
+      providerMessageId: "recv_prior",
       threadKey: "lead:site_1",
     });
 
     fetchReceived.mockResolvedValueOnce({
-      id: "recv_public",
-      from: "bonjour@chez-lea.test",
+      id: "recv_inbound_reference",
+      from: "stranger@example.test",
       to: ["vincent@restofront.com"],
-      subject: "Unrelated public-address mail",
-      text: "This address must not identify the private lead thread.",
+      subject: "Re: unrelated inbound",
+      text: "An inbound reference is not proof of our outbound thread.",
       html: null,
-      messageId: "<public-address@chez-lea.test>",
+      messageId: "<second-inbound@example.test>",
       receivedFor: ["vincent@restofront.com"],
-      headers: {},
+      headers: { "in-reply-to": "<prior-inbound@example.test>" },
     });
 
-    const publicResult = await recordInboundOutreachMessage({
-      eventId: "svix_public",
-      occurredAt: new Date("2026-08-19T09:06:00.000Z"),
+    const result = await recordInboundOutreachMessage({
+      eventId: "svix_inbound_reference",
+      occurredAt: new Date("2026-08-19T09:08:00.000Z"),
       metadata: {
-        emailId: "recv_public",
-        from: "bonjour@chez-lea.test",
+        emailId: "recv_inbound_reference",
+        from: "stranger@example.test",
         to: ["vincent@restofront.com"],
-        subject: "Unrelated public-address mail",
-        rfcMessageId: "<public-address@chez-lea.test>",
+        subject: "Re: unrelated inbound",
+        rfcMessageId: "<second-inbound@example.test>",
         receivedFor: ["vincent@restofront.com"],
       },
     });
 
-    expect(publicResult).toEqual({
+    expect(result).toEqual({
       handled: false,
       created: false,
       retry: false,
@@ -456,11 +551,8 @@ describe("inbound outreach mailbox", () => {
       messageId: "inbound_existing",
     });
     expect(fetchReceived).not.toHaveBeenCalled();
-    expect(forwards).toHaveLength(1);
-    expect(forwards[0]).toMatchObject({
-      outreachMessageId: "inbound_existing",
-      targetAddress: "operator@example.test",
-    });
+    expect(forwards).toHaveLength(0);
+    expect(alerts).toHaveLength(0);
   });
 
   it("repairs a missing intent when the duplicate appears inside the transaction", async () => {
@@ -493,13 +585,8 @@ describe("inbound outreach mailbox", () => {
       created: false,
       messageId: "inbound_racing",
     });
-    expect(forwards).toEqual([
-      expect.objectContaining({
-        outreachMessageId: "inbound_racing",
-        targetAddress: "operator@example.test",
-        createdInsideTransaction: true,
-      }),
-    ]);
+    expect(forwards).toHaveLength(0);
+    expect(alerts).toHaveLength(0);
   });
 
   it("retries when Resend has not published the received body yet", async () => {

--- a/src/lib/outreach-inbound.ts
+++ b/src/lib/outreach-inbound.ts
@@ -1,12 +1,9 @@
 import "server-only";
-import { normalizeAccountEmail } from "@/lib/account-email";
 import { getDb } from "@/lib/db";
-import { captureOperatorAlert } from "@/lib/operator-alerts";
 import {
   extractEmailAddress,
   extractEmailAddresses,
   htmlToPlainText,
-  inboundThreadTokens,
   normalizeRfcMessageId,
   outreachThreadKey,
   parseRfcMessageIds,
@@ -17,7 +14,11 @@ import { emailReplyTo } from "@/lib/email-identity";
 import { listOutreachVerticals } from "@/lib/lead-generation/registry";
 import type { VerticalId } from "@/lib/verticals/types";
 import { lockOutreachDelivery, lockOutreachSite } from "@/lib/outreach-lock";
-import { enqueueOutreachInboundForward } from "@/lib/outreach-inbound-forward";
+
+const INBOUND_SENDER_DOMAIN_ALLOWLIST = new Set([
+  "genfeed.ai",
+  "send.genfeed.ai",
+]);
 
 export type RecordInboundOutreachResult = {
   handled: boolean;
@@ -44,15 +45,9 @@ export async function recordInboundOutreachMessage(input: {
   const db = getDb();
   const existing = await db.outreachMessage.findUnique({
     where: { providerMessageId: input.metadata.emailId },
-    select: { id: true, siteId: true, fromAddress: true, toAddress: true },
+    select: { id: true, siteId: true },
   });
   if (existing) {
-    await enqueueOutreachInboundForward(db, {
-      outreachMessageId: existing.id,
-      siteId: existing.siteId,
-      fromAddress: existing.fromAddress,
-      toAddress: existing.toAddress,
-    });
     return {
       handled: true,
       created: false,
@@ -87,16 +82,10 @@ export async function recordInboundOutreachMessage(input: {
   };
   const matched = await matchInboundOutreachThread(fields);
   if (!matched) {
-    await captureOperatorAlert({
-      kind: "OUTREACH_REPLY",
-      dedupKey: `inbound-unmatched:${input.metadata.emailId}`,
-      title: "Inbound outreach reply could not be matched",
-      message:
-        "A signed inbound email did not match a configured outreach thread. Inspect the From/To headers and mailbox.",
-      context: {
-        emailId: input.metadata.emailId,
-        from: fields.from,
-      },
+    await recordUnmatchedInbound(db, {
+      eventId: input.eventId,
+      emailId: input.metadata.emailId,
+      from: fields.from,
       occurredAt: input.occurredAt,
     });
     return {
@@ -134,20 +123,9 @@ export async function recordInboundOutreachMessage(input: {
       await lockOutreachSite(tx, matched.siteId);
       const duplicate = await tx.outreachMessage.findUnique({
         where: { providerMessageId: input.metadata.emailId },
-        select: {
-          id: true,
-          siteId: true,
-          fromAddress: true,
-          toAddress: true,
-        },
+        select: { id: true, siteId: true },
       });
       if (duplicate) {
-        await enqueueOutreachInboundForward(tx, {
-          outreachMessageId: duplicate.id,
-          siteId: duplicate.siteId,
-          fromAddress: duplicate.fromAddress,
-          toAddress: duplicate.toAddress,
-        });
         return { created: false as const, message: duplicate };
       }
 
@@ -187,12 +165,6 @@ export async function recordInboundOutreachMessage(input: {
           createdAt: receivedAt,
         },
       });
-      await enqueueOutreachInboundForward(tx, {
-        outreachMessageId: created.id,
-        siteId: matched.siteId,
-        fromAddress,
-        toAddress,
-      });
       return { created: true as const, message: created };
     });
     if (!persisted.created) {
@@ -204,18 +176,6 @@ export async function recordInboundOutreachMessage(input: {
         messageId: persisted.message.id,
       };
     }
-    await captureOperatorAlert({
-      kind: "OUTREACH_REPLY",
-      dedupKey: `inbound:${input.metadata.emailId}`,
-      title: "A lead replied",
-      message:
-        "An inbound reply was stored on the lead thread. Follow-up campaign sends are stopped; reply from /admin.",
-      context: {
-        siteId: matched.siteId,
-        outreachMessageId: persisted.message.id,
-      },
-      occurredAt: receivedAt,
-    });
     return {
       handled: true,
       created: true,
@@ -226,15 +186,9 @@ export async function recordInboundOutreachMessage(input: {
   } catch (error) {
     const duplicate = await db.outreachMessage.findUnique({
       where: { providerMessageId: input.metadata.emailId },
-      select: { id: true, siteId: true, fromAddress: true, toAddress: true },
+      select: { id: true, siteId: true },
     });
     if (duplicate) {
-      await enqueueOutreachInboundForward(db, {
-        outreachMessageId: duplicate.id,
-        siteId: duplicate.siteId,
-        fromAddress: duplicate.fromAddress,
-        toAddress: duplicate.toAddress,
-      });
       return {
         handled: true,
         created: false,
@@ -251,70 +205,37 @@ export async function matchInboundOutreachThread(
   fields: InboundAddressFields,
 ): Promise<{ siteId: string; threadKey: string } | null> {
   const db = getDb();
-  const tokens = inboundThreadTokens(fields);
-  if (tokens.length > 0) {
-    const byHeader = await db.outreachMessage.findFirst({
-      where: {
-        OR: [
-          { rfcMessageId: { in: tokens } },
-          { id: { in: tokens } },
-          { providerMessageId: { in: tokens } },
-          {
-            threadKey: {
-              in: tokens.map((token) =>
-                token.startsWith("lead:") ? token : `lead:${token}`,
-              ),
-            },
-          },
-        ],
-      },
-      orderBy: { createdAt: "desc" },
-      select: { siteId: true, threadKey: true },
-    });
-    if (byHeader) {
-      return {
-        siteId: byHeader.siteId,
-        threadKey: byHeader.threadKey ?? outreachThreadKey(byHeader.siteId),
-      };
-    }
-
-    const plusTags = tokens.filter((token) => !token.includes("@"));
-    const recipientVerticals = inboundRecipientVerticals(fields);
-    if (plusTags.length > 0 && recipientVerticals.length > 0) {
-      const byPlus = await db.site.findFirst({
-        where: {
-          vertical: { in: recipientVerticals },
-          OR: [{ slug: { in: plusTags } }, { id: { in: plusTags } }],
-        },
-        orderBy: { updatedAt: "desc" },
-        select: { id: true },
-      });
-      if (byPlus) {
-        return {
-          siteId: byPlus.id,
-          threadKey: outreachThreadKey(byPlus.id),
-        };
-      }
-    }
-  }
-
-  const from = safeEmail(fields.from);
-  const recipientVerticals = inboundRecipientVerticals(fields);
-  if (!from || recipientVerticals.length === 0) return null;
-  const byContact = await db.site.findMany({
-    where: {
-      vertical: { in: recipientVerticals },
-      leadContactEmail: from,
-    },
-    orderBy: { updatedAt: "desc" },
-    take: 2,
-    select: { id: true },
+  const tokens = inboundHeaderMessageIds({
+    "in-reply-to": fields.inReplyTo ?? "",
+    references: fields.references ?? "",
   });
-  if (byContact.length !== 1) return null;
-  return {
-    siteId: byContact[0]!.id,
-    threadKey: outreachThreadKey(byContact[0]!.id),
-  };
+  if (tokens.length === 0) return null;
+  const byHeader = await db.outreachMessage.findFirst({
+    where: {
+      direction: "OUTBOUND",
+      OR: [
+        { rfcMessageId: { in: tokens } },
+        { id: { in: tokens } },
+        { providerMessageId: { in: tokens } },
+        {
+          threadKey: {
+            in: tokens.map((token) =>
+              token.startsWith("lead:") ? token : `lead:${token}`,
+            ),
+          },
+        },
+      ],
+    },
+    orderBy: { createdAt: "desc" },
+    select: { siteId: true, threadKey: true },
+  });
+  if (byHeader) {
+    return {
+      siteId: byHeader.siteId,
+      threadKey: byHeader.threadKey ?? outreachThreadKey(byHeader.siteId),
+    };
+  }
+  return null;
 }
 
 export function inboundRecipientVerticals(
@@ -349,16 +270,6 @@ export function isRestofrontInboundRecipient(
   return inboundRecipientVerticals(fields).includes("RESTAURANT");
 }
 
-function safeEmail(value: string): string | null {
-  const extracted = extractEmailAddress(value);
-  if (!extracted) return null;
-  try {
-    return normalizeAccountEmail(extracted);
-  } catch {
-    return extracted;
-  }
-}
-
 export function inboundHeaderMessageIds(
   headers: Record<string, string>,
 ): string[] {
@@ -366,4 +277,57 @@ export function inboundHeaderMessageIds(
     ...parseRfcMessageIds(headers["in-reply-to"]),
     ...parseRfcMessageIds(headers.references),
   ];
+}
+
+export function isAllowlistedInboundSender(value: string): boolean {
+  const email = extractEmailAddress(value);
+  if (!email) return false;
+  return INBOUND_SENDER_DOMAIN_ALLOWLIST.has(
+    email.slice(email.lastIndexOf("@") + 1),
+  );
+}
+
+async function recordUnmatchedInbound(
+  db: ReturnType<typeof getDb>,
+  input: {
+    eventId: string;
+    emailId: string;
+    from: string;
+    occurredAt: Date;
+  },
+): Promise<void> {
+  const email = extractEmailAddress(input.from);
+  const senderDomain = email?.slice(email.lastIndexOf("@") + 1) ?? null;
+  const allowlisted = isAllowlistedInboundSender(input.from);
+  const action = allowlisted ? "retained_at_provider" : "dropped";
+
+  console.info("[outreach-inbound] unmatched email", {
+    emailId: input.emailId,
+    senderDomain,
+    allowlisted,
+    action,
+  });
+  try {
+    await db.operatorAuditEvent.create({
+      data: {
+        type: allowlisted
+          ? "outreach.inbound.allowlisted_unmatched"
+          : "outreach.inbound.unmatched_dropped",
+        actor: "system:resend-inbound",
+        metadata: {
+          eventId: input.eventId,
+          emailId: input.emailId,
+          senderDomain,
+          allowlisted,
+          action,
+        },
+        createdAt: input.occurredAt,
+      },
+    });
+  } catch {
+    console.error("[outreach-inbound] unmatched audit failed", {
+      emailId: input.emailId,
+      allowlisted,
+    });
+  }
 }

--- a/src/lib/resend-inbound-webhook-route.test.ts
+++ b/src/lib/resend-inbound-webhook-route.test.ts
@@ -81,7 +81,17 @@ describe("Resend inbound webhook", () => {
       error: "Resend webhook is not configured",
     });
     expect(recordInbound).not.toHaveBeenCalled();
-    expect(captureOperatorAlert).toHaveBeenCalledTimes(1);
+    expect(captureOperatorAlert).not.toHaveBeenCalled();
+  });
+
+  it("does not send an alert when persistence is unavailable", async () => {
+    delete process.env.DATABASE_URL;
+
+    const response = await POST(signedInbound());
+
+    expect(response.status).toBe(503);
+    expect(recordInbound).not.toHaveBeenCalled();
+    expect(captureOperatorAlert).not.toHaveBeenCalled();
   });
 
   it("stores a signed inbound reply on the matched lead thread", async () => {
@@ -96,6 +106,33 @@ describe("Resend inbound webhook", () => {
       siteId: "site_1",
     });
     expect(recordInbound).toHaveBeenCalledTimes(1);
+    expect(captureOperatorAlert).not.toHaveBeenCalled();
+  });
+
+  it("accepts unmatched genfeed mail at a root without sending an alert", async () => {
+    recordInbound.mockResolvedValueOnce({
+      handled: false,
+      created: false,
+      retry: false,
+      siteId: null,
+      messageId: null,
+    });
+
+    const response = await POST(
+      signedInbound(undefined, inboundWebhookSecret, {
+        from: "test@genfeed.ai",
+        to: ["vincent@cornershop.dev"],
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      received: true,
+      handled: false,
+      created: false,
+      siteId: null,
+    });
+    expect(captureOperatorAlert).not.toHaveBeenCalled();
   });
 
   it("asks Resend to retry when the received body is not visible yet", async () => {
@@ -138,6 +175,7 @@ describe("Resend inbound webhook", () => {
       const serialized = JSON.stringify(consoleError.mock.calls);
       expect(serialized).not.toContain("private mailbox body");
       expect(serialized).not.toContain("operator@example.test");
+      expect(captureOperatorAlert).not.toHaveBeenCalled();
     } finally {
       console.error = previousConsoleError;
     }
@@ -147,6 +185,13 @@ describe("Resend inbound webhook", () => {
 function signedInbound(
   signatureOverride?: string,
   signingSecret = inboundWebhookSecret,
+  addresses: {
+    from: string;
+    to: string[];
+  } = {
+    from: "owner@chez-lea.test",
+    to: ["vincent@restofront.com"],
+  },
 ): Request {
   const timestamp = new Date();
   const messageId = "inbound_webhook_1";
@@ -155,8 +200,8 @@ function signedInbound(
     created_at: timestamp.toISOString(),
     data: {
       email_id: "recv_1",
-      from: "owner@chez-lea.test",
-      to: ["vincent@restofront.com"],
+      from: addresses.from,
+      to: addresses.to,
       subject: "Re: your preview",
       message_id: "<reply@chez-lea.test>",
     },


### PR DESCRIPTION
## Summary

- match inbound outreach only when In-Reply-To or References identifies an outbound OutreachMessage
- allowlist exact genfeed.ai and send.genfeed.ai sender domains without requiring a customer site; unmatched allowlisted mail remains unpersisted and returns safely
- log unmatched mail to console and OperatorAuditEvent while removing operator-alert emails and inbound forward scheduling from ingestion
- keep matched inbound persistence and its existing campaign-suppression transaction

## Verification

- `bun run lint`
- `bunx next typegen && bunx tsc --noEmit`
- affected inbound/outreach tests: 94 passed, 12 PostgreSQL-gated skipped
- full `bun test`: 1,285 passed, 124 PostgreSQL-gated skipped, 0 failed

## Safety scope

- no auto-replies or restaurant sequence starts
- no root-domain sending configuration changes
- no DNS, Resend configuration, Namecheap, or deployment changes
- ready for review; do not merge as part of this task