### PR TITLE
Factory: persist reviewed restaurant recut imagery

### DIFF
--- a/scripts/import-reviewed-drafts.ts
+++ b/scripts/import-reviewed-drafts.ts
@@ -1,5 +1,9 @@
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
+import {
+  reviewedRestaurantPreviewExpectation,
+  verifyReviewedRestaurantPreview,
+} from "@/lib/reviewed-restaurant-preview";
 
 type ReviewedDraft = {
   slug?: unknown;
@@ -23,6 +27,11 @@ async function main() {
   const batch = parseBatch(
     JSON.parse(await readFile(cli.input, "utf8")) as ReviewedDraftBatch,
   );
+  const expectations = batch.drafts.map((draft) =>
+    batch.vertical === "RESTAURANT"
+      ? reviewedRestaurantPreviewExpectation(draft)
+      : null,
+  );
   if (!cli.execute) {
     console.log(
       JSON.stringify({
@@ -30,7 +39,9 @@ async function main() {
         batch: batch.name,
         vertical: batch.vertical,
         count: batch.drafts.length,
-        slugs: batch.drafts.map((draft) => draft.slug),
+        ...(batch.vertical === "RESTAURANT"
+          ? { previews: expectations }
+          : { slugs: batch.drafts.map((draft) => draft.slug) }),
       }),
     );
     return;
@@ -64,6 +75,7 @@ async function main() {
       slug?: string;
       created?: boolean;
       verified?: boolean;
+      photoCount?: number;
       urls?: { preview?: string };
     }>;
     error?: string;
@@ -83,9 +95,11 @@ async function main() {
   const results = [];
   for (const [index, draft] of batch.drafts.entries()) {
     const result = imported.results[index];
+    const expectation = expectations[index];
     if (
       result?.slug !== draft.slug ||
       result.verified !== true ||
+      (expectation && result.photoCount !== expectation.sourcePhotoCount) ||
       !result.urls?.preview
     ) {
       throw new Error(`${draft.slug} returned an invalid verification result`);
@@ -98,8 +112,21 @@ async function main() {
         `${draft.slug} preview returned ${preview.status} after import`,
       );
     }
+    if (expectation && expectation.slug !== draft.slug) {
+      throw new Error(`${draft.slug} has no locked preview expectation`);
+    }
+    if (expectation) {
+      verifyReviewedRestaurantPreview(await preview.text(), expectation);
+    }
     results.push({
       slug: draft.slug,
+      ...(expectation
+        ? {
+            themeId: expectation.themeId,
+            rendererVersion: expectation.rendererVersion,
+            sourcePhotoCount: expectation.sourcePhotoCount,
+          }
+        : {}),
       created: result.created === true,
       verified: true,
       previewStatus: preview.status,

--- a/src/lib/operator-reviewed-draft-import.test.ts
+++ b/src/lib/operator-reviewed-draft-import.test.ts
@@ -1,10 +1,14 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, mock } from "bun:test";
 import { Vertical } from "@/generated/prisma/enums";
 import { leadSiteDrafts } from "@/lib/lead-drafts";
-import {
+
+mock.module("server-only", () => ({}));
+
+const {
   parseReviewedDraftBatchImport,
   parseReviewedDraftImport,
-} from "@/lib/operator-reviewed-draft-import";
+  reviewedDraftPhotoPlan,
+} = await import("@/lib/operator-reviewed-draft-import");
 
 const approvedDraft = leadSiteDrafts["le-petit-meunier"];
 
@@ -18,6 +22,32 @@ describe("reviewed operator draft import", () => {
     expect(input.vertical).toBe(Vertical.RESTAURANT);
     expect(input.draft).toEqual(approvedDraft);
     expect(input.draft.slug).toBe("le-petit-meunier");
+  });
+
+  it("turns reviewed hero and gallery originals into official photo slots", () => {
+    const hero = "https://restaurant.example/hero.jpg";
+    const gallery = "https://restaurant.example/gallery.jpg";
+    expect(
+      reviewedDraftPhotoPlan({
+        ...approvedDraft,
+        heroImageUrl: hero,
+        heroOriginalImageUrl: hero,
+        galleryImages: [
+          { url: gallery, originalUrl: gallery, provenance: "official" },
+        ],
+      }),
+    ).toEqual([
+      {
+        sourceUrl: hero,
+        sourcePageUrl: approvedDraft.sourceUrl!,
+        usage: "HERO",
+      },
+      {
+        sourceUrl: gallery,
+        sourcePageUrl: approvedDraft.sourceUrl!,
+        usage: "GALLERY",
+      },
+    ]);
   });
 
   it("requires the public source that binds import identity", () => {

--- a/src/lib/operator-reviewed-draft-import.test.ts
+++ b/src/lib/operator-reviewed-draft-import.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, mock } from "bun:test";
 import { Vertical } from "@/generated/prisma/enums";
 import { leadSiteDrafts } from "@/lib/lead-drafts";
+import { restoreAutomaticRestaurantTheme } from "@/lib/site-themes/restaurant/selection";
 
 mock.module("server-only", () => ({}));
 
@@ -11,6 +12,15 @@ const {
 } = await import("@/lib/operator-reviewed-draft-import");
 
 const approvedDraft = leadSiteDrafts["le-petit-meunier"];
+const scoredApprovedDraft = {
+  ...approvedDraft,
+  attributes: {
+    ...approvedDraft.attributes,
+    themeSelection: restoreAutomaticRestaurantTheme(
+      approvedDraft.attributes.designProfile,
+    ),
+  },
+};
 
 describe("reviewed operator draft import", () => {
   it("accepts an exact vertical draft without changing private content", () => {
@@ -74,8 +84,12 @@ describe("reviewed operator draft import", () => {
       locked: true,
       vertical: Vertical.RESTAURANT,
       drafts: [
-        approvedDraft,
-        { ...approvedDraft, slug: "second", sourceUrl: "https://second.example" },
+        scoredApprovedDraft,
+        {
+          ...scoredApprovedDraft,
+          slug: "second",
+          sourceUrl: "https://second.example",
+        },
       ],
     });
 
@@ -97,10 +111,18 @@ describe("reviewed operator draft import", () => {
     ).toThrow();
     expect(() =>
       parseReviewedDraftBatchImport({
+        batch: "unscored",
+        locked: true,
+        vertical: Vertical.RESTAURANT,
+        drafts: [approvedDraft],
+      }),
+    ).toThrow("requires scored vertical themes");
+    expect(() =>
+      parseReviewedDraftBatchImport({
         batch: "duplicate",
         locked: true,
         vertical: Vertical.RESTAURANT,
-        drafts: [approvedDraft, approvedDraft],
+        drafts: [scoredApprovedDraft, scoredApprovedDraft],
       }),
     ).toThrow("must be unique");
   });

--- a/src/lib/operator-reviewed-draft-import.ts
+++ b/src/lib/operator-reviewed-draft-import.ts
@@ -10,6 +10,11 @@ import {
 } from "@/lib/site-persistence";
 import { resolveVerticalConfig } from "@/lib/verticals/registry";
 import type { VerticalId } from "@/lib/verticals/types";
+import {
+  ingestReviewedSitePhotos,
+  type ReviewedSitePhoto,
+} from "@/lib/photo-library";
+import { registeredSiteTheme } from "@/lib/site-themes/adapters";
 
 const reviewedDraftEnvelopeSchema = z.object({
   vertical: z.enum(Vertical),
@@ -32,6 +37,38 @@ export type ReviewedDraftBatchImport = {
   batch: string;
   imports: ReviewedDraftImport[];
 };
+
+export function reviewedDraftPhotoPlan(
+  draft: PersistableSiteDraft,
+): ReviewedSitePhoto[] {
+  if (!draft.sourceUrl) return [];
+  const hero = draft.heroOriginalImageUrl ?? draft.heroImageUrl;
+  return [
+    ...(hero
+      ? [
+          {
+            sourceUrl: hero,
+            sourcePageUrl: draft.sourceUrl,
+            usage: "HERO" as const,
+          },
+        ]
+      : []),
+    ...(draft.galleryImages ?? [])
+      .map((image) => ({
+        sourceUrl: image.originalUrl,
+        sourcePageUrl: draft.sourceUrl!,
+        usage: "GALLERY" as const,
+      }))
+      .filter((photo) => photo.sourceUrl !== hero),
+  ].filter(
+    (photo, index, photos) =>
+      photos.findIndex(
+        (candidate) =>
+          candidate.sourceUrl === photo.sourceUrl &&
+          candidate.usage === photo.usage,
+      ) === index,
+  );
+}
 
 export function parseReviewedDraftImport(input: unknown): ReviewedDraftImport {
   const envelope = reviewedDraftEnvelopeSchema.parse(input);
@@ -66,6 +103,13 @@ export function parseReviewedDraftBatchImport(
  */
 export async function importReviewedOperatorDraft(input: ReviewedDraftImport) {
   const source = input.draft.sourceUrl!;
+  const expectedTheme = registeredSiteTheme(
+    input.vertical,
+    input.draft.attributes,
+  );
+  if (!expectedTheme) {
+    throw new Error("A reviewed draft requires a scored vertical theme");
+  }
   const identity = buildOperatorImportIdentity(
     input.draft,
     source,
@@ -83,6 +127,17 @@ export async function importReviewedOperatorDraft(input: ReviewedDraftImport) {
       actor: "operator:reviewed-draft-import",
       requiredSlug: identity.slug,
     });
+    const photoPlan = reviewedDraftPhotoPlan(input.draft);
+    const photoImport = await ingestReviewedSitePhotos({
+      siteId: imported.siteId,
+      siteSlug: imported.draft.slug,
+      vertical: input.vertical,
+      photos: photoPlan,
+      actor: "reviewed-draft-import",
+    });
+    if (photoImport.selected !== photoPlan.length) {
+      throw new Error("The reviewed draft failed its photo verification");
+    }
     const db = getDb();
     const expectedItemCount = input.draft.catalogSections.reduce(
       (sum, section) => sum + section.items.length,
@@ -94,9 +149,21 @@ export async function importReviewedOperatorDraft(input: ReviewedDraftImport) {
         slug: true,
         sourceKey: true,
         status: true,
+        logoUrl: true,
+        heroImageUrl: true,
+        draftThemeVersion: true,
+        draftTheme: true,
+        defaultLocale: true,
         _count: { select: { catalogSections: true, integrations: true } },
         catalogSections: {
           select: { _count: { select: { items: true } } },
+        },
+        photos: {
+          where: {
+            reviewStatus: "APPROVED",
+            selectedUsage: { in: ["HERO", "GALLERY"] },
+          },
+          select: { selectedUsage: true },
         },
       },
     });
@@ -105,14 +172,31 @@ export async function importReviewedOperatorDraft(input: ReviewedDraftImport) {
         (sum, section) => sum + section._count.items,
         0,
       ) ?? -1;
+    const verifiedTheme = verified?.draftTheme as {
+      id?: unknown;
+      themeId?: unknown;
+      rendererVersion?: unknown;
+    } | null;
+    const verifiedPhotoUsages = verified?.photos.map(
+      (photo) => photo.selectedUsage,
+    );
     if (
       !verified ||
       verified.slug !== identity.slug ||
       verified.sourceKey !== identity.sourceKey ||
       verified.status !== "PREVIEW_READY" ||
+      verified.logoUrl !== input.draft.logoUrl ||
+      !verified.heroImageUrl ||
+      verified.draftThemeVersion !== expectedTheme.version ||
+      (verifiedTheme?.themeId ?? verifiedTheme?.id) !== expectedTheme.id ||
+      verified.defaultLocale !== input.draft.defaultLocale ||
       verified._count.catalogSections !== input.draft.catalogSections.length ||
       verifiedItemCount !== expectedItemCount ||
-      verified._count.integrations !== input.draft.integrations.length
+      verified._count.integrations !== input.draft.integrations.length ||
+      verifiedPhotoUsages?.filter((usage) => usage === "HERO").length !==
+        photoPlan.filter((photo) => photo.usage === "HERO").length ||
+      verifiedPhotoUsages?.filter((usage) => usage === "GALLERY").length !==
+        photoPlan.filter((photo) => photo.usage === "GALLERY").length
     ) {
       throw new Error("The reviewed draft failed its database verification");
     }
@@ -122,6 +206,7 @@ export async function importReviewedOperatorDraft(input: ReviewedDraftImport) {
       created: imported.created,
       urls: imported.urls,
       verified: true as const,
+      photoCount: photoImport.selected,
     };
   } catch (error) {
     await recordImportFailure(importJob.id, error);

--- a/src/lib/operator-reviewed-draft-import.ts
+++ b/src/lib/operator-reviewed-draft-import.ts
@@ -88,6 +88,14 @@ export function parseReviewedDraftBatchImport(
   const imports = batch.drafts.map((draft) =>
     parseReviewedDraftImport({ vertical: batch.vertical, draft }),
   );
+  if (
+    imports.some(
+      (entry) =>
+        !registeredSiteTheme(entry.vertical, entry.draft.attributes),
+    )
+  ) {
+    throw new Error("A reviewed draft batch requires scored vertical themes");
+  }
   const slugs = imports.map((entry) => entry.draft.slug);
   if (new Set(slugs).size !== slugs.length) {
     throw new Error("Reviewed draft slugs must be unique");
@@ -107,9 +115,6 @@ export async function importReviewedOperatorDraft(input: ReviewedDraftImport) {
     input.vertical,
     input.draft.attributes,
   );
-  if (!expectedTheme) {
-    throw new Error("A reviewed draft requires a scored vertical theme");
-  }
   const identity = buildOperatorImportIdentity(
     input.draft,
     source,
@@ -127,15 +132,20 @@ export async function importReviewedOperatorDraft(input: ReviewedDraftImport) {
       actor: "operator:reviewed-draft-import",
       requiredSlug: identity.slug,
     });
-    const photoPlan = reviewedDraftPhotoPlan(input.draft);
-    const photoImport = await ingestReviewedSitePhotos({
-      siteId: imported.siteId,
-      siteSlug: imported.draft.slug,
-      vertical: input.vertical,
-      photos: photoPlan,
-      actor: "reviewed-draft-import",
-    });
-    if (photoImport.selected !== photoPlan.length) {
+    // The authenticated batch boundary requires scored themes. Keep this
+    // lower-level primitive compatible with legacy atomicity callers while
+    // limiting immutable photo adoption to the new renderer contract.
+    const photoPlan = expectedTheme ? reviewedDraftPhotoPlan(input.draft) : [];
+    const photoImport = expectedTheme
+      ? await ingestReviewedSitePhotos({
+          siteId: imported.siteId,
+          siteSlug: imported.draft.slug,
+          vertical: input.vertical,
+          photos: photoPlan,
+          actor: "reviewed-draft-import",
+        })
+      : { selected: 0, ingested: 0, deduplicated: 0 };
+    if (expectedTheme && photoImport.selected !== photoPlan.length) {
       throw new Error("The reviewed draft failed its photo verification");
     }
     const db = getDb();
@@ -186,17 +196,19 @@ export async function importReviewedOperatorDraft(input: ReviewedDraftImport) {
       verified.sourceKey !== identity.sourceKey ||
       verified.status !== "PREVIEW_READY" ||
       verified.logoUrl !== input.draft.logoUrl ||
-      !verified.heroImageUrl ||
-      verified.draftThemeVersion !== expectedTheme.version ||
-      (verifiedTheme?.themeId ?? verifiedTheme?.id) !== expectedTheme.id ||
+      (Boolean(input.draft.heroImageUrl) && !verified.heroImageUrl) ||
+      (expectedTheme &&
+        (verified.draftThemeVersion !== expectedTheme.version ||
+          (verifiedTheme?.themeId ?? verifiedTheme?.id) !== expectedTheme.id)) ||
       verified.defaultLocale !== input.draft.defaultLocale ||
       verified._count.catalogSections !== input.draft.catalogSections.length ||
       verifiedItemCount !== expectedItemCount ||
       verified._count.integrations !== input.draft.integrations.length ||
-      verifiedPhotoUsages?.filter((usage) => usage === "HERO").length !==
-        photoPlan.filter((photo) => photo.usage === "HERO").length ||
-      verifiedPhotoUsages?.filter((usage) => usage === "GALLERY").length !==
-        photoPlan.filter((photo) => photo.usage === "GALLERY").length
+      (expectedTheme &&
+        (verifiedPhotoUsages?.filter((usage) => usage === "HERO").length !==
+          photoPlan.filter((photo) => photo.usage === "HERO").length ||
+          verifiedPhotoUsages?.filter((usage) => usage === "GALLERY").length !==
+            photoPlan.filter((photo) => photo.usage === "GALLERY").length))
     ) {
       throw new Error("The reviewed draft failed its database verification");
     }

--- a/src/lib/photo-library.ts
+++ b/src/lib/photo-library.ts
@@ -64,7 +64,7 @@ export async function ingestDiscoveredSitePhotos(input: {
     async (photo) => {
       try {
         const fetched = await fetchPublicImage(photo.sourceUrl);
-        return await ingestPhotoBytes({
+        const ingested = await ingestPhotoBytes({
           siteId: input.siteId,
           siteSlug: input.siteSlug,
           vertical: input.vertical,
@@ -78,6 +78,7 @@ export async function ingestDiscoveredSitePhotos(input: {
           claimedMediaType: fetched.mediaType,
           actor: input.actor ?? "system:photo-ingest",
         });
+        return ingested.outcome;
       } catch {
         return "failed" as const;
       }
@@ -134,7 +135,7 @@ export async function ingestOwnerPhoto(input: {
     sourceUrl = input.sourceUrl!;
     sourceKind = "OWNER_REFERENCE";
   }
-  const result = await ingestPhotoBytes({
+  const ingested = await ingestPhotoBytes({
     siteId: input.siteId,
     siteSlug: input.siteSlug,
     vertical: input.vertical,
@@ -149,7 +150,113 @@ export async function ingestOwnerPhoto(input: {
     claimedMediaType,
     actor: actorLabel(input.actor),
   });
-  return { result, library: await getPhotoLibrary(input.siteId) };
+  return {
+    result: ingested.outcome,
+    library: await getPhotoLibrary(input.siteId),
+  };
+}
+
+export type ReviewedSitePhoto = {
+  sourceUrl: string;
+  sourcePageUrl: string;
+  usage: "HERO" | "GALLERY";
+};
+
+/**
+ * Copies an operator-reviewed first-party photo into immutable storage, marks
+ * the authentic original approved, and selects it for the supplied storefront
+ * slot. Unlike discovery, this path never leaves reviewed preview imagery in a
+ * pending state; unlike owner upload, it preserves official provenance.
+ */
+export async function ingestReviewedSitePhotos(input: {
+  siteId: string;
+  siteSlug: string;
+  vertical: Vertical;
+  photos: ReviewedSitePhoto[];
+  actor: string;
+}): Promise<{ selected: number; ingested: number; deduplicated: number }> {
+  const config = getPhotoSystemConfig();
+  const photos = input.photos.slice(0, config.discoveryMaxImages);
+  const ingested = await mapWithConcurrency(
+    photos,
+    config.ingestConcurrency,
+    async (photo) => {
+      const fetched = await fetchPublicImage(photo.sourceUrl);
+      const result = await ingestPhotoBytes({
+        siteId: input.siteId,
+        siteSlug: input.siteSlug,
+        vertical: input.vertical,
+        sourceUrl: photo.sourceUrl,
+        sourcePageUrl: photo.sourcePageUrl,
+        provenance: "OFFICIAL",
+        sourceKind: "FIRST_PARTY",
+        reviewStatus: "APPROVED",
+        candidateUsages: [photo.usage],
+        data: fetched.data,
+        claimedMediaType: fetched.mediaType,
+        actor: input.actor,
+        promoteDuplicateToApproved: true,
+      });
+      return { photo, ...result };
+    },
+  );
+
+  const selectedPhotoIds = new Set(ingested.map((result) => result.photoId));
+  if (selectedPhotoIds.size !== ingested.length) {
+    throw new PhotoLibraryError(
+      "One reviewed image cannot fill more than one storefront slot",
+      409,
+      "DUPLICATE_REVIEWED_PHOTO_SLOT",
+    );
+  }
+  const desiredPhotoIds = [...selectedPhotoIds];
+  const staleSelections = await getDb().photoAsset.findMany({
+    where: {
+      siteId: input.siteId,
+      selectedUsage: { in: ["HERO", "GALLERY"] },
+      ...(desiredPhotoIds.length > 0
+        ? { id: { notIn: desiredPhotoIds } }
+        : {}),
+    },
+    select: { id: true },
+  });
+  for (const photo of staleSelections) {
+    await reviewPhoto({
+      siteId: input.siteId,
+      photoId: photo.id,
+      actor: { id: input.actor, role: "operator" },
+      review: { action: "unselect" },
+    });
+  }
+
+  for (const result of ingested) {
+    await reviewPhoto({
+      siteId: input.siteId,
+      photoId: result.photoId,
+      actor: { id: input.actor, role: "operator" },
+      review: {
+        action:
+          result.photo.usage === "HERO" ? "select_hero" : "select_gallery",
+      },
+    });
+  }
+
+  const summary = {
+    selected: ingested.length,
+    ingested: ingested.filter((result) => result.outcome === "ingested").length,
+    deduplicated: ingested.filter(
+      (result) => result.outcome === "deduplicated",
+    ).length,
+  };
+  await getDb().auditEvent.create({
+    data: {
+      siteId: input.siteId,
+      type: "photo.reviewed-import.completed",
+      actor: input.actor,
+      metadata: { requested: photos.length, ...summary },
+    },
+  });
+  return summary;
 }
 
 async function ingestPhotoBytes(input: {
@@ -165,7 +272,11 @@ async function ingestPhotoBytes(input: {
   data: Uint8Array;
   claimedMediaType: string;
   actor: string;
-}): Promise<"ingested" | "deduplicated"> {
+  promoteDuplicateToApproved?: boolean;
+}): Promise<{
+  outcome: "ingested" | "deduplicated";
+  photoId: string;
+}> {
   let validatedImage: Awaited<ReturnType<typeof validatePhotoImageBytes>>;
   try {
     validatedImage = await validatePhotoImageBytes({
@@ -192,11 +303,18 @@ async function ingestPhotoBytes(input: {
         contentSha256: stored.sha256,
       },
     },
-    select: { id: true },
+    select: { id: true, candidateUsages: true },
   });
-  if (existing) return "deduplicated";
+  if (existing) {
+    await promoteOperatorReviewedDuplicate({
+      photoId: existing.id,
+      candidateUsages: existing.candidateUsages,
+      input,
+    });
+    return { outcome: "deduplicated", photoId: existing.id };
+  }
   try {
-    await db.$transaction(async (transaction) => {
+    const photoId = await db.$transaction(async (transaction) => {
       const photo = await transaction.photoAsset.create({
         data: {
           siteId: input.siteId,
@@ -233,14 +351,56 @@ async function ingestPhotoBytes(input: {
           },
         },
       });
+      return photo.id;
     });
-    return "ingested";
+    return { outcome: "ingested", photoId };
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
-      return "deduplicated";
+      const duplicate = await db.photoAsset.findUniqueOrThrow({
+        where: {
+          siteId_contentSha256: {
+            siteId: input.siteId,
+            contentSha256: stored.sha256,
+          },
+        },
+        select: { id: true, candidateUsages: true },
+      });
+      await promoteOperatorReviewedDuplicate({
+        photoId: duplicate.id,
+        candidateUsages: duplicate.candidateUsages,
+        input,
+      });
+      return { outcome: "deduplicated", photoId: duplicate.id };
     }
     throw error;
   }
+}
+
+async function promoteOperatorReviewedDuplicate(input: {
+  photoId: string;
+  candidateUsages: PhotoUsage[];
+  input: {
+    reviewStatus: "PENDING" | "APPROVED";
+    candidateUsages: PhotoUsage[];
+    actor: string;
+    promoteDuplicateToApproved?: boolean;
+  };
+}) {
+  if (!input.input.promoteDuplicateToApproved) return;
+  await getDb().photoAsset.update({
+    where: { id: input.photoId },
+    data: {
+      reviewStatus: "APPROVED",
+      reviewedAt: new Date(),
+      reviewedBy: input.input.actor,
+      candidateUsages: [
+        ...new Set([
+          ...input.candidateUsages,
+          ...input.input.candidateUsages,
+        ]),
+      ],
+    },
+  });
 }
 
 export async function getPhotoLibrary(siteId: string) {

--- a/src/lib/reviewed-restaurant-preview.test.ts
+++ b/src/lib/reviewed-restaurant-preview.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "bun:test";
+import {
+  reviewedRestaurantPreviewExpectation,
+  verifyReviewedRestaurantPreview,
+} from "@/lib/reviewed-restaurant-preview";
+
+const reviewedDraft = {
+  slug: "malta-table",
+  name: "Malta Table",
+  defaultLocale: "mt",
+  heroImageUrl: "https://restaurant.example/hero.jpg",
+  logoUrl: "https://restaurant.example/logo.svg",
+  galleryImages: [
+    {
+      url: "https://restaurant.example/dining-room.jpg",
+      originalUrl: "https://restaurant.example/dining-room.jpg",
+      provenance: "official",
+    },
+    {
+      url: "https://restaurant.example/dish.jpg",
+      originalUrl: "https://restaurant.example/dish.jpg",
+      provenance: "official",
+    },
+  ],
+  attributes: {
+    themeSelection: {
+      schemaVersion: 1,
+      rendererVersion: 1,
+      themeId: "neighborhood-table",
+      source: "deterministic",
+    },
+  },
+  catalogSections: [
+    {
+      items: [{ name: "Aljotta", currency: "EUR" }],
+    },
+  ],
+  translations: [{ locale: "en" }],
+};
+
+describe("reviewed restaurant preview verification", () => {
+  it("locks a branded mt/en restaurant onto the scored registry", () => {
+    expect(reviewedRestaurantPreviewExpectation(reviewedDraft)).toEqual({
+      slug: "malta-table",
+      name: "Malta Table",
+      themeId: "neighborhood-table",
+      rendererVersion: "restaurant-renderer-v1",
+      heroImageUrl: "https://restaurant.example/hero.jpg",
+      logoUrl: "https://restaurant.example/logo.svg",
+      sourcePhotoCount: 3,
+    });
+  });
+
+  it("rejects legacy, unbranded, monolingual and non-EUR drafts", () => {
+    for (const draft of [
+      { ...reviewedDraft, defaultLocale: "en" },
+      { ...reviewedDraft, logoUrl: null },
+      { ...reviewedDraft, galleryImages: reviewedDraft.galleryImages.slice(0, 1) },
+      {
+        ...reviewedDraft,
+        galleryImages: [
+          reviewedDraft.galleryImages[0],
+          {
+            ...reviewedDraft.galleryImages[1],
+            url: reviewedDraft.heroImageUrl,
+            originalUrl: reviewedDraft.heroImageUrl,
+          },
+        ],
+      },
+      { ...reviewedDraft, translations: [] },
+      {
+        ...reviewedDraft,
+        attributes: { themeSelection: { themeId: "legacy-v1" } },
+      },
+      {
+        ...reviewedDraft,
+        catalogSections: [{ items: [{ name: "Aljotta", currency: "USD" }] }],
+      },
+    ]) {
+      expect(() => reviewedRestaurantPreviewExpectation(draft)).toThrow();
+    }
+  });
+
+  it("requires the public preview to render the selected theme and source hero", () => {
+    const expectation = reviewedRestaurantPreviewExpectation(reviewedDraft);
+    const html = `<main data-site-theme="neighborhood-table" data-site-theme-version="restaurant-renderer-v1" style="background-image:url(&quot;https://restaurant.example/hero.jpg&quot;)"><span style="background-image:url(&quot;https://restaurant.example/logo.svg&quot;)">Malta Table</span><section data-site-photo-gallery></section></main>`;
+
+    expect(() => verifyReviewedRestaurantPreview(html, expectation)).not.toThrow();
+    expect(() =>
+      verifyReviewedRestaurantPreview(
+        html.replace("restaurant-renderer-v1", "legacy-v1"),
+        expectation,
+      ),
+    ).toThrow("did not render its scored restaurant theme");
+    expect(() =>
+      verifyReviewedRestaurantPreview(
+        html.replace("https://restaurant.example/hero.jpg", ""),
+        expectation,
+      ),
+    ).toThrow("did not render its source hero photo");
+    expect(() =>
+      verifyReviewedRestaurantPreview(
+        html.replace("https://restaurant.example/logo.svg", ""),
+        expectation,
+      ),
+    ).toThrow("did not render its restaurant logo");
+    expect(() =>
+      verifyReviewedRestaurantPreview(
+        html.replace("data-site-photo-gallery", ""),
+        expectation,
+      ),
+    ).toThrow("did not render its source photo gallery");
+  });
+});

--- a/src/lib/reviewed-restaurant-preview.ts
+++ b/src/lib/reviewed-restaurant-preview.ts
@@ -1,0 +1,168 @@
+const RESTAURANT_RENDERER_VERSION = "restaurant-renderer-v1";
+
+const RESTAURANT_THEME_IDS = new Set([
+  "terroir-editorial",
+  "counter-service",
+  "after-dark",
+  "neighborhood-table",
+  "daylight-cafe",
+  "family-feast",
+  "vesper-room",
+]);
+
+type ReviewedRestaurantDraft = {
+  slug?: unknown;
+  name?: unknown;
+  defaultLocale?: unknown;
+  heroImageUrl?: unknown;
+  logoUrl?: unknown;
+  galleryImages?: unknown;
+  translations?: unknown;
+  catalogSections?: unknown;
+  attributes?: unknown;
+};
+
+export type ReviewedRestaurantPreviewExpectation = {
+  slug: string;
+  name: string;
+  themeId: string;
+  rendererVersion: typeof RESTAURANT_RENDERER_VERSION;
+  heroImageUrl: string;
+  logoUrl: string;
+  sourcePhotoCount: number;
+};
+
+/**
+ * Closes the private Malta batch over the public restaurant contract before it
+ * crosses the operator boundary. The API owns full Zod validation; this guard
+ * owns the launch-specific mt/en, EUR, branding, photo and renderer promises.
+ */
+export function reviewedRestaurantPreviewExpectation(
+  draft: ReviewedRestaurantDraft,
+): ReviewedRestaurantPreviewExpectation {
+  const slug = requiredString(draft.slug, "slug");
+  const name = requiredString(draft.name, `${slug} name`);
+  if (draft.defaultLocale !== "mt") {
+    throw new Error(`${slug} must use mt as its default locale`);
+  }
+  if (
+    !Array.isArray(draft.translations) ||
+    !draft.translations.some(
+      (translation) =>
+        isRecord(translation) && translation.locale === "en",
+    )
+  ) {
+    throw new Error(`${slug} must include an en translation`);
+  }
+
+  const heroImageUrl = requiredHttpsUrl(
+    draft.heroImageUrl,
+    `${slug} hero image`,
+  );
+  const logoUrl = requiredHttpsUrl(draft.logoUrl, `${slug} logo`);
+  const galleryImages = Array.isArray(draft.galleryImages)
+    ? draft.galleryImages
+    : [];
+  if (galleryImages.length < 2) {
+    throw new Error(`${slug} must include at least two source photos`);
+  }
+  const gallerySourceUrls: string[] = [];
+  for (const image of galleryImages) {
+    if (!isRecord(image) || image.provenance !== "official") {
+      throw new Error(`${slug} source photos must be official`);
+    }
+    requiredHttpsUrl(image.url, `${slug} gallery image`);
+    gallerySourceUrls.push(
+      requiredHttpsUrl(image.originalUrl, `${slug} original gallery image`),
+    );
+  }
+  const sourcePhotoUrls = [heroImageUrl, ...gallerySourceUrls];
+  if (new Set(sourcePhotoUrls).size !== sourcePhotoUrls.length) {
+    throw new Error(`${slug} must use a different source photo for each slot`);
+  }
+
+  const themeSelection = isRecord(draft.attributes)
+    ? draft.attributes.themeSelection
+    : null;
+  if (!isRecord(themeSelection)) {
+    throw new Error(`${slug} must use the scored restaurant theme registry`);
+  }
+  const themeId = requiredString(themeSelection.themeId, `${slug} theme`);
+  if (
+    !RESTAURANT_THEME_IDS.has(themeId) ||
+    themeSelection.rendererVersion !== 1 ||
+    themeSelection.schemaVersion !== 1 ||
+    themeSelection.source !== "deterministic"
+  ) {
+    throw new Error(`${slug} has an invalid restaurant theme selection`);
+  }
+
+  if (!Array.isArray(draft.catalogSections) || draft.catalogSections.length === 0) {
+    throw new Error(`${slug} must include a sourced menu`);
+  }
+  for (const section of draft.catalogSections) {
+    if (!isRecord(section) || !Array.isArray(section.items)) {
+      throw new Error(`${slug} has an invalid menu section`);
+    }
+    for (const item of section.items) {
+      if (!isRecord(item) || item.currency !== "EUR") {
+        throw new Error(`${slug} menu items must use EUR`);
+      }
+    }
+  }
+
+  return {
+    slug,
+    name,
+    themeId,
+    rendererVersion: RESTAURANT_RENDERER_VERSION,
+    heroImageUrl,
+    logoUrl,
+    sourcePhotoCount: sourcePhotoUrls.length,
+  };
+}
+
+export function verifyReviewedRestaurantPreview(
+  html: string,
+  expectation: ReviewedRestaurantPreviewExpectation,
+): void {
+  const expectedAttributes = [
+    `data-site-theme="${expectation.themeId}"`,
+    `data-site-theme-version="${expectation.rendererVersion}"`,
+  ];
+  if (expectedAttributes.some((attribute) => !html.includes(attribute))) {
+    throw new Error(
+      `${expectation.slug} did not render its scored restaurant theme`,
+    );
+  }
+  if (!html.includes(expectation.heroImageUrl)) {
+    throw new Error(`${expectation.slug} did not render its source hero photo`);
+  }
+  if (!html.includes(expectation.logoUrl)) {
+    throw new Error(`${expectation.slug} did not render its restaurant logo`);
+  }
+  if (!html.includes("data-site-photo-gallery")) {
+    throw new Error(`${expectation.slug} did not render its source photo gallery`);
+  }
+  if (!html.includes(expectation.name)) {
+    throw new Error(`${expectation.slug} did not render its restaurant brand`);
+  }
+}
+
+function requiredString(value: unknown, label: string): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${label} is required`);
+  }
+  return value.trim();
+}
+
+function requiredHttpsUrl(value: unknown, label: string): string {
+  const raw = requiredString(value, label);
+  const url = new URL(raw);
+  if (url.protocol !== "https:") throw new Error(`${label} must use HTTPS`);
+  return url.toString();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## Summary

- persist operator-reviewed first-party hero and gallery originals in immutable Factory storage
- require restaurant reviewed batches to use the scored restaurant registry with mt + en, EUR menus, branding, and real photo galleries
- verify the public preview renders the selected non-legacy theme, source hero, restaurant logo, and gallery
- make repeated locked imports converge by approving reviewed deduplicates and retiring stale hero/gallery selections

## Verification

- `bun run lint`
- `bun run design:lint`
- `bun test` — 1,545 passed, 126 integration tests skipped by their normal env gates
- `bunx next typegen`
- `bunx tsc --noEmit --pretty false`
- production `bun run build` with the repository's documented build-only environment
- `bun run verify:brand-fonts`

## Operations

The reviewed restaurant payload and source research remain private and are not committed. No restaurant email, outreach/send path, DNS action, or production mutation is included. The locked 11-restaurant import should run only after this Factory change is released.