### PR TITLE
fix(import): transfer blocked Google Sites photos

### DIFF
--- a/docs/operations/platform-services.md
+++ b/docs/operations/platform-services.md
@@ -127,9 +127,16 @@ bun run operator:import:reviewed-drafts -- \
 ```
 
 The first command validates and prints only slugs. Execute requires
-`OPERATOR_LEAD_INGEST_TOKEN`, imports each exact draft over HTTPS, then requires
-its returned slug/database verification and a live `200` preview before moving
-to the next row. The command never sends outreach.
+`OPERATOR_LEAD_INGEST_TOKEN`. Before the API request, the operator machine
+downloads selected Google Sites `/sitesv/` hero and gallery images. The command
+sends those bytes in the authenticated request. The same URLs return `200` from
+Studio but Google returns `403` to the production AWS address with importer,
+default, or browser headers, with and without the source Referer. The API caps
+the request at 28 MB, verifies that each transferred URL belongs to a selected
+draft slot, validates the image bytes, and stores the original URL as
+provenance. Other image hosts still use the server's DNS-pinned fetch path. The
+command then requires the returned slug/database verification and a live `200`
+preview for every row. It never sends outreach.
 
 Store the exact legal controller at
 `/shipshit/production/cornershopdev/OUTREACH_LEGAL_CONTROLLER`. Deployment

--- a/scripts/import-reviewed-drafts.ts
+++ b/scripts/import-reviewed-drafts.ts
@@ -1,9 +1,13 @@
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
+import { fetchPublicImage } from "@/lib/importer";
 import {
   reviewedRestaurantPreviewExpectation,
   verifyReviewedRestaurantPreview,
 } from "@/lib/reviewed-restaurant-preview";
+import {
+  buildReviewedGoogleSitesPhotoTransfers,
+} from "@/lib/reviewed-photo-transfer";
 
 type ReviewedDraft = {
   slug?: unknown;
@@ -51,6 +55,10 @@ async function main() {
   if (!token) {
     throw new Error("OPERATOR_LEAD_INGEST_TOKEN is required with --execute");
   }
+  const photoTransfers = await buildReviewedGoogleSitesPhotoTransfers({
+    drafts: batch.drafts,
+    fetchImage: fetchPublicImage,
+  });
   const response = await fetch(
     `${cli.apiUrl}/api/admin/leads/reviewed-draft`,
     {
@@ -64,6 +72,7 @@ async function main() {
         locked: true,
         vertical: batch.vertical,
         drafts: batch.drafts,
+        photoTransfers,
       }),
     },
   );

--- a/src/app/api/admin/leads/reviewed-draft/route.ts
+++ b/src/app/api/admin/leads/reviewed-draft/route.ts
@@ -5,7 +5,12 @@ import {
   parseReviewedDraftBatchImport,
 } from "@/lib/operator-reviewed-draft-import";
 import { isOperatorLeadIngestAuthorized } from "@/lib/operator-lead-ingest-auth";
+import {
+  PhotoUploadBodyError,
+  readBoundedRequestBody,
+} from "@/lib/photo-upload-body";
 import { limitOperatorLeadIngest } from "@/lib/rate-limit";
+import { MAX_REVIEWED_DRAFT_IMPORT_BODY_BYTES } from "@/lib/reviewed-photo-transfer";
 import {
   ImportConflictError,
   OperatorImportConflictError,
@@ -41,16 +46,34 @@ export async function POST(request: Request) {
   }
 
   try {
-    const input = parseReviewedDraftBatchImport(await request.json());
+    const body = await readBoundedRequestBody(
+      request,
+      MAX_REVIEWED_DRAFT_IMPORT_BODY_BYTES,
+      "The reviewed draft import is larger than 28 MB",
+    );
+    const input = parseReviewedDraftBatchImport(
+      JSON.parse(new TextDecoder().decode(body)),
+    );
     const imported = await importReviewedOperatorDraftBatch(input);
     return NextResponse.json(
       { ok: true, ...imported },
       { headers: { "Cache-Control": "no-store" } },
     );
   } catch (error) {
-    if (error instanceof z.ZodError) {
+    if (error instanceof PhotoUploadBodyError) {
       return NextResponse.json(
-        { error: error.issues[0]?.message ?? "Check the reviewed draft." },
+        { error: error.message },
+        { status: error.status },
+      );
+    }
+    if (error instanceof z.ZodError || error instanceof SyntaxError) {
+      return NextResponse.json(
+        {
+          error:
+            error instanceof z.ZodError
+              ? (error.issues[0]?.message ?? "Check the reviewed draft.")
+              : "Check the reviewed draft.",
+        },
         { status: 400 },
       );
     }

--- a/src/lib/operator-reviewed-draft-import.test.ts
+++ b/src/lib/operator-reviewed-draft-import.test.ts
@@ -21,6 +21,8 @@ const scoredApprovedDraft = {
     ),
   },
 };
+const googleHero =
+  "https://lh3.googleusercontent.com/sitesv/refreshed-hero-token=w1280";
 
 describe("reviewed operator draft import", () => {
   it("accepts an exact vertical draft without changing private content", () => {
@@ -97,6 +99,45 @@ describe("reviewed operator draft import", () => {
     expect(batch.imports.map((entry) => entry.draft.slug)).toEqual([
       "le-petit-meunier",
       "second",
+    ]);
+  });
+
+  it("requires and decodes transferred Google Sites photo bytes", () => {
+    const draft = {
+      ...scoredApprovedDraft,
+      heroImageUrl: googleHero,
+      heroOriginalImageUrl: googleHero,
+      galleryImages: [],
+    };
+    expect(() =>
+      parseReviewedDraftBatchImport({
+        batch: "missing-google-transfer",
+        locked: true,
+        vertical: Vertical.RESTAURANT,
+        drafts: [draft],
+      }),
+    ).toThrow("must be transferred by the operator client");
+
+    const batch = parseReviewedDraftBatchImport({
+      batch: "transferred-google-photo",
+      locked: true,
+      vertical: Vertical.RESTAURANT,
+      drafts: [draft],
+      photoTransfers: [
+        {
+          sourceUrl: googleHero,
+          mediaType: "image/png",
+          dataBase64: "iVBORw==",
+        },
+      ],
+    });
+
+    expect(batch.imports[0]?.transferredPhotos).toEqual([
+      {
+        sourceUrl: googleHero,
+        mediaType: "image/png",
+        data: Uint8Array.from([0x89, 0x50, 0x4e, 0x47]),
+      },
     ]);
   });
 

--- a/src/lib/operator-reviewed-draft-import.ts
+++ b/src/lib/operator-reviewed-draft-import.ts
@@ -14,6 +14,11 @@ import {
   ingestReviewedSitePhotos,
   type ReviewedSitePhoto,
 } from "@/lib/photo-library";
+import {
+  isGoogleSitesPhotoUrl,
+  MAX_REVIEWED_PHOTO_TRANSFER_BYTES,
+  MAX_REVIEWED_PHOTO_TRANSFER_TOTAL_BYTES,
+} from "@/lib/reviewed-photo-transfer";
 import { registeredSiteTheme } from "@/lib/site-themes/adapters";
 
 const reviewedDraftEnvelopeSchema = z.object({
@@ -26,11 +31,40 @@ const reviewedDraftBatchSchema = z.object({
   locked: z.literal(true),
   vertical: z.enum(Vertical),
   drafts: z.array(z.unknown()).min(1).max(20),
+  photoTransfers: z
+    .array(
+      z.object({
+        sourceUrl: z
+          .url()
+          .refine(
+            isGoogleSitesPhotoUrl,
+            "Only reviewed Google Sites photos may be transferred",
+          ),
+        mediaType: z.enum([
+          "image/avif",
+          "image/jpeg",
+          "image/png",
+          "image/webp",
+        ]),
+        dataBase64: z
+          .base64()
+          .max(Math.ceil((MAX_REVIEWED_PHOTO_TRANSFER_BYTES * 4) / 3) + 4),
+      }),
+    )
+    .max(160)
+    .default([]),
 });
+
+type TransferredReviewedPhoto = {
+  sourceUrl: string;
+  mediaType: "image/avif" | "image/jpeg" | "image/png" | "image/webp";
+  data: Uint8Array;
+};
 
 export type ReviewedDraftImport = {
   vertical: VerticalId;
   draft: PersistableSiteDraft;
+  transferredPhotos?: TransferredReviewedPhoto[];
 };
 
 export type ReviewedDraftBatchImport = {
@@ -100,7 +134,51 @@ export function parseReviewedDraftBatchImport(
   if (new Set(slugs).size !== slugs.length) {
     throw new Error("Reviewed draft slugs must be unique");
   }
-  return { batch: batch.batch, imports };
+  const photoUrls = new Set(
+    imports.flatMap((entry) =>
+      reviewedDraftPhotoPlan(entry.draft).map((photo) => photo.sourceUrl),
+    ),
+  );
+  const transferredPhotos = batch.photoTransfers.map((transfer) => ({
+    sourceUrl: transfer.sourceUrl,
+    mediaType: transfer.mediaType,
+    data: new Uint8Array(Buffer.from(transfer.dataBase64, "base64")),
+  }));
+  const transferredUrls = transferredPhotos.map((photo) => photo.sourceUrl);
+  if (new Set(transferredUrls).size !== transferredUrls.length) {
+    throw new Error("Transferred reviewed photo URLs must be unique");
+  }
+  if (transferredPhotos.some((photo) => !photoUrls.has(photo.sourceUrl))) {
+    throw new Error("A transferred photo is not selected by the reviewed draft");
+  }
+  if (
+    transferredPhotos.some(
+      (photo) => photo.data.byteLength > MAX_REVIEWED_PHOTO_TRANSFER_BYTES,
+    ) ||
+    transferredPhotos.reduce((total, photo) => total + photo.data.byteLength, 0) >
+      MAX_REVIEWED_PHOTO_TRANSFER_TOTAL_BYTES
+  ) {
+    throw new Error("Transferred reviewed photos exceed the import size limit");
+  }
+  const missingGoogleSitesPhoto = [...photoUrls].find(
+    (url) => isGoogleSitesPhotoUrl(url) && !transferredUrls.includes(url),
+  );
+  if (missingGoogleSitesPhoto) {
+    throw new Error(
+      "Reviewed Google Sites photos must be transferred by the operator client",
+    );
+  }
+  return {
+    batch: batch.batch,
+    imports: imports.map((entry) => ({
+      ...entry,
+      transferredPhotos: transferredPhotos.filter((photo) =>
+        reviewedDraftPhotoPlan(entry.draft).some(
+          (planned) => planned.sourceUrl === photo.sourceUrl,
+        ),
+      ),
+    })),
+  };
 }
 
 /**
@@ -135,7 +213,15 @@ export async function importReviewedOperatorDraft(input: ReviewedDraftImport) {
     // The authenticated batch boundary requires scored themes. Keep this
     // lower-level primitive compatible with legacy atomicity callers while
     // limiting immutable photo adoption to the new renderer contract.
-    const photoPlan = expectedTheme ? reviewedDraftPhotoPlan(input.draft) : [];
+    const transferredPhotos = new Map(
+      (input.transferredPhotos ?? []).map((photo) => [photo.sourceUrl, photo]),
+    );
+    const photoPlan = expectedTheme
+      ? reviewedDraftPhotoPlan(input.draft).map((photo) => ({
+          ...photo,
+          transferred: transferredPhotos.get(photo.sourceUrl),
+        }))
+      : [];
     const photoImport = expectedTheme
       ? await ingestReviewedSitePhotos({
           siteId: imported.siteId,

--- a/src/lib/photo-library.test.ts
+++ b/src/lib/photo-library.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it, mock } from "bun:test";
 
 mock.module("server-only", () => ({}));
 
-const { detectSupportedImageMediaType } = await import("@/lib/photo-library");
+const { detectSupportedImageMediaType, resolveReviewedSitePhoto } =
+  await import("@/lib/photo-library");
 
 describe("photo library binary validation", () => {
   it("detects supported image signatures rather than trusting upload headers", () => {
@@ -25,5 +26,40 @@ describe("photo library binary validation", () => {
 
   it("rejects executable and malformed content", () => {
     expect(detectSupportedImageMediaType(Buffer.from("<script>"))).toBeNull();
+  });
+});
+
+describe("reviewed photo source resolution", () => {
+  const googlePhoto = {
+    sourceUrl:
+      "https://lh3.googleusercontent.com/sitesv/refreshed-photo-token=w1280",
+    sourcePageUrl: "https://restaurant.example",
+    usage: "HERO" as const,
+  };
+
+  it("preserves a live-fetch 403 when no operator transfer is available", async () => {
+    await expect(
+      resolveReviewedSitePhoto(googlePhoto, async () => {
+        throw new Error("The source image returned HTTP 403");
+      }),
+    ).rejects.toThrow("The source image returned HTTP 403");
+  });
+
+  it("uses transferred Google Sites bytes without making the blocked fetch", async () => {
+    const fetchImage = mock(async () => {
+      throw new Error("The source image returned HTTP 403");
+    });
+    const transferred = {
+      data: Uint8Array.from([0xff, 0xd8, 0xff, 0xe0]),
+      mediaType: "image/jpeg",
+    };
+
+    await expect(
+      resolveReviewedSitePhoto(
+        { ...googlePhoto, transferred },
+        fetchImage,
+      ),
+    ).resolves.toEqual(transferred);
+    expect(fetchImage).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/photo-library.ts
+++ b/src/lib/photo-library.ts
@@ -160,7 +160,18 @@ export type ReviewedSitePhoto = {
   sourceUrl: string;
   sourcePageUrl: string;
   usage: "HERO" | "GALLERY";
+  transferred?: {
+    data: Uint8Array;
+    mediaType: string;
+  };
 };
+
+export async function resolveReviewedSitePhoto(
+  photo: ReviewedSitePhoto,
+  fetchImage: typeof fetchPublicImage = fetchPublicImage,
+): Promise<{ data: Uint8Array; mediaType: string }> {
+  return photo.transferred ?? fetchImage(photo.sourceUrl);
+}
 
 /**
  * Copies an operator-reviewed first-party photo into immutable storage, marks
@@ -181,7 +192,7 @@ export async function ingestReviewedSitePhotos(input: {
     photos,
     config.ingestConcurrency,
     async (photo) => {
-      const fetched = await fetchPublicImage(photo.sourceUrl);
+      const fetched = await resolveReviewedSitePhoto(photo);
       const result = await ingestPhotoBytes({
         siteId: input.siteId,
         siteSlug: input.siteSlug,

--- a/src/lib/reviewed-photo-transfer.test.ts
+++ b/src/lib/reviewed-photo-transfer.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, mock } from "bun:test";
+import {
+  buildReviewedGoogleSitesPhotoTransfers,
+  isGoogleSitesPhotoUrl,
+  reviewedGoogleSitesPhotoUrls,
+} from "@/lib/reviewed-photo-transfer";
+
+const googleHero =
+  "https://lh3.googleusercontent.com/sitesv/refreshed-hero-token=w1280";
+const googleGallery =
+  "https://lh3.googleusercontent.com/sitesv/refreshed-gallery-token=w16383";
+
+describe("reviewed Google Sites photo transfer", () => {
+  it("selects unique Google Sites hero and gallery originals only", () => {
+    expect(
+      reviewedGoogleSitesPhotoUrls([
+        {
+          heroImageUrl: googleHero,
+          heroOriginalImageUrl: googleHero,
+          logoUrl:
+            "https://lh3.googleusercontent.com/sitesv/unselected-logo=w400",
+          galleryImages: [
+            { originalUrl: googleGallery },
+            { originalUrl: googleGallery },
+            { originalUrl: "https://restaurant.example/gallery.jpg" },
+          ],
+        },
+      ]),
+    ).toEqual([googleHero, googleGallery]);
+    expect(isGoogleSitesPhotoUrl(googleHero)).toBe(true);
+    expect(
+      isGoogleSitesPhotoUrl("https://lh3.googleusercontent.com/not-sites/photo"),
+    ).toBe(false);
+  });
+
+  it("serializes Studio-fetched bytes for the authenticated import", async () => {
+    const fetchImage = mock(async () => ({
+      data: Uint8Array.from([0x89, 0x50, 0x4e, 0x47]),
+      mediaType: "image/png",
+    }));
+
+    const transfers = await buildReviewedGoogleSitesPhotoTransfers({
+      drafts: [{ heroOriginalImageUrl: googleHero }],
+      fetchImage,
+    });
+
+    expect(fetchImage).toHaveBeenCalledWith(googleHero);
+    expect(transfers).toEqual([
+      {
+        sourceUrl: googleHero,
+        mediaType: "image/png",
+        dataBase64: "iVBORw==",
+      },
+    ]);
+  });
+
+  it("fails before API mutation when Studio cannot fetch a selected photo", async () => {
+    await expect(
+      buildReviewedGoogleSitesPhotoTransfers({
+        drafts: [{ heroOriginalImageUrl: googleHero }],
+        fetchImage: async () => {
+          throw new Error("The source image returned HTTP 403");
+        },
+      }),
+    ).rejects.toThrow("The source image returned HTTP 403");
+  });
+});

--- a/src/lib/reviewed-photo-transfer.ts
+++ b/src/lib/reviewed-photo-transfer.ts
@@ -1,0 +1,82 @@
+export const MAX_REVIEWED_PHOTO_TRANSFER_BYTES = 12_000_000;
+export const MAX_REVIEWED_PHOTO_TRANSFER_TOTAL_BYTES = 20_000_000;
+export const MAX_REVIEWED_DRAFT_IMPORT_BODY_BYTES = 28_000_000;
+
+export type ReviewedPhotoTransferPayload = {
+  sourceUrl: string;
+  mediaType: string;
+  dataBase64: string;
+};
+
+type PublicImageFetcher = (url: string) => Promise<{
+  data: Uint8Array;
+  mediaType: string;
+}>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function isGoogleSitesPhotoUrl(rawUrl: string): boolean {
+  try {
+    const url = new URL(rawUrl);
+    return (
+      url.protocol === "https:" &&
+      url.hostname === "lh3.googleusercontent.com" &&
+      url.pathname.startsWith("/sitesv/")
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Selects only the reviewed storefront slots. Logos, favicons, source evidence,
+ * and unselected candidates stay out of the authenticated transfer payload.
+ */
+export function reviewedGoogleSitesPhotoUrls(
+  drafts: readonly unknown[],
+): string[] {
+  const urls: string[] = [];
+  for (const draft of drafts) {
+    if (!isRecord(draft)) continue;
+    const hero =
+      typeof draft.heroOriginalImageUrl === "string"
+        ? draft.heroOriginalImageUrl
+        : typeof draft.heroImageUrl === "string"
+          ? draft.heroImageUrl
+          : null;
+    if (hero && isGoogleSitesPhotoUrl(hero)) urls.push(hero);
+
+    if (!Array.isArray(draft.galleryImages)) continue;
+    for (const image of draft.galleryImages) {
+      if (!isRecord(image) || typeof image.originalUrl !== "string") continue;
+      if (isGoogleSitesPhotoUrl(image.originalUrl)) urls.push(image.originalUrl);
+    }
+  }
+  return [...new Set(urls)];
+}
+
+export async function buildReviewedGoogleSitesPhotoTransfers(input: {
+  drafts: readonly unknown[];
+  fetchImage: PublicImageFetcher;
+}): Promise<ReviewedPhotoTransferPayload[]> {
+  const transfers: ReviewedPhotoTransferPayload[] = [];
+  let totalBytes = 0;
+  for (const sourceUrl of reviewedGoogleSitesPhotoUrls(input.drafts)) {
+    const image = await input.fetchImage(sourceUrl);
+    if (image.data.byteLength > MAX_REVIEWED_PHOTO_TRANSFER_BYTES) {
+      throw new Error("A reviewed Google Sites photo is larger than 12 MB");
+    }
+    totalBytes += image.data.byteLength;
+    if (totalBytes > MAX_REVIEWED_PHOTO_TRANSFER_TOTAL_BYTES) {
+      throw new Error("Reviewed Google Sites photos are larger than 20 MB");
+    }
+    transfers.push({
+      sourceUrl,
+      mediaType: image.mediaType,
+      dataBase64: Buffer.from(image.data).toString("base64"),
+    });
+  }
+  return transfers;
+}


### PR DESCRIPTION
## Summary

- reproduce all 8 selected reviewed Google Sites photo URLs as HTTP 200 from Studio and HTTP 403 from the healthy production container
- prefetch only selected `lh3.googleusercontent.com/sitesv/` hero and gallery bytes on the trusted operator machine
- carry those bytes through the authenticated reviewed-draft request with per-photo, total-payload, source-slot, media-type, and request-body limits
- preserve the original Google URL and official first-party provenance; all non-Google image sources keep the DNS-pinned live fetch path

## 403 evidence

Studio egress `46.11.92.251` returned 200 for all 8 URLs through the exact importer fetch path. Production egress `52.8.153.188` returned direct Google `fife` 403 responses for all 8 URLs with no redirect. Default headers, importer headers, browser headers, and source Referer variants all remained 403 from production. The source pages themselves remained 200.

This verifies that the current production egress path is the differentiator. It does not claim that Google blocks every AWS address.

## Verification

- `bun test`: 1,553 passed, 126 opt-in PostgreSQL tests skipped, 0 failed
- `bun run lint`
- `node node_modules/next/dist/bin/next typegen && bunx tsc --noEmit`
- production Next build under the CI environment contract
- real private batch dry harness: 11 drafts, 8 selected Google photos, all 8 fetched and transferred, 6.22 MB request under the 28 MB limit
- operator script standalone bundle smoke test

## Operational hold

- did not run the locked 11 live import
- sent no restaurant email or other restaurant outbound
- PR must not be merged or admin-merged as part of this task