### PR TITLE
fix(deploy): fail closed on candidate rollback

### DIFF
--- a/deploy/aws/deploy.sh
+++ b/deploy/aws/deploy.sh
@@ -279,37 +279,44 @@ wait_for_article_quiescence() {
 
 article_rollout_active=0
 rollback_article_rollout() {
-  local failure_status="${1:-1}"
-  trap - ERR
-  set +e
-  local edge_gate_verified=0
-  local database_gate_verified=0
-  if [[ "$article_rollout_active" == 1 ]]; then
-    echo "Article rollout failed; retaining both mutation gates" >&2
-    if set_article_edge_gate closed && verify_article_edge_gate closed; then
-      edge_gate_verified=1
+  # Rollback deliberately tolerates cleanup failures, but `set +e` must never
+  # escape into the deployment shell. A leaked option would let the script
+  # continue after the ERR trap, print success sentinels, and leave the
+  # predecessor running under a supposedly deployed release. The subshell
+  # confines both the disabled ERR trap and relaxed error handling.
+  (
+    local failure_status="${1:-1}"
+    trap - ERR
+    set +e
+    local edge_gate_verified=0
+    local database_gate_verified=0
+    if [[ "$article_rollout_active" == 1 ]]; then
+      echo "Article rollout failed; retaining both mutation gates" >&2
+      if set_article_edge_gate closed && verify_article_edge_gate closed; then
+        edge_gate_verified=1
+      fi
+      if run_article_rollout close >/dev/null; then
+        database_gate_verified=1
+      fi
     fi
-    if run_article_rollout close >/dev/null; then
-      database_gate_verified=1
+    docker rm -f "$candidate" >/dev/null 2>&1
+    if
+      [[ "$article_rollout_active" == 1 ]] &&
+      [[ "$edge_gate_verified" != 1 || "$database_gate_verified" != 1 ]]
+    then
+      echo "Article gates could not be verified; leaving application containers stopped" >&2
+      docker stop "$container" >/dev/null 2>&1
+      docker stop "$previous" >/dev/null 2>&1
+      return "$failure_status"
     fi
-  fi
-  docker rm -f "$candidate" >/dev/null 2>&1
-  if
-    [[ "$article_rollout_active" == 1 ]] &&
-    [[ "$edge_gate_verified" != 1 || "$database_gate_verified" != 1 ]]
-  then
-    echo "Article gates could not be verified; leaving application containers stopped" >&2
-    docker stop "$container" >/dev/null 2>&1
-    docker stop "$previous" >/dev/null 2>&1
+    if docker inspect "$previous" >/dev/null 2>&1; then
+      docker rm -f "$container" >/dev/null 2>&1
+      docker rename "$previous" "$container"
+      docker start "$container" >/dev/null
+      reload_caddy
+    fi
     return "$failure_status"
-  fi
-  if docker inspect "$previous" >/dev/null 2>&1; then
-    docker rm -f "$container" >/dev/null 2>&1
-    docker rename "$previous" "$container"
-    docker start "$container" >/dev/null
-    reload_caddy
-  fi
-  return "$failure_status"
+  )
 }
 
 # Close both public article mutation routes before any schema change. The
@@ -389,11 +396,15 @@ echo "release-state article-candidate-verified sha=${deployed_sha}"
 # emits the pixel on factory pages and the explicit preview event on previews,
 # while a customer platform hostname remains free of third-party analytics.
 docker exec "$candidate" node --input-type=module -e '
-  const get = async (host, path) => {
+  const get = async (host, path, requireOk = true) => {
     const response = await fetch(`http://127.0.0.1:3000${path}`, {
-      headers: { host },
+      // The application deliberately trusts the Caddy-forwarded hostname first.
+      // Node fetch does not reliably forward a caller-supplied Host header.
+      headers: { "x-forwarded-host": host },
     });
-    if (!response.ok) throw new Error(`${host}${path} returned ${response.status}`);
+    if (requireOk && !response.ok) {
+      throw new Error(`${host}${path} returned ${response.status}`);
+    }
     return response.text();
   };
   const factory = await get("cornershop.dev", "/");
@@ -404,7 +415,10 @@ docker exec "$candidate" node --input-type=module -e '
   if (!preview.includes("id=\"factory-analytics\"") || !preview.includes("preview_view")) {
     throw new Error("Factory preview analytics event is absent");
   }
-  const customer = await get("le-petit-meunier.restofront.com", "/");
+  // The seeded customer hostname may remain unpublished (404). Its rendered
+  // response must still be free of the factory pixel; factory surfaces above
+  // remain strict 200 checks.
+  const customer = await get("le-petit-meunier.restofront.com", "/", false);
   if (customer.includes("id=\"factory-analytics\"")) {
     throw new Error("Factory analytics leaked onto a customer storefront");
   }

--- a/deploy/aws/test-article-rollout.sh
+++ b/deploy/aws/test-article-rollout.sh
@@ -133,4 +133,34 @@ run_rollback_case 0 1 0 0
 run_rollback_case 0 0 1 0
 run_rollback_case 0 0 0 1
 
+# A production failure enters rollback from an ERR trap while errexit is on.
+# The handler may relax error handling internally, but the command after the
+# original failure must remain unreachable or the deploy can print false
+# success sentinels after restoring the predecessor.
+errexit_log="${root}/rollback-errexit.log"
+set +e
+(
+  set -Eeuo pipefail
+  source "$rollback_function"
+  container="api-cornershop-dev"
+  candidate="api-cornershop-dev-candidate"
+  previous="api-cornershop-dev-previous"
+  article_rollout_active=0
+  reload_caddy() { return 0; }
+  docker() { return 0; }
+  trap 'rollback_article_rollout $?' ERR
+  false
+  printf '%s\n' "continued-after-rollback" >"$errexit_log"
+) 2>>"$errexit_log"
+errexit_status="$?"
+set -e
+if [[ "$errexit_status" == 0 ]]; then
+  echo "Rollback swallowed the deployment failure" >&2
+  exit 1
+fi
+if grep -Fxq "continued-after-rollback" "$errexit_log"; then
+  echo "Deployment continued after rollback" >&2
+  exit 1
+fi
+
 echo "article rollout failure-path tests passed"

--- a/deploy/aws/test-release-bundle.sh
+++ b/deploy/aws/test-release-bundle.sh
@@ -35,4 +35,9 @@ assert_embedded_checksum \
   expected_host_launcher_sha256 \
   "${deploy_directory}/host-launcher.sh"
 
+if ! grep -Fq 'headers: { "x-forwarded-host": host },' "$deploy_script"; then
+  echo "Candidate host probe does not match the trusted forwarded-host path" >&2
+  exit 1
+fi
+
 echo "release bundle checksum tests passed"

--- a/src/lib/operator-alert-deployment.test.ts
+++ b/src/lib/operator-alert-deployment.test.ts
@@ -99,8 +99,9 @@ describe("production deployment contract", () => {
     );
     expect(deployScript).toContain('preview.includes("preview_view")');
     expect(deployScript).toContain(
-      'get("le-petit-meunier.restofront.com", "/")',
+      'get("le-petit-meunier.restofront.com", "/", false)',
     );
+    expect(deployScript).toContain("if (requireOk && !response.ok)");
     expect(deployScript).toContain(
       'customer.includes("id=\\\"factory-analytics\\\"")',
     );


### PR DESCRIPTION
## Outcome

Fixes the v0.4.8 production cutover defect discovered during live verification.

- sends the trusted `x-forwarded-host` header in the candidate analytics probe, matching Caddy and the application router
- requires factory and preview surfaces to return 2xx while allowing an unpublished customer hostname to remain 404 and still proving the factory pixel is absent
- confines rollback `set +e` to a subshell so the original deployment failure remains fatal
- adds a regression test proving execution cannot continue after an ERR-trap rollback

## Production evidence

The v0.4.8 candidate correctly failed its analytics probe, restored v0.4.7, then the leaked `set +e` allowed the deploy script to ignore missing-candidate errors and print a false `production-deployed` sentinel. Live inspection confirmed the host still ran `cornershopdev:7df6ff12...` and the new operator route returned 404.

## Verification

- `bash -n` for changed deploy scripts
- `shellcheck` for changed deploy scripts
- article rollout failure-path harness
- release bundle harness
- 16 focused release/deployment contract tests
- ESLint
- TypeScript `--noEmit`

No customer email, invitation, import, or charge is performed by this PR.

Refs #189
Refs #192