### PR TITLE
fix(factory): complete production launch funnel

### DIFF
--- a/deploy/aws/deploy.sh
+++ b/deploy/aws/deploy.sh
@@ -118,7 +118,10 @@ required_parameters=(
   FIRST_CUSTOMER_EVIDENCE_PUBLIC_KEY
   HEALTHCHECK_TOKEN
   NEXT_PUBLIC_APP_URL
+  NEXT_PUBLIC_POSTHOG_HOST
+  NEXT_PUBLIC_POSTHOG_KEY
   OUTREACH_LEGAL_CONTROLLER
+  OPERATOR_LEAD_INGEST_TOKEN
   OPERATOR_ALERT_EMAILS
   PLATFORM_HOSTNAMES
   PUBLIC_APP_IP
@@ -382,6 +385,31 @@ fi
 docker exec "$candidate" bun run db:migrate:status
 docker exec "$candidate" bun run operator:article-rollout --action check >/dev/null
 echo "release-state article-candidate-verified sha=${deployed_sha}"
+# Analytics configuration is runtime-bound. Prove that the exact candidate
+# emits the pixel on factory pages and the explicit preview event on previews,
+# while a customer platform hostname remains free of third-party analytics.
+docker exec "$candidate" node --input-type=module -e '
+  const get = async (host, path) => {
+    const response = await fetch(`http://127.0.0.1:3000${path}`, {
+      headers: { host },
+    });
+    if (!response.ok) throw new Error(`${host}${path} returned ${response.status}`);
+    return response.text();
+  };
+  const factory = await get("cornershop.dev", "/");
+  if (!factory.includes("id=\"factory-analytics\"")) {
+    throw new Error("Factory analytics pixel is absent");
+  }
+  const preview = await get("cornershop.dev", "/preview/le-petit-meunier");
+  if (!preview.includes("id=\"factory-analytics\"") || !preview.includes("preview_view")) {
+    throw new Error("Factory preview analytics event is absent");
+  }
+  const customer = await get("le-petit-meunier.restofront.com", "/");
+  if (customer.includes("id=\"factory-analytics\"")) {
+    throw new Error("Factory analytics leaked onto a customer storefront");
+  }
+'
+echo "release-state factory-analytics-ready sha=${deployed_sha}"
 docker exec "$candidate" \
   bun run operator:preflight-outreach --environment production
 echo "release-state outreach-configured sha=${deployed_sha}"

--- a/docs/operations/platform-services.md
+++ b/docs/operations/platform-services.md
@@ -104,6 +104,33 @@ value-first rationales, and a bare `ELIGIBLE` flag do not authorize email.
 The operator can edit the record and must still review the current preview
 before delivery.
 
+Source-reviewed drafts that already exist in the private customer repository
+use `POST /api/admin/leads/reviewed-draft` with the same dedicated bearer token.
+One request carries a locked `{ batch, vertical, drafts }` envelope of at most
+20 rows; every row is validated by the selected vertical schema. This path
+never crawls, generates, or sends mail: it persists the reviewed content
+exactly, requires the approved slug and source to remain bound, updates only
+mutable prospect/preview rows, and fails closed for claimed sites or identity
+collisions. Re-running the same envelope is the supported idempotent recovery
+path.
+
+Run a locked private batch from a trusted operator machine without copying it
+into this repository:
+
+```bash
+bun run operator:import:reviewed-drafts -- \
+  --input /absolute/path/to/private/reviewed-drafts.json
+
+bun run operator:import:reviewed-drafts -- \
+  --input /absolute/path/to/private/reviewed-drafts.json \
+  --execute
+```
+
+The first command validates and prints only slugs. Execute requires
+`OPERATOR_LEAD_INGEST_TOKEN`, imports each exact draft over HTTPS, then requires
+its returned slug/database verification and a live `200` preview before moving
+to the next row. The command never sends outreach.
+
 Store the exact legal controller at
 `/shipshit/production/cornershopdev/OUTREACH_LEGAL_CONTROLLER`. Deployment
 requires the parameter and the no-send outreach preflight reports only its
@@ -171,18 +198,19 @@ niche receiving domain are rejected so forwarding cannot loop back through
 `email.received`. Changing this setting never changes root MX records or plus-tag
 thread routing.
 
-The webhook transaction commits the inbound `OutreachMessage`, its audit event,
-and a unique forwarding outbox intent together. The Postgres message and admin
-thread remain the source of truth; provider delivery happens later from the
-leased outbox worker. Webhook replay converges on the same outbox row, and every
-provider retry reuses the row's stable Resend idempotency key. The worker makes
-at most three attempts, retrying after one and five minutes while the key is
-inside the provider idempotency window. A terminal row is retained as
-`EXHAUSTED` and creates a content-free operator alert for reconciliation.
+The webhook transaction commits the inbound `OutreachMessage` and its audit
+event without creating a new forwarding intent. Postgres and the admin thread
+are the source of truth; receiving a reply therefore consumes no outbound send
+quota and never copies customer content to a personal mailbox. The separately
+deployed worker remains only to drain or reconcile forwarding rows created by a
+pre-#194 release. It makes at most three attempts for those legacy rows,
+retrying after one and five minutes while the key is inside the provider
+idempotency window. A terminal row is retained as `EXHAUSTED` and creates a
+content-free operator alert for reconciliation.
 
-Each provider request carries the immutable forwarding-row identifier as a
-Resend tag. Signed `sent`, `delivered`, `failed`, `suppressed`, `bounced`, and
-`complained` receipts are stored in a dedicated append-only provider-event
+Each legacy provider request carries the immutable forwarding-row identifier as
+a Resend tag. Signed `sent`, `delivered`, `failed`, `suppressed`, `bounced`,
+and `complained` receipts are stored in a dedicated append-only provider-event
 ledger keyed by the Svix event ID. `deliveryStatus` is deliberately separate
 from the forwarding outbox `status`: provider acceptance completes the outbox,
 while a later delivery failure advances only the receipt snapshot and enqueues
@@ -194,10 +222,11 @@ no-ops, older events cannot regress the snapshot, and a tagged row that is not
 visible yet returns a retryable response instead of acknowledging and losing
 the receipt.
 
-Read copies contain a bounded site name, slug, original sender/subject, and a
-bounded plain-text message body. Raw inbound HTML is never rendered. The copy is
-visibly marked read-only and deliberately has no `Reply-To` or threading header:
-reply from the admin outreach panel so the operator workflow stays authoritative.
+Legacy read copies contain a bounded site name, slug, original sender/subject,
+and a bounded plain-text message body. Raw inbound HTML is never rendered. The
+copy is visibly marked read-only and deliberately has no `Reply-To` or
+threading header: reply from the admin outreach panel so the operator workflow
+stays authoritative.
 Dispatcher output and application logs contain aggregate outcomes, row IDs, and
 generic failure codes only—never the destination, subject, message body, or raw
 provider response. The code path and provider acceptance do not prove personal
@@ -281,11 +310,12 @@ endpoint. Alert draining is deliberately isolated in
 most five rows per invocation. Five worst-case five-second delivery timeouts
 consume 25 seconds inside its 45-second service limit; a saturated alert queue
 therefore cannot delay or terminate the independent public health check.
-Inbound read-copy draining is separately isolated in
+Legacy inbound read-copy draining is separately isolated in
 `cornershopdev-inbound-forwards.timer`. It runs every minute and processes at
-most five rows; five worst-case eight-second provider timeouts remain inside its
-55-second service limit. All three timers use the existing host and providers;
-they create no separate billable monitoring service.
+most five rows left by pre-#194 releases; five worst-case eight-second provider
+timeouts remain inside its 55-second service limit. New inbound replies never
+enter that queue. All three timers use the existing host and providers; they
+create no separate billable monitoring service.
 
 Useful commands:
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "db:migrate:deploy": "bunx --bun prisma migrate deploy",
     "operator:grant-superadmin": "bun scripts/grant-superadmin.ts",
     "operator:import:le-petit-meunier": "bun scripts/import-le-petit-meunier.ts",
+    "operator:import:reviewed-drafts": "bun scripts/import-reviewed-drafts.ts",
     "operator:verify-environment-isolation": "bun scripts/verify-environment-isolation.ts",
     "operator:verify-image-storage": "bun scripts/verify-image-storage-roundtrip.ts",
     "operator:verify-first-customer": "bun scripts/verify-first-customer-production.ts",

--- a/scripts/import-reviewed-drafts.ts
+++ b/scripts/import-reviewed-drafts.ts
@@ -1,0 +1,185 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+type ReviewedDraft = {
+  slug?: unknown;
+};
+
+type ReviewedDraftBatch = {
+  batch?: unknown;
+  locked?: unknown;
+  vertical?: unknown;
+  drafts?: unknown;
+};
+
+type Cli = {
+  input: string;
+  apiUrl: string;
+  execute: boolean;
+};
+
+async function main() {
+  const cli = parseArguments(process.argv.slice(2));
+  const batch = parseBatch(
+    JSON.parse(await readFile(cli.input, "utf8")) as ReviewedDraftBatch,
+  );
+  if (!cli.execute) {
+    console.log(
+      JSON.stringify({
+        mode: "dry-run",
+        batch: batch.name,
+        vertical: batch.vertical,
+        count: batch.drafts.length,
+        slugs: batch.drafts.map((draft) => draft.slug),
+      }),
+    );
+    return;
+  }
+
+  const token = process.env.OPERATOR_LEAD_INGEST_TOKEN?.trim();
+  if (!token) {
+    throw new Error("OPERATOR_LEAD_INGEST_TOKEN is required with --execute");
+  }
+  const response = await fetch(
+    `${cli.apiUrl}/api/admin/leads/reviewed-draft`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        batch: batch.name,
+        locked: true,
+        vertical: batch.vertical,
+        drafts: batch.drafts,
+      }),
+    },
+  );
+  const imported = (await response.json()) as {
+    ok?: boolean;
+    batch?: string;
+    count?: number;
+    results?: Array<{
+      slug?: string;
+      created?: boolean;
+      verified?: boolean;
+      urls?: { preview?: string };
+    }>;
+    error?: string;
+  };
+  if (!response.ok || !imported.ok || imported.batch !== batch.name) {
+    throw new Error(
+      `Batch import failed (${response.status}): ${imported.error ?? "unknown error"}`,
+    );
+  }
+  if (
+    imported.count !== batch.drafts.length ||
+    imported.results?.length !== batch.drafts.length
+  ) {
+    throw new Error("Batch import returned an invalid result count");
+  }
+
+  const results = [];
+  for (const [index, draft] of batch.drafts.entries()) {
+    const result = imported.results[index];
+    if (
+      result?.slug !== draft.slug ||
+      result.verified !== true ||
+      !result.urls?.preview
+    ) {
+      throw new Error(`${draft.slug} returned an invalid verification result`);
+    }
+    const preview = await fetch(`${cli.apiUrl}${result.urls.preview}`, {
+      redirect: "follow",
+    });
+    if (!preview.ok) {
+      throw new Error(
+        `${draft.slug} preview returned ${preview.status} after import`,
+      );
+    }
+    results.push({
+      slug: draft.slug,
+      created: result.created === true,
+      verified: true,
+      previewStatus: preview.status,
+    });
+  }
+
+  console.log(
+    JSON.stringify({
+      mode: "execute",
+      batch: batch.name,
+      count: results.length,
+      results,
+    }),
+  );
+}
+
+function parseArguments(args: string[]): Cli {
+  let input = "";
+  let apiUrl = "https://cornershop.dev";
+  let execute = false;
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--execute") {
+      execute = true;
+      continue;
+    }
+    if (argument === "--input") {
+      input = args[++index] ?? "";
+      continue;
+    }
+    if (argument === "--api-url") {
+      apiUrl = args[++index] ?? "";
+      continue;
+    }
+    throw new Error(
+      "Usage: bun run operator:import:reviewed-drafts -- --input <private-json> [--api-url <origin>] [--execute]",
+    );
+  }
+  if (!input) throw new Error("--input is required");
+  const origin = new URL(apiUrl);
+  if (origin.protocol !== "https:" && origin.hostname !== "127.0.0.1") {
+    throw new Error("--api-url must use HTTPS outside local verification");
+  }
+  if (origin.pathname !== "/" || origin.search || origin.hash) {
+    throw new Error("--api-url must be an origin without a path");
+  }
+  return {
+    input: resolve(input),
+    apiUrl: origin.origin,
+    execute,
+  };
+}
+
+function parseBatch(input: ReviewedDraftBatch) {
+  if (input.locked !== true) throw new Error("Reviewed draft batch is not locked");
+  const name = typeof input.batch === "string" ? input.batch.trim() : "";
+  const vertical =
+    typeof input.vertical === "string" ? input.vertical.trim() : "";
+  const drafts = Array.isArray(input.drafts)
+    ? (input.drafts as ReviewedDraft[])
+    : [];
+  if (!name || !vertical || drafts.length === 0 || drafts.length > 20) {
+    throw new Error("Reviewed draft batch metadata is invalid");
+  }
+  const slugs = drafts.map((draft) =>
+    typeof draft.slug === "string" ? draft.slug.trim() : "",
+  );
+  if (slugs.some((slug) => !slug) || new Set(slugs).size !== slugs.length) {
+    throw new Error("Reviewed draft slugs must be present and unique");
+  }
+  return {
+    name,
+    vertical,
+    drafts: drafts.map((draft, index) => ({ ...draft, slug: slugs[index] })),
+  };
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : "Import failed");
+  process.exitCode = 1;
+}

--- a/src/app/api/admin/leads/reviewed-draft/route.ts
+++ b/src/app/api/admin/leads/reviewed-draft/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import {
+  importReviewedOperatorDraftBatch,
+  parseReviewedDraftBatchImport,
+} from "@/lib/operator-reviewed-draft-import";
+import { isOperatorLeadIngestAuthorized } from "@/lib/operator-lead-ingest-auth";
+import { limitOperatorLeadIngest } from "@/lib/rate-limit";
+import {
+  ImportConflictError,
+  OperatorImportConflictError,
+} from "@/lib/site-persistence";
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  if (!isOperatorLeadIngestAuthorized(request)) {
+    return NextResponse.json(
+      { error: "Unauthorized" },
+      {
+        status: 401,
+        headers: {
+          "Cache-Control": "no-store",
+          "WWW-Authenticate": "Bearer",
+        },
+      },
+    );
+  }
+
+  const rateLimit = await limitOperatorLeadIngest(request);
+  if (!rateLimit.success) {
+    return NextResponse.json(
+      {
+        error:
+          rateLimit.reason === "unavailable"
+            ? "Reviewed draft import is temporarily unavailable."
+            : "Too many reviewed draft imports. Try again later.",
+      },
+      { status: rateLimit.reason === "unavailable" ? 503 : 429 },
+    );
+  }
+
+  try {
+    const input = parseReviewedDraftBatchImport(await request.json());
+    const imported = await importReviewedOperatorDraftBatch(input);
+    return NextResponse.json(
+      { ok: true, ...imported },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: error.issues[0]?.message ?? "Check the reviewed draft." },
+        { status: 400 },
+      );
+    }
+    if (error instanceof Error && error.message.includes("public source URL")) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    if (
+      error instanceof ImportConflictError ||
+      error instanceof OperatorImportConflictError
+    ) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
+    console.error("[operator-reviewed-draft-import] failed", {
+      error: error instanceof Error ? error.message : "unknown",
+    });
+    return NextResponse.json(
+      { error: "The reviewed draft could not be imported." },
+      { status: 503 },
+    );
+  }
+}

--- a/src/app/claim/[slug]/claim-panel.tsx
+++ b/src/app/claim/[slug]/claim-panel.tsx
@@ -15,6 +15,7 @@ import { Button } from "@/components/ui/button";
 import { Field } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import type { ClaimPanelProps } from "@/lib/claim-launch-offer";
+import { captureFactoryAnalyticsEvent } from "@/lib/factory-analytics-browser";
 
 export function ClaimPanel({
   slug,
@@ -79,6 +80,14 @@ export function ClaimPanel({
           error?: string;
         };
         if (response.ok && result.ready && result.url) {
+          captureFactoryAnalyticsEvent({
+            name: "checkout_completed",
+            properties: {
+              slug,
+              vertical,
+              ...(offer ? { plan: offer.planId } : {}),
+            },
+          });
           window.location.assign(result.url);
           return;
         }
@@ -113,7 +122,7 @@ export function ClaimPanel({
       stopped = true;
       if (retryTimer !== undefined) window.clearTimeout(retryTimer);
     };
-  }, [checkoutReturn]);
+  }, [checkoutReturn, offer, slug, vertical]);
 
   async function requestInvitation() {
     if (!email) return;
@@ -166,6 +175,10 @@ export function ClaimPanel({
       if (!response.ok || !result.url) {
         throw new Error(result.error ?? "Checkout could not start");
       }
+      captureFactoryAnalyticsEvent({
+        name: "checkout_started",
+        properties: { slug, vertical, plan: offer.planId },
+      });
       window.location.assign(result.url);
     } catch (caught) {
       setError(

--- a/src/app/preview/[slug]/[locale]/page.tsx
+++ b/src/app/preview/[slug]/[locale]/page.tsx
@@ -3,6 +3,7 @@ import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { PreviewThemeSwitcher } from "@/components/preview-theme-switcher";
 import { SiteRenderer } from "@/components/site-renderer";
+import { FactoryAnalytics } from "@/components/factory-analytics";
 import { FACTORY_BRAND } from "@/lib/brand";
 import {
   customerHostname,
@@ -92,6 +93,14 @@ export default async function LocalizedPreviewPage({
 
   return (
     <>
+      {!isLiveSurface ? (
+        <FactoryAnalytics
+          initialEvent={{
+            name: "preview_view",
+            properties: { slug, vertical: site.vertical },
+          }}
+        />
+      ) : null}
       <SiteRenderer
         draft={localizeSiteDraft(alternates?.draft ?? site.draft, locale)}
         vertical={site.vertical}

--- a/src/app/preview/[slug]/page.tsx
+++ b/src/app/preview/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { PreviewThemeSwitcher } from "@/components/preview-theme-switcher";
 import { SiteRenderer } from "@/components/site-renderer";
+import { FactoryAnalytics } from "@/components/factory-analytics";
 import { FACTORY_BRAND } from "@/lib/brand";
 import {
   customerHostname,
@@ -75,6 +76,14 @@ export default async function PreviewPage({
 
   return (
     <>
+      {!isLiveSurface ? (
+        <FactoryAnalytics
+          initialEvent={{
+            name: "preview_view",
+            properties: { slug, vertical: site.vertical },
+          }}
+        />
+      ) : null}
       <SiteRenderer
         draft={alternates?.draft ?? site.draft}
         vertical={site.vertical}

--- a/src/components/factory-analytics.tsx
+++ b/src/components/factory-analytics.tsx
@@ -1,24 +1,39 @@
+import { headers } from "next/headers";
 import {
   factoryAnalyticsSnippet,
   resolveFactoryAnalytics,
+  type FactoryAnalyticsEvent,
 } from "@/lib/factory-analytics";
+import { isFactoryHostname } from "@/lib/hostnames";
+import { requestHostname } from "@/lib/request-hostname";
 
 /**
- * Next inlines `process.env.NEXT_PUBLIC_*` only where it reads as a literal
- * member expression, so the reads stay here and the decision stays testable in
- * `resolveFactoryAnalytics`.
+ * Read the key from the running container, not the GitHub image build. Next
+ * freezes literal `process.env.NEXT_PUBLIC_*` expressions during `next build`;
+ * aliasing `process.env` keeps these deliberately public values runtime-bound.
+ * The Host check also protects custom-domain rewrites onto `/preview`.
  */
-export function FactoryAnalytics() {
+export async function FactoryAnalytics({
+  initialEvent,
+}: {
+  initialEvent?: FactoryAnalyticsEvent;
+} = {}) {
+  const requestHeaders = await headers();
+  if (!isFactoryHostname(requestHostname(requestHeaders))) return null;
+
+  const runtimeEnvironment = process.env;
   const config = resolveFactoryAnalytics({
-    NEXT_PUBLIC_POSTHOG_KEY: process.env.NEXT_PUBLIC_POSTHOG_KEY,
-    NEXT_PUBLIC_POSTHOG_HOST: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    NEXT_PUBLIC_POSTHOG_KEY: runtimeEnvironment.NEXT_PUBLIC_POSTHOG_KEY,
+    NEXT_PUBLIC_POSTHOG_HOST: runtimeEnvironment.NEXT_PUBLIC_POSTHOG_HOST,
   });
   if (!config) return null;
 
   return (
     <script
       id="factory-analytics"
-      dangerouslySetInnerHTML={{ __html: factoryAnalyticsSnippet(config) }}
+      dangerouslySetInnerHTML={{
+        __html: factoryAnalyticsSnippet(config, initialEvent),
+      }}
     />
   );
 }

--- a/src/lib/factory-analytics-browser.ts
+++ b/src/lib/factory-analytics-browser.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import type { FactoryAnalyticsEvent } from "@/lib/factory-analytics";
+
+type FactoryAnalyticsWindow = Window & {
+  __factoryAnalyticsQueue?: FactoryAnalyticsEvent[];
+  posthog?: {
+    capture: (
+      name: FactoryAnalyticsEvent["name"],
+      properties: FactoryAnalyticsEvent["properties"],
+    ) => void;
+  };
+};
+
+export function captureFactoryAnalyticsEvent(
+  event: FactoryAnalyticsEvent,
+): void {
+  const analyticsWindow = window as FactoryAnalyticsWindow;
+  if (analyticsWindow.posthog) {
+    analyticsWindow.posthog.capture(event.name, event.properties);
+    return;
+  }
+  analyticsWindow.__factoryAnalyticsQueue ??= [];
+  analyticsWindow.__factoryAnalyticsQueue.push(event);
+}

--- a/src/lib/factory-analytics.test.ts
+++ b/src/lib/factory-analytics.test.ts
@@ -26,7 +26,6 @@ const INSTRUMENTED_SURFACES = [
  */
 const UNINSTRUMENTED_SURFACES = [
   "src/app/layout.tsx",
-  "src/app/preview/layout.tsx",
   "src/app/pro/layout.tsx",
   "src/app/dashboard/page.tsx",
   "src/app/workspace/layout.tsx",
@@ -106,6 +105,21 @@ describe("factory analytics snippet", () => {
     expect(snippet).toContain("s.onload=function()");
     expect(snippet).toContain('window.posthog.init("phc_example"');
     expect(snippet).toContain('"capture_pageview":"history_change"');
+    expect(snippet).toContain("window.__factoryAnalyticsQueue");
+  });
+
+  it("queues a privacy-bounded initial event until PostHog is ready", () => {
+    expect(config).not.toBeNull();
+    const snippet = factoryAnalyticsSnippet(config!, {
+      name: "preview_view",
+      properties: { slug: "sample-preview", vertical: "RESTAURANT" },
+    });
+
+    expect(snippet).toContain('"name":"preview_view"');
+    expect(snippet).toContain('"slug":"sample-preview"');
+    expect(snippet).toContain('"vertical":"RESTAURANT"');
+    expect(snippet).not.toContain("email");
+    expect(snippet).not.toContain("token");
   });
 
   it("emits no character that could close the inline script element", () => {
@@ -135,5 +149,43 @@ describe("factory analytics mount points", () => {
     for (const path of UNINSTRUMENTED_SURFACES) {
       expect(await surfaceSource(path)).not.toContain("FactoryAnalytics");
     }
+  });
+
+  it("instruments factory previews without mounting analytics in their layout", async () => {
+    for (const path of [
+      "src/app/preview/[slug]/page.tsx",
+      "src/app/preview/[slug]/[locale]/page.tsx",
+    ]) {
+      const source = await surfaceSource(path);
+      expect(source).toContain("<FactoryAnalytics");
+      expect(source).toContain('name: "preview_view"');
+      expect(source).toContain("!isLiveSurface");
+    }
+    expect(await surfaceSource("src/app/preview/layout.tsx")).not.toContain(
+      "FactoryAnalytics",
+    );
+  });
+
+  it("captures checkout milestones without passing contact or claim data", async () => {
+    const source = await surfaceSource(
+      "src/app/claim/[slug]/claim-panel.tsx",
+    );
+    expect(source).toContain('name: "checkout_started"');
+    expect(source).toContain('name: "checkout_completed"');
+    expect(source).toContain("{ slug, vertical, plan: offer.planId }");
+    expect(source).not.toContain("properties: { email");
+    expect(source).not.toContain("properties: { invitationToken");
+  });
+
+  it("reads analytics configuration from the running container", async () => {
+    const source = await surfaceSource("src/components/factory-analytics.tsx");
+    expect(source).toContain("const runtimeEnvironment = process.env");
+    expect(source).not.toContain(
+      "process.env.NEXT_PUBLIC_POSTHOG_KEY",
+    );
+    expect(source).not.toContain(
+      "process.env.NEXT_PUBLIC_POSTHOG_HOST",
+    );
+    expect(source).toContain("isFactoryHostname(requestHostname(requestHeaders))");
   });
 });

--- a/src/lib/factory-analytics.ts
+++ b/src/lib/factory-analytics.ts
@@ -20,6 +20,24 @@ export type FactoryAnalyticsConfig = {
   assetHost: string;
 };
 
+export const FACTORY_ANALYTICS_EVENT_NAMES = [
+  "preview_view",
+  "checkout_started",
+  "checkout_completed",
+] as const;
+
+export type FactoryAnalyticsEventName =
+  (typeof FACTORY_ANALYTICS_EVENT_NAMES)[number];
+
+export type FactoryAnalyticsEvent = {
+  name: FactoryAnalyticsEventName;
+  properties: {
+    slug: string;
+    vertical: string;
+    plan?: string;
+  };
+};
+
 /**
  * Returns null — a complete no-op — whenever the project key is absent or the
  * host is unusable. An unconfigured deployment, a fork, and a local checkout all
@@ -51,7 +69,10 @@ export function resolveFactoryAnalytics(
  * before `array.js` arrives. Initialising in `onload` needs no queue, so the
  * loader stays readable in a public repository and still guarantees ordering.
  */
-export function factoryAnalyticsSnippet(config: FactoryAnalyticsConfig): string {
+export function factoryAnalyticsSnippet(
+  config: FactoryAnalyticsConfig,
+  initialEvent?: FactoryAnalyticsEvent,
+): string {
   const source = JSON.stringify(`${config.assetHost}/static/array.js`);
   const projectKey = JSON.stringify(config.projectKey);
   const options = JSON.stringify({
@@ -59,14 +80,21 @@ export function factoryAnalyticsSnippet(config: FactoryAnalyticsConfig): string 
     capture_pageview: "history_change",
     person_profiles: "identified_only",
   });
+  const queuedEvent = initialEvent
+    ? `window.__factoryAnalyticsQueue.push(${JSON.stringify(initialEvent)});`
+    : "";
   return [
     "(function(){",
+    "window.__factoryAnalyticsQueue=window.__factoryAnalyticsQueue||[];",
+    queuedEvent,
     'var s=document.createElement("script");',
     `s.src=${source};`,
     "s.async=true;",
     's.crossOrigin="anonymous";',
     "s.onload=function(){",
-    `if(window.posthog)window.posthog.init(${projectKey},${options});`,
+    `if(!window.posthog)return;window.posthog.init(${projectKey},${options});`,
+    "var q=window.__factoryAnalyticsQueue.splice(0);",
+    "q.forEach(function(e){window.posthog.capture(e.name,e.properties);});",
     "};",
     "document.head.appendChild(s);",
     "})();",

--- a/src/lib/operator-alert-deployment.test.ts
+++ b/src/lib/operator-alert-deployment.test.ts
@@ -78,6 +78,9 @@ describe("production deployment contract", () => {
 
     for (const name of [
       "FIRST_CUSTOMER_EVIDENCE_PUBLIC_KEY",
+      "NEXT_PUBLIC_POSTHOG_HOST",
+      "NEXT_PUBLIC_POSTHOG_KEY",
+      "OPERATOR_LEAD_INGEST_TOKEN",
       "RESEND_INBOUND_WEBHOOK_SECRET",
       "RESEND_WEBHOOK_SECRET",
       "SUPERADMIN_EMAILS",
@@ -88,6 +91,22 @@ describe("production deployment contract", () => {
     expect(required).not.toContain("OUTREACH_INBOUND_FORWARD_TO");
     expect(optional).toContain("OUTREACH_INBOUND_FORWARD_TO");
     expect(environmentExample).toContain("OUTREACH_INBOUND_FORWARD_TO=\n");
+  });
+
+  it("proves analytics on factory previews and off customer storefronts before cutover", () => {
+    expect(deployScript).toContain(
+      'get("cornershop.dev", "/preview/le-petit-meunier")',
+    );
+    expect(deployScript).toContain('preview.includes("preview_view")');
+    expect(deployScript).toContain(
+      'get("le-petit-meunier.restofront.com", "/")',
+    );
+    expect(deployScript).toContain(
+      'customer.includes("id=\\\"factory-analytics\\\"")',
+    );
+    expect(deployScript).toContain(
+      "release-state factory-analytics-ready sha=",
+    );
   });
 
   it("propagates every documented photo model, cost, concurrency, and policy control", () => {

--- a/src/lib/operator-lead-ingest.postgres.test.ts
+++ b/src/lib/operator-lead-ingest.postgres.test.ts
@@ -28,6 +28,10 @@ const fenceTriggerName = `lead_ingest_fence_trigger_${safeSuffix}`;
 const fenceTriggerFunction = `lead_ingest_fence_function_${safeSuffix}`;
 const fenceLockClassId = 1381259068;
 const fenceLockObjectId = 172;
+const reviewedSource = `https://reviewed-${suffix}.example.test`;
+const reviewedSlug = `reviewed-${suffix}`;
+const reviewedCollisionSource = `https://reviewed-collision-${suffix}.example.test`;
+const reviewedCollisionSlug = `reviewed-collision-${suffix}`;
 
 let db: ReturnType<typeof import("@/lib/db").getDb>;
 let createImportJob: typeof import("@/lib/site-persistence").createImportJob;
@@ -42,6 +46,7 @@ let ingestOperatorProspectLead: typeof import("@/lib/operator-lead-ingest").inge
 let createOrReopenOperatorLead: typeof import("@/lib/operator-leads").createOrReopenOperatorLead;
 let recordOperatorLeadAction: typeof import("@/lib/operator-leads").recordOperatorLeadAction;
 let normalizeImportSource: typeof import("@/lib/import-identity").normalizeImportSource;
+let importReviewedOperatorDraft: typeof import("@/lib/operator-reviewed-draft-import").importReviewedOperatorDraft;
 
 describe.skipIf(!enabled)("operator discovery import PostgreSQL atomicity", () => {
   beforeAll(async () => {
@@ -63,6 +68,9 @@ describe.skipIf(!enabled)("operator discovery import PostgreSQL atomicity", () =
       "@/lib/operator-leads"
     ));
     ({ normalizeImportSource } = await import("@/lib/import-identity"));
+    ({ importReviewedOperatorDraft } = await import(
+      "@/lib/operator-reviewed-draft-import"
+    ));
 
     await db.$executeRawUnsafe(`
       CREATE FUNCTION "${triggerFunction}"() RETURNS trigger AS $failure$
@@ -121,15 +129,25 @@ describe.skipIf(!enabled)("operator discovery import PostgreSQL atomicity", () =
             reopenSlug,
             redirectUpdateSlug,
             fenceSlug,
+            reviewedSlug,
+            reviewedCollisionSlug,
           ],
         },
       },
     });
     await db.importJob.deleteMany({
       where: {
-        source: {
-          in: [originalSource, failedOriginalSource],
-        },
+        OR: [
+          { source: { in: [originalSource, failedOriginalSource] } },
+          {
+            sourceKey: {
+              in: [
+                normalizeImportSource(reviewedSource),
+                normalizeImportSource(reviewedCollisionSource),
+              ],
+            },
+          },
+        ],
       },
     });
   });
@@ -481,6 +499,92 @@ describe.skipIf(!enabled)("operator discovery import PostgreSQL atomicity", () =
         where: { type: "site.lead.eligibility.updated", site: { slug: fenceSlug } },
       }),
     ).toBe(1);
+  });
+
+  test("reviewed draft reruns update one exact preview without changing its slug", async () => {
+    const draft = {
+      ...sampleSiteDraft,
+      slug: reviewedSlug,
+      name: "Reviewed private lead",
+      sourceUrl: reviewedSource,
+    };
+    const created = await importReviewedOperatorDraft({
+      vertical: "RESTAURANT",
+      draft,
+    });
+    expect(created).toMatchObject({
+      slug: reviewedSlug,
+      created: true,
+      verified: true,
+    });
+
+    const updated = await importReviewedOperatorDraft({
+      vertical: "RESTAURANT",
+      draft: { ...draft, description: "Reviewed copy updated idempotently." },
+    });
+    expect(updated).toMatchObject({
+      slug: reviewedSlug,
+      created: false,
+      verified: true,
+    });
+    expect(
+      await db.site.count({
+        where: {
+          OR: [
+            { slug: reviewedSlug },
+            { sourceKey: normalizeImportSource(reviewedSource) },
+          ],
+        },
+      }),
+    ).toBe(1);
+    expect(
+      await db.site.findUniqueOrThrow({
+        where: { slug: reviewedSlug },
+        select: { description: true, status: true },
+      }),
+    ).toMatchObject({
+      description: "Reviewed copy updated idempotently.",
+      status: "PREVIEW_READY",
+    });
+  });
+
+  test("reviewed draft import fails closed when its exact slug belongs to another source", async () => {
+    await db.site.create({
+      data: {
+        slug: reviewedCollisionSlug,
+        name: "Unrelated existing site",
+        sourceUrl: `https://unrelated-${suffix}.example.test`,
+        sourceKey: `url:unrelated-${suffix}.example.test`,
+        vertical: "RESTAURANT",
+        status: "PREVIEW_READY",
+        attributes: {},
+      },
+    });
+
+    await expect(
+      importReviewedOperatorDraft({
+        vertical: "RESTAURANT",
+        draft: {
+          ...sampleSiteDraft,
+          slug: reviewedCollisionSlug,
+          sourceUrl: reviewedCollisionSource,
+        },
+      }),
+    ).rejects.toThrow("conflicts with an existing site");
+    expect(
+      await db.site.count({
+        where: { sourceKey: normalizeImportSource(reviewedCollisionSource) },
+      }),
+    ).toBe(0);
+    expect(
+      await db.importJob.findFirstOrThrow({
+        where: {
+          sourceKey: normalizeImportSource(reviewedCollisionSource),
+        },
+        orderBy: { createdAt: "desc" },
+        select: { status: true, siteId: true },
+      }),
+    ).toEqual({ status: "FAILED", siteId: null });
   });
 });
 

--- a/src/lib/operator-reviewed-draft-import.test.ts
+++ b/src/lib/operator-reviewed-draft-import.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+import { Vertical } from "@/generated/prisma/enums";
+import { leadSiteDrafts } from "@/lib/lead-drafts";
+import {
+  parseReviewedDraftBatchImport,
+  parseReviewedDraftImport,
+} from "@/lib/operator-reviewed-draft-import";
+
+const approvedDraft = leadSiteDrafts["le-petit-meunier"];
+
+describe("reviewed operator draft import", () => {
+  it("accepts an exact vertical draft without changing private content", () => {
+    const input = parseReviewedDraftImport({
+      vertical: Vertical.RESTAURANT,
+      draft: approvedDraft,
+    });
+
+    expect(input.vertical).toBe(Vertical.RESTAURANT);
+    expect(input.draft).toEqual(approvedDraft);
+    expect(input.draft.slug).toBe("le-petit-meunier");
+  });
+
+  it("requires the public source that binds import identity", () => {
+    expect(() =>
+      parseReviewedDraftImport({
+        vertical: Vertical.RESTAURANT,
+        draft: { ...approvedDraft, sourceUrl: null },
+      }),
+    ).toThrow("public source URL");
+  });
+
+  it("rejects content that does not satisfy the selected vertical", () => {
+    expect(() =>
+      parseReviewedDraftImport({
+        vertical: Vertical.RESTAURANT,
+        draft: { ...approvedDraft, catalogSections: [] },
+      }),
+    ).toThrow();
+  });
+
+  it("validates a locked batch as one bounded operator request", () => {
+    const batch = parseReviewedDraftBatchImport({
+      batch: "malta-first-11",
+      locked: true,
+      vertical: Vertical.RESTAURANT,
+      drafts: [
+        approvedDraft,
+        { ...approvedDraft, slug: "second", sourceUrl: "https://second.example" },
+      ],
+    });
+
+    expect(batch.batch).toBe("malta-first-11");
+    expect(batch.imports.map((entry) => entry.draft.slug)).toEqual([
+      "le-petit-meunier",
+      "second",
+    ]);
+  });
+
+  it("rejects unlocked or duplicate batches", () => {
+    expect(() =>
+      parseReviewedDraftBatchImport({
+        batch: "unlocked",
+        locked: false,
+        vertical: Vertical.RESTAURANT,
+        drafts: [approvedDraft],
+      }),
+    ).toThrow();
+    expect(() =>
+      parseReviewedDraftBatchImport({
+        batch: "duplicate",
+        locked: true,
+        vertical: Vertical.RESTAURANT,
+        drafts: [approvedDraft, approvedDraft],
+      }),
+    ).toThrow("must be unique");
+  });
+});

--- a/src/lib/operator-reviewed-draft-import.ts
+++ b/src/lib/operator-reviewed-draft-import.ts
@@ -1,0 +1,142 @@
+import { z } from "zod";
+import { Vertical } from "@/generated/prisma/enums";
+import { getDb } from "@/lib/db";
+import {
+  buildOperatorImportIdentity,
+  createImportJob,
+  persistSiteImport,
+  recordImportFailure,
+  type PersistableSiteDraft,
+} from "@/lib/site-persistence";
+import { resolveVerticalConfig } from "@/lib/verticals/registry";
+import type { VerticalId } from "@/lib/verticals/types";
+
+const reviewedDraftEnvelopeSchema = z.object({
+  vertical: z.enum(Vertical),
+  draft: z.unknown(),
+});
+
+const reviewedDraftBatchSchema = z.object({
+  batch: z.string().trim().min(1).max(100),
+  locked: z.literal(true),
+  vertical: z.enum(Vertical),
+  drafts: z.array(z.unknown()).min(1).max(20),
+});
+
+export type ReviewedDraftImport = {
+  vertical: VerticalId;
+  draft: PersistableSiteDraft;
+};
+
+export type ReviewedDraftBatchImport = {
+  batch: string;
+  imports: ReviewedDraftImport[];
+};
+
+export function parseReviewedDraftImport(input: unknown): ReviewedDraftImport {
+  const envelope = reviewedDraftEnvelopeSchema.parse(input);
+  const draft = resolveVerticalConfig(envelope.vertical).draftSchema.parse(
+    envelope.draft,
+  ) as PersistableSiteDraft;
+  if (!draft.sourceUrl?.trim()) {
+    throw new Error("A reviewed draft requires its public source URL");
+  }
+  return { vertical: envelope.vertical, draft };
+}
+
+export function parseReviewedDraftBatchImport(
+  input: unknown,
+): ReviewedDraftBatchImport {
+  const batch = reviewedDraftBatchSchema.parse(input);
+  const imports = batch.drafts.map((draft) =>
+    parseReviewedDraftImport({ vertical: batch.vertical, draft }),
+  );
+  const slugs = imports.map((entry) => entry.draft.slug);
+  if (new Set(slugs).size !== slugs.length) {
+    throw new Error("Reviewed draft slugs must be unique");
+  }
+  return { batch: batch.batch, imports };
+}
+
+/**
+ * Persists one private, source-reviewed draft exactly as supplied. The payload
+ * stays outside the public repository and crosses only the authenticated
+ * operator boundary. Re-running the same input updates a mutable preview;
+ * claimed sites and any slug/source disagreement fail closed.
+ */
+export async function importReviewedOperatorDraft(input: ReviewedDraftImport) {
+  const source = input.draft.sourceUrl!;
+  const identity = buildOperatorImportIdentity(
+    input.draft,
+    source,
+    [],
+    input.vertical,
+  );
+  const importJob = await createImportJob(source, input.vertical);
+
+  try {
+    const imported = await persistSiteImport({
+      draft: input.draft,
+      vertical: input.vertical,
+      source,
+      importJobId: importJob.id,
+      actor: "operator:reviewed-draft-import",
+      requiredSlug: identity.slug,
+    });
+    const db = getDb();
+    const expectedItemCount = input.draft.catalogSections.reduce(
+      (sum, section) => sum + section.items.length,
+      0,
+    );
+    const verified = await db.site.findUnique({
+      where: { id: imported.siteId },
+      select: {
+        slug: true,
+        sourceKey: true,
+        status: true,
+        _count: { select: { catalogSections: true, integrations: true } },
+        catalogSections: {
+          select: { _count: { select: { items: true } } },
+        },
+      },
+    });
+    const verifiedItemCount =
+      verified?.catalogSections.reduce(
+        (sum, section) => sum + section._count.items,
+        0,
+      ) ?? -1;
+    if (
+      !verified ||
+      verified.slug !== identity.slug ||
+      verified.sourceKey !== identity.sourceKey ||
+      verified.status !== "PREVIEW_READY" ||
+      verified._count.catalogSections !== input.draft.catalogSections.length ||
+      verifiedItemCount !== expectedItemCount ||
+      verified._count.integrations !== input.draft.integrations.length
+    ) {
+      throw new Error("The reviewed draft failed its database verification");
+    }
+
+    return {
+      slug: imported.draft.slug,
+      created: imported.created,
+      urls: imported.urls,
+      verified: true as const,
+    };
+  } catch (error) {
+    await recordImportFailure(importJob.id, error);
+    throw error;
+  }
+}
+
+export async function importReviewedOperatorDraftBatch(
+  input: ReviewedDraftBatchImport,
+) {
+  const results = [];
+  // A failed run may have committed earlier rows. Each row is idempotent, so
+  // retrying the same locked batch safely converges without duplicate slugs.
+  for (const reviewedDraft of input.imports) {
+    results.push(await importReviewedOperatorDraft(reviewedDraft));
+  }
+  return { batch: input.batch, count: results.length, results };
+}

--- a/src/lib/release-integration-contract.test.ts
+++ b/src/lib/release-integration-contract.test.ts
@@ -87,6 +87,7 @@ describe("release integration contract", () => {
       "configuration-loaded",
       "caddy-configured",
       "migrations-applied",
+      "factory-analytics-ready",
       "outreach-configured",
       "wildcard-dns-ready",
       "platform-tls-ready",

--- a/src/lib/site-persistence.ts
+++ b/src/lib/site-persistence.ts
@@ -277,6 +277,8 @@ export async function persistSiteImport<
   actor?: string;
   contactEmail?: string;
   leadIngest?: PersistedLeadIngest;
+  /** Trusted reviewed imports may require their private, pre-approved slug. */
+  requiredSlug?: string;
 }): Promise<PersistedSiteImport<TDraft>> {
   const db = requireImportDatabase();
   const config = resolveVerticalConfig(input.vertical);
@@ -372,6 +374,10 @@ export async function persistSiteImport<
                 throw new Error("A unique preview URL could not be reserved");
               }
             }
+          }
+
+          if (input.requiredSlug && slug !== input.requiredSlug) {
+            throw new OperatorImportConflictError();
           }
 
           if (existing && !mutableImportStatuses.has(existing.status)) {


### PR DESCRIPTION
## Outcome

Closes the implementation and deployment gaps behind the four remaining launch cards without committing private customer data or sending outreach.

- accepts one locked private reviewed-draft batch through an idempotent bearer-authenticated operator path, with exact slug/source binding and post-write verification
- loads PostHog from runtime SSM-backed container env on factory hosts only; records preview and checkout milestones without email, token, or body properties
- fails the candidate deployment if analytics is absent from factory/preview pages or leaks onto a customer storefront
- makes PostHog and the operator ingest token required production parameters
- aligns the inbound-mail runbook with #194: replies remain in Postgres/admin and create no new forwarding send

## Verification

- 1,541 unit/component/contract tests passed; 0 failed
- focused migrated PostgreSQL atomicity suite: 8 passed, including idempotent rerun and slug/source collision rollback
- ESLint, design lint, generated route types, TypeScript, shell syntax, and diff checks passed
- production Docker image built successfully with Next 16.3.3 Turbopack
- container runtime contract passed on Node 24.20.0 / Bun 1.4.0 against a disposable migrated PostgreSQL database
- private Malta workflow is green and builds/snapshots the exact locked 11-draft payload

No mail, invitation, charge, or production import was performed by this PR.

Refs #189
Refs #190
Refs #191
Refs #192